### PR TITLE
Include all builds as normal dependencies

### DIFF
--- a/.changeset/young-pans-help.md
+++ b/.changeset/young-pans-help.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Added a workaround for an npm bug by using all builds as normal dependencies

--- a/.github/workflows/edr-npm-release.yml
+++ b/.github/workflows/edr-npm-release.yml
@@ -395,6 +395,10 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           path: ./crates/edr_napi/artifacts
+      - name: Install sponge
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y moreutils
       - name: Move artifacts
         run: pnpm artifacts
       - name: Publish

--- a/crates/edr_napi/npm/darwin-arm64/package.json
+++ b/crates/edr_napi/npm/darwin-arm64/package.json
@@ -5,12 +5,6 @@
     "type": "git"
   },
   "version": "0.2.0-alpha.1",
-  "os": [
-    "darwin"
-  ],
-  "cpu": [
-    "arm64"
-  ],
   "main": "edr.darwin-arm64.node",
   "files": [
     "edr.darwin-arm64.node"

--- a/crates/edr_napi/npm/darwin-x64/package.json
+++ b/crates/edr_napi/npm/darwin-x64/package.json
@@ -5,12 +5,6 @@
     "type": "git"
   },
   "version": "0.2.0-alpha.1",
-  "os": [
-    "darwin"
-  ],
-  "cpu": [
-    "x64"
-  ],
   "main": "edr.darwin-x64.node",
   "files": [
     "edr.darwin-x64.node"

--- a/crates/edr_napi/npm/linux-arm64-gnu/package.json
+++ b/crates/edr_napi/npm/linux-arm64-gnu/package.json
@@ -5,12 +5,6 @@
     "type": "git"
   },
   "version": "0.2.0-alpha.1",
-  "os": [
-    "linux"
-  ],
-  "cpu": [
-    "arm64"
-  ],
   "main": "edr.linux-arm64-gnu.node",
   "files": [
     "edr.linux-arm64-gnu.node"
@@ -18,8 +12,5 @@
   "license": "MIT",
   "engines": {
     "node": ">= 18"
-  },
-  "libc": [
-    "glibc"
-  ]
+  }
 }

--- a/crates/edr_napi/npm/linux-arm64-musl/package.json
+++ b/crates/edr_napi/npm/linux-arm64-musl/package.json
@@ -5,12 +5,6 @@
     "type": "git"
   },
   "version": "0.2.0-alpha.1",
-  "os": [
-    "linux"
-  ],
-  "cpu": [
-    "arm64"
-  ],
   "main": "edr.linux-arm64-musl.node",
   "files": [
     "edr.linux-arm64-musl.node"
@@ -18,8 +12,5 @@
   "license": "MIT",
   "engines": {
     "node": ">= 18"
-  },
-  "libc": [
-    "musl"
-  ]
+  }
 }

--- a/crates/edr_napi/npm/linux-x64-gnu/package.json
+++ b/crates/edr_napi/npm/linux-x64-gnu/package.json
@@ -5,12 +5,6 @@
     "type": "git"
   },
   "version": "0.2.0-alpha.1",
-  "os": [
-    "linux"
-  ],
-  "cpu": [
-    "x64"
-  ],
   "main": "edr.linux-x64-gnu.node",
   "files": [
     "edr.linux-x64-gnu.node"
@@ -18,8 +12,5 @@
   "license": "MIT",
   "engines": {
     "node": ">= 18"
-  },
-  "libc": [
-    "glibc"
-  ]
+  }
 }

--- a/crates/edr_napi/npm/linux-x64-musl/package.json
+++ b/crates/edr_napi/npm/linux-x64-musl/package.json
@@ -5,12 +5,6 @@
     "type": "git"
   },
   "version": "0.2.0-alpha.1",
-  "os": [
-    "linux"
-  ],
-  "cpu": [
-    "x64"
-  ],
   "main": "edr.linux-x64-musl.node",
   "files": [
     "edr.linux-x64-musl.node"
@@ -18,8 +12,5 @@
   "license": "MIT",
   "engines": {
     "node": ">= 18"
-  },
-  "libc": [
-    "musl"
-  ]
+  }
 }

--- a/crates/edr_napi/npm/win32-x64-msvc/package.json
+++ b/crates/edr_napi/npm/win32-x64-msvc/package.json
@@ -5,12 +5,6 @@
     "type": "git"
   },
   "version": "0.2.0-alpha.1",
-  "os": [
-    "win32"
-  ],
-  "cpu": [
-    "x64"
-  ],
   "main": "edr.win32-x64-msvc.node",
   "files": [
     "edr.win32-x64-msvc.node"

--- a/crates/edr_napi/package.json
+++ b/crates/edr_napi/package.json
@@ -17,11 +17,15 @@
   "napi": {
     "name": "edr",
     "triples": {
+      "defaults": false,
       "additional": [
         "aarch64-apple-darwin",
+        "x86_64-apple-darwin",
         "aarch64-unknown-linux-gnu",
         "aarch64-unknown-linux-musl",
-        "x86_64-unknown-linux-musl"
+        "x86_64-unknown-linux-gnu",
+        "x86_64-unknown-linux-musl",
+        "x86_64-pc-windows-msvc"
       ]
     }
   },

--- a/crates/edr_napi/package.json
+++ b/crates/edr_napi/package.json
@@ -51,7 +51,7 @@
     "build:debug": "napi build --platform",
     "build:tracing": "napi build --platform --release --features tracing",
     "build:scenarios": "napi build --platform --release --features scenarios",
-    "prepublishOnly": "napi prepublish -t npm --skip-gh-release",
+    "prepublishOnly": "bash scripts/prepublish.sh",
     "universal": "napi universal",
     "version": "napi version",
     "pretest": "pnpm build",

--- a/crates/edr_napi/scripts/prepublish.sh
+++ b/crates/edr_napi/scripts/prepublish.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+
+pnpm napi prepublish -t npm --skip-gh-release
+
+# rename optionalDependencies key to dependencies
+jq 'with_entries(if .key == "optionalDependencies" then .key = "dependencies" else . end)' package.json | sponge package.json
+
+# remove os, cpu, libc from builds package.json files
+for i in npm/*/package.json; do jq 'del(.os, .cpu, .libc)' $i | sponge $i; done

--- a/crates/edr_napi/scripts/prepublish.sh
+++ b/crates/edr_napi/scripts/prepublish.sh
@@ -7,6 +7,3 @@ pnpm napi prepublish -t npm --skip-gh-release
 
 # rename optionalDependencies key to dependencies
 jq 'with_entries(if .key == "optionalDependencies" then .key = "dependencies" else . end)' package.json | sponge package.json
-
-# remove os, cpu, libc from builds package.json files
-for i in npm/*/package.json; do jq 'del(.os, .cpu, .libc)' $i | sponge $i; done


### PR DESCRIPTION
Hardhat users are frequently running into https://github.com/npm/cli/issues/4828. As a blunt workaround, we are going to turn all the builds into dependencies of the entry-point package `@nomicfoundation/edr`, instead of being optional dependencies. For this to work, two things have to happen:

1. The `package.json` of EDR has to use them as plain `dependencies` instead of `optionalDependencies`
2. The `package.json`s of the builds don't have to include things like `os` and `arch`, because the package manager might check them and complain if they don't match.

Since the `optionalDependencies` field of the entry-point package.json are added/modified by the NAPI-RS CLI, the only way to deal with 1 is to modify the `package.json` after running `napi prepublish`. This is done with `jq` and `sponge` (sponge is needed because you can't do `jq '...' package.json > package.json` and `jq` doesn't have a "modify in place" flag like sed's `-i`). `sponge` doesn't come pre-installed, so we need to install `moreutils` in the publish job.

For 2, it's enough to just modify the `package.json`s we already have under `crates/edr_napi/npm`. The `arch`, `os` and `libc` fields are not re-added by `napi`.