### PR TITLE
Rename changesets PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Open changesets PR
 
 on:
   push:


### PR DESCRIPTION
I find it super confusing to have an "EDR npm release" and a "Release" workflow and I never remember what the second one is about. I renamed it to make it more clear.