### PR TITLE
Use patch bump for blob txs support

### DIFF
--- a/.changeset/curly-carpets-join.md
+++ b/.changeset/curly-carpets-join.md
@@ -1,5 +1,5 @@
 ---
-"@nomicfoundation/edr": minor
+"@nomicfoundation/edr": patch
 ---
 
 Added support for blob transactions (EIP-4844) when auto-mining is enabled and the mempool is empty


### PR DESCRIPTION
We are going to use minor versions only for breaking changes. Shipping new features in 0.x with patch versions increases the amount of users that receive this change.