### PR TITLE
research: validate #406

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
 
 [[package]]
 name = "archery"
@@ -1034,7 +1034,7 @@ dependencies = [
  "reqwest-middleware",
  "reqwest-retry",
  "reqwest-tracing",
- "revm-primitives",
+ "revm-primitives 3.1.1 (git+https://github.com/Wodann/revm?rev=451f122)",
  "serde",
  "serde_json",
  "serial_test",
@@ -1047,6 +1047,13 @@ dependencies = [
  "url",
  "uuid",
  "walkdir",
+]
+
+[[package]]
+name = "edr_eth2"
+version = "0.1.0"
+dependencies = [
+ "revm 8.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1072,7 +1079,7 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.1",
  "paste",
- "revm",
+ "revm 8.0.0 (git+https://github.com/Wodann/revm?rev=451f122)",
  "rpds",
  "serde",
  "serde_json",
@@ -1081,6 +1088,15 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "edr_multi"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "edr_eth2",
+ "edr_opt",
 ]
 
 [[package]]
@@ -1110,6 +1126,13 @@ dependencies = [
  "tracing",
  "tracing-flame",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "edr_opt"
+version = "0.1.0"
+dependencies = [
+ "revm 8.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2921,13 +2944,38 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72a454c1c650b2b2e23f0c461af09e6c31e1d15e1cbebe905a701c46b8a50afc"
+dependencies = [
+ "auto_impl",
+ "cfg-if",
+ "dyn-clone",
+ "revm-interpreter 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-precompile 6.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "revm"
+version = "8.0.0"
 source = "git+https://github.com/Wodann/revm?rev=451f122#451f122b5a234db90e3fa00dedfaec6c03b46d61"
 dependencies = [
  "auto_impl",
  "cfg-if",
  "dyn-clone",
- "revm-interpreter",
- "revm-precompile",
+ "revm-interpreter 4.0.0 (git+https://github.com/Wodann/revm?rev=451f122)",
+ "revm-precompile 6.0.0 (git+https://github.com/Wodann/revm?rev=451f122)",
+ "serde",
+]
+
+[[package]]
+name = "revm-interpreter"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d322f2730cd300e99d271a1704a2dfb8973d832428f5aa282aaa40e2473b5eec"
+dependencies = [
+ "revm-primitives 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
 ]
 
@@ -2936,8 +2984,25 @@ name = "revm-interpreter"
 version = "4.0.0"
 source = "git+https://github.com/Wodann/revm?rev=451f122#451f122b5a234db90e3fa00dedfaec6c03b46d61"
 dependencies = [
- "revm-primitives",
+ "revm-primitives 3.1.1 (git+https://github.com/Wodann/revm?rev=451f122)",
  "serde",
+]
+
+[[package]]
+name = "revm-precompile"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "931f692f3f4fc72ec39d5d270f8e9d208c4a6008de7590ee96cf948e3b6d3f8d"
+dependencies = [
+ "aurora-engine-modexp",
+ "c-kzg",
+ "k256",
+ "once_cell",
+ "revm-primitives 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ripemd",
+ "secp256k1",
+ "sha2",
+ "substrate-bn",
 ]
 
 [[package]]
@@ -2949,10 +3014,31 @@ dependencies = [
  "c-kzg",
  "k256",
  "once_cell",
- "revm-primitives",
+ "revm-primitives 3.1.1 (git+https://github.com/Wodann/revm?rev=451f122)",
  "ripemd",
  "sha2",
  "substrate-bn",
+]
+
+[[package]]
+name = "revm-primitives"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbbc9640790cebcb731289afb7a7d96d16ad94afeb64b5d0b66443bd151e79d6"
+dependencies = [
+ "alloy-primitives 0.7.0",
+ "auto_impl",
+ "bitflags 2.5.0",
+ "bitvec",
+ "c-kzg",
+ "cfg-if",
+ "derive_more",
+ "dyn-clone",
+ "enumn",
+ "hashbrown 0.14.3",
+ "hex",
+ "once_cell",
+ "serde",
 ]
 
 [[package]]
@@ -3194,6 +3280,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "secp256k1"
+version = "0.28.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
+dependencies = [
+ "rand",
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d1746aae42c19d583c3c1a8c646bfad910498e2051c551a7f2e3c0c9fbb7eb"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3266,6 +3371,7 @@ version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
+ "indexmap 2.2.6",
  "itoa",
  "ryu",
  "serde",

--- a/crates/edr_eth2/Cargo.toml
+++ b/crates/edr_eth2/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "edr_eth2"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+revm = { version = "8.0.0", default-features = false, features = ["c-kzg", "secp256k1", "std"] }

--- a/crates/edr_eth2/src/lib.rs
+++ b/crates/edr_eth2/src/lib.rs
@@ -1,0 +1,12 @@
+use revm::{db::EmptyDB, Evm};
+
+pub struct TestEth<'evm> {
+    pub evm: revm::Evm<'evm, (), EmptyDB>,
+}
+
+impl<'evm> Default for TestEth<'evm> {
+    fn default() -> Self {
+        let evm = Evm::builder().with_empty_db().build();
+        Self { evm }
+    }
+}

--- a/crates/edr_eth2/src/lib.rs
+++ b/crates/edr_eth2/src/lib.rs
@@ -1,3 +1,4 @@
+pub use revm::primitives::{SpecId, B256};
 use revm::{db::EmptyDB, Evm};
 
 pub struct TestEth<'evm> {

--- a/crates/edr_multi/Cargo.toml
+++ b/crates/edr_multi/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "edr_multi"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = { version = "1.0.82", default-features = false, features = ["std"] }
+edr_eth2 = { path = "../edr_eth2", version = "0.1.0" }
+edr_opt = { path = "../edr_opt", version = "0.1.0" }

--- a/crates/edr_multi/src/main.rs
+++ b/crates/edr_multi/src/main.rs
@@ -1,0 +1,12 @@
+use edr_eth2::TestEth;
+use edr_opt::TestOpt;
+
+fn main() -> anyhow::Result<()> {
+    let mut test_opt = TestOpt::default();
+    let mut test_eth = TestEth::default();
+
+    test_eth.evm.transact()?;
+    test_opt.evm.transact()?;
+
+    Ok(())
+}

--- a/crates/edr_multi/src/main.rs
+++ b/crates/edr_multi/src/main.rs
@@ -1,12 +1,17 @@
-use edr_eth2::TestEth;
-use edr_opt::TestOpt;
-
 fn main() -> anyhow::Result<()> {
-    let mut test_opt = TestOpt::default();
-    let mut test_eth = TestEth::default();
+    let eth_hash = edr_eth2::B256::ZERO;
+    let opt_hash = edr_opt::B256::ZERO;
 
-    test_eth.evm.transact()?;
-    test_opt.evm.transact()?;
+    if eth_hash == opt_hash {
+        println!("The same hash");
+    }
+
+    let eth_spec_id = edr_eth2::SpecId::ECOTONE;
+    let opt_spec_id = edr_opt::SpecId::LATEST;
+
+    if eth_spec_id == opt_spec_id {
+        println!("The same spec id");
+    }
 
     Ok(())
 }

--- a/crates/edr_opt/Cargo.toml
+++ b/crates/edr_opt/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "edr_opt"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+revm = { version = "8.0.0", default-features = false, features = ["c-kzg", "optimism", "secp256k1", "std"] }

--- a/crates/edr_opt/src/lib.rs
+++ b/crates/edr_opt/src/lib.rs
@@ -1,0 +1,20 @@
+use revm::{
+    db::EmptyDB,
+    primitives::{HandlerCfg, SpecId},
+    Evm,
+};
+
+pub struct TestOpt<'evm> {
+    pub evm: revm::Evm<'evm, (), EmptyDB>,
+}
+
+impl<'evm> Default for TestOpt<'evm> {
+    fn default() -> Self {
+        let evm = Evm::builder()
+            .with_empty_db()
+            .with_handler_cfg(HandlerCfg::new_with_optimism(SpecId::LATEST, true))
+            .build();
+
+        Self { evm }
+    }
+}

--- a/crates/edr_opt/src/lib.rs
+++ b/crates/edr_opt/src/lib.rs
@@ -1,8 +1,5 @@
-use revm::{
-    db::EmptyDB,
-    primitives::{HandlerCfg, SpecId},
-    Evm,
-};
+pub use revm::primitives::{SpecId, B256};
+use revm::{db::EmptyDB, primitives::HandlerCfg, Evm};
 
 pub struct TestOpt<'evm> {
     pub evm: revm::Evm<'evm, (), EmptyDB>,


### PR DESCRIPTION
This code shows that it's possible to compile two versions of `revm`, one with and one without optimism support, and use them together in a third crate.

Closes #406 