### PR TITLE
refactor: Provide helpful error msg when deserializing big timestamp

### DIFF
--- a/.changeset/fair-rice-vanish.md
+++ b/.changeset/fair-rice-vanish.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Provide a more helpful message when passing a timestamp bigger than 2^64 via JSON-RPC

--- a/crates/edr_provider/src/lib.rs
+++ b/crates/edr_provider/src/lib.rs
@@ -39,7 +39,7 @@ pub use self::{
     mock::CallOverrideResult,
     requests::{
         hardhat::rpc_types as hardhat_rpc_types, IntervalConfig as IntervalConfigRequest,
-        InvalidRequestReason, MethodInvocation, ProviderRequest, U64OrUsize,
+        InvalidRequestReason, MethodInvocation, ProviderRequest, Timestamp,
     },
     subscribe::*,
 };

--- a/crates/edr_provider/src/requests.rs
+++ b/crates/edr_provider/src/requests.rs
@@ -15,8 +15,8 @@ use ::serde::{
 };
 
 pub use crate::requests::{
-    methods::{IntervalConfig, MethodInvocation, U64OrUsize},
-    serde::InvalidRequestReason,
+    methods::{IntervalConfig, MethodInvocation},
+    serde::{InvalidRequestReason, Timestamp},
 };
 
 /// JSON-RPC request for the provider.

--- a/crates/edr_provider/src/requests/eth/evm.rs
+++ b/crates/edr_provider/src/requests/eth/evm.rs
@@ -4,13 +4,11 @@ use std::num::NonZeroU64;
 use edr_eth::{block::BlockOptions, U64};
 use edr_evm::trace::Trace;
 
-use crate::{
-    data::ProviderData, requests::methods::U64OrUsize, time::TimeSinceEpoch, ProviderError,
-};
+use crate::{data::ProviderData, time::TimeSinceEpoch, ProviderError, Timestamp};
 
 pub fn handle_increase_time_request<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
     data: &mut ProviderData<LoggerErrorT, TimerT>,
-    increment: U64OrUsize,
+    increment: Timestamp,
 ) -> Result<String, ProviderError<LoggerErrorT>> {
     let new_block_time = data.increase_block_time(increment.into());
 
@@ -20,10 +18,10 @@ pub fn handle_increase_time_request<LoggerErrorT: Debug, TimerT: Clone + TimeSin
 
 pub fn handle_mine_request<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
     data: &mut ProviderData<LoggerErrorT, TimerT>,
-    timestamp: Option<U64OrUsize>,
+    timestamp: Option<Timestamp>,
 ) -> Result<(String, Vec<Trace>), ProviderError<LoggerErrorT>> {
     let mine_block_result = data.mine_and_commit_block(BlockOptions {
-        timestamp: timestamp.map(U64OrUsize::into),
+        timestamp: timestamp.map(Into::into),
         ..BlockOptions::default()
     })?;
 
@@ -71,7 +69,7 @@ pub fn handle_set_next_block_timestamp_request<
     TimerT: Clone + TimeSinceEpoch,
 >(
     data: &mut ProviderData<LoggerErrorT, TimerT>,
-    timestamp: U64OrUsize,
+    timestamp: Timestamp,
 ) -> Result<String, ProviderError<LoggerErrorT>> {
     let new_timestamp = data.set_next_block_timestamp(timestamp.into())?;
 

--- a/crates/edr_provider/src/requests/methods.rs
+++ b/crates/edr_provider/src/requests/methods.rs
@@ -7,7 +7,7 @@ use edr_eth::{
 };
 use edr_rpc_eth::{CallRequest, StateOverrideOptions};
 
-use super::serde::RpcAddress;
+use super::serde::{RpcAddress, Timestamp};
 use crate::requests::{
     debug::DebugTraceConfig,
     hardhat::rpc_types::{CompilerInput, CompilerOutput, ResetProviderConfig},
@@ -256,14 +256,14 @@ pub enum MethodInvocation {
     Web3Sha3(Bytes),
     /// `evm_increaseTime`
     #[serde(rename = "evm_increaseTime", with = "edr_eth::serde::sequence")]
-    EvmIncreaseTime(U64OrUsize),
+    EvmIncreaseTime(Timestamp),
     /// `evm_mine`
     #[serde(
         rename = "evm_mine",
         serialize_with = "optional_single_to_sequence",
         deserialize_with = "sequence_to_optional_single"
     )]
-    EvmMine(Option<U64OrUsize>),
+    EvmMine(Option<Timestamp>),
     /// `evm_revert`
     #[serde(rename = "evm_revert", with = "edr_eth::serde::sequence")]
     EvmRevert(U64),
@@ -281,7 +281,7 @@ pub enum MethodInvocation {
         rename = "evm_setNextBlockTimestamp",
         with = "edr_eth::serde::sequence"
     )]
-    EvmSetNextBlockTimestamp(U64OrUsize),
+    EvmSetNextBlockTimestamp(Timestamp),
     /// `evm_snapshot`
     #[serde(rename = "evm_snapshot", with = "edr_eth::serde::empty_params")]
     EvmSnapshot(()),
@@ -505,23 +505,4 @@ pub enum IntervalConfig {
     FixedOrDisabled(u64),
     /// an array of two `u64` values
     Range([u64; 2]),
-}
-
-/// an input that can be either a U256 or a usize
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(untagged)]
-pub enum U64OrUsize {
-    /// usize
-    Usize(usize),
-    /// U256
-    U64(U64),
-}
-
-impl From<U64OrUsize> for u64 {
-    fn from(either: U64OrUsize) -> Self {
-        match either {
-            U64OrUsize::U64(u) => u.as_limbs()[0],
-            U64OrUsize::Usize(u) => u as u64,
-        }
-    }
 }

--- a/crates/edr_provider/src/requests/serde.rs
+++ b/crates/edr_provider/src/requests/serde.rs
@@ -380,9 +380,9 @@ impl<'de> Deserialize<'de> for Timestamp {
         // TODO: Accept only `0x`-prefixed hex strings (and possibly base 10 strings).
         U64::deserialize(deserializer)
             .map(|value| Timestamp(value.as_limbs()[0]))
-            .map_err(|_| {
+            .map_err(|_err| {
                 serde::de::Error::custom(
-                    "Timestamp must be a positive integer or a string not exceeding 2^64 - 1",
+                    "Timestamp must be a non-negative number not exceeding 2^64 - 1",
                 )
             })
     }
@@ -553,19 +553,19 @@ mod tests {
             serde_json::from_str::<Timestamp>("1000000000000000000000000000000")
                 .unwrap_err()
                 .to_string(),
-            "Timestamp must be a positive integer or a string not exceeding 2^64 - 1"
+            "Timestamp must be a non-negative number not exceeding 2^64 - 1"
         );
         assert_eq!(
             serde_json::from_str::<Timestamp>("\"1000000000000000000000000000000\"")
                 .unwrap_err()
                 .to_string(),
-            "Timestamp must be a positive integer or a string not exceeding 2^64 - 1"
+            "Timestamp must be a non-negative number not exceeding 2^64 - 1"
         );
         assert_eq!(
             serde_json::from_str::<Timestamp>("\"0x11223344556677889900\"")
                 .unwrap_err()
                 .to_string(),
-            "Timestamp must be a positive integer or a string not exceeding 2^64 - 1"
+            "Timestamp must be a non-negative number not exceeding 2^64 - 1"
         );
     }
 }

--- a/crates/edr_provider/src/requests/serde.rs
+++ b/crates/edr_provider/src/requests/serde.rs
@@ -394,10 +394,10 @@ where
     match serde_json::Value::deserialize(deserializer)? {
         serde_json::Value::Number(num) => num.as_u64().ok_or_else(error_msg),
         serde_json::Value::String(value) => {
-            if value.starts_with("0x") {
-                u64::from_str_radix(&value[2..], 16).map_err(|_| error_msg())
+            if let Some(hex_str) = value.strip_prefix("0x") {
+                u64::from_str_radix(hex_str, 16).map_err(|_err| error_msg())
             } else {
-                value.parse::<u64>().map_err(|_| error_msg())
+                value.parse::<u64>().map_err(|_err| error_msg())
             }
         }
         _ => Err(error_msg()),

--- a/crates/edr_provider/tests/eth_request_serialization.rs
+++ b/crates/edr_provider/tests/eth_request_serialization.rs
@@ -3,10 +3,10 @@ mod common;
 use edr_eth::{
     filter::{LogFilterOptions, LogOutput, OneOrMore},
     transaction::EthTransactionRequest,
-    Address, BlockSpec, BlockTag, Bytes, PreEip1898BlockSpec, B256, U256, U64,
+    Address, BlockSpec, BlockTag, Bytes, PreEip1898BlockSpec, B256, U256,
 };
 use edr_evm::alloy_primitives::U160;
-use edr_provider::{IntervalConfigRequest, MethodInvocation, U64OrUsize};
+use edr_provider::{IntervalConfigRequest, MethodInvocation, Timestamp};
 use edr_rpc_eth::CallRequest;
 
 use crate::common::{
@@ -446,24 +446,19 @@ fn test_serde_one_or_more_addresses() {
 
 #[test]
 fn test_evm_increase_time() {
-    help_test_method_invocation_serde(MethodInvocation::EvmIncreaseTime(U64OrUsize::U64(
-        U64::from(12345),
-    )));
+    help_test_method_invocation_serde(MethodInvocation::EvmIncreaseTime(Timestamp::from(12345)));
 }
 
 #[test]
 fn test_evm_mine() {
-    help_test_method_invocation_serde(MethodInvocation::EvmMine(Some(U64OrUsize::U64(U64::from(
-        12345,
-    )))));
-    help_test_method_invocation_serde(MethodInvocation::EvmMine(Some(U64OrUsize::Usize(12345))));
+    help_test_method_invocation_serde(MethodInvocation::EvmMine(Some(Timestamp::from(12345))));
     help_test_method_invocation_serde(MethodInvocation::EvmMine(None));
 }
 
 #[test]
 fn test_evm_set_next_block_timestamp() {
-    help_test_method_invocation_serde(MethodInvocation::EvmSetNextBlockTimestamp(U64OrUsize::U64(
-        U64::from(12345),
+    help_test_method_invocation_serde(MethodInvocation::EvmSetNextBlockTimestamp(Timestamp::from(
+        12345,
     )));
 }
 

--- a/crates/edr_provider/tests/timestamp.rs
+++ b/crates/edr_provider/tests/timestamp.rs
@@ -2,11 +2,11 @@
 
 use std::{convert::Infallible, sync::Arc};
 
-use edr_eth::{PreEip1898BlockSpec, B256, U64};
+use edr_eth::{PreEip1898BlockSpec, B256};
 use edr_provider::{
     test_utils::create_test_config,
     time::{MockTime, TimeSinceEpoch},
-    MethodInvocation, NoopLogger, Provider, ProviderRequest, U64OrUsize,
+    MethodInvocation, NoopLogger, Provider, ProviderRequest, Timestamp,
 };
 use tokio::runtime;
 
@@ -41,7 +41,7 @@ impl TimestampFixture {
 
     fn increase_time(&self, seconds: u64) -> anyhow::Result<()> {
         self.provider.handle_request(ProviderRequest::Single(
-            MethodInvocation::EvmIncreaseTime(U64OrUsize::U64(U64::from(seconds))),
+            MethodInvocation::EvmIncreaseTime(Timestamp::from(seconds)),
         ))?;
 
         Ok(())
@@ -57,7 +57,7 @@ impl TimestampFixture {
     fn mine_block_with_timestamp(&self, timestamp: u64) -> anyhow::Result<()> {
         self.provider
             .handle_request(ProviderRequest::Single(MethodInvocation::EvmMine(Some(
-                U64OrUsize::U64(U64::from(timestamp)),
+                Timestamp::from(timestamp),
             ))))?;
 
         Ok(())
@@ -74,7 +74,7 @@ impl TimestampFixture {
 
     fn set_next_block_timestamp(&self, timestamp: u64) -> anyhow::Result<()> {
         self.provider.handle_request(ProviderRequest::Single(
-            MethodInvocation::EvmSetNextBlockTimestamp(U64OrUsize::U64(U64::from(timestamp))),
+            MethodInvocation::EvmSetNextBlockTimestamp(Timestamp::from(timestamp)),
         ))?;
 
         Ok(())

--- a/hardhat-tests/test/internal/hardhat-network/provider/modules/evm.ts
+++ b/hardhat-tests/test/internal/hardhat-network/provider/modules/evm.ts
@@ -152,13 +152,13 @@ describe("Evm module", function () {
             this.provider,
             "evm_increaseTime",
             ["10000000000000000000000000000000"],
-            "Timestamp must be a positive integer or a (`0x`-prefixed hex) string not exceeding 2^64"
+            "Timestamp must be a positive integer or a string not exceeding 2^64 - 1"
           );
           await assertInvalidArgumentsError(
             this.provider,
             "evm_increaseTime",
             ["0x1111111111111111111111111111111111111"],
-            "Timestamp must be a positive integer or a (`0x`-prefixed hex) string not exceeding 2^64"
+            "Timestamp must be a positive integer or a string not exceeding 2^64 - 1"
           );
         });
       });
@@ -339,13 +339,13 @@ describe("Evm module", function () {
                 this.provider,
                 "evm_setNextBlockTimestamp",
                 ["10000000000000000000000000000000"],
-                "Timestamp must be a positive integer or a (`0x`-prefixed hex) string not exceeding 2^64"
+                "Timestamp must be a positive integer or a string not exceeding 2^64 - 1"
               );
               await assertInvalidArgumentsError(
                 this.provider,
                 "evm_setNextBlockTimestamp",
                 ["0x1111111111111111111111111111111111111"],
-                "Timestamp must be a positive integer or a (`0x`-prefixed hex) string not exceeding 2^64"
+                "Timestamp must be a positive integer or a string not exceeding 2^64 - 1"
               );
             });
 
@@ -647,13 +647,13 @@ describe("Evm module", function () {
             this.provider,
             "evm_mine",
             ["10000000000000000000000000000000"],
-            "Timestamp must be a positive integer or a (`0x`-prefixed hex) string not exceeding 2^64"
+            "Timestamp must be a positive integer or a string not exceeding 2^64 - 1"
           );
           await assertInvalidArgumentsError(
             this.provider,
             "evm_mine",
             ["0x1111111111111111111111111111111111111"],
-            "Timestamp must be a positive integer or a (`0x`-prefixed hex) string not exceeding 2^64"
+            "Timestamp must be a positive integer or a string not exceeding 2^64 - 1"
           );
         });
 

--- a/hardhat-tests/test/internal/hardhat-network/provider/modules/evm.ts
+++ b/hardhat-tests/test/internal/hardhat-network/provider/modules/evm.ts
@@ -152,13 +152,26 @@ describe("Evm module", function () {
             this.provider,
             "evm_increaseTime",
             ["10000000000000000000000000000000"],
-            "Timestamp must be a positive integer or a string not exceeding 2^64 - 1"
+            "Timestamp must be a non-negative number not exceeding 2^64 - 1"
           );
           await assertInvalidArgumentsError(
             this.provider,
             "evm_increaseTime",
             ["0x1111111111111111111111111111111111111"],
-            "Timestamp must be a positive integer or a string not exceeding 2^64 - 1"
+            "Timestamp must be a non-negative number not exceeding 2^64 - 1"
+          );
+
+          await assertInvalidArgumentsError(
+            this.provider,
+            "evm_increaseTime",
+            [(2n ** 64n).toString()],
+            "Timestamp must be a non-negative number not exceeding 2^64 - 1"
+          );
+          await assertInvalidArgumentsError(
+            this.provider,
+            "evm_increaseTime",
+            ["0x10000000000000000"],
+            "Timestamp must be a non-negative number not exceeding 2^64 - 1"
           );
         });
       });
@@ -339,14 +352,34 @@ describe("Evm module", function () {
                 this.provider,
                 "evm_setNextBlockTimestamp",
                 ["10000000000000000000000000000000"],
-                "Timestamp must be a positive integer or a string not exceeding 2^64 - 1"
+                "Timestamp must be a non-negative number not exceeding 2^64 - 1"
               );
               await assertInvalidArgumentsError(
                 this.provider,
                 "evm_setNextBlockTimestamp",
                 ["0x1111111111111111111111111111111111111"],
-                "Timestamp must be a positive integer or a string not exceeding 2^64 - 1"
+                "Timestamp must be a non-negative number not exceeding 2^64 - 1"
               );
+
+              // Check that the limit is in fact 2^64 - 1
+              await assertInvalidArgumentsError(
+                this.provider,
+                "evm_setNextBlockTimestamp",
+                [(2n ** 64n).toString()],
+                "Timestamp must be a non-negative number not exceeding 2^64 - 1"
+              );
+              await assertInvalidArgumentsError(
+                this.provider,
+                "evm_setNextBlockTimestamp",
+                ["0x10000000000000000"],
+                "Timestamp must be a non-negative number not exceeding 2^64 - 1"
+              );
+              await this.provider.send("evm_setNextBlockTimestamp", [
+                (2n ** 64n - 1n).toString(),
+              ]);
+              await this.provider.send("evm_setNextBlockTimestamp", [
+                "0xFFFFFFFFFFFFFFFF",
+              ]);
             });
 
             describe("When the initial date is in the past", function () {
@@ -647,13 +680,13 @@ describe("Evm module", function () {
             this.provider,
             "evm_mine",
             ["10000000000000000000000000000000"],
-            "Timestamp must be a positive integer or a string not exceeding 2^64 - 1"
+            "Timestamp must be a non-negative number not exceeding 2^64 - 1"
           );
           await assertInvalidArgumentsError(
             this.provider,
             "evm_mine",
             ["0x1111111111111111111111111111111111111"],
-            "Timestamp must be a positive integer or a string not exceeding 2^64 - 1"
+            "Timestamp must be a non-negative number not exceeding 2^64 - 1"
           );
         });
 

--- a/hardhat-tests/test/internal/hardhat-network/provider/modules/evm.ts
+++ b/hardhat-tests/test/internal/hardhat-network/provider/modules/evm.ts
@@ -146,6 +146,21 @@ describe("Evm module", function () {
           assert.strictEqual(totalOffset1, originalOffset + offset1);
           assert.strictEqual(totalOffset2, originalOffset + offset1 + offset2);
         });
+
+        it("should provide a reasonable error for big numbers", async function () {
+          await assertInvalidArgumentsError(
+            this.provider,
+            "evm_increaseTime",
+            ["10000000000000000000000000000000"],
+            "Timestamp must be a positive integer or a string not exceeding 2^64"
+          );
+          await assertInvalidArgumentsError(
+            this.provider,
+            "evm_increaseTime",
+            ["0x1111111111111111111111111111111111111"],
+            "Timestamp must be a positive integer or a string not exceeding 2^64"
+          );
+        });
       });
 
       describe("evm_setNextBlockTimestamp", function () {
@@ -317,6 +332,21 @@ describe("Evm module", function () {
               );
 
               assertQuantity(block.timestamp, timestamp);
+            });
+
+            it("should provide a reasonable error for big numbers", async function () {
+              await assertInvalidArgumentsError(
+                this.provider,
+                "evm_setNextBlockTimestamp",
+                ["10000000000000000000000000000000"],
+                "Timestamp must be a positive integer or a string not exceeding 2^64"
+              );
+              await assertInvalidArgumentsError(
+                this.provider,
+                "evm_setNextBlockTimestamp",
+                ["0x1111111111111111111111111111111111111"],
+                "Timestamp must be a positive integer or a string not exceeding 2^64"
+              );
             });
 
             describe("When the initial date is in the past", function () {
@@ -610,6 +640,21 @@ describe("Evm module", function () {
           );
 
           assertQuantity(block.timestamp, timestamp);
+        });
+
+        it("should provide a reasonable error for big numbers", async function () {
+          await assertInvalidArgumentsError(
+            this.provider,
+            "evm_mine",
+            ["10000000000000000000000000000000"],
+            "Timestamp must be a positive integer or a string not exceeding 2^64"
+          );
+          await assertInvalidArgumentsError(
+            this.provider,
+            "evm_mine",
+            ["0x1111111111111111111111111111111111111"],
+            "Timestamp must be a positive integer or a string not exceeding 2^64"
+          );
         });
 
         describe.skip("tests using sinon", () => {

--- a/hardhat-tests/test/internal/hardhat-network/provider/modules/evm.ts
+++ b/hardhat-tests/test/internal/hardhat-network/provider/modules/evm.ts
@@ -152,13 +152,13 @@ describe("Evm module", function () {
             this.provider,
             "evm_increaseTime",
             ["10000000000000000000000000000000"],
-            "Timestamp must be a positive integer or a string not exceeding 2^64"
+            "Timestamp must be a positive integer or a (`0x`-prefixed hex) string not exceeding 2^64"
           );
           await assertInvalidArgumentsError(
             this.provider,
             "evm_increaseTime",
             ["0x1111111111111111111111111111111111111"],
-            "Timestamp must be a positive integer or a string not exceeding 2^64"
+            "Timestamp must be a positive integer or a (`0x`-prefixed hex) string not exceeding 2^64"
           );
         });
       });
@@ -339,13 +339,13 @@ describe("Evm module", function () {
                 this.provider,
                 "evm_setNextBlockTimestamp",
                 ["10000000000000000000000000000000"],
-                "Timestamp must be a positive integer or a string not exceeding 2^64"
+                "Timestamp must be a positive integer or a (`0x`-prefixed hex) string not exceeding 2^64"
               );
               await assertInvalidArgumentsError(
                 this.provider,
                 "evm_setNextBlockTimestamp",
                 ["0x1111111111111111111111111111111111111"],
-                "Timestamp must be a positive integer or a string not exceeding 2^64"
+                "Timestamp must be a positive integer or a (`0x`-prefixed hex) string not exceeding 2^64"
               );
             });
 
@@ -647,13 +647,13 @@ describe("Evm module", function () {
             this.provider,
             "evm_mine",
             ["10000000000000000000000000000000"],
-            "Timestamp must be a positive integer or a string not exceeding 2^64"
+            "Timestamp must be a positive integer or a (`0x`-prefixed hex) string not exceeding 2^64"
           );
           await assertInvalidArgumentsError(
             this.provider,
             "evm_mine",
             ["0x1111111111111111111111111111111111111"],
-            "Timestamp must be a positive integer or a string not exceeding 2^64"
+            "Timestamp must be a positive integer or a (`0x`-prefixed hex) string not exceeding 2^64"
           );
         });
 


### PR DESCRIPTION
Fixes #435 

In place of the existing `U64OrUsize` we provide a newtype `Timestamp` around `u64` with a custom Deserialize impl that leniently first deserializes to a number/string and then attempts to parse the value to see if it's within the valid range.

We keep providing `From` and `Into` for the new type, so the existing code keeps using the impls whenever possible.