### PR TITLE
ci: custom publish release profile for `edr_napi`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,9 @@ rpath = true
 # Uncomment this section if you're using a debugger.
 debug = 1
 
-# Optimized release profile.
-[profile.release]
+# Optimized profile for released packages.
+[profile.napi-publish]
+inherits = "release"
 rpath = true
 opt-level = 3
 lto = "fat"

--- a/crates/edr_napi/Cargo.toml
+++ b/crates/edr_napi/Cargo.toml
@@ -49,6 +49,3 @@ napi-build = "2.0.1"
 [features]
 tracing = ["edr_evm/tracing", "edr_provider/tracing"]
 scenarios = ["rand"]
-
-[profile.release]
-lto = true

--- a/crates/edr_napi/package.json
+++ b/crates/edr_napi/package.json
@@ -47,14 +47,15 @@
   },
   "scripts": {
     "artifacts": "napi artifacts",
-    "build": "napi build --platform --release",
+    "build": "napi build --platform --profile napi-publish",
+    "build:test": "napi build --platform --release",
     "build:debug": "napi build --platform",
     "build:tracing": "napi build --platform --release --features tracing",
     "build:scenarios": "napi build --platform --release --features scenarios",
     "prepublishOnly": "bash scripts/prepublish.sh",
     "universal": "napi universal",
     "version": "napi version",
-    "pretest": "pnpm build",
+    "pretest": "pnpm build:test",
     "test": "pnpm tsc && mocha --recursive \"test/**/*.ts\"",
     "testNoBuild": "pnpm tsc && mocha --recursive \"test/**/*.ts\"",
     "clean": "rm -rf @nomicfoundation/edr.node"

--- a/hardhat-tests/package.json
+++ b/hardhat-tests/package.json
@@ -15,7 +15,7 @@
     "test:integration": "bash run-integration-tests.sh",
     "test:ci": "pnpm test && pnpm test:integration",
     "build": "tsc --build --force --incremental .",
-    "build:edr": "cd ../crates/edr_napi && pnpm build",
+    "build:edr": "cd ../crates/edr_napi && pnpm build:test",
     "clean": "rimraf build-test tsconfig.tsbuildinfo test/internal/hardhat-network/provider/.hardhat_node_test_cache test/internal/hardhat-network/stack-traces/test-files/artifacts"
   },
   "devDependencies": {


### PR DESCRIPTION
We build `edr_napi` for JS tests with the release profile for speedy execution. As part of forking Foundry for Solidity tests we adopted their release flags. This significantly increased the running time of tests which is annoying for local development.

This change fixes that by adopting a custom publish release profile for `edr_napi`. I took the approach of opting out of this profile for tests to ensure that no release can be published by accident with inferior optimizations.