### PR TITLE
Add Solidity tests JS benchmark

### DIFF
--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -536,7 +536,7 @@ export class Response {
 /** Executes solidity tests. */
 export class SolidityTestRunner {
   /**Creates a new instance of the SolidityTestRunner. The callback function will be called with suite results as they finish. */
-  constructor(resultsCallback: (...args: any[]) => any)
+  constructor(cacheDir: string, gasReport: boolean, resultsCallback: (...args: any[]) => any)
   /**Runs the given test suites. */
   runTests(testSuites: Array<TestSuite>): Promise<Array<SuiteResult>>
 }

--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -536,7 +536,7 @@ export class Response {
 /** Executes solidity tests. */
 export class SolidityTestRunner {
   /**Creates a new instance of the SolidityTestRunner. The callback function will be called with suite results as they finish. */
-  constructor(cacheDir: string, gasReport: boolean, resultsCallback: (...args: any[]) => any)
+  constructor(gasReport: boolean, resultsCallback: (...args: any[]) => any)
   /**Runs the given test suites. */
   runTests(testSuites: Array<TestSuite>): Promise<Array<SuiteResult>>
 }

--- a/crates/edr_napi/src/solidity_tests.rs
+++ b/crates/edr_napi/src/solidity_tests.rs
@@ -2,7 +2,10 @@ mod runner;
 mod test_results;
 mod test_suite;
 
-use std::{path::Path, sync::Arc};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use forge::TestFilter;
 use napi::{
@@ -24,6 +27,8 @@ use crate::solidity_tests::{
 pub struct SolidityTestRunner {
     /// The callback to call with the results as they become available.
     results_callback_fn: ThreadsafeFunction<SuiteResult>,
+    cache_dir: PathBuf,
+    gas_report: bool,
 }
 
 // The callback has to be passed in the constructor because it's not `Send`.
@@ -31,7 +36,12 @@ pub struct SolidityTestRunner {
 impl SolidityTestRunner {
     #[doc = "Creates a new instance of the SolidityTestRunner. The callback function will be called with suite results as they finish."]
     #[napi(constructor)]
-    pub fn new(env: Env, results_callback: JsFunction) -> napi::Result<Self> {
+    pub fn new(
+        env: Env,
+        cache_dir: String,
+        gas_report: bool,
+        results_callback: JsFunction,
+    ) -> napi::Result<Self> {
         let mut results_callback_fn: ThreadsafeFunction<_, ErrorStrategy::CalleeHandled> =
             results_callback.create_threadsafe_function(
                 // Unbounded queue size
@@ -42,8 +52,12 @@ impl SolidityTestRunner {
         // Allow the event loop to exit before the function is destroyed
         results_callback_fn.unref(&env)?;
 
+        let cache_dir: PathBuf = cache_dir.into();
+
         Ok(Self {
             results_callback_fn,
+            cache_dir,
+            gas_report,
         })
     }
 
@@ -54,7 +68,7 @@ impl SolidityTestRunner {
             .into_iter()
             .map(|item| Ok((item.id.try_into()?, item.contract.try_into()?)))
             .collect::<Result<Vec<_>, napi::Error>>()?;
-        let runner = build_runner(test_suites)?;
+        let runner = build_runner(self.cache_dir.clone(), test_suites, self.gas_report)?;
 
         let (tx_results, mut rx_results) =
             tokio::sync::mpsc::unbounded_channel::<(String, forge::result::SuiteResult)>();

--- a/crates/edr_napi/test/solidity-tests.ts
+++ b/crates/edr_napi/test/solidity-tests.ts
@@ -1,4 +1,7 @@
 import { assert } from "chai";
+import { mkdtemp } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
 
 import {
   SolidityTestRunner,
@@ -15,8 +18,11 @@ describe("Solidity Tests", () => {
       loadContract("./artifacts/PaymentFailureTest.json"),
     ];
 
+    const tmpDir = await mkdtemp(path.join(tmpdir(), "solidity-tests-"));
+    const gasReport = false;
+
     const resultsFromCallback: Array<SuiteResult> = [];
-    const runner = new SolidityTestRunner((...args) => {
+    const runner = new SolidityTestRunner(tmpDir, gasReport, (...args) => {
       resultsFromCallback.push(args[1] as SuiteResult);
     });
 

--- a/crates/edr_napi/test/solidity-tests.ts
+++ b/crates/edr_napi/test/solidity-tests.ts
@@ -18,11 +18,10 @@ describe("Solidity Tests", () => {
       loadContract("./artifacts/PaymentFailureTest.json"),
     ];
 
-    const tmpDir = await mkdtemp(path.join(tmpdir(), "solidity-tests-"));
     const gasReport = false;
 
     const resultsFromCallback: Array<SuiteResult> = [];
-    const runner = new SolidityTestRunner(tmpDir, gasReport, (...args) => {
+    const runner = new SolidityTestRunner(gasReport, (...args) => {
       resultsFromCallback.push(args[1] as SuiteResult);
     });
 

--- a/crates/tools/js/benchmark/.gitignore
+++ b/crates/tools/js/benchmark/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+forge-std

--- a/crates/tools/js/benchmark/package.json
+++ b/crates/tools/js/benchmark/package.json
@@ -7,6 +7,8 @@
   "scripts": {
     "benchmark": "node --noconcurrent_sweeping --noconcurrent_recompilation --max-old-space-size=28000 index.js benchmark",
     "prebenchmark": "cd ../../../edr_napi/ && pnpm build",
+    "soltests": "node --noconcurrent_sweeping --noconcurrent_recompilation --max-old-space-size=28000 index.js solidity-tests",
+    "presoltests": "cd ../../../edr_napi/ && pnpm build",
     "verify": "node index.js verify",
     "report": "node index.js report",
     "test": "mocha --recursive \"test/**/*.js\"",
@@ -16,11 +18,13 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@nomicfoundation/edr": "workspace:^",
     "argparse": "^2.0.1",
     "chai": "^4.2.0",
     "hardhat": "2.22.5",
     "lodash": "^4.17.11",
     "mocha": "^10.0.0",
+    "simple-git": "^3.25.0",
     "tsx": "^4.7.1"
   }
 }

--- a/crates/tools/js/benchmark/solidity-tests.js
+++ b/crates/tools/js/benchmark/solidity-tests.js
@@ -7,8 +7,6 @@ const { execSync } = require("child_process");
 const path = require("path");
 const simpleGit = require("simple-git");
 const { SolidityTestRunner } = require("@nomicfoundation/edr");
-const { mkdtemp } = require("fs/promises");
-const { tmpdir } = require("os");
 
 const EXCLUDED_TEST_SUITES = new Set([
   "StdChainsTest",
@@ -49,7 +47,6 @@ async function setupForgeStdRepo() {
 }
 
 async function runForgeStdTests(forgeStdRepoPath) {
-  const tmpDir = await mkdtemp(path.join(tmpdir(), "solidity-tests-"));
   const gasReport = false;
 
   const start = performance.now();
@@ -64,7 +61,7 @@ async function runForgeStdTests(forgeStdRepoPath) {
     .map(loadContract.bind(null, hardhatConfig))
     .filter((ts) => !EXCLUDED_TEST_SUITES.has(ts.id.name));
 
-  const runner = new SolidityTestRunner(tmpDir, gasReport, (...args) => {
+  const runner = new SolidityTestRunner(gasReport, (...args) => {
     console.error(`${args[1].name} took ${elapsedSec(start)} seconds`);
   });
   const results = await runner.runTests(testSuites);

--- a/crates/tools/js/benchmark/solidity-tests.js
+++ b/crates/tools/js/benchmark/solidity-tests.js
@@ -1,0 +1,138 @@
+// Baseline
+// foundryup --commit 0a5b22f07
+// forge test --no-match-contract 'StdChainsTest|StdCheatsTest|MockERC721Test|MockERC20Test|StdCheatsForkTest|StdJsonTest|StdUtilsForkTest|StdTomlTest'
+
+const fs = require("fs");
+const { execSync } = require("child_process");
+const path = require("path");
+const simpleGit = require("simple-git");
+const { SolidityTestRunner } = require("@nomicfoundation/edr");
+
+const EXCLUDED_TEST_SUITES = new Set([
+  "StdChainsTest",
+  "StdCheatsTest",
+  "MockERC721Test",
+  "MockERC20Test",
+  "StdCheatsForkTest",
+  "StdJsonTest",
+  "StdUtilsForkTest",
+  "StdTomlTest",
+]);
+const EXPECTED_RESULTS = 7;
+
+const REPO_DIR = "forge-std";
+const REPO_URL = "https://github.com/NomicFoundation/forge-std.git";
+const BRANCH_NAME = "js-benchmark-config";
+
+async function setupForgeStdRepo() {
+  const repoPath = path.join(__dirname, REPO_DIR);
+  // Ensure directory exists
+  if (!fs.existsSync(repoPath)) {
+    const git = simpleGit();
+    await git.clone(REPO_URL, repoPath);
+  }
+
+  const git = simpleGit(repoPath);
+  await git.fetch();
+  await git.checkout(BRANCH_NAME);
+  await git.pull();
+
+  // Run npx hardhat compile
+  execSync("npx hardhat compile", {
+    cwd: repoPath,
+    stdio: "inherit",
+  });
+
+  return repoPath;
+}
+
+async function runForgeStdTests(forgeStdRepoPath) {
+  const start = performance.now();
+  console.log(forgeStdRepoPath);
+
+  const artifactsDir = path.join(forgeStdRepoPath, "artifacts");
+  const hardhatConfig = require(
+    path.join(forgeStdRepoPath, "hardhat.config.js"),
+  );
+
+  const testSuites = listFilesRecursively(artifactsDir)
+    .filter((p) => !p.endsWith(".dbg.json") && p.includes(".t.sol"))
+    .map(loadContract.bind(null, hardhatConfig))
+    .filter((ts) => !EXCLUDED_TEST_SUITES.has(ts.id.name));
+
+  const runner = new SolidityTestRunner((...args) => {
+    console.error(`${args[1].name} took ${elapsedSec(start)} seconds`);
+  });
+  const results = await runner.runTests(testSuites);
+  console.error("elapsed (s)", elapsedSec(start));
+
+  if (results.length !== EXPECTED_RESULTS) {
+    console.log(results.map((r) => r.name));
+    throw new Error(
+      `Expected ${EXPECTED_RESULTS} results, got ${results.length}`,
+    );
+  }
+
+  const failed = new Set();
+  for (let res of results) {
+    for (let r of res.testResults) {
+      if (r.status !== "Success") {
+        failed.add(`${res.name} ${r.name} ${r.status}`);
+      }
+    }
+  }
+  if (failed.size !== 0) {
+    console.error(failed);
+    throw new Error(`Some tests failed`);
+  }
+}
+
+function elapsedSec(since) {
+  const elapsedSec = (performance.now() - since) / 1000;
+  return Math.round(elapsedSec * 1000) / 1000;
+}
+
+function listFilesRecursively(dir, fileList = []) {
+  const files = fs.readdirSync(dir);
+
+  files.forEach((file) => {
+    const filePath = path.join(dir, file);
+    if (fs.statSync(filePath).isDirectory()) {
+      listFilesRecursively(filePath, fileList);
+    } else {
+      fileList.push(filePath);
+    }
+  });
+
+  return fileList;
+}
+
+// Load a contract built with Hardhat into a test suite
+function loadContract(hardhatConfig, artifactPath) {
+  const compiledContract = require(artifactPath);
+
+  const artifactId = {
+    // Artifact cache path is ignored
+    artifactCachePath: "./none",
+    name: compiledContract.contractName,
+    solcVersion: hardhatConfig.solidity.version,
+    source: compiledContract.sourceName,
+  };
+
+  const testContract = {
+    abi: JSON.stringify(compiledContract.abi),
+    bytecode: compiledContract.bytecode,
+    libsToDeploy: [],
+    libraries: [],
+  };
+
+  return {
+    id: artifactId,
+    contract: testContract,
+  };
+}
+
+module.exports = {
+  runForgeStdTests,
+  setupForgeStdRepo,
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3274,7 +3274,7 @@ snapshots:
       '@ethersproject/bignumber': 5.7.0
       '@ethersproject/bytes': 5.7.0
       '@ethersproject/constants': 5.7.0
-      '@ethersproject/logger': 5.7.0
+      '@ethersproject/logger': 5.0.6
       '@ethersproject/properties': 5.7.0
       '@ethersproject/transactions': 5.7.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
 
   crates/tools/js/benchmark:
     devDependencies:
+      '@nomicfoundation/edr':
+        specifier: workspace:^
+        version: link:../../../edr_napi
       argparse:
         specifier: ^2.0.1
         version: 2.0.1
@@ -68,6 +71,9 @@ importers:
       mocha:
         specifier: ^10.0.0
         version: 10.3.0
+      simple-git:
+        specifier: ^3.25.0
+        version: 3.25.0
       tsx:
         specifier: ^4.7.1
         version: 4.7.1
@@ -583,6 +589,12 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@kwsites/file-exists@1.1.1':
+    resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
+
+  '@kwsites/promise-deferred@1.1.1':
+    resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -1287,6 +1299,15 @@ packages:
 
   debug@4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@4.3.5:
+    resolution: {integrity: sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -2515,6 +2536,9 @@ packages:
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
+  simple-git@3.25.0:
+    resolution: {integrity: sha512-KIY5sBnzc4yEcJXW7Tdv4viEz8KyG+nU0hay+DWZasvdFOYKeUZ6Xc25LUHHjw0tinPT7O1eY6pzX7pRT1K8rw==}
+
   sinon@9.2.4:
     resolution: {integrity: sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==}
     deprecated: 16.1.1
@@ -3274,7 +3298,7 @@ snapshots:
       '@ethersproject/bignumber': 5.7.0
       '@ethersproject/bytes': 5.7.0
       '@ethersproject/constants': 5.7.0
-      '@ethersproject/logger': 5.0.6
+      '@ethersproject/logger': 5.7.0
       '@ethersproject/properties': 5.7.0
       '@ethersproject/transactions': 5.7.0
 
@@ -3481,6 +3505,14 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
+
+  '@kwsites/file-exists@1.1.1':
+    dependencies:
+      debug: 4.3.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@kwsites/promise-deferred@1.1.1': {}
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -4279,6 +4311,10 @@ snapshots:
       ms: 2.1.2
     optionalDependencies:
       supports-color: 8.1.1
+
+  debug@4.3.5:
+    dependencies:
+      ms: 2.1.2
 
   decamelize-keys@1.1.1:
     dependencies:
@@ -5765,6 +5801,14 @@ snapshots:
       object-inspect: 1.13.1
 
   signal-exit@3.0.7: {}
+
+  simple-git@3.25.0:
+    dependencies:
+      '@kwsites/file-exists': 1.1.1
+      '@kwsites/promise-deferred': 1.1.1
+      debug: 4.3.5
+    transitivePeerDependencies:
+      - supports-color
 
   sinon@9.2.4:
     dependencies:


### PR DESCRIPTION
Adds a JS benchmark command to execute certain `forge-std` tests to benchmark the EDR Solidity tests implementation against `forge`. The benchmark can be executed with `pnpm i && pnpm soltests` from the `crates/tools/js/benchmark` directory. There is no difference in execution time on my machine between `forge test` and `pnpm soltests`.

Baseline: 

```
git clone https://github.com/NomicFoundation/forge-std.git
cd forge-std
git checkout js-benchmark-config
foundryup --commit 0a5b22f07
forge test --no-match-contract 'StdChainsTest|StdCheatsTest|MockERC721Test|MockERC20Test|StdCheatsForkTest|StdJsonTest|StdUtilsForkTest|StdTomlTest'
```

The ignored `forge-std` tests use fork mode or depend on Foundry project format.