### PR TITLE
refactor: add generic trait bound to ExecutableTransaction

### DIFF
--- a/crates/edr_eth/src/transaction.rs
+++ b/crates/edr_eth/src/transaction.rs
@@ -17,7 +17,7 @@ pub use revm_primitives::alloy_primitives::TxKind;
 use revm_primitives::B256;
 
 pub use self::r#type::TransactionType;
-use crate::{access_list::AccessListItem, Address, Bytes, U256};
+use crate::{access_list::AccessListItem, signature::SignatureError, Address, Bytes, U256};
 
 pub const INVALID_TX_TYPE_ERROR_MESSAGE: &str = "invalid tx type";
 
@@ -50,6 +50,12 @@ pub enum Signed {
     Eip1559(signed::Eip1559),
     /// EIP-4844 transaction
     Eip4844(signed::Eip4844),
+}
+
+/// Trait for signed transactions.
+pub trait SignedTransaction: Transaction {
+    /// Recovers the Ethereum address which was used to sign the transaction.
+    fn recover(&self) -> Result<Address, SignatureError>;
 }
 
 pub trait Transaction {

--- a/crates/edr_eth/src/transaction.rs
+++ b/crates/edr_eth/src/transaction.rs
@@ -17,7 +17,11 @@ pub use revm_primitives::alloy_primitives::TxKind;
 use revm_primitives::B256;
 
 pub use self::r#type::TransactionType;
-use crate::{access_list::AccessListItem, signature::SignatureError, Address, Bytes, U256};
+use crate::{
+    access_list::{AccessList, AccessListItem},
+    signature::SignatureError,
+    Address, Bytes, U256,
+};
 
 pub const INVALID_TX_TYPE_ERROR_MESSAGE: &str = "invalid tx type";
 
@@ -59,6 +63,12 @@ pub trait SignedTransaction: Transaction {
 }
 
 pub trait Transaction {
+    /// Returns the access list of the transaction, if any.
+    fn access_list(&self) -> Option<&AccessList>;
+
+    /// Returns the input data of the transaction.
+    fn data(&self) -> &Bytes;
+
     /// The effective gas price of the transaction, calculated using the
     /// provided block base fee.
     fn effective_gas_price(&self, block_base_fee: U256) -> U256;
@@ -68,6 +78,9 @@ pub trait Transaction {
 
     /// The gas price the sender is willing to pay.
     fn gas_price(&self) -> U256;
+
+    /// Returns what kind of transaction this is.
+    fn kind(&self) -> TxKind;
 
     /// The maximum fee per gas the sender is willing to pay. Only applicable
     /// for post-EIP-1559 transactions.
@@ -83,9 +96,6 @@ pub trait Transaction {
 
     /// The transaction's nonce.
     fn nonce(&self) -> u64;
-
-    /// The address that receives the call, if any.
-    fn to(&self) -> Option<Address>;
 
     /// The total amount of blob gas used by the transaction. Only applicable
     /// for EIP-4844 transactions.

--- a/crates/edr_eth/src/transaction/signed.rs
+++ b/crates/edr_eth/src/transaction/signed.rs
@@ -10,7 +10,9 @@ use revm_primitives::{TransactTo, TxEnv};
 pub use self::{
     eip155::Eip155, eip1559::Eip1559, eip2930::Eip2930, eip4844::Eip4844, legacy::Legacy,
 };
-use super::{Signed, Transaction, TransactionType, TxKind, INVALID_TX_TYPE_ERROR_MESSAGE};
+use super::{
+    Signed, SignedTransaction, Transaction, TransactionType, TxKind, INVALID_TX_TYPE_ERROR_MESSAGE,
+};
 use crate::{
     access_list::AccessList,
     signature::{Signature, SignatureError},
@@ -110,17 +112,6 @@ impl Signed {
             Signed::Eip2930(tx) => tx.kind,
             Signed::Eip1559(tx) => tx.kind,
             Signed::Eip4844(tx) => TxKind::Call(tx.to),
-        }
-    }
-
-    /// Recovers the Ethereum address which was used to sign the transaction.
-    pub fn recover(&self) -> Result<Address, SignatureError> {
-        match self {
-            Signed::PreEip155Legacy(tx) => tx.recover(),
-            Signed::PostEip155Legacy(tx) => tx.recover(),
-            Signed::Eip2930(tx) => tx.recover(),
-            Signed::Eip1559(tx) => tx.recover(),
-            Signed::Eip4844(tx) => tx.recover(),
         }
     }
 
@@ -249,6 +240,18 @@ impl From<self::eip1559::Eip1559> for Signed {
 impl From<self::eip4844::Eip4844> for Signed {
     fn from(transaction: self::eip4844::Eip4844) -> Self {
         Self::Eip4844(transaction)
+    }
+}
+
+impl SignedTransaction for Signed {
+    fn recover(&self) -> Result<Address, SignatureError> {
+        match self {
+            Signed::PreEip155Legacy(tx) => tx.recover(),
+            Signed::PostEip155Legacy(tx) => tx.recover(),
+            Signed::Eip2930(tx) => tx.recover(),
+            Signed::Eip1559(tx) => tx.recover(),
+            Signed::Eip4844(tx) => tx.recover(),
+        }
     }
 }
 

--- a/crates/edr_eth/src/transaction/signed.rs
+++ b/crates/edr_eth/src/transaction/signed.rs
@@ -5,7 +5,7 @@ mod eip4844;
 mod legacy;
 
 use alloy_rlp::{Buf, BufMut, Decodable};
-use revm_primitives::{TransactTo, TxEnv};
+use revm_primitives::TransactTo;
 
 pub use self::{
     eip155::Eip155, eip1559::Eip1559, eip2930::Eip2930, eip4844::Eip4844, legacy::Legacy,
@@ -103,17 +103,6 @@ impl Signed {
                 s: tx.s,
                 v: u64::from(tx.odd_y_parity),
             },
-        }
-    }
-
-    /// Converts this transaction into a `TxEnv` struct.
-    pub fn into_tx_env(self, caller: Address) -> TxEnv {
-        match self {
-            Signed::PreEip155Legacy(tx) => tx.into_tx_env(caller),
-            Signed::PostEip155Legacy(tx) => tx.into_tx_env(caller),
-            Signed::Eip2930(tx) => tx.into_tx_env(caller),
-            Signed::Eip1559(tx) => tx.into_tx_env(caller),
-            Signed::Eip4844(tx) => tx.into_tx_env(caller),
         }
     }
 

--- a/crates/edr_evm/src/block.rs
+++ b/crates/edr_evm/src/block.rs
@@ -17,11 +17,11 @@ pub use self::{
     local::LocalBlock,
     remote::{CreationError as RemoteBlockCreationError, RemoteBlock},
 };
-use crate::{chain_spec::ChainSpec, ExecutableTransaction};
+use crate::{chain_spec::L1ChainSpec, ExecutableTransaction};
 
 /// Trait for implementations of an Ethereum block.
 #[auto_impl(Arc)]
-pub trait Block<ChainSpecT: ChainSpec>: Debug {
+pub trait Block: Debug {
     /// The blockchain error type.
     type Error;
 
@@ -38,7 +38,7 @@ pub trait Block<ChainSpecT: ChainSpec>: Debug {
     fn rlp_size(&self) -> u64;
 
     /// Returns the block's transactions.
-    fn transactions(&self) -> &[ExecutableTransaction];
+    fn transactions(&self) -> &[ExecutableTransaction<L1ChainSpec>];
 
     /// Returns the receipts of the block's transactions.
     fn transaction_receipts(&self) -> Result<Vec<Arc<BlockReceipt>>, Self::Error>;

--- a/crates/edr_evm/src/block.rs
+++ b/crates/edr_evm/src/block.rs
@@ -17,11 +17,11 @@ pub use self::{
     local::LocalBlock,
     remote::{CreationError as RemoteBlockCreationError, RemoteBlock},
 };
-use crate::ExecutableTransaction;
+use crate::{chain_spec::ChainSpec, ExecutableTransaction};
 
 /// Trait for implementations of an Ethereum block.
 #[auto_impl(Arc)]
-pub trait Block: Debug {
+pub trait Block<ChainSpecT: ChainSpec>: Debug {
     /// The blockchain error type.
     type Error;
 

--- a/crates/edr_evm/src/block/builder.rs
+++ b/crates/edr_evm/src/block/builder.rs
@@ -25,6 +25,7 @@ use revm::{
 use super::local::LocalBlock;
 use crate::{
     blockchain::SyncBlockchain,
+    chain_spec::L1ChainSpec,
     debug::{DebugContext, EvmContext},
     state::{AccountModifierFn, StateDebug, StateDiff, SyncState},
     ExecutableTransaction, SyncBlock,
@@ -129,7 +130,7 @@ pub struct BuildBlockResult {
 pub struct BlockBuilder {
     cfg: CfgEnvWithHandlerCfg,
     header: PartialHeader,
-    transactions: Vec<ExecutableTransaction>,
+    transactions: Vec<ExecutableTransaction<L1ChainSpec>>,
     state_diff: StateDiff,
     receipts: Vec<TransactionReceipt<Log>>,
     parent_gas_limit: Option<u64>,
@@ -218,7 +219,7 @@ impl BlockBuilder {
         &mut self,
         blockchain: &'blockchain dyn SyncBlockchain<BlockchainErrorT, StateErrorT>,
         state: StateT,
-        transaction: ExecutableTransaction,
+        transaction: ExecutableTransaction<L1ChainSpec>,
         debug_context: Option<DebugContext<'evm, BlockchainErrorT, DebugDataT, StateT>>,
     ) -> ExecutionResultWithContext<'evm, BlockchainErrorT, StateErrorT, DebugDataT, StateT>
     where
@@ -421,7 +422,7 @@ impl BlockBuilder {
             transaction_hash: *transaction.transaction_hash(),
             transaction_index: self.transactions.len() as u64,
             from: *transaction.caller(),
-            to: transaction.to(),
+            to: transaction.kind().to().copied(),
             contract_address,
             gas_used: result.gas_used(),
             effective_gas_price: Some(transaction.effective_gas_price(block.basefee)),

--- a/crates/edr_evm/src/block/local.rs
+++ b/crates/edr_evm/src/block/local.rs
@@ -13,8 +13,8 @@ use itertools::izip;
 use revm::primitives::keccak256;
 
 use crate::{
-    blockchain::BlockchainError, Block, DetailedTransaction, ExecutableTransaction, SpecId,
-    SyncBlock,
+    blockchain::BlockchainError, chain_spec::L1ChainSpec, Block, DetailedTransaction,
+    ExecutableTransaction, SpecId, SyncBlock,
 };
 
 /// A locally mined block, which contains complete information.
@@ -22,7 +22,7 @@ use crate::{
 #[rlp(trailing)]
 pub struct LocalBlock {
     header: block::Header,
-    transactions: Vec<ExecutableTransaction>,
+    transactions: Vec<ExecutableTransaction<L1ChainSpec>>,
     #[rlp(skip)]
     transaction_receipts: Vec<Arc<BlockReceipt>>,
     ommers: Vec<block::Header>,
@@ -54,7 +54,7 @@ impl LocalBlock {
     /// Constructs a new instance with the provided data.
     pub fn new(
         partial_header: PartialHeader,
-        transactions: Vec<ExecutableTransaction>,
+        transactions: Vec<ExecutableTransaction<L1ChainSpec>>,
         transaction_receipts: Vec<TransactionReceipt<Log>>,
         ommers: Vec<Header>,
         withdrawals: Option<Vec<Withdrawal>>,
@@ -123,7 +123,7 @@ impl Block for LocalBlock {
             .expect("usize fits into u64")
     }
 
-    fn transactions(&self) -> &[ExecutableTransaction] {
+    fn transactions(&self) -> &[ExecutableTransaction<L1ChainSpec>] {
         &self.transactions
     }
 

--- a/crates/edr_evm/src/block/remote.rs
+++ b/crates/edr_evm/src/block/remote.rs
@@ -12,6 +12,7 @@ use tokio::runtime;
 
 use crate::{
     blockchain::{BlockchainError, ForkedBlockchainError},
+    chain_spec::L1ChainSpec,
     Block, ExecutableTransaction, SyncBlock, TransactionConversionError,
 };
 
@@ -42,7 +43,7 @@ pub enum CreationError {
 #[derive(Clone, Debug)]
 pub struct RemoteBlock {
     header: Header,
-    transactions: Vec<ExecutableTransaction>,
+    transactions: Vec<ExecutableTransaction<L1ChainSpec>>,
     /// The receipts of the block's transactions
     receipts: OnceLock<Vec<Arc<BlockReceipt>>>,
     /// The hashes of the block's ommers
@@ -133,7 +134,7 @@ impl Block for RemoteBlock {
         self.size
     }
 
-    fn transactions(&self) -> &[ExecutableTransaction] {
+    fn transactions(&self) -> &[ExecutableTransaction<L1ChainSpec>] {
         &self.transactions
     }
 

--- a/crates/edr_evm/src/chain_spec.rs
+++ b/crates/edr_evm/src/chain_spec.rs
@@ -23,7 +23,8 @@ impl ChainSpec for L1ChainSpec {
     type SignedTransaction = edr_eth::transaction::Signed;
 }
 
-// TODO: This is a temporary solution until the revm fork has been merged. In
+// TODO: https://github.com/NomicFoundation/edr/issues/495
+// This is a temporary solution until the revm fork has been merged. In
 // the fork each chain type has its own transaction type with an accompanying
 // trait.
 /// A trait for converting a transaction into a [`revm::primitives::TxEnv`].

--- a/crates/edr_evm/src/chain_spec.rs
+++ b/crates/edr_evm/src/chain_spec.rs
@@ -1,6 +1,7 @@
 use std::fmt::Debug;
 
-use edr_eth::transaction::SignedTransaction;
+use edr_eth::{transaction::SignedTransaction, Address};
+use revm::primitives::TxEnv;
 
 /// A trait for defining a chain's associated types.
 pub trait ChainSpec {
@@ -8,6 +9,7 @@ pub trait ChainSpec {
     type SignedTransaction: alloy_rlp::Encodable
         + Clone
         + Debug
+        + IntoTxEnv
         + PartialEq
         + Eq
         + SignedTransaction;
@@ -19,4 +21,26 @@ pub struct L1ChainSpec;
 
 impl ChainSpec for L1ChainSpec {
     type SignedTransaction = edr_eth::transaction::Signed;
+}
+
+// TODO: This is a temporary solution until the revm fork has been merged. In
+// the fork each chain type has its own transaction type with an accompanying
+// trait.
+/// A trait for converting a transaction into a [`revm::primitives::TxEnv`].
+pub trait IntoTxEnv {
+    /// Converts the transaction into a [`revm::primitives::TxEnv`] using the
+    /// provided caller address.
+    fn into_tx_env(self, caller: Address) -> TxEnv;
+}
+
+impl IntoTxEnv for edr_eth::transaction::Signed {
+    fn into_tx_env(self, caller: Address) -> TxEnv {
+        match self {
+            Self::PreEip155Legacy(tx) => tx.into_tx_env(caller),
+            Self::PostEip155Legacy(tx) => tx.into_tx_env(caller),
+            Self::Eip2930(tx) => tx.into_tx_env(caller),
+            Self::Eip1559(tx) => tx.into_tx_env(caller),
+            Self::Eip4844(tx) => tx.into_tx_env(caller),
+        }
+    }
 }

--- a/crates/edr_evm/src/chain_spec.rs
+++ b/crates/edr_evm/src/chain_spec.rs
@@ -2,11 +2,19 @@ use std::fmt::Debug;
 
 use edr_eth::transaction::SignedTransaction;
 
+/// A trait for defining a chain's associated types.
 pub trait ChainSpec {
     /// The type of signed transactions used by this chain.
-    type SignedTransaction: Clone + Debug + PartialEq + Eq + SignedTransaction;
+    type SignedTransaction: alloy_rlp::Encodable
+        + Clone
+        + Debug
+        + PartialEq
+        + Eq
+        + SignedTransaction;
 }
 
+/// The chain specification for Ethereum Layer 1.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct L1ChainSpec;
 
 impl ChainSpec for L1ChainSpec {

--- a/crates/edr_evm/src/chain_spec.rs
+++ b/crates/edr_evm/src/chain_spec.rs
@@ -1,0 +1,14 @@
+use std::fmt::Debug;
+
+use edr_eth::transaction::SignedTransaction;
+
+pub trait ChainSpec {
+    /// The type of signed transactions used by this chain.
+    type SignedTransaction: Clone + Debug + PartialEq + Eq + SignedTransaction;
+}
+
+pub struct L1ChainSpec;
+
+impl ChainSpec for L1ChainSpec {
+    type SignedTransaction = edr_eth::transaction::Signed;
+}

--- a/crates/edr_evm/src/debug_trace.rs
+++ b/crates/edr_evm/src/debug_trace.rs
@@ -19,6 +19,7 @@ use revm::{
 
 use crate::{
     blockchain::SyncBlockchain,
+    chain_spec::L1ChainSpec,
     debug::GetContextData,
     state::SyncState,
     trace::{register_trace_collector_handles, Trace, TraceCollector},
@@ -76,7 +77,7 @@ pub fn debug_trace_transaction<BlockchainErrorT, StateErrorT>(
     evm_config: CfgEnvWithHandlerCfg,
     trace_config: DebugTraceConfig,
     block_env: BlockEnv,
-    transactions: Vec<ExecutableTransaction>,
+    transactions: Vec<ExecutableTransaction<L1ChainSpec>>,
     transaction_hash: &B256,
     verbose_tracing: bool,
 ) -> Result<DebugTraceResultWithTraces, DebugTraceError<BlockchainErrorT, StateErrorT>>

--- a/crates/edr_evm/src/lib.rs
+++ b/crates/edr_evm/src/lib.rs
@@ -33,6 +33,8 @@ pub mod state;
 pub mod trace;
 
 mod block;
+/// Types for chain specification.
+pub mod chain_spec;
 pub(crate) mod collections;
 mod debug;
 mod debug_trace;

--- a/crates/edr_evm/src/test_utils.rs
+++ b/crates/edr_evm/src/test_utils.rs
@@ -6,6 +6,7 @@ use edr_eth::{
 };
 
 use crate::{
+    chain_spec::L1ChainSpec,
     state::{AccountTrie, StateError, TrieState},
     ExecutableTransaction, MemPool, MemPoolAddTransactionError, TransactionCreationError,
 };
@@ -34,7 +35,7 @@ impl MemPoolTestFixture {
     /// Tries to add the provided transaction to the mem pool.
     pub fn add_transaction(
         &mut self,
-        transaction: ExecutableTransaction,
+        transaction: ExecutableTransaction<L1ChainSpec>,
     ) -> Result<(), MemPoolAddTransactionError<StateError>> {
         self.mem_pool.add_transaction(&self.state, transaction)
     }
@@ -55,7 +56,7 @@ impl MemPoolTestFixture {
 pub fn dummy_eip155_transaction(
     caller: Address,
     nonce: u64,
-) -> Result<ExecutableTransaction, TransactionCreationError> {
+) -> Result<ExecutableTransaction<L1ChainSpec>, TransactionCreationError> {
     dummy_eip155_transaction_with_price(caller, nonce, U256::ZERO)
 }
 
@@ -64,7 +65,7 @@ pub fn dummy_eip155_transaction_with_price(
     caller: Address,
     nonce: u64,
     gas_price: U256,
-) -> Result<ExecutableTransaction, TransactionCreationError> {
+) -> Result<ExecutableTransaction<L1ChainSpec>, TransactionCreationError> {
     dummy_eip155_transaction_with_price_and_limit(caller, nonce, gas_price, 30_000)
 }
 
@@ -73,7 +74,7 @@ pub fn dummy_eip155_transaction_with_limit(
     caller: Address,
     nonce: u64,
     gas_limit: u64,
-) -> Result<ExecutableTransaction, TransactionCreationError> {
+) -> Result<ExecutableTransaction<L1ChainSpec>, TransactionCreationError> {
     dummy_eip155_transaction_with_price_and_limit(caller, nonce, U256::ZERO, gas_limit)
 }
 
@@ -82,7 +83,7 @@ fn dummy_eip155_transaction_with_price_and_limit(
     nonce: u64,
     gas_price: U256,
     gas_limit: u64,
-) -> Result<ExecutableTransaction, TransactionCreationError> {
+) -> Result<ExecutableTransaction<L1ChainSpec>, TransactionCreationError> {
     dummy_eip155_transaction_with_price_limit_and_value(
         caller,
         nonce,
@@ -100,7 +101,7 @@ pub fn dummy_eip155_transaction_with_price_limit_and_value(
     gas_price: U256,
     gas_limit: u64,
     value: U256,
-) -> Result<ExecutableTransaction, TransactionCreationError> {
+) -> Result<ExecutableTransaction<L1ChainSpec>, TransactionCreationError> {
     let from = Address::random();
     let request = transaction::request::Eip155 {
         nonce,
@@ -113,7 +114,7 @@ pub fn dummy_eip155_transaction_with_price_limit_and_value(
     };
     let transaction = request.fake_sign(&caller);
 
-    ExecutableTransaction::with_caller(SpecId::LATEST, transaction.into(), caller)
+    ExecutableTransaction::<L1ChainSpec>::with_caller(SpecId::LATEST, transaction.into(), caller)
 }
 
 /// Creates a dummy EIP-1559 transaction with the provided max fee and max
@@ -123,7 +124,7 @@ pub fn dummy_eip1559_transaction(
     nonce: u64,
     max_fee_per_gas: U256,
     max_priority_fee_per_gas: U256,
-) -> Result<ExecutableTransaction, TransactionCreationError> {
+) -> Result<ExecutableTransaction<L1ChainSpec>, TransactionCreationError> {
     let from = Address::random();
     let request = transaction::request::Eip1559 {
         chain_id: 123,
@@ -138,5 +139,5 @@ pub fn dummy_eip1559_transaction(
     };
     let transaction = request.fake_sign(&caller);
 
-    ExecutableTransaction::with_caller(SpecId::LATEST, transaction.into(), caller)
+    ExecutableTransaction::<L1ChainSpec>::with_caller(SpecId::LATEST, transaction.into(), caller)
 }

--- a/crates/edr_evm/src/transaction/detailed.rs
+++ b/crates/edr_evm/src/transaction/detailed.rs
@@ -2,12 +2,12 @@ use std::sync::Arc;
 
 use edr_eth::receipt::BlockReceipt;
 
-use crate::ExecutableTransaction;
+use crate::{chain_spec::L1ChainSpec, ExecutableTransaction};
 
 /// Wrapper struct for a transaction and its receipt.
 pub struct DetailedTransaction<'t> {
     /// The transaction
-    pub transaction: &'t ExecutableTransaction,
+    pub transaction: &'t ExecutableTransaction<L1ChainSpec>,
     /// The transaction's receipt
     pub receipt: &'t Arc<BlockReceipt>,
 }

--- a/crates/edr_evm/src/transaction/executable.rs
+++ b/crates/edr_evm/src/transaction/executable.rs
@@ -3,7 +3,7 @@ use std::sync::OnceLock;
 use alloy_rlp::BufMut;
 use edr_eth::{
     signature::Signature,
-    transaction::{self, Transaction, TransactionType, TxKind},
+    transaction::{self, SignedTransaction, Transaction, TransactionType, TxKind},
     Address, B256, U256,
 };
 use revm::{
@@ -12,22 +12,23 @@ use revm::{
 };
 
 use super::TransactionCreationError;
+use crate::chain_spec::ChainSpec;
 
 /// A transaction that can be executed by the EVM. It allows manual
 /// specification of the caller, e.g. to override the caller of a transaction
 /// that can be recovered from a signature.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct ExecutableTransaction {
-    transaction: transaction::Signed,
+pub struct ExecutableTransaction<ChainSpecT: ChainSpec> {
+    transaction: ChainSpecT::SignedTransaction,
     caller: Address,
 }
 
-impl ExecutableTransaction {
+impl<ChainSpecT: ChainSpec> ExecutableTransaction<ChainSpecT> {
     /// Create an [`ExecutableTransaction`] by attempting to validate and
     /// recover the caller address of the provided transaction.
     pub fn new(
         spec_id: SpecId,
-        transaction: transaction::Signed,
+        transaction: ChainSpecT::SignedTransaction,
     ) -> Result<Self, TransactionCreationError> {
         let caller = transaction
             .recover()
@@ -40,7 +41,7 @@ impl ExecutableTransaction {
     /// caller address.
     pub fn with_caller(
         spec_id: SpecId,
-        transaction: transaction::Signed,
+        transaction: ChainSpecT::SignedTransaction,
         caller: Address,
     ) -> Result<Self, TransactionCreationError> {
         if transaction.kind() == TxKind::Create && transaction.data().is_empty() {
@@ -72,17 +73,17 @@ impl ExecutableTransaction {
     }
 
     /// Returns the inner [`transaction::Signed`]
-    pub fn as_inner(&self) -> &transaction::Signed {
+    pub fn as_inner(&self) -> &ChainSpecT::SignedTransaction {
         &self.transaction
     }
 
     /// Returns the inner transaction and caller
-    pub fn into_inner(self) -> (transaction::Signed, Address) {
+    pub fn into_inner(self) -> (ChainSpecT::SignedTransaction, Address) {
         (self.transaction, self.caller)
     }
 }
 
-impl alloy_rlp::Encodable for ExecutableTransaction {
+impl<ChainSpecT: ChainSpec> alloy_rlp::Encodable for ExecutableTransaction<ChainSpecT> {
     fn encode(&self, out: &mut dyn BufMut) {
         self.transaction.encode(out);
     }
@@ -92,13 +93,13 @@ impl alloy_rlp::Encodable for ExecutableTransaction {
     }
 }
 
-impl From<ExecutableTransaction> for TxEnv {
-    fn from(value: ExecutableTransaction) -> Self {
+impl<ChainSpecT: ChainSpec> From<ExecutableTransaction<ChainSpecT>> for TxEnv {
+    fn from(value: ExecutableTransaction<ChainSpecT>) -> Self {
         value.transaction.into_tx_env(value.caller)
     }
 }
 
-impl Transaction for ExecutableTransaction {
+impl<ChainSpecT: ChainSpec> Transaction for ExecutableTransaction<ChainSpecT> {
     fn effective_gas_price(&self, block_base_fee: U256) -> U256 {
         self.transaction.effective_gas_price(block_base_fee)
     }
@@ -174,7 +175,9 @@ pub enum TransactionConversionError {
     MissingReceiverAddress,
 }
 
-impl TryFrom<edr_rpc_eth::Transaction> for ExecutableTransaction {
+impl<ChainSpecT: ChainSpec> TryFrom<edr_rpc_eth::Transaction>
+    for ExecutableTransaction<ChainSpecT>
+{
     type Error = TransactionConversionError;
 
     fn try_from(value: edr_rpc_eth::Transaction) -> Result<Self, Self::Error> {
@@ -328,7 +331,7 @@ impl TryFrom<edr_rpc_eth::Transaction> for ExecutableTransaction {
     }
 }
 
-fn initial_cost(spec_id: SpecId, transaction: &transaction::Signed) -> u64 {
+fn initial_cost(spec_id: SpecId, transaction: &impl Transaction) -> u64 {
     let access_list = transaction
         .access_list()
         .cloned()

--- a/crates/edr_evm/src/transaction/executable.rs
+++ b/crates/edr_evm/src/transaction/executable.rs
@@ -12,7 +12,7 @@ use revm::{
 };
 
 use super::TransactionCreationError;
-use crate::chain_spec::{ChainSpec, L1ChainSpec};
+use crate::chain_spec::{ChainSpec, IntoTxEnv, L1ChainSpec};
 
 /// A transaction that can be executed by the EVM. It allows manual
 /// specification of the caller, e.g. to override the caller of a transaction

--- a/crates/edr_evm/tests/blockchain.rs
+++ b/crates/edr_evm/tests/blockchain.rs
@@ -183,7 +183,7 @@ fn insert_dummy_block_with_transaction(
         transaction_hash: *transaction.transaction_hash(),
         transaction_index: 0,
         from: *transaction.caller(),
-        to: transaction.to(),
+        to: transaction.kind().to().copied(),
         contract_address: None,
         gas_used: GAS_USED,
         effective_gas_price: None,
@@ -314,6 +314,8 @@ async fn block_by_number_some() {
 async fn block_by_number_with_create() -> anyhow::Result<()> {
     use std::str::FromStr;
 
+    use edr_eth::transaction::TxKind;
+
     const DAI_CREATION_BLOCK_NUMBER: u64 = 4_719_568;
     const DAI_CREATION_TRANSACTION_INDEX: usize = 85;
     const DAI_CREATION_TRANSACTION_HASH: &str =
@@ -330,7 +332,10 @@ async fn block_by_number_with_create() -> anyhow::Result<()> {
         *transactions[DAI_CREATION_TRANSACTION_INDEX].transaction_hash(),
         B256::from_str(DAI_CREATION_TRANSACTION_HASH)?
     );
-    assert_eq!(transactions[DAI_CREATION_TRANSACTION_INDEX].to(), None);
+    assert_eq!(
+        transactions[DAI_CREATION_TRANSACTION_INDEX].kind(),
+        TxKind::Create
+    );
 
     Ok(())
 }

--- a/crates/edr_napi/src/logger.rs
+++ b/crates/edr_napi/src/logger.rs
@@ -4,6 +4,7 @@ use ansi_term::{Color, Style};
 use edr_eth::{transaction::Transaction, Bytes, B256, U256};
 use edr_evm::{
     blockchain::BlockchainError,
+    chain_spec::L1ChainSpec,
     precompile::{self, Precompiles},
     trace::{AfterMessage, TraceMessage},
     ExecutableTransaction, ExecutionResult, SyncBlock,
@@ -135,7 +136,7 @@ impl edr_provider::Logger for Logger {
     fn log_call(
         &mut self,
         spec_id: edr_eth::SpecId,
-        transaction: &ExecutableTransaction,
+        transaction: &ExecutableTransaction<L1ChainSpec>,
         result: &edr_provider::CallResult,
     ) -> Result<(), Self::LoggerError> {
         self.collector.log_call(spec_id, transaction, result);
@@ -146,7 +147,7 @@ impl edr_provider::Logger for Logger {
     fn log_estimate_gas_failure(
         &mut self,
         spec_id: edr_eth::SpecId,
-        transaction: &ExecutableTransaction,
+        transaction: &ExecutableTransaction<L1ChainSpec>,
         failure: &edr_provider::EstimateGasFailure,
     ) -> Result<(), Self::LoggerError> {
         self.collector
@@ -176,7 +177,7 @@ impl edr_provider::Logger for Logger {
     fn log_send_transaction(
         &mut self,
         spec_id: edr_eth::SpecId,
-        transaction: &edr_evm::ExecutableTransaction,
+        transaction: &edr_evm::ExecutableTransaction<L1ChainSpec>,
         mining_results: &[edr_provider::DebugMineBlockResult<Self::BlockchainError>],
     ) -> Result<(), Self::LoggerError> {
         self.collector
@@ -335,7 +336,7 @@ impl LogCollector {
     pub fn log_call(
         &mut self,
         spec_id: edr_eth::SpecId,
-        transaction: &ExecutableTransaction,
+        transaction: &ExecutableTransaction<L1ChainSpec>,
         result: &edr_provider::CallResult,
     ) {
         let edr_provider::CallResult {
@@ -350,7 +351,7 @@ impl LogCollector {
             logger.log_contract_and_function_name::<true>(spec_id, trace);
 
             logger.log_with_title("From", format!("0x{:x}", transaction.caller()));
-            if let Some(to) = transaction.to() {
+            if let Some(to) = transaction.kind().to() {
                 logger.log_with_title("To", format!("0x{to:x}"));
             }
             if transaction.value() > U256::ZERO {
@@ -370,7 +371,7 @@ impl LogCollector {
     pub fn log_estimate_gas(
         &mut self,
         spec_id: edr_eth::SpecId,
-        transaction: &ExecutableTransaction,
+        transaction: &ExecutableTransaction<L1ChainSpec>,
         result: &edr_provider::EstimateGasFailure,
     ) {
         let edr_provider::EstimateGasFailure {
@@ -387,7 +388,7 @@ impl LogCollector {
             );
 
             logger.log_with_title("From", format!("0x{:x}", transaction.caller()));
-            if let Some(to) = transaction.to() {
+            if let Some(to) = transaction.kind().to() {
                 logger.log_with_title("To", format!("0x{to:x}"));
             }
             logger.log_with_title("Value", wei_to_human_readable(transaction.value()));
@@ -491,7 +492,7 @@ impl LogCollector {
     pub fn log_send_transaction(
         &mut self,
         spec_id: edr_eth::SpecId,
-        transaction: &edr_evm::ExecutableTransaction,
+        transaction: &edr_evm::ExecutableTransaction<L1ChainSpec>,
         mining_results: &[edr_provider::DebugMineBlockResult<BlockchainError>],
     ) {
         if !mining_results.is_empty() {
@@ -708,7 +709,7 @@ impl LogCollector {
     fn log_block_transaction(
         &mut self,
         spec_id: edr_eth::SpecId,
-        transaction: &edr_evm::ExecutableTransaction,
+        transaction: &edr_evm::ExecutableTransaction<L1ChainSpec>,
         result: &edr_evm::ExecutionResult,
         trace: &edr_evm::trace::Trace,
         console_log_inputs: &[Bytes],
@@ -727,7 +728,7 @@ impl LogCollector {
         self.indented(|logger| {
             logger.log_contract_and_function_name::<false>(spec_id, trace);
             logger.log_with_title("From", format!("0x{:x}", transaction.caller()));
-            if let Some(to) = transaction.to() {
+            if let Some(to) = transaction.kind().to() {
                 logger.log_with_title("To", format!("0x{to:x}"));
             }
             logger.log_with_title("Value", wei_to_human_readable(transaction.value()));
@@ -1054,7 +1055,7 @@ impl LogCollector {
         &mut self,
         spec_id: edr_eth::SpecId,
         block_result: &edr_provider::DebugMineBlockResult<BlockchainError>,
-        transaction: &ExecutableTransaction,
+        transaction: &ExecutableTransaction<L1ChainSpec>,
         transaction_result: &edr_evm::ExecutionResult,
         trace: &edr_evm::trace::Trace,
     ) {
@@ -1076,7 +1077,7 @@ impl LogCollector {
         &mut self,
         spec_id: edr_eth::SpecId,
         result: &edr_provider::DebugMineBlockResult<BlockchainError>,
-        transaction: &ExecutableTransaction,
+        transaction: &ExecutableTransaction<L1ChainSpec>,
     ) {
         let trace = result
             .transaction_traces
@@ -1095,7 +1096,7 @@ impl LogCollector {
         &mut self,
         spec_id: edr_eth::SpecId,
         block_result: &edr_provider::DebugMineBlockResult<BlockchainError>,
-        transaction: &ExecutableTransaction,
+        transaction: &ExecutableTransaction<L1ChainSpec>,
         transaction_result: &edr_evm::ExecutionResult,
         trace: &edr_evm::trace::Trace,
     ) {
@@ -1106,7 +1107,7 @@ impl LogCollector {
             logger.log_with_title("Transaction", transaction_hash);
 
             logger.log_with_title("From", format!("0x{:x}", transaction.caller()));
-            if let Some(to) = transaction.to() {
+            if let Some(to) = transaction.kind().to() {
                 logger.log_with_title("To", format!("0x{to:x}"));
             }
             logger.log_with_title("Value", wei_to_human_readable(transaction.value()));

--- a/crates/edr_provider/src/logger.rs
+++ b/crates/edr_provider/src/logger.rs
@@ -2,7 +2,7 @@ use core::fmt::Debug;
 use std::convert::Infallible;
 
 use dyn_clone::DynClone;
-use edr_evm::{blockchain::BlockchainError, ExecutableTransaction};
+use edr_evm::{blockchain::BlockchainError, chain_spec::L1ChainSpec, ExecutableTransaction};
 
 use crate::{
     data::CallResult, debug_mine::DebugMineBlockResult, error::EstimateGasFailure, ProviderError,
@@ -22,7 +22,7 @@ pub trait Logger {
     fn log_call(
         &mut self,
         spec_id: edr_eth::SpecId,
-        transaction: &ExecutableTransaction,
+        transaction: &ExecutableTransaction<L1ChainSpec>,
         result: &CallResult,
     ) -> Result<(), Self::LoggerError> {
         let _spec_id = spec_id;
@@ -35,7 +35,7 @@ pub trait Logger {
     fn log_estimate_gas_failure(
         &mut self,
         spec_id: edr_eth::SpecId,
-        transaction: &ExecutableTransaction,
+        transaction: &ExecutableTransaction<L1ChainSpec>,
         result: &EstimateGasFailure,
     ) -> Result<(), Self::LoggerError> {
         let _spec_id = spec_id;
@@ -70,7 +70,7 @@ pub trait Logger {
     fn log_send_transaction(
         &mut self,
         spec_id: edr_eth::SpecId,
-        transaction: &ExecutableTransaction,
+        transaction: &ExecutableTransaction<L1ChainSpec>,
         mining_results: &[DebugMineBlockResult<Self::BlockchainError>],
     ) -> Result<(), Self::LoggerError> {
         let _spec_id = spec_id;

--- a/crates/edr_provider/src/requests/eth/call.rs
+++ b/crates/edr_provider/src/requests/eth/call.rs
@@ -1,7 +1,9 @@
 use core::fmt::Debug;
 
 use edr_eth::{transaction, BlockSpec, Bytes, SpecId, U256};
-use edr_evm::{state::StateOverrides, trace::Trace, ExecutableTransaction};
+use edr_evm::{
+    chain_spec::L1ChainSpec, state::StateOverrides, trace::Trace, ExecutableTransaction,
+};
 use edr_rpc_eth::{CallRequest, StateOverrideOptions};
 
 use crate::{
@@ -55,7 +57,7 @@ pub(crate) fn resolve_call_request<LoggerErrorT: Debug, TimerT: Clone + TimeSinc
     request: CallRequest,
     block_spec: &BlockSpec,
     state_overrides: &StateOverrides,
-) -> Result<ExecutableTransaction, ProviderError<LoggerErrorT>> {
+) -> Result<ExecutableTransaction<L1ChainSpec>, ProviderError<LoggerErrorT>> {
     resolve_call_request_inner(
         data,
         request,
@@ -89,7 +91,7 @@ pub(crate) fn resolve_call_request_inner<LoggerErrorT: Debug, TimerT: Clone + Ti
         // max_priority_fee_per_gas
         Option<U256>,
     ) -> Result<(U256, U256), ProviderError<LoggerErrorT>>,
-) -> Result<ExecutableTransaction, ProviderError<LoggerErrorT>> {
+) -> Result<ExecutableTransaction<L1ChainSpec>, ProviderError<LoggerErrorT>> {
     let CallRequest {
         from,
         to,

--- a/crates/edr_provider/src/requests/eth/gas.rs
+++ b/crates/edr_provider/src/requests/eth/gas.rs
@@ -4,7 +4,9 @@ use edr_eth::{
     fee_history::FeeHistoryResult, reward_percentile::RewardPercentile, BlockSpec, SpecId, U256,
     U64,
 };
-use edr_evm::{state::StateOverrides, trace::Trace, ExecutableTransaction};
+use edr_evm::{
+    chain_spec::L1ChainSpec, state::StateOverrides, trace::Trace, ExecutableTransaction,
+};
 use edr_rpc_eth::CallRequest;
 
 use super::resolve_call_request_inner;
@@ -103,7 +105,7 @@ fn resolve_estimate_gas_request<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEp
     request: CallRequest,
     block_spec: &BlockSpec,
     state_overrides: &StateOverrides,
-) -> Result<ExecutableTransaction, ProviderError<LoggerErrorT>> {
+) -> Result<ExecutableTransaction<L1ChainSpec>, ProviderError<LoggerErrorT>> {
     resolve_call_request_inner(
         data,
         request,

--- a/crates/edr_provider/src/requests/validation.rs
+++ b/crates/edr_provider/src/requests/validation.rs
@@ -227,7 +227,7 @@ You can use them by running Hardhat Network with 'hardfork' {minimum_hardfork:?}
 pub fn validate_eip3860_max_initcode_size<LoggerErrorT: Debug>(
     spec_id: SpecId,
     allow_unlimited_contract_code_size: bool,
-    to: &Option<Address>,
+    to: Option<&Address>,
     data: &Bytes,
 ) -> Result<(), ProviderError<LoggerErrorT>> {
     if spec_id < SpecId::SHANGHAI || to.is_some() || allow_unlimited_contract_code_size {

--- a/crates/edr_provider/tests/eip4844.rs
+++ b/crates/edr_provider/tests/eip4844.rs
@@ -6,7 +6,9 @@ use edr_defaults::SECRET_KEYS;
 use edr_eth::{
     rlp::{self, Decodable},
     signature::{secret_key_from_str, secret_key_to_address},
-    transaction::{self, pooled::PooledTransaction, EthTransactionRequest, Transaction},
+    transaction::{
+        self, pooled::PooledTransaction, EthTransactionRequest, SignedTransaction, Transaction,
+    },
     AccountInfo, Address, Blob, Bytes, Bytes48, PreEip1898BlockSpec, SpecId, B256, BYTES_PER_BLOB,
     U256,
 };
@@ -138,7 +140,7 @@ fn fake_call_request() -> anyhow::Result<CallRequest> {
 
     Ok(CallRequest {
         from: Some(from),
-        to: transaction.to(),
+        to: transaction.kind().to().copied(),
         max_fee_per_gas: transaction.max_fee_per_gas(),
         max_priority_fee_per_gas: transaction.max_priority_fee_per_gas(),
         gas: Some(transaction.gas_limit()),
@@ -167,7 +169,7 @@ fn fake_transaction_request() -> anyhow::Result<EthTransactionRequest> {
 
     Ok(EthTransactionRequest {
         from,
-        to: transaction.to(),
+        to: transaction.kind().to().copied(),
         max_fee_per_gas: transaction.max_fee_per_gas(),
         max_priority_fee_per_gas: transaction.max_priority_fee_per_gas(),
         gas: Some(transaction.gas_limit()),


### PR DESCRIPTION
This PR is intended as an incremental change towards chain-specific blockchains. In particular, it adds a generic trait bound to `ExecutableTransaction`. For now, we always use the `L1ChainSpec` at compile-time.