### PR TITLE
ci: add workflows for PR reviews slack notifications

### DIFF
--- a/.github/workflows/review-requested-slack-notification.yml
+++ b/.github/workflows/review-requested-slack-notification.yml
@@ -1,0 +1,10 @@
+name: PR review requested Slack notification
+
+on:
+  pull_request_target:
+    types: [review_requested]
+
+jobs:
+  requested:
+    uses: NomicFoundation/github-actions-workflows/.github/workflows/review-requested-slack-notification.yml@main
+    secrets: inherit

--- a/.github/workflows/review-submitted-slack-notification.yml
+++ b/.github/workflows/review-submitted-slack-notification.yml
@@ -1,0 +1,10 @@
+name: PR reviewed Slack notification
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  reviewed:
+    uses: NomicFoundation/github-actions-workflows/.github/workflows/review-submitted-slack-notification.yml@main
+    secrets: inherit


### PR DESCRIPTION
These workflows will notify us on Slack when a PR review is requested or submitted. They use the jobs defined here: https://github.com/NomicFoundation/github-actions-workflows/tree/main/.github/workflows