### PR TITLE
Fix eth_sign parameters order

### DIFF
--- a/.changeset/neat-keys-promise.md
+++ b/.changeset/neat-keys-promise.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Fixed order of parameters for eth_sign (#455)

--- a/crates/edr_provider/src/lib.rs
+++ b/crates/edr_provider/src/lib.rs
@@ -223,6 +223,10 @@ impl<LoggerErrorT: Debug + Send + Sync + 'static, TimerT: Clone + TimeSinceEpoch
                 eth::handle_estimate_gas(data, call_request, block_spec)
                     .and_then(to_json_with_traces)
             }
+            MethodInvocation::EthSign(address, message)
+            | MethodInvocation::PersonalSign(message, address) => {
+                eth::handle_sign_request(data, message, address).and_then(to_json)
+            }
             MethodInvocation::FeeHistory(block_count, newest_block, reward_percentiles) => {
                 eth::handle_fee_history(data, block_count, newest_block, reward_percentiles)
                     .and_then(to_json)
@@ -310,9 +314,6 @@ impl<LoggerErrorT: Debug + Send + Sync + 'static, TimerT: Clone + TimeSinceEpoch
             MethodInvocation::SendTransaction(transaction_request) => {
                 eth::handle_send_transaction_request(data, transaction_request)
                     .and_then(to_json_with_traces)
-            }
-            MethodInvocation::Sign(message, address) => {
-                eth::handle_sign_request(data, message, address).and_then(to_json)
             }
             MethodInvocation::SignTypedDataV4(address, message) => {
                 eth::handle_sign_typed_data_v4(data, address, message).and_then(to_json)

--- a/crates/edr_provider/src/requests/methods.rs
+++ b/crates/edr_provider/src/requests/methods.rs
@@ -68,6 +68,12 @@ pub enum MethodInvocation {
         )]
         Option<BlockSpec>,
     ),
+    /// `eth_sign`
+    #[serde(rename = "eth_sign")]
+    EthSign(
+        #[serde(deserialize_with = "crate::requests::serde::deserialize_address")] Address,
+        Bytes,
+    ),
     /// `eth_feeHistory`
     #[serde(rename = "eth_feeHistory")]
     FeeHistory(
@@ -212,9 +218,9 @@ pub enum MethodInvocation {
     /// `eth_sendTransaction`
     #[serde(rename = "eth_sendTransaction", with = "edr_eth::serde::sequence")]
     SendTransaction(EthTransactionRequest),
-    /// `eth_sign`
-    #[serde(rename = "eth_sign", alias = "personal_sign")]
-    Sign(
+    /// `personal_sign`
+    #[serde(rename = "personal_sign")]
+    PersonalSign(
         Bytes,
         #[serde(deserialize_with = "crate::requests::serde::deserialize_address")] Address,
     ),
@@ -410,6 +416,7 @@ impl MethodInvocation {
             MethodInvocation::ChainId(_) => "eth_chainId",
             MethodInvocation::Coinbase(_) => "eth_coinbase",
             MethodInvocation::EstimateGas(_, _) => "eth_estimateGas",
+            MethodInvocation::EthSign(_, _) => "eth_sign",
             MethodInvocation::FeeHistory(_, _, _) => "eth_feeHistory",
             MethodInvocation::GasPrice(_) => "eth_gasPrice",
             MethodInvocation::GetBalance(_, _) => "eth_getBalance",
@@ -443,9 +450,9 @@ impl MethodInvocation {
             MethodInvocation::NewFilter(_) => "eth_newFilter",
             MethodInvocation::NewPendingTransactionFilter(_) => "eth_newPendingTransactionFilter",
             MethodInvocation::PendingTransactions(_) => "eth_pendingTransactions",
+            MethodInvocation::PersonalSign(_, _) => "personal_sign",
             MethodInvocation::SendRawTransaction(_) => "eth_sendRawTransaction",
             MethodInvocation::SendTransaction(_) => "eth_sendTransaction",
-            MethodInvocation::Sign(_, _) => "eth_sign",
             MethodInvocation::SignTypedDataV4(_, _) => "eth_signTypedData_v4",
             MethodInvocation::Subscribe(_, _) => "eth_subscribe",
             MethodInvocation::Syncing(_) => "eth_syncing",

--- a/crates/edr_provider/tests/eth_request_serialization.rs
+++ b/crates/edr_provider/tests/eth_request_serialization.rs
@@ -345,10 +345,18 @@ fn test_serde_eth_send_transaction() {
 }
 
 #[test]
-fn test_serde_eth_sign() {
-    help_test_method_invocation_serde(MethodInvocation::Sign(
+fn test_serde_personal_sign() {
+    help_test_method_invocation_serde(MethodInvocation::PersonalSign(
         Bytes::from(&b"whatever"[..]),
         Address::from(U160::from(1)),
+    ));
+}
+
+#[test]
+fn test_serde_eth_sign() {
+    help_test_method_invocation_serde(MethodInvocation::EthSign(
+        Address::from(U160::from(1)),
+        Bytes::from(&b"whatever"[..]),
     ));
 }
 
@@ -504,11 +512,23 @@ fn test_net_peer_count() {
 
 #[test]
 fn test_personal_sign() {
-    let call = MethodInvocation::Sign(Bytes::from(&b"whatever"[..]), Address::from(U160::from(1)));
+    let call =
+        MethodInvocation::PersonalSign(Bytes::from(&b"whatever"[..]), Address::from(U160::from(1)));
 
-    let serialized = serde_json::json!(call)
-        .to_string()
-        .replace("eth_sign", "personal_sign");
+    let serialized = serde_json::json!(call).to_string();
+
+    let call_deserialized: MethodInvocation = serde_json::from_str(&serialized)
+        .unwrap_or_else(|_| panic!("should have successfully deserialized json {serialized}"));
+
+    assert_eq!(call, call_deserialized);
+}
+
+#[test]
+fn test_eth_sign() {
+    let call =
+        MethodInvocation::EthSign(Address::from(U160::from(1)), Bytes::from(&b"whatever"[..]));
+
+    let serialized = serde_json::json!(call).to_string();
 
     let call_deserialized: MethodInvocation = serde_json::from_str(&serialized)
         .unwrap_or_else(|_| panic!("should have successfully deserialized json {serialized}"));


### PR DESCRIPTION
eth_sign was implemented as an alias of personal_sign. This was not correct, as the order of the parameters is different for both methods.

Closes https://github.com/NomicFoundation/edr/issues/455