### PR TITLE
refactor: make blockchain types generic

### DIFF
--- a/crates/edr_evm/src/block.rs
+++ b/crates/edr_evm/src/block.rs
@@ -15,7 +15,7 @@ pub use self::{
         ExecutionResultWithContext,
     },
     local::LocalBlock,
-    remote::{CreationError as RemoteBlockCreationError, RemoteBlock},
+    remote::{CreationError as RemoteBlockCreationError, IntoRemoteBlock, RemoteBlock},
 };
 use crate::chain_spec::ChainSpec;
 
@@ -63,7 +63,7 @@ where
 
 /// The result returned by requesting a block by number.
 #[derive(Debug)]
-pub struct BlockAndTotalDifficulty<BlockchainErrorT, ChainSpecT: ChainSpec> {
+pub struct BlockAndTotalDifficulty<ChainSpecT: ChainSpec, BlockchainErrorT> {
     /// The block
     pub block: Arc<dyn SyncBlock<ChainSpecT, Error = BlockchainErrorT>>,
     /// The total difficulty with the block
@@ -71,7 +71,7 @@ pub struct BlockAndTotalDifficulty<BlockchainErrorT, ChainSpecT: ChainSpec> {
 }
 
 impl<BlockchainErrorT, ChainSpecT: ChainSpec> Clone
-    for BlockAndTotalDifficulty<BlockchainErrorT, ChainSpecT>
+    for BlockAndTotalDifficulty<ChainSpecT, BlockchainErrorT>
 {
     fn clone(&self) -> Self {
         Self {
@@ -82,9 +82,9 @@ impl<BlockchainErrorT, ChainSpecT: ChainSpec> Clone
 }
 
 impl<BlockchainErrorT, ChainSpecT: ChainSpec>
-    From<BlockAndTotalDifficulty<BlockchainErrorT, ChainSpecT>> for edr_rpc_eth::Block<B256>
+    From<BlockAndTotalDifficulty<ChainSpecT, BlockchainErrorT>> for edr_rpc_eth::Block<B256>
 {
-    fn from(value: BlockAndTotalDifficulty<BlockchainErrorT, ChainSpecT>) -> Self {
+    fn from(value: BlockAndTotalDifficulty<ChainSpecT, BlockchainErrorT>) -> Self {
         let transactions = value
             .block
             .transactions()

--- a/crates/edr_evm/src/block.rs
+++ b/crates/edr_evm/src/block.rs
@@ -6,11 +6,7 @@ use std::{fmt::Debug, sync::Arc};
 
 use auto_impl::auto_impl;
 use edr_eth::{
-    block,
-    receipt::BlockReceipt,
-    transaction::{self, Transaction},
-    withdrawal::Withdrawal,
-    B256, U256,
+    block, receipt::BlockReceipt, transaction::Transaction, withdrawal::Withdrawal, B256, U256,
 };
 
 pub use self::{
@@ -21,10 +17,11 @@ pub use self::{
     local::LocalBlock,
     remote::{CreationError as RemoteBlockCreationError, RemoteBlock},
 };
+use crate::chain_spec::ChainSpec;
 
 /// Trait for implementations of an Ethereum block.
 #[auto_impl(Arc)]
-pub trait Block: Debug {
+pub trait Block<ChainSpecT: ChainSpec>: Debug {
     /// The blockchain error type.
     type Error;
 
@@ -41,7 +38,7 @@ pub trait Block: Debug {
     fn rlp_size(&self) -> u64;
 
     /// Returns the block's transactions.
-    fn transactions(&self) -> &[transaction::Signed];
+    fn transactions(&self) -> &[ChainSpecT::SignedTransaction];
 
     /// Returns the receipts of the block's transactions.
     fn transaction_receipts(&self) -> Result<Vec<Arc<BlockReceipt>>, Self::Error>;
@@ -51,20 +48,31 @@ pub trait Block: Debug {
 }
 
 /// Trait that meets all requirements for a synchronous block.
-pub trait SyncBlock: Block + Send + Sync {}
+pub trait SyncBlock<ChainSpecT>: Block<ChainSpecT> + Send + Sync
+where
+    ChainSpecT: ChainSpec,
+{
+}
 
-impl<BlockT> SyncBlock for BlockT where BlockT: Block + Send + Sync {}
+impl<BlockT, ChainSpecT> SyncBlock<ChainSpecT> for BlockT
+where
+    BlockT: Block<ChainSpecT> + Send + Sync,
+    ChainSpecT: ChainSpec,
+{
+}
 
 /// The result returned by requesting a block by number.
 #[derive(Debug)]
-pub struct BlockAndTotalDifficulty<BlockchainErrorT> {
+pub struct BlockAndTotalDifficulty<BlockchainErrorT, ChainSpecT: ChainSpec> {
     /// The block
-    pub block: Arc<dyn SyncBlock<Error = BlockchainErrorT>>,
+    pub block: Arc<dyn SyncBlock<ChainSpecT, Error = BlockchainErrorT>>,
     /// The total difficulty with the block
     pub total_difficulty: Option<U256>,
 }
 
-impl<BlockchainErrorT> Clone for BlockAndTotalDifficulty<BlockchainErrorT> {
+impl<BlockchainErrorT, ChainSpecT: ChainSpec> Clone
+    for BlockAndTotalDifficulty<BlockchainErrorT, ChainSpecT>
+{
     fn clone(&self) -> Self {
         Self {
             block: self.block.clone(),
@@ -73,10 +81,10 @@ impl<BlockchainErrorT> Clone for BlockAndTotalDifficulty<BlockchainErrorT> {
     }
 }
 
-impl<BlockchainErrorT> From<BlockAndTotalDifficulty<BlockchainErrorT>>
-    for edr_rpc_eth::Block<B256>
+impl<BlockchainErrorT, ChainSpecT: ChainSpec>
+    From<BlockAndTotalDifficulty<BlockchainErrorT, ChainSpecT>> for edr_rpc_eth::Block<B256>
 {
-    fn from(value: BlockAndTotalDifficulty<BlockchainErrorT>) -> Self {
+    fn from(value: BlockAndTotalDifficulty<BlockchainErrorT, ChainSpecT>) -> Self {
         let transactions = value
             .block
             .transactions()

--- a/crates/edr_evm/src/block.rs
+++ b/crates/edr_evm/src/block.rs
@@ -15,7 +15,9 @@ pub use self::{
         ExecutionResultWithContext,
     },
     local::LocalBlock,
-    remote::{CreationError as RemoteBlockCreationError, IntoRemoteBlock, RemoteBlock},
+    remote::{
+        CreationError as RemoteBlockCreationError, EthRpcBlock, IntoRemoteBlock, RemoteBlock,
+    },
 };
 use crate::chain_spec::ChainSpec;
 

--- a/crates/edr_evm/src/block/local.rs
+++ b/crates/edr_evm/src/block/local.rs
@@ -15,7 +15,8 @@ use revm::primitives::keccak256;
 use crate::{
     blockchain::BlockchainError,
     chain_spec::{ChainSpec, SyncChainSpec},
-    Block, DetailedTransaction, SpecId, SyncBlock,
+    transaction::DetailedTransaction,
+    Block, SpecId, SyncBlock,
 };
 
 /// A locally mined block, which contains complete information.
@@ -206,7 +207,6 @@ impl<ChainSpecT> From<LocalBlock<ChainSpecT>>
     for Arc<dyn SyncBlock<ChainSpecT, Error = BlockchainError>>
 where
     ChainSpecT: SyncChainSpec,
-    ChainSpecT::SignedTransaction: Send + Sync,
 {
     fn from(value: LocalBlock<ChainSpecT>) -> Self {
         Arc::new(value)

--- a/crates/edr_evm/src/block/local.rs
+++ b/crates/edr_evm/src/block/local.rs
@@ -13,8 +13,9 @@ use itertools::izip;
 use revm::primitives::keccak256;
 
 use crate::{
-    blockchain::BlockchainError, chain_spec::ChainSpec, Block, DetailedTransaction, SpecId,
-    SyncBlock,
+    blockchain::BlockchainError,
+    chain_spec::{ChainSpec, SyncChainSpec},
+    Block, DetailedTransaction, SpecId, SyncBlock,
 };
 
 /// A locally mined block, which contains complete information.
@@ -204,7 +205,7 @@ fn transaction_to_block_receipts(
 impl<ChainSpecT> From<LocalBlock<ChainSpecT>>
     for Arc<dyn SyncBlock<ChainSpecT, Error = BlockchainError>>
 where
-    ChainSpecT: ChainSpec,
+    ChainSpecT: SyncChainSpec,
     ChainSpecT::SignedTransaction: Send + Sync,
 {
     fn from(value: LocalBlock<ChainSpecT>) -> Self {

--- a/crates/edr_evm/src/blockchain.rs
+++ b/crates/edr_evm/src/blockchain.rs
@@ -84,7 +84,6 @@ pub enum BlockchainError {
 pub trait Blockchain<ChainSpecT>
 where
     ChainSpecT: SyncChainSpec,
-    ChainSpecT::SignedTransaction: Send + Sync,
 {
     /// The blockchain's error type
     type BlockchainError;
@@ -209,7 +208,6 @@ pub trait SyncBlockchain<ChainSpecT, BlockchainErrorT, StateErrorT>:
 where
     BlockchainErrorT: Debug + Send,
     ChainSpecT: SyncChainSpec,
-    ChainSpecT::SignedTransaction: Send + Sync,
 {
 }
 
@@ -224,7 +222,6 @@ where
         + Debug,
     BlockchainErrorT: Debug + Send,
     ChainSpecT: SyncChainSpec,
-    ChainSpecT::SignedTransaction: Send + Sync,
 {
 }
 

--- a/crates/edr_evm/src/blockchain/forked.rs
+++ b/crates/edr_evm/src/blockchain/forked.rs
@@ -87,7 +87,6 @@ pub enum ForkedBlockchainError {
 pub struct ForkedBlockchain<ChainSpecT>
 where
     ChainSpecT: SyncChainSpec,
-    ChainSpecT::SignedTransaction: Send + Sync,
 {
     local_storage: ReservableSparseBlockchainStorage<
         Arc<dyn SyncBlock<ChainSpecT, Error = BlockchainError>>,
@@ -111,7 +110,6 @@ where
 impl<ChainSpecT> ForkedBlockchain<ChainSpecT>
 where
     ChainSpecT: SyncChainSpec,
-    ChainSpecT::SignedTransaction: Send + Sync,
 {
     /// Constructs a new instance.
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
@@ -257,7 +255,6 @@ where
 impl<ChainSpecT> BlockHashRef for ForkedBlockchain<ChainSpecT>
 where
     ChainSpecT: SyncChainSpec,
-    ChainSpecT::SignedTransaction: Send + Sync,
 {
     type Error = BlockchainError;
 
@@ -283,7 +280,6 @@ where
 impl<ChainSpecT> Blockchain<ChainSpecT> for ForkedBlockchain<ChainSpecT>
 where
     ChainSpecT: SyncChainSpec,
-    ChainSpecT::SignedTransaction: Send + Sync,
 {
     type BlockchainError = BlockchainError;
 
@@ -540,7 +536,6 @@ where
 impl<ChainSpecT> BlockchainMut<ChainSpecT> for ForkedBlockchain<ChainSpecT>
 where
     ChainSpecT: SyncChainSpec,
-    ChainSpecT::SignedTransaction: Send + Sync,
 {
     type Error = BlockchainError;
 

--- a/crates/edr_evm/src/blockchain/local.rs
+++ b/crates/edr_evm/src/blockchain/local.rs
@@ -79,7 +79,6 @@ impl From<GenesisBlockOptions> for BlockOptions {
 pub struct LocalBlockchain<ChainSpecT>
 where
     ChainSpecT: SyncChainSpec,
-    ChainSpecT::SignedTransaction: Send + Sync,
 {
     storage: ReservableSparseBlockchainStorage<
         Arc<dyn SyncBlock<ChainSpecT, Error = BlockchainError>>,
@@ -92,7 +91,6 @@ where
 impl<ChainSpecT> LocalBlockchain<ChainSpecT>
 where
     ChainSpecT: SyncChainSpec,
-    ChainSpecT::SignedTransaction: Send + Sync,
 {
     /// Constructs a new instance using the provided arguments to build a
     /// genesis block.
@@ -220,7 +218,6 @@ where
 impl<ChainSpecT> Blockchain<ChainSpecT> for LocalBlockchain<ChainSpecT>
 where
     ChainSpecT: SyncChainSpec,
-    ChainSpecT::SignedTransaction: Send + Sync,
 {
     type BlockchainError = BlockchainError;
 
@@ -342,7 +339,6 @@ where
 impl<ChainSpecT> BlockchainMut<ChainSpecT> for LocalBlockchain<ChainSpecT>
 where
     ChainSpecT: SyncChainSpec,
-    ChainSpecT::SignedTransaction: Send + Sync,
 {
     type Error = BlockchainError;
 
@@ -413,7 +409,6 @@ where
 impl<ChainSpecT> BlockHashRef for LocalBlockchain<ChainSpecT>
 where
     ChainSpecT: SyncChainSpec,
-    ChainSpecT::SignedTransaction: Send + Sync,
 {
     type Error = BlockchainError;
 

--- a/crates/edr_evm/src/blockchain/local.rs
+++ b/crates/edr_evm/src/blockchain/local.rs
@@ -24,6 +24,7 @@ use super::{
     Blockchain, BlockchainError, BlockchainMut,
 };
 use crate::{
+    chain_spec::SyncChainSpec,
     state::{StateDebug, StateDiff, StateError, StateOverride, SyncState, TrieState},
     Block, BlockAndTotalDifficulty, LocalBlock, SyncBlock,
 };
@@ -75,13 +76,24 @@ impl From<GenesisBlockOptions> for BlockOptions {
 
 /// A blockchain consisting of locally created blocks.
 #[derive(Debug)]
-pub struct LocalBlockchain {
-    storage: ReservableSparseBlockchainStorage<Arc<dyn SyncBlock<Error = BlockchainError>>>,
+pub struct LocalBlockchain<ChainSpecT>
+where
+    ChainSpecT: SyncChainSpec,
+    ChainSpecT::SignedTransaction: Send + Sync,
+{
+    storage: ReservableSparseBlockchainStorage<
+        Arc<dyn SyncBlock<ChainSpecT, Error = BlockchainError>>,
+        ChainSpecT,
+    >,
     chain_id: u64,
     spec_id: SpecId,
 }
 
-impl LocalBlockchain {
+impl<ChainSpecT> LocalBlockchain<ChainSpecT>
+where
+    ChainSpecT: SyncChainSpec,
+    ChainSpecT::SignedTransaction: Send + Sync,
+{
     /// Constructs a new instance using the provided arguments to build a
     /// genesis block.
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
@@ -151,7 +163,7 @@ impl LocalBlockchain {
     /// zero block number.
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
     pub fn with_genesis_block(
-        genesis_block: LocalBlock,
+        genesis_block: LocalBlock<ChainSpecT>,
         genesis_diff: StateDiff,
         chain_id: u64,
         spec_id: SpecId,
@@ -182,12 +194,13 @@ impl LocalBlockchain {
     /// Ensure that the genesis block's number is zero.
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
     pub unsafe fn with_genesis_block_unchecked(
-        genesis_block: LocalBlock,
+        genesis_block: LocalBlock<ChainSpecT>,
         genesis_diff: StateDiff,
         chain_id: u64,
         spec_id: SpecId,
     ) -> Self {
-        let genesis_block: Arc<dyn SyncBlock<Error = BlockchainError>> = Arc::new(genesis_block);
+        let genesis_block: Arc<dyn SyncBlock<ChainSpecT, Error = BlockchainError>> =
+            Arc::new(genesis_block);
 
         let total_difficulty = genesis_block.header().difficulty;
         let storage = ReservableSparseBlockchainStorage::with_genesis_block(
@@ -204,7 +217,11 @@ impl LocalBlockchain {
     }
 }
 
-impl Blockchain for LocalBlockchain {
+impl<ChainSpecT> Blockchain<ChainSpecT> for LocalBlockchain<ChainSpecT>
+where
+    ChainSpecT: SyncChainSpec,
+    ChainSpecT::SignedTransaction: Send + Sync,
+{
     type BlockchainError = BlockchainError;
 
     type StateError = StateError;
@@ -214,8 +231,10 @@ impl Blockchain for LocalBlockchain {
     fn block_by_hash(
         &self,
         hash: &B256,
-    ) -> Result<Option<Arc<dyn SyncBlock<Error = Self::BlockchainError>>>, Self::BlockchainError>
-    {
+    ) -> Result<
+        Option<Arc<dyn SyncBlock<ChainSpecT, Error = Self::BlockchainError>>>,
+        Self::BlockchainError,
+    > {
         Ok(self.storage.block_by_hash(hash))
     }
 
@@ -224,8 +243,10 @@ impl Blockchain for LocalBlockchain {
     fn block_by_number(
         &self,
         number: u64,
-    ) -> Result<Option<Arc<dyn SyncBlock<Error = Self::BlockchainError>>>, Self::BlockchainError>
-    {
+    ) -> Result<
+        Option<Arc<dyn SyncBlock<ChainSpecT, Error = Self::BlockchainError>>>,
+        Self::BlockchainError,
+    > {
         Ok(self.storage.block_by_number(number)?)
     }
 
@@ -234,8 +255,10 @@ impl Blockchain for LocalBlockchain {
     fn block_by_transaction_hash(
         &self,
         transaction_hash: &B256,
-    ) -> Result<Option<Arc<dyn SyncBlock<Error = Self::BlockchainError>>>, Self::BlockchainError>
-    {
+    ) -> Result<
+        Option<Arc<dyn SyncBlock<ChainSpecT, Error = Self::BlockchainError>>>,
+        Self::BlockchainError,
+    > {
         Ok(self.storage.block_by_transaction_hash(transaction_hash))
     }
 
@@ -246,7 +269,8 @@ impl Blockchain for LocalBlockchain {
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
     fn last_block(
         &self,
-    ) -> Result<Arc<dyn SyncBlock<Error = Self::BlockchainError>>, Self::BlockchainError> {
+    ) -> Result<Arc<dyn SyncBlock<ChainSpecT, Error = Self::BlockchainError>>, Self::BlockchainError>
+    {
         Ok(self
             .storage
             .block_by_number(self.storage.last_block_number())?
@@ -315,15 +339,19 @@ impl Blockchain for LocalBlockchain {
     }
 }
 
-impl BlockchainMut for LocalBlockchain {
+impl<ChainSpecT> BlockchainMut<ChainSpecT> for LocalBlockchain<ChainSpecT>
+where
+    ChainSpecT: SyncChainSpec,
+    ChainSpecT::SignedTransaction: Send + Sync,
+{
     type Error = BlockchainError;
 
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
     fn insert_block(
         &mut self,
-        block: LocalBlock,
+        block: LocalBlock<ChainSpecT>,
         state_diff: StateDiff,
-    ) -> Result<BlockAndTotalDifficulty<Self::Error>, Self::Error> {
+    ) -> Result<BlockAndTotalDifficulty<ChainSpecT, Self::Error>, Self::Error> {
         let last_block = self.last_block()?;
 
         validate_next_block(self.spec_id, &last_block, &block)?;
@@ -382,7 +410,11 @@ impl BlockchainMut for LocalBlockchain {
     }
 }
 
-impl BlockHashRef for LocalBlockchain {
+impl<ChainSpecT> BlockHashRef for LocalBlockchain<ChainSpecT>
+where
+    ChainSpecT: SyncChainSpec,
+    ChainSpecT::SignedTransaction: Send + Sync,
+{
     type Error = BlockchainError;
 
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
@@ -403,7 +435,7 @@ mod tests {
     use revm::primitives::{Account, AccountStatus};
 
     use super::*;
-    use crate::state::IrregularState;
+    use crate::{chain_spec::L1ChainSpec, state::IrregularState};
 
     #[test]
     fn compute_state_after_reserve() -> anyhow::Result<()> {
@@ -431,7 +463,7 @@ mod tests {
             .collect::<HashMap<_, _>>()
             .into();
 
-        let mut blockchain = LocalBlockchain::new(
+        let mut blockchain = LocalBlockchain::<L1ChainSpec>::new(
             genesis_diff,
             123,
             SpecId::SHANGHAI,

--- a/crates/edr_evm/src/blockchain/remote.rs
+++ b/crates/edr_evm/src/blockchain/remote.rs
@@ -259,9 +259,12 @@ mod tests {
     async fn no_cache_for_unsafe_block_number() {
         let tempdir = tempfile::tempdir().expect("can create tempdir");
 
-        let rpc_client =
-            EthRpcClient::<EthRpcSpec>::new(&get_alchemy_url(), tempdir.path().to_path_buf(), None)
-                .expect("url ok");
+        let rpc_client = EthRpcClient::<L1ChainSpec>::new(
+            &get_alchemy_url(),
+            tempdir.path().to_path_buf(),
+            None,
+        )
+        .expect("url ok");
 
         // Latest block number is always unsafe to cache
         let block_number = rpc_client.block_number().await.unwrap();

--- a/crates/edr_evm/src/blockchain/storage/sparse.rs
+++ b/crates/edr_evm/src/blockchain/storage/sparse.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{marker::PhantomData, sync::Arc};
 
 use edr_eth::{
     log::{matches_address_filter, matches_topics_filter},
@@ -9,19 +9,28 @@ use edr_eth::{
 use revm::primitives::{HashMap, HashSet};
 
 use super::InsertError;
-use crate::{hash_map::OccupiedError, Block};
+use crate::{chain_spec::ChainSpec, hash_map::OccupiedError, Block};
 
 /// A storage solution for storing a subset of a Blockchain's blocks in-memory.
 #[derive(Debug)]
-pub struct SparseBlockchainStorage<BlockT: Block + Clone + ?Sized> {
+pub struct SparseBlockchainStorage<BlockT, ChainSpecT>
+where
+    BlockT: Block<ChainSpecT> + Clone + ?Sized,
+    ChainSpecT: ChainSpec,
+{
     hash_to_block: HashMap<B256, BlockT>,
     hash_to_total_difficulty: HashMap<B256, U256>,
     number_to_block: HashMap<u64, BlockT>,
     transaction_hash_to_block: HashMap<B256, BlockT>,
     transaction_hash_to_receipt: HashMap<B256, Arc<BlockReceipt>>,
+    phantom: PhantomData<ChainSpecT>,
 }
 
-impl<BlockT: Block + Clone + ?Sized> SparseBlockchainStorage<BlockT> {
+impl<BlockT, ChainSpecT> SparseBlockchainStorage<BlockT, ChainSpecT>
+where
+    BlockT: Block<ChainSpecT> + Clone + ?Sized,
+    ChainSpecT: ChainSpec,
+{
     /// Constructs a new instance with the provided block.
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
     pub fn with_block(block: BlockT, total_difficulty: U256) -> Self {
@@ -48,6 +57,7 @@ impl<BlockT: Block + Clone + ?Sized> SparseBlockchainStorage<BlockT> {
             number_to_block,
             transaction_hash_to_block,
             transaction_hash_to_receipt: HashMap::new(),
+            phantom: PhantomData,
         }
     }
 
@@ -208,7 +218,11 @@ impl<BlockT: Block + Clone + ?Sized> SparseBlockchainStorage<BlockT> {
     }
 }
 
-impl<BlockT: Block + Clone> Default for SparseBlockchainStorage<BlockT> {
+impl<BlockT, ChainSpecT> Default for SparseBlockchainStorage<BlockT, ChainSpecT>
+where
+    BlockT: Block<ChainSpecT> + Clone,
+    ChainSpecT: ChainSpec,
+{
     fn default() -> Self {
         Self {
             hash_to_block: HashMap::default(),
@@ -216,18 +230,23 @@ impl<BlockT: Block + Clone> Default for SparseBlockchainStorage<BlockT> {
             number_to_block: HashMap::default(),
             transaction_hash_to_block: HashMap::default(),
             transaction_hash_to_receipt: HashMap::default(),
+            phantom: PhantomData,
         }
     }
 }
 
 /// Retrieves the logs that match the provided filter.
-pub fn logs<BlockT: Block + Clone>(
-    storage: &SparseBlockchainStorage<BlockT>,
+pub fn logs<BlockT, ChainSpecT>(
+    storage: &SparseBlockchainStorage<BlockT, ChainSpecT>,
     from_block: u64,
     to_block: u64,
     addresses: &HashSet<Address>,
     topics_filter: &[Option<Vec<B256>>],
-) -> Result<Vec<edr_eth::log::FilterLog>, BlockT::Error> {
+) -> Result<Vec<edr_eth::log::FilterLog>, BlockT::Error>
+where
+    BlockT: Block<ChainSpecT> + Clone,
+    ChainSpecT: ChainSpec,
+{
     let mut logs = Vec::new();
     let addresses: HashSet<Address> = addresses.iter().copied().collect();
 

--- a/crates/edr_evm/src/chain_spec.rs
+++ b/crates/edr_evm/src/chain_spec.rs
@@ -7,7 +7,7 @@ use revm::primitives::TxEnv;
 use serde::{de::DeserializeOwned, Serialize};
 
 /// A trait for defining a chain's associated types.
-pub trait ChainSpec: Debug + alloy_rlp::Encodable + RpcSpec + 'static {
+pub trait ChainSpec: Debug + alloy_rlp::Encodable + RpcSpec {
     /// The type of signed transactions used by this chain.
     type SignedTransaction: alloy_rlp::Encodable
         + Clone
@@ -16,6 +16,20 @@ pub trait ChainSpec: Debug + alloy_rlp::Encodable + RpcSpec + 'static {
         + PartialEq
         + Eq
         + SignedTransaction;
+}
+
+/// A supertrait for [`ChainSpec`] that is safe to send between threads.
+pub trait SyncChainSpec: ChainSpec + Send + Sync + 'static
+where
+    Self::SignedTransaction: Send + Sync,
+{
+}
+
+impl<ChainSpecT> SyncChainSpec for ChainSpecT
+where
+    ChainSpecT: ChainSpec + Send + Sync + 'static,
+    ChainSpecT::SignedTransaction: Send + Sync,
+{
 }
 
 /// The chain specification for Ethereum Layer 1.

--- a/crates/edr_evm/src/chain_spec.rs
+++ b/crates/edr_evm/src/chain_spec.rs
@@ -1,10 +1,13 @@
 use std::fmt::Debug;
 
+use alloy_rlp::RlpEncodable;
 use edr_eth::transaction::SignedTransaction;
+use edr_rpc_eth::spec::{EthRpcSpec, RpcSpec};
 use revm::primitives::TxEnv;
+use serde::{de::DeserializeOwned, Serialize};
 
 /// A trait for defining a chain's associated types.
-pub trait ChainSpec {
+pub trait ChainSpec: Debug + alloy_rlp::Encodable + RpcSpec + 'static {
     /// The type of signed transactions used by this chain.
     type SignedTransaction: alloy_rlp::Encodable
         + Clone
@@ -16,9 +19,14 @@ pub trait ChainSpec {
 }
 
 /// The chain specification for Ethereum Layer 1.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, RlpEncodable)]
 pub struct L1ChainSpec;
 
 impl ChainSpec for L1ChainSpec {
     type SignedTransaction = edr_eth::transaction::Signed;
+}
+
+impl RpcSpec for L1ChainSpec {
+    type RpcBlock<Data> = <EthRpcSpec as RpcSpec>::RpcBlock<Data> where Data: Default + DeserializeOwned + Serialize;
+    type RpcTransaction = <EthRpcSpec as RpcSpec>::RpcTransaction;
 }

--- a/crates/edr_evm/src/debug.rs
+++ b/crates/edr_evm/src/debug.rs
@@ -4,28 +4,28 @@ use revm::db::{DatabaseComponents, StateRef, WrapDatabaseRef};
 use crate::blockchain::SyncBlockchain;
 
 /// Type for registering handles, specialised for EDR database component types.
-pub type HandleRegister<'evm, BlockchainErrorT, DebugDataT, StateT> =
+pub type HandleRegister<'evm, ChainSpecT, BlockchainErrorT, DebugDataT, StateT> =
     revm::handler::register::HandleRegister<
         DebugDataT,
         WrapDatabaseRef<
             DatabaseComponents<
                 StateT,
-                &'evm dyn SyncBlockchain<BlockchainErrorT, <StateT as StateRef>::Error>,
+                &'evm dyn SyncBlockchain<ChainSpecT, BlockchainErrorT, <StateT as StateRef>::Error>,
             >,
         >,
     >;
 
 /// Type for encapsulating contextual data and handler registration in an
 /// `EvmBuilder`.
-pub struct DebugContext<'evm, BlockchainErrorT, DebugDataT, StateT: StateRef> {
+pub struct DebugContext<'evm, ChainSpecT, BlockchainErrorT, DebugDataT, StateT: StateRef> {
     /// The contextual data.
     pub data: DebugDataT,
     /// The function to register handles.
-    pub register_handles_fn: HandleRegister<'evm, BlockchainErrorT, DebugDataT, StateT>,
+    pub register_handles_fn: HandleRegister<'evm, ChainSpecT, BlockchainErrorT, DebugDataT, StateT>,
 }
 
-pub struct EvmContext<'evm, BlockchainErrorT, DebugDataT, StateT: StateRef> {
-    pub debug: Option<DebugContext<'evm, BlockchainErrorT, DebugDataT, StateT>>,
+pub struct EvmContext<'evm, ChainSpecT, BlockchainErrorT, DebugDataT, StateT: StateRef> {
+    pub debug: Option<DebugContext<'evm, ChainSpecT, BlockchainErrorT, DebugDataT, StateT>>,
     pub state: StateT,
 }
 

--- a/crates/edr_evm/src/debug_trace.rs
+++ b/crates/edr_evm/src/debug_trace.rs
@@ -24,7 +24,7 @@ use crate::{
     debug::GetContextData,
     state::SyncState,
     trace::{register_trace_collector_handles, Trace, TraceCollector},
-    TransactionError,
+    transaction::TransactionError,
 };
 
 /// EIP-3155 and raw tracers.

--- a/crates/edr_evm/src/debug_trace.rs
+++ b/crates/edr_evm/src/debug_trace.rs
@@ -71,8 +71,8 @@ pub fn register_eip_3155_and_raw_tracers_handles<
 /// Get trace output for `debug_traceTransaction`
 #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
 #[allow(clippy::too_many_arguments)]
-pub fn debug_trace_transaction<BlockchainErrorT, StateErrorT>(
-    blockchain: &dyn SyncBlockchain<BlockchainErrorT, StateErrorT>,
+pub fn debug_trace_transaction<ChainSpecT, BlockchainErrorT, StateErrorT>(
+    blockchain: &dyn SyncBlockchain<ChainSpecT, BlockchainErrorT, StateErrorT>,
     // Take ownership of the state so that we can apply throw-away modifications on it
     mut state: Box<dyn SyncState<StateErrorT>>,
     evm_config: CfgEnvWithHandlerCfg,

--- a/crates/edr_evm/src/lib.rs
+++ b/crates/edr_evm/src/lib.rs
@@ -20,7 +20,6 @@ pub use crate::{
     miner::*,
     random::RandomHashGenerator,
     runtime::{dry_run, guaranteed_dry_run, run, SyncDatabase},
-    transaction::*,
 };
 
 /// Types for managing Ethereum blockchain

--- a/crates/edr_evm/src/miner.rs
+++ b/crates/edr_evm/src/miner.rs
@@ -90,6 +90,8 @@ pub enum MineBlockError<BE, SE> {
 
 /// Mines a block using as many transactions as can fit in it.
 #[allow(clippy::too_many_arguments)]
+// `DebugContext` cannot be simplified further
+#[allow(clippy::type_complexity)]
 #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
 pub fn mine_block<'blockchain, 'evm, BlockchainErrorT, DebugDataT, StateErrorT>(
     blockchain: &'blockchain dyn SyncBlockchain<L1ChainSpec, BlockchainErrorT, StateErrorT>,
@@ -274,6 +276,8 @@ pub enum MineTransactionError<BlockchainErrorT, StateErrorT> {
 ///
 /// If the transaction is invalid, returns an error.
 #[allow(clippy::too_many_arguments)]
+// `DebugContext` cannot be simplified further
+#[allow(clippy::type_complexity)]
 #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
 pub fn mine_block_with_single_transaction<
     'blockchain,

--- a/crates/edr_evm/src/miner.rs
+++ b/crates/edr_evm/src/miner.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     block::BlockBuilderCreationError,
     blockchain::SyncBlockchain,
+    chain_spec::{ChainSpec, L1ChainSpec},
     debug::DebugContext,
     mempool::OrderedTransaction,
     state::{StateDiff, SyncState},
@@ -22,16 +23,16 @@ use crate::{
 
 /// The result of mining a block, after having been committed to the blockchain.
 #[derive(Debug)]
-pub struct MineBlockResult<BlockchainErrorT> {
+pub struct MineBlockResult<ChainSpecT, BlockchainErrorT> {
     /// Mined block
-    pub block: Arc<dyn SyncBlock<Error = BlockchainErrorT>>,
+    pub block: Arc<dyn SyncBlock<ChainSpecT, Error = BlockchainErrorT>>,
     /// Transaction results
     pub transaction_results: Vec<ExecutionResult>,
     /// Transaction traces
     pub transaction_traces: Vec<Trace>,
 }
 
-impl<BlockchainErrorT> Clone for MineBlockResult<BlockchainErrorT> {
+impl<BlockchainErrorT, ChainSpecT> Clone for MineBlockResult<ChainSpecT, BlockchainErrorT> {
     fn clone(&self) -> Self {
         Self {
             block: self.block.clone(),
@@ -43,9 +44,12 @@ impl<BlockchainErrorT> Clone for MineBlockResult<BlockchainErrorT> {
 
 /// The result of mining a block, including the state. This result needs to be
 /// inserted into the blockchain to be persistent.
-pub struct MineBlockResultAndState<StateErrorT> {
+pub struct MineBlockResultAndState<ChainSpecT, StateErrorT>
+where
+    ChainSpecT: ChainSpec,
+{
     /// Mined block
-    pub block: LocalBlock,
+    pub block: LocalBlock<ChainSpecT>,
     /// State after mining the block
     pub state: Box<dyn SyncState<StateErrorT>>,
     /// State diff applied by block
@@ -88,7 +92,7 @@ pub enum MineBlockError<BE, SE> {
 #[allow(clippy::too_many_arguments)]
 #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
 pub fn mine_block<'blockchain, 'evm, BlockchainErrorT, DebugDataT, StateErrorT>(
-    blockchain: &'blockchain dyn SyncBlockchain<BlockchainErrorT, StateErrorT>,
+    blockchain: &'blockchain dyn SyncBlockchain<L1ChainSpec, BlockchainErrorT, StateErrorT>,
     mut state: Box<dyn SyncState<StateErrorT>>,
     mem_pool: &MemPool,
     cfg: &CfgEnvWithHandlerCfg,
@@ -98,9 +102,18 @@ pub fn mine_block<'blockchain, 'evm, BlockchainErrorT, DebugDataT, StateErrorT>(
     reward: U256,
     dao_hardfork_activation_block: Option<u64>,
     mut debug_context: Option<
-        DebugContext<'evm, BlockchainErrorT, DebugDataT, Box<dyn SyncState<StateErrorT>>>,
+        DebugContext<
+            'evm,
+            L1ChainSpec,
+            BlockchainErrorT,
+            DebugDataT,
+            Box<dyn SyncState<StateErrorT>>,
+        >,
     >,
-) -> Result<MineBlockResultAndState<StateErrorT>, MineBlockError<BlockchainErrorT, StateErrorT>>
+) -> Result<
+    MineBlockResultAndState<L1ChainSpec, StateErrorT>,
+    MineBlockError<BlockchainErrorT, StateErrorT>,
+>
 where
     'blockchain: 'evm,
     BlockchainErrorT: Debug + Send,
@@ -269,7 +282,7 @@ pub fn mine_block_with_single_transaction<
     DebugDataT,
     StateErrorT,
 >(
-    blockchain: &'blockchain dyn SyncBlockchain<BlockchainErrorT, StateErrorT>,
+    blockchain: &'blockchain dyn SyncBlockchain<L1ChainSpec, BlockchainErrorT, StateErrorT>,
     state: Box<dyn SyncState<StateErrorT>>,
     transaction: transaction::Signed,
     cfg: &CfgEnvWithHandlerCfg,
@@ -278,9 +291,18 @@ pub fn mine_block_with_single_transaction<
     reward: U256,
     dao_hardfork_activation_block: Option<u64>,
     debug_context: Option<
-        DebugContext<'evm, BlockchainErrorT, DebugDataT, Box<dyn SyncState<StateErrorT>>>,
+        DebugContext<
+            'evm,
+            L1ChainSpec,
+            BlockchainErrorT,
+            DebugDataT,
+            Box<dyn SyncState<StateErrorT>>,
+        >,
     >,
-) -> Result<MineBlockResultAndState<StateErrorT>, MineTransactionError<BlockchainErrorT, StateErrorT>>
+) -> Result<
+    MineBlockResultAndState<L1ChainSpec, StateErrorT>,
+    MineTransactionError<BlockchainErrorT, StateErrorT>,
+>
 where
     'blockchain: 'evm,
     BlockchainErrorT: Debug + Send,

--- a/crates/edr_evm/src/runtime.rs
+++ b/crates/edr_evm/src/runtime.rs
@@ -25,6 +25,8 @@ pub type SyncDatabase<'blockchain, 'state, ChainSpecT, BlockchainErrorT, StateEr
     >;
 
 /// Runs a transaction without committing the state.
+// `DebugContext` cannot be simplified further
+#[allow(clippy::type_complexity)]
 #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
 pub fn dry_run<'blockchain, 'evm, 'overrides, 'state, DebugDataT, BlockchainErrorT, StateErrorT>(
     blockchain: &'blockchain dyn SyncBlockchain<L1ChainSpec, BlockchainErrorT, StateErrorT>,
@@ -79,6 +81,8 @@ where
 
 /// Runs a transaction without committing the state, while disabling balance
 /// checks and creating accounts for new addresses.
+// `DebugContext` cannot be simplified further
+#[allow(clippy::type_complexity)]
 #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
 pub fn guaranteed_dry_run<
     'blockchain,

--- a/crates/edr_evm/src/runtime.rs
+++ b/crates/edr_evm/src/runtime.rs
@@ -11,21 +11,23 @@ use revm::{
 
 use crate::{
     blockchain::SyncBlockchain,
+    chain_spec::L1ChainSpec,
     debug::DebugContext,
     state::{StateOverrides, StateRefOverrider, SyncState},
     transaction::TransactionError,
 };
 
 /// Asynchronous implementation of the Database super-trait
-pub type SyncDatabase<'blockchain, 'state, BlockchainErrorT, StateErrorT> = DatabaseComponents<
-    &'state dyn StateRef<Error = StateErrorT>,
-    &'blockchain dyn SyncBlockchain<BlockchainErrorT, StateErrorT>,
->;
+pub type SyncDatabase<'blockchain, 'state, ChainSpecT, BlockchainErrorT, StateErrorT> =
+    DatabaseComponents<
+        &'state dyn StateRef<Error = StateErrorT>,
+        &'blockchain dyn SyncBlockchain<ChainSpecT, BlockchainErrorT, StateErrorT>,
+    >;
 
 /// Runs a transaction without committing the state.
 #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
 pub fn dry_run<'blockchain, 'evm, 'overrides, 'state, DebugDataT, BlockchainErrorT, StateErrorT>(
-    blockchain: &'blockchain dyn SyncBlockchain<BlockchainErrorT, StateErrorT>,
+    blockchain: &'blockchain dyn SyncBlockchain<L1ChainSpec, BlockchainErrorT, StateErrorT>,
     state: &'state dyn SyncState<StateErrorT>,
     state_overrides: &'overrides StateOverrides,
     cfg: CfgEnvWithHandlerCfg,
@@ -34,6 +36,7 @@ pub fn dry_run<'blockchain, 'evm, 'overrides, 'state, DebugDataT, BlockchainErro
     debug_context: Option<
         DebugContext<
             'evm,
+            L1ChainSpec,
             BlockchainErrorT,
             DebugDataT,
             StateRefOverrider<'overrides, &'evm dyn SyncState<StateErrorT>>,
@@ -86,7 +89,7 @@ pub fn guaranteed_dry_run<
     BlockchainErrorT,
     StateErrorT,
 >(
-    blockchain: &'blockchain dyn SyncBlockchain<BlockchainErrorT, StateErrorT>,
+    blockchain: &'blockchain dyn SyncBlockchain<L1ChainSpec, BlockchainErrorT, StateErrorT>,
     state: &'state dyn SyncState<StateErrorT>,
     state_overrides: &'overrides StateOverrides,
     mut cfg: CfgEnvWithHandlerCfg,
@@ -95,6 +98,7 @@ pub fn guaranteed_dry_run<
     debug_context: Option<
         DebugContext<
             'evm,
+            L1ChainSpec,
             BlockchainErrorT,
             DebugDataT,
             StateRefOverrider<'overrides, &'evm dyn SyncState<StateErrorT>>,
@@ -124,12 +128,12 @@ where
 /// Runs a transaction, committing the state in the process.
 #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
 pub fn run<'blockchain, 'evm, BlockchainErrorT, DebugDataT, StateT>(
-    blockchain: &'blockchain dyn SyncBlockchain<BlockchainErrorT, StateT::Error>,
+    blockchain: &'blockchain dyn SyncBlockchain<L1ChainSpec, BlockchainErrorT, StateT::Error>,
     state: StateT,
     cfg: CfgEnvWithHandlerCfg,
     transaction: TxEnv,
     block: BlockEnv,
-    debug_context: Option<DebugContext<'evm, BlockchainErrorT, DebugDataT, StateT>>,
+    debug_context: Option<DebugContext<'evm, L1ChainSpec, BlockchainErrorT, DebugDataT, StateT>>,
 ) -> Result<ExecutionResult, TransactionError<BlockchainErrorT, StateT::Error>>
 where
     'blockchain: 'evm,

--- a/crates/edr_evm/src/state/fork.rs
+++ b/crates/edr_evm/src/state/fork.rs
@@ -1,10 +1,7 @@
 use std::sync::Arc;
 
 use edr_eth::{trie::KECCAK_NULL_RLP, Address, B256, U256};
-use edr_rpc_eth::{
-    client::EthRpcClient,
-    spec::{EthRpcSpec, RpcSpec},
-};
+use edr_rpc_eth::{client::EthRpcClient, spec::RpcSpec};
 use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};
 use revm::{
     db::components::{State, StateRef},
@@ -234,11 +231,12 @@ mod tests {
     use edr_test_utils::env::get_alchemy_url;
 
     use super::*;
+    use crate::chain_spec::L1ChainSpec;
 
     const FORK_BLOCK: u64 = 16220843;
 
     struct TestForkState {
-        fork_state: ForkState<EthRpcSpec>,
+        fork_state: ForkState<L1ChainSpec>,
         // We need to keep it around as long as the fork state is alive
         _tempdir: tempfile::TempDir,
     }
@@ -255,7 +253,7 @@ mod tests {
             let tempdir = tempfile::tempdir().expect("can create tempdir");
 
             let runtime = runtime::Handle::current();
-            let rpc_client = EthRpcClient::<EthRpcSpec>::new(
+            let rpc_client = EthRpcClient::<L1ChainSpec>::new(
                 &get_alchemy_url(),
                 tempdir.path().to_path_buf(),
                 None,
@@ -284,7 +282,7 @@ mod tests {
     }
 
     impl Deref for TestForkState {
-        type Target = ForkState<EthRpcSpec>;
+        type Target = ForkState<L1ChainSpec>;
 
         fn deref(&self) -> &Self::Target {
             &self.fork_state

--- a/crates/edr_evm/src/state/remote.rs
+++ b/crates/edr_evm/src/state/remote.rs
@@ -6,7 +6,7 @@ pub use cached::CachedRemoteState;
 use edr_eth::{Address, BlockSpec, PreEip1898BlockSpec, B256, U256};
 use edr_rpc_eth::{
     client::{EthRpcClient, RpcClientError},
-    spec::EthRpcSpec,
+    spec::RpcSpec,
 };
 use revm::{
     db::StateRef,
@@ -18,18 +18,18 @@ use super::StateError;
 
 /// A state backed by a remote Ethereum node
 #[derive(Debug)]
-pub struct RemoteState {
-    client: Arc<EthRpcClient<EthRpcSpec>>,
+pub struct RemoteState<ChainSpecT: RpcSpec> {
+    client: Arc<EthRpcClient<ChainSpecT>>,
     runtime: runtime::Handle,
     block_number: u64,
 }
 
-impl RemoteState {
+impl<ChainSpecT: RpcSpec> RemoteState<ChainSpecT> {
     /// Construct a new instance using an RPC client for a remote Ethereum node
     /// and a block number from which data will be pulled.
     pub fn new(
         runtime: runtime::Handle,
-        client: Arc<EthRpcClient<EthRpcSpec>>,
+        client: Arc<EthRpcClient<ChainSpecT>>,
         block_number: u64,
     ) -> Self {
         Self {
@@ -69,7 +69,7 @@ impl RemoteState {
     }
 }
 
-impl StateRef for RemoteState {
+impl<ChainSpecT: RpcSpec> StateRef for RemoteState<ChainSpecT> {
     type Error = StateError;
 
     #[cfg_attr(feature = "tracing", tracing::instrument(level = "trace", skip(self)))]
@@ -108,6 +108,7 @@ impl StateRef for RemoteState {
 mod tests {
     use std::str::FromStr;
 
+    use edr_rpc_eth::spec::EthRpcSpec;
     use tokio::runtime;
 
     use super::*;

--- a/crates/edr_evm/src/state/remote.rs
+++ b/crates/edr_evm/src/state/remote.rs
@@ -15,6 +15,7 @@ use revm::{
 use tokio::runtime;
 
 use super::StateError;
+use crate::{chain_spec::ChainSpec, EthRpcBlock as _};
 
 /// A state backed by a remote Ethereum node
 #[derive(Debug)]
@@ -56,7 +57,9 @@ impl<ChainSpecT: RpcSpec> RemoteState<ChainSpecT> {
     pub fn set_block_number(&mut self, block_number: u64) {
         self.block_number = block_number;
     }
+}
 
+impl<ChainSpecT: ChainSpec> RemoteState<ChainSpecT> {
     /// Retrieve the state root of the given block, if it exists.
     pub fn state_root(&self, block_number: u64) -> Result<Option<B256>, RpcClientError> {
         Ok(tokio::task::block_in_place(move || {
@@ -65,7 +68,7 @@ impl<ChainSpecT: RpcSpec> RemoteState<ChainSpecT> {
                     .get_block_by_number(PreEip1898BlockSpec::Number(block_number)),
             )
         })?
-        .map(|block| block.state_root))
+        .map(|block| *block.state_root()))
     }
 }
 

--- a/crates/edr_evm/src/state/remote/cached.rs
+++ b/crates/edr_evm/src/state/remote/cached.rs
@@ -1,4 +1,5 @@
 use edr_eth::{Address, B256, U256};
+use edr_rpc_eth::spec::RpcSpec;
 use revm::{
     db::components::{State, StateRef},
     primitives::{hash_map::Entry, AccountInfo, Bytecode, HashMap},
@@ -9,17 +10,17 @@ use crate::state::{account::EdrAccount, StateError};
 
 /// A cached version of [`RemoteState`].
 #[derive(Debug)]
-pub struct CachedRemoteState {
-    remote: RemoteState,
+pub struct CachedRemoteState<ChainSpecT: RpcSpec> {
+    remote: RemoteState<ChainSpecT>,
     /// Mapping of block numbers to cached accounts
     account_cache: HashMap<u64, HashMap<Address, EdrAccount>>,
     /// Mapping of block numbers to cached code
     code_cache: HashMap<u64, HashMap<B256, Bytecode>>,
 }
 
-impl CachedRemoteState {
+impl<ChainSpecT: RpcSpec> CachedRemoteState<ChainSpecT> {
     /// Constructs a new [`CachedRemoteState`].
-    pub fn new(remote: RemoteState) -> Self {
+    pub fn new(remote: RemoteState<ChainSpecT>) -> Self {
         Self {
             remote,
             account_cache: HashMap::new(),
@@ -28,7 +29,7 @@ impl CachedRemoteState {
     }
 }
 
-impl State for CachedRemoteState {
+impl<ChainSpecT: RpcSpec> State for CachedRemoteState<ChainSpecT> {
     type Error = StateError;
 
     fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {

--- a/crates/edr_evm/src/test_utils.rs
+++ b/crates/edr_evm/src/test_utils.rs
@@ -4,7 +4,7 @@ use edr_eth::{transaction::TxKind, AccountInfo, Address, Bytes, HashMap, SpecId,
 
 use crate::{
     state::{AccountTrie, StateError, TrieState},
-    transaction, MemPool, MemPoolAddTransactionError, TransactionCreationError,
+    transaction, MemPool, MemPoolAddTransactionError,
 };
 
 /// A test fixture for `MemPool`.
@@ -52,7 +52,7 @@ impl MemPoolTestFixture {
 pub fn dummy_eip155_transaction(
     caller: Address,
     nonce: u64,
-) -> Result<transaction::Signed, TransactionCreationError> {
+) -> Result<transaction::Signed, transaction::CreationError> {
     dummy_eip155_transaction_with_price(caller, nonce, U256::ZERO)
 }
 
@@ -61,7 +61,7 @@ pub fn dummy_eip155_transaction_with_price(
     caller: Address,
     nonce: u64,
     gas_price: U256,
-) -> Result<transaction::Signed, TransactionCreationError> {
+) -> Result<transaction::Signed, transaction::CreationError> {
     dummy_eip155_transaction_with_price_and_limit(caller, nonce, gas_price, 30_000)
 }
 
@@ -70,7 +70,7 @@ pub fn dummy_eip155_transaction_with_limit(
     caller: Address,
     nonce: u64,
     gas_limit: u64,
-) -> Result<transaction::Signed, TransactionCreationError> {
+) -> Result<transaction::Signed, transaction::CreationError> {
     dummy_eip155_transaction_with_price_and_limit(caller, nonce, U256::ZERO, gas_limit)
 }
 
@@ -79,7 +79,7 @@ fn dummy_eip155_transaction_with_price_and_limit(
     nonce: u64,
     gas_price: U256,
     gas_limit: u64,
-) -> Result<transaction::Signed, TransactionCreationError> {
+) -> Result<transaction::Signed, transaction::CreationError> {
     dummy_eip155_transaction_with_price_limit_and_value(
         caller,
         nonce,
@@ -97,7 +97,7 @@ pub fn dummy_eip155_transaction_with_price_limit_and_value(
     gas_price: U256,
     gas_limit: u64,
     value: U256,
-) -> Result<transaction::Signed, TransactionCreationError> {
+) -> Result<transaction::Signed, transaction::CreationError> {
     let from = Address::random();
     let request = transaction::request::Eip155 {
         nonce,
@@ -121,7 +121,7 @@ pub fn dummy_eip1559_transaction(
     nonce: u64,
     max_fee_per_gas: U256,
     max_priority_fee_per_gas: U256,
-) -> Result<transaction::Signed, TransactionCreationError> {
+) -> Result<transaction::Signed, transaction::CreationError> {
     let from = Address::random();
     let request = transaction::request::Eip1559 {
         chain_id: 123,

--- a/crates/edr_evm/src/transaction/detailed.rs
+++ b/crates/edr_evm/src/transaction/detailed.rs
@@ -1,11 +1,13 @@
 use std::sync::Arc;
 
-use edr_eth::{receipt::BlockReceipt, transaction};
+use edr_eth::receipt::BlockReceipt;
+
+use crate::chain_spec::ChainSpec;
 
 /// Wrapper struct for a transaction and its receipt.
-pub struct DetailedTransaction<'t> {
+pub struct DetailedTransaction<'transaction, ChainSpecT: ChainSpec> {
     /// The transaction
-    pub transaction: &'t transaction::Signed,
+    pub transaction: &'transaction ChainSpecT::SignedTransaction,
     /// The transaction's receipt
-    pub receipt: &'t Arc<BlockReceipt>,
+    pub receipt: &'transaction Arc<BlockReceipt>,
 }

--- a/crates/edr_evm/src/transaction/remote.rs
+++ b/crates/edr_evm/src/transaction/remote.rs
@@ -1,0 +1,14 @@
+use edr_eth::B256;
+
+/// Trait for retrieving information from an Ethereum JSON-RPC transaction.
+pub trait EthRpcTransaction {
+    /// Returns the hash of the finalised block associated with the transaction.
+    /// If the transaction is pending, returns `None`.
+    fn block_hash(&self) -> Option<&B256>;
+}
+
+impl EthRpcTransaction for edr_rpc_eth::Transaction {
+    fn block_hash(&self) -> Option<&B256> {
+        self.block_hash.as_ref()
+    }
+}

--- a/crates/edr_evm/tests/blockchain.rs
+++ b/crates/edr_evm/tests/blockchain.rs
@@ -147,7 +147,7 @@ fn create_dummy_block_with_header(spec_id: SpecId, partial_header: PartialHeader
 }
 
 struct DummyBlockAndTransaction {
-    block: Arc<dyn SyncBlock<Error = BlockchainError>>,
+    block: Arc<dyn SyncBlock<ChainSpecT, Error = BlockchainError>>,
     transaction_hash: B256,
     transaction_receipt: TransactionReceipt<Log>,
 }

--- a/crates/edr_evm/tests/issues.rs
+++ b/crates/edr_evm/tests/issues.rs
@@ -6,11 +6,12 @@ use edr_defaults::CACHE_DIR;
 use edr_eth::{Address, HashMap, SpecId, U256};
 use edr_evm::{
     blockchain::ForkedBlockchain,
+    chain_spec::L1ChainSpec,
     precompile::{self, Precompiles},
     state::{AccountModifierFn, ForkState, IrregularState, StateDebug},
     RandomHashGenerator,
 };
-use edr_rpc_eth::{client::EthRpcClient, spec::EthRpcSpec};
+use edr_rpc_eth::client::EthRpcClient;
 use edr_test_utils::env::get_alchemy_url;
 use parking_lot::Mutex;
 use tokio::runtime;
@@ -22,7 +23,7 @@ async fn issue_336_set_balance_after_forking() -> anyhow::Result<()> {
 
     let contract_address = Address::from_str(TEST_CONTRACT_ADDRESS).unwrap();
 
-    let rpc_client = EthRpcClient::<EthRpcSpec>::new(
+    let rpc_client = EthRpcClient::<L1ChainSpec>::new(
         &get_alchemy_url().replace("mainnet", "sepolia"),
         CACHE_DIR.into(),
         None,
@@ -54,7 +55,7 @@ async fn issue_hh_4974_forking_avalanche_c_chain() -> anyhow::Result<()> {
     const FORK_BLOCK_NUMBER: u64 = 12_508_443;
 
     let url = "https://coston-api.flare.network/ext/bc/C/rpc";
-    let rpc_client = EthRpcClient::<EthRpcSpec>::new(url, CACHE_DIR.into(), None)?;
+    let rpc_client = EthRpcClient::<L1ChainSpec>::new(url, CACHE_DIR.into(), None)?;
     let mut irregular_state = IrregularState::default();
     let state_root_generator = Arc::new(Mutex::new(RandomHashGenerator::with_seed("test")));
     let hardfork_activation_overrides = HashMap::new();

--- a/crates/edr_evm/tests/optimism.rs
+++ b/crates/edr_evm/tests/optimism.rs
@@ -6,10 +6,11 @@ use edr_defaults::CACHE_DIR;
 use edr_eth::{HashMap, SpecId};
 use edr_evm::{
     blockchain::{Blockchain, ForkedBlockchain},
+    chain_spec::L1ChainSpec,
     state::IrregularState,
     RandomHashGenerator,
 };
-use edr_rpc_eth::{client::EthRpcClient, spec::EthRpcSpec};
+use edr_rpc_eth::client::EthRpcClient;
 use edr_test_utils::env::get_alchemy_url;
 use parking_lot::Mutex;
 use tokio::runtime;
@@ -19,7 +20,9 @@ async fn unknown_transaction_types() -> anyhow::Result<()> {
     const BLOCK_NUMBER_WITH_TRANSACTIONS: u64 = 117_156_000;
 
     let url = get_alchemy_url().replace("eth-", "opt-");
-    let rpc_client = EthRpcClient::<EthRpcSpec>::new(&url, CACHE_DIR.into(), None)?;
+    // TODO: https://github.com/NomicFoundation/edr/issues/512
+    // Change the spec to `OptimismChainSpec` once it's implemented
+    let rpc_client = EthRpcClient::<L1ChainSpec>::new(&url, CACHE_DIR.into(), None)?;
     let mut irregular_state = IrregularState::default();
     let state_root_generator = Arc::new(Mutex::new(RandomHashGenerator::with_seed("test")));
     let hardfork_activation_overrides = HashMap::new();

--- a/crates/edr_napi/src/logger.rs
+++ b/crates/edr_napi/src/logger.rs
@@ -7,9 +7,11 @@ use edr_eth::{
 };
 use edr_evm::{
     blockchain::BlockchainError,
+    chain_spec::L1ChainSpec,
     precompile::{self, Precompiles},
     trace::{AfterMessage, TraceMessage},
-    ExecutionResult, SignedTransaction as _, SyncBlock,
+    transaction::SignedTransaction as _,
+    ExecutionResult, SyncBlock,
 };
 use edr_provider::{ProviderError, TransactionFailure};
 use itertools::izip;
@@ -688,20 +690,20 @@ impl LogCollector {
         self.log_empty_line();
     }
 
-    fn log_block_hash(&mut self, block: &dyn SyncBlock<ChainSpecT, Error = BlockchainError>) {
+    fn log_block_hash(&mut self, block: &dyn SyncBlock<L1ChainSpec, Error = BlockchainError>) {
         let block_hash = block.hash();
 
         self.log(format!("Block: {block_hash}"));
     }
 
-    fn log_block_id(&mut self, block: &dyn SyncBlock<ChainSpecT, Error = BlockchainError>) {
+    fn log_block_id(&mut self, block: &dyn SyncBlock<L1ChainSpec, Error = BlockchainError>) {
         let block_number = block.header().number;
         let block_hash = block.hash();
 
         self.log(format!("Block #{block_number}: {block_hash}"));
     }
 
-    fn log_block_number(&mut self, block: &dyn SyncBlock<ChainSpecT, Error = BlockchainError>) {
+    fn log_block_number(&mut self, block: &dyn SyncBlock<L1ChainSpec, Error = BlockchainError>) {
         let block_number = block.header().number;
 
         self.log(format!("Mined block #{block_number}"));
@@ -884,7 +886,7 @@ impl LogCollector {
         }
     }
 
-    fn log_empty_block(&mut self, block: &dyn SyncBlock<ChainSpecT, Error = BlockchainError>) {
+    fn log_empty_block(&mut self, block: &dyn SyncBlock<L1ChainSpec, Error = BlockchainError>) {
         let block_header = block.header();
         let block_number = block_header.number;
 
@@ -909,7 +911,7 @@ impl LogCollector {
 
     fn log_hardhat_mined_empty_block(
         &mut self,
-        block: &dyn SyncBlock<ChainSpecT, Error = BlockchainError>,
+        block: &dyn SyncBlock<L1ChainSpec, Error = BlockchainError>,
         empty_blocks_range_start: Option<u64>,
     ) {
         self.indented(|logger| {

--- a/crates/edr_napi/src/logger.rs
+++ b/crates/edr_napi/src/logger.rs
@@ -688,20 +688,20 @@ impl LogCollector {
         self.log_empty_line();
     }
 
-    fn log_block_hash(&mut self, block: &dyn SyncBlock<Error = BlockchainError>) {
+    fn log_block_hash(&mut self, block: &dyn SyncBlock<ChainSpecT, Error = BlockchainError>) {
         let block_hash = block.hash();
 
         self.log(format!("Block: {block_hash}"));
     }
 
-    fn log_block_id(&mut self, block: &dyn SyncBlock<Error = BlockchainError>) {
+    fn log_block_id(&mut self, block: &dyn SyncBlock<ChainSpecT, Error = BlockchainError>) {
         let block_number = block.header().number;
         let block_hash = block.hash();
 
         self.log(format!("Block #{block_number}: {block_hash}"));
     }
 
-    fn log_block_number(&mut self, block: &dyn SyncBlock<Error = BlockchainError>) {
+    fn log_block_number(&mut self, block: &dyn SyncBlock<ChainSpecT, Error = BlockchainError>) {
         let block_number = block.header().number;
 
         self.log(format!("Mined block #{block_number}"));
@@ -884,7 +884,7 @@ impl LogCollector {
         }
     }
 
-    fn log_empty_block(&mut self, block: &dyn SyncBlock<Error = BlockchainError>) {
+    fn log_empty_block(&mut self, block: &dyn SyncBlock<ChainSpecT, Error = BlockchainError>) {
         let block_header = block.header();
         let block_number = block_header.number;
 
@@ -909,7 +909,7 @@ impl LogCollector {
 
     fn log_hardhat_mined_empty_block(
         &mut self,
-        block: &dyn SyncBlock<Error = BlockchainError>,
+        block: &dyn SyncBlock<ChainSpecT, Error = BlockchainError>,
         empty_blocks_range_start: Option<u64>,
     ) {
         self.indented(|logger| {

--- a/crates/edr_provider/src/data.rs
+++ b/crates/edr_provider/src/data.rs
@@ -385,7 +385,7 @@ impl<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch> ProviderData<LoggerErr
     /// Returns the last block in the blockchain.
     pub fn last_block(
         &self,
-    ) -> Result<Arc<dyn SyncBlock<Error = BlockchainError>>, BlockchainError> {
+    ) -> Result<Arc<dyn SyncBlock<ChainSpecT, Error = BlockchainError>>, BlockchainError> {
         self.blockchain.last_block()
     }
 
@@ -465,8 +465,10 @@ impl<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch> ProviderData<LoggerErr
     pub fn block_by_block_spec(
         &self,
         block_spec: &BlockSpec,
-    ) -> Result<Option<Arc<dyn SyncBlock<Error = BlockchainError>>>, ProviderError<LoggerErrorT>>
-    {
+    ) -> Result<
+        Option<Arc<dyn SyncBlock<ChainSpecT, Error = BlockchainError>>>,
+        ProviderError<LoggerErrorT>,
+    > {
         let result = match block_spec {
             BlockSpec::Number(block_number) => Some(
                 self.blockchain
@@ -557,8 +559,10 @@ impl<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch> ProviderData<LoggerErr
     pub fn block_by_hash(
         &self,
         block_hash: &B256,
-    ) -> Result<Option<Arc<dyn SyncBlock<Error = BlockchainError>>>, ProviderError<LoggerErrorT>>
-    {
+    ) -> Result<
+        Option<Arc<dyn SyncBlock<ChainSpecT, Error = BlockchainError>>>,
+        ProviderError<LoggerErrorT>,
+    > {
         self.blockchain
             .block_by_hash(block_hash)
             .map_err(ProviderError::Blockchain)
@@ -1911,7 +1915,7 @@ impl<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch> ProviderData<LoggerErr
         block_spec: Option<&BlockSpec>,
         function: impl FnOnce(
             &dyn SyncBlockchain<BlockchainError, StateError>,
-            &Arc<dyn SyncBlock<Error = BlockchainError>>,
+            &Arc<dyn SyncBlock<ChainSpecT, Error = BlockchainError>>,
             &Box<dyn SyncState<StateError>>,
         ) -> T,
     ) -> Result<T, ProviderError<LoggerErrorT>> {
@@ -2569,7 +2573,7 @@ pub struct TransactionAndBlock {
 /// Block metadata for a transaction.
 #[derive(Debug, Clone)]
 pub struct BlockDataForTransaction {
-    pub block: Arc<dyn SyncBlock<Error = BlockchainError>>,
+    pub block: Arc<dyn SyncBlock<ChainSpecT, Error = BlockchainError>>,
     pub transaction_index: u64,
 }
 

--- a/crates/edr_provider/src/data/call.rs
+++ b/crates/edr_provider/src/data/call.rs
@@ -6,6 +6,7 @@ use edr_eth::{
 };
 use edr_evm::{
     blockchain::{BlockchainError, SyncBlockchain},
+    chain_spec::L1ChainSpec,
     guaranteed_dry_run,
     state::{StateError, StateOverrides, StateRefOverrider, SyncState},
     BlobExcessGasAndPrice, BlockEnv, CfgEnvWithHandlerCfg, DebugContext, ExecutionResult, TxEnv,
@@ -17,15 +18,18 @@ pub(super) struct RunCallArgs<'a, 'evm, DebugDataT>
 where
     'a: 'evm,
 {
-    pub blockchain: &'a dyn SyncBlockchain<BlockchainError, StateError>,
+    pub blockchain: &'a dyn SyncBlockchain<L1ChainSpec, BlockchainError, StateError>,
     pub header: &'a Header,
     pub state: &'a dyn SyncState<StateError>,
     pub state_overrides: &'a StateOverrides,
     pub cfg_env: CfgEnvWithHandlerCfg,
     pub tx_env: TxEnv,
+    // `DebugContext` cannot be simplified further
+    #[allow(clippy::type_complexity)]
     pub debug_context: Option<
         DebugContext<
             'evm,
+            L1ChainSpec,
             BlockchainError,
             DebugDataT,
             StateRefOverrider<'a, &'evm dyn SyncState<StateError>>,

--- a/crates/edr_provider/src/data/gas.rs
+++ b/crates/edr_provider/src/data/gas.rs
@@ -4,6 +4,7 @@ use std::cmp;
 use edr_eth::{block::Header, reward_percentile::RewardPercentile, transaction::Transaction, U256};
 use edr_evm::{
     blockchain::{BlockchainError, SyncBlockchain},
+    chain_spec::L1ChainSpec,
     state::{StateError, StateOverrides, SyncState},
     trace::{register_trace_collector_handles, TraceCollector},
     CfgEnvWithHandlerCfg, DebugContext, ExecutionResult, SyncBlock, TxEnv,
@@ -16,7 +17,7 @@ use crate::{
 };
 
 pub(super) struct CheckGasLimitArgs<'a> {
-    pub blockchain: &'a dyn SyncBlockchain<BlockchainError, StateError>,
+    pub blockchain: &'a dyn SyncBlockchain<L1ChainSpec, BlockchainError, StateError>,
     pub header: &'a Header,
     pub state: &'a dyn SyncState<StateError>,
     pub state_overrides: &'a StateOverrides,
@@ -62,7 +63,7 @@ pub(super) fn check_gas_limit<LoggerErrorT: Debug>(
 }
 
 pub(super) struct BinarySearchEstimationArgs<'a> {
-    pub blockchain: &'a dyn SyncBlockchain<BlockchainError, StateError>,
+    pub blockchain: &'a dyn SyncBlockchain<L1ChainSpec, BlockchainError, StateError>,
     pub header: &'a Header,
     pub state: &'a dyn SyncState<StateError>,
     pub state_overrides: &'a StateOverrides,
@@ -147,7 +148,7 @@ fn min_difference(lower_bound: u64) -> u64 {
 
 /// Compute miner rewards for percentiles.
 pub(super) fn compute_rewards<LoggerErrorT: Debug>(
-    block: &dyn SyncBlock<ChainSpecT, Error = BlockchainError>,
+    block: &dyn SyncBlock<L1ChainSpec, Error = BlockchainError>,
     reward_percentiles: &[RewardPercentile],
 ) -> Result<Vec<U256>, ProviderError<LoggerErrorT>> {
     if block.transactions().is_empty() {

--- a/crates/edr_provider/src/data/gas.rs
+++ b/crates/edr_provider/src/data/gas.rs
@@ -147,7 +147,7 @@ fn min_difference(lower_bound: u64) -> u64 {
 
 /// Compute miner rewards for percentiles.
 pub(super) fn compute_rewards<LoggerErrorT: Debug>(
-    block: &dyn SyncBlock<Error = BlockchainError>,
+    block: &dyn SyncBlock<ChainSpecT, Error = BlockchainError>,
     reward_percentiles: &[RewardPercentile],
 ) -> Result<Vec<U256>, ProviderError<LoggerErrorT>> {
     if block.transactions().is_empty() {

--- a/crates/edr_provider/src/debug_mine.rs
+++ b/crates/edr_provider/src/debug_mine.rs
@@ -49,7 +49,7 @@ impl<StateErrorT> DebugMineBlockResultAndState<StateErrorT> {
 #[derive(Debug)]
 pub struct DebugMineBlockResult<BlockchainErrorT> {
     /// Mined block
-    pub block: Arc<dyn SyncBlock<Error = BlockchainErrorT>>,
+    pub block: Arc<dyn SyncBlock<ChainSpecT, Error = BlockchainErrorT>>,
     /// Transaction results
     pub transaction_results: Vec<ExecutionResult>,
     /// Transaction traces

--- a/crates/edr_provider/src/debug_mine.rs
+++ b/crates/edr_provider/src/debug_mine.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use edr_eth::{transaction::Transaction, Bytes, B256};
 use edr_evm::{
+    chain_spec::L1ChainSpec,
     state::{StateDiff, SyncState},
     trace::Trace,
     ExecutionResult, LocalBlock, MineBlockResultAndState, SyncBlock,
@@ -12,7 +13,7 @@ use edr_evm::{
 /// result needs to be inserted into the blockchain to be persistent.
 pub struct DebugMineBlockResultAndState<StateErrorT> {
     /// Mined block
-    pub block: LocalBlock,
+    pub block: LocalBlock<L1ChainSpec>,
     /// State after mining the block
     pub state: Box<dyn SyncState<StateErrorT>>,
     /// State diff applied by block
@@ -29,7 +30,7 @@ impl<StateErrorT> DebugMineBlockResultAndState<StateErrorT> {
     /// Constructs a new instance from a [`MineBlockResultAndState`],
     /// transaction traces, and decoded console log messages.
     pub fn new(
-        result: MineBlockResultAndState<StateErrorT>,
+        result: MineBlockResultAndState<L1ChainSpec, StateErrorT>,
         transaction_traces: Vec<Trace>,
         console_log_decoded_messages: Vec<Bytes>,
     ) -> Self {
@@ -49,7 +50,7 @@ impl<StateErrorT> DebugMineBlockResultAndState<StateErrorT> {
 #[derive(Debug)]
 pub struct DebugMineBlockResult<BlockchainErrorT> {
     /// Mined block
-    pub block: Arc<dyn SyncBlock<ChainSpecT, Error = BlockchainErrorT>>,
+    pub block: Arc<dyn SyncBlock<L1ChainSpec, Error = BlockchainErrorT>>,
     /// Transaction results
     pub transaction_results: Vec<ExecutionResult>,
     /// Transaction traces

--- a/crates/edr_provider/src/error.rs
+++ b/crates/edr_provider/src/error.rs
@@ -8,8 +8,9 @@ use edr_evm::{
     hex,
     state::{AccountOverrideConversionError, StateError},
     trace::Trace,
+    transaction::{self, TransactionError},
     DebugTraceError, ExecutionResult, HaltReason, MemPoolAddTransactionError, MineBlockError,
-    MineTransactionError, OutOfGasError, TransactionCreationError, TransactionError,
+    MineTransactionError, OutOfGasError,
 };
 use edr_rpc_eth::{client::RpcClientError, jsonrpc};
 
@@ -169,7 +170,7 @@ pub enum ProviderError<LoggerErrorT> {
     TimestampEqualsPrevious { proposed: u64 },
     /// An error occurred while creating a pending transaction.
     #[error(transparent)]
-    TransactionCreationError(#[from] TransactionCreationError),
+    TransactionCreationError(#[from] transaction::CreationError),
     /// `eth_sendTransaction` failed and
     /// [`crate::config::ProviderConfig::bail_on_call_failure`] was enabled
     #[error(transparent)]

--- a/crates/edr_provider/src/pending.rs
+++ b/crates/edr_provider/src/pending.rs
@@ -1,8 +1,9 @@
 use std::{collections::BTreeMap, sync::Arc};
 
-use edr_eth::{receipt::BlockReceipt, transaction::Transaction, SpecId, B256, U256};
+use edr_eth::{receipt::BlockReceipt, transaction::Transaction as _, SpecId, B256, U256};
 use edr_evm::{
     blockchain::{Blockchain, BlockchainError, BlockchainMut, SyncBlockchain},
+    chain_spec::L1ChainSpec,
     db::BlockHashRef,
     state::{StateDiff, StateError, StateOverride, SyncState},
     BlockAndTotalDifficulty, LocalBlock, SyncBlock,
@@ -20,8 +21,8 @@ use edr_evm::{
 /// <https://github.com/NomicFoundation/edr/issues/284>
 #[derive(Debug)]
 pub(crate) struct BlockchainWithPending<'blockchain> {
-    blockchain: &'blockchain dyn SyncBlockchain<BlockchainError, StateError>,
-    pending_block: Arc<dyn SyncBlock<ChainSpecT, Error = BlockchainError>>,
+    blockchain: &'blockchain dyn SyncBlockchain<L1ChainSpec, BlockchainError, StateError>,
+    pending_block: Arc<dyn SyncBlock<L1ChainSpec, Error = BlockchainError>>,
     pending_state_diff: StateDiff,
 }
 
@@ -29,8 +30,8 @@ impl<'blockchain> BlockchainWithPending<'blockchain> {
     /// Constructs a new instance with the provided blockchain and pending
     /// block.
     pub fn new(
-        blockchain: &'blockchain dyn SyncBlockchain<BlockchainError, StateError>,
-        pending_block: LocalBlock,
+        blockchain: &'blockchain dyn SyncBlockchain<L1ChainSpec, BlockchainError, StateError>,
+        pending_block: LocalBlock<L1ChainSpec>,
         pending_state_diff: StateDiff,
     ) -> Self {
         Self {
@@ -41,7 +42,7 @@ impl<'blockchain> BlockchainWithPending<'blockchain> {
     }
 }
 
-impl<'blockchain> Blockchain for BlockchainWithPending<'blockchain> {
+impl<'blockchain> Blockchain<L1ChainSpec> for BlockchainWithPending<'blockchain> {
     type BlockchainError = BlockchainError;
 
     type StateError = StateError;
@@ -50,7 +51,7 @@ impl<'blockchain> Blockchain for BlockchainWithPending<'blockchain> {
         &self,
         hash: &B256,
     ) -> Result<
-        Option<Arc<dyn SyncBlock<ChainSpecT, Error = Self::BlockchainError>>>,
+        Option<Arc<dyn SyncBlock<L1ChainSpec, Error = Self::BlockchainError>>>,
         Self::BlockchainError,
     > {
         if hash == self.pending_block.hash() {
@@ -64,7 +65,7 @@ impl<'blockchain> Blockchain for BlockchainWithPending<'blockchain> {
         &self,
         number: u64,
     ) -> Result<
-        Option<Arc<dyn SyncBlock<ChainSpecT, Error = Self::BlockchainError>>>,
+        Option<Arc<dyn SyncBlock<L1ChainSpec, Error = Self::BlockchainError>>>,
         Self::BlockchainError,
     > {
         if number == self.pending_block.header().number {
@@ -78,7 +79,7 @@ impl<'blockchain> Blockchain for BlockchainWithPending<'blockchain> {
         &self,
         transaction_hash: &B256,
     ) -> Result<
-        Option<Arc<dyn SyncBlock<ChainSpecT, Error = Self::BlockchainError>>>,
+        Option<Arc<dyn SyncBlock<L1ChainSpec, Error = Self::BlockchainError>>>,
         Self::BlockchainError,
     > {
         let contains_transaction = self
@@ -100,7 +101,7 @@ impl<'blockchain> Blockchain for BlockchainWithPending<'blockchain> {
 
     fn last_block(
         &self,
-    ) -> Result<Arc<dyn SyncBlock<ChainSpecT, Error = Self::BlockchainError>>, Self::BlockchainError>
+    ) -> Result<Arc<dyn SyncBlock<L1ChainSpec, Error = Self::BlockchainError>>, Self::BlockchainError>
     {
         Ok(self.pending_block.clone())
     }
@@ -193,14 +194,14 @@ impl<'blockchain> Blockchain for BlockchainWithPending<'blockchain> {
     }
 }
 
-impl<'blockchain> BlockchainMut for BlockchainWithPending<'blockchain> {
+impl<'blockchain> BlockchainMut<L1ChainSpec> for BlockchainWithPending<'blockchain> {
     type Error = BlockchainError;
 
     fn insert_block(
         &mut self,
-        _block: LocalBlock,
+        _block: LocalBlock<L1ChainSpec>,
         _state_diff: StateDiff,
-    ) -> Result<BlockAndTotalDifficulty<Self::Error>, Self::Error> {
+    ) -> Result<BlockAndTotalDifficulty<L1ChainSpec, Self::Error>, Self::Error> {
         panic!("Inserting blocks into a pending blockchain is not supported.");
     }
 

--- a/crates/edr_provider/src/pending.rs
+++ b/crates/edr_provider/src/pending.rs
@@ -21,7 +21,7 @@ use edr_evm::{
 #[derive(Debug)]
 pub(crate) struct BlockchainWithPending<'blockchain> {
     blockchain: &'blockchain dyn SyncBlockchain<BlockchainError, StateError>,
-    pending_block: Arc<dyn SyncBlock<Error = BlockchainError>>,
+    pending_block: Arc<dyn SyncBlock<ChainSpecT, Error = BlockchainError>>,
     pending_state_diff: StateDiff,
 }
 
@@ -49,8 +49,10 @@ impl<'blockchain> Blockchain for BlockchainWithPending<'blockchain> {
     fn block_by_hash(
         &self,
         hash: &B256,
-    ) -> Result<Option<Arc<dyn SyncBlock<Error = Self::BlockchainError>>>, Self::BlockchainError>
-    {
+    ) -> Result<
+        Option<Arc<dyn SyncBlock<ChainSpecT, Error = Self::BlockchainError>>>,
+        Self::BlockchainError,
+    > {
         if hash == self.pending_block.hash() {
             Ok(Some(self.pending_block.clone()))
         } else {
@@ -61,8 +63,10 @@ impl<'blockchain> Blockchain for BlockchainWithPending<'blockchain> {
     fn block_by_number(
         &self,
         number: u64,
-    ) -> Result<Option<Arc<dyn SyncBlock<Error = Self::BlockchainError>>>, Self::BlockchainError>
-    {
+    ) -> Result<
+        Option<Arc<dyn SyncBlock<ChainSpecT, Error = Self::BlockchainError>>>,
+        Self::BlockchainError,
+    > {
         if number == self.pending_block.header().number {
             Ok(Some(self.pending_block.clone()))
         } else {
@@ -73,8 +77,10 @@ impl<'blockchain> Blockchain for BlockchainWithPending<'blockchain> {
     fn block_by_transaction_hash(
         &self,
         transaction_hash: &B256,
-    ) -> Result<Option<Arc<dyn SyncBlock<Error = Self::BlockchainError>>>, Self::BlockchainError>
-    {
+    ) -> Result<
+        Option<Arc<dyn SyncBlock<ChainSpecT, Error = Self::BlockchainError>>>,
+        Self::BlockchainError,
+    > {
         let contains_transaction = self
             .pending_block
             .transactions()
@@ -94,7 +100,8 @@ impl<'blockchain> Blockchain for BlockchainWithPending<'blockchain> {
 
     fn last_block(
         &self,
-    ) -> Result<Arc<dyn SyncBlock<Error = Self::BlockchainError>>, Self::BlockchainError> {
+    ) -> Result<Arc<dyn SyncBlock<ChainSpecT, Error = Self::BlockchainError>>, Self::BlockchainError>
+    {
         Ok(self.pending_block.clone())
     }
 

--- a/crates/edr_provider/src/requests/eth/blocks.rs
+++ b/crates/edr_provider/src/requests/eth/blocks.rs
@@ -1,8 +1,10 @@
 use core::fmt::Debug;
 use std::sync::Arc;
 
-use edr_eth::{transaction::Transaction, BlockSpec, PreEip1898BlockSpec, SpecId, B256, U256, U64};
-use edr_evm::{blockchain::BlockchainError, SyncBlock};
+use edr_eth::{
+    transaction::Transaction as _, BlockSpec, PreEip1898BlockSpec, SpecId, B256, U256, U64,
+};
+use edr_evm::{blockchain::BlockchainError, chain_spec::L1ChainSpec, SyncBlock};
 
 use crate::{
     data::{BlockDataForTransaction, ProviderData, TransactionAndBlock},
@@ -89,7 +91,7 @@ pub fn handle_get_block_transaction_count_by_block_number<
 #[derive(Debug, Clone)]
 struct BlockByNumberResult {
     /// The block
-    pub block: Arc<dyn SyncBlock<ChainSpecT, Error = BlockchainError>>,
+    pub block: Arc<dyn SyncBlock<L1ChainSpec, Error = BlockchainError>>,
     /// Whether the block is a pending block.
     pub pending: bool,
     /// The total difficulty with the block
@@ -114,7 +116,7 @@ fn block_by_number<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
         // Pending block
         Ok(None) => {
             let result = data.mine_pending_block()?;
-            let block: Arc<dyn SyncBlock<ChainSpecT, Error = BlockchainError>> =
+            let block: Arc<dyn SyncBlock<L1ChainSpec, Error = BlockchainError>> =
                 Arc::new(result.block);
 
             let last_block = data.last_block()?;
@@ -136,7 +138,7 @@ fn block_by_number<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
 
 fn block_to_rpc_output<LoggerErrorT: Debug>(
     spec_id: SpecId,
-    block: Arc<dyn SyncBlock<ChainSpecT, Error = BlockchainError>>,
+    block: Arc<dyn SyncBlock<L1ChainSpec, Error = BlockchainError>>,
     pending: bool,
     total_difficulty: Option<U256>,
     transaction_detail_flag: bool,

--- a/crates/edr_provider/src/requests/eth/blocks.rs
+++ b/crates/edr_provider/src/requests/eth/blocks.rs
@@ -89,7 +89,7 @@ pub fn handle_get_block_transaction_count_by_block_number<
 #[derive(Debug, Clone)]
 struct BlockByNumberResult {
     /// The block
-    pub block: Arc<dyn SyncBlock<Error = BlockchainError>>,
+    pub block: Arc<dyn SyncBlock<ChainSpecT, Error = BlockchainError>>,
     /// Whether the block is a pending block.
     pub pending: bool,
     /// The total difficulty with the block
@@ -114,7 +114,8 @@ fn block_by_number<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
         // Pending block
         Ok(None) => {
             let result = data.mine_pending_block()?;
-            let block: Arc<dyn SyncBlock<Error = BlockchainError>> = Arc::new(result.block);
+            let block: Arc<dyn SyncBlock<ChainSpecT, Error = BlockchainError>> =
+                Arc::new(result.block);
 
             let last_block = data.last_block()?;
             let previous_total_difficulty = data
@@ -135,7 +136,7 @@ fn block_by_number<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
 
 fn block_to_rpc_output<LoggerErrorT: Debug>(
     spec_id: SpecId,
-    block: Arc<dyn SyncBlock<Error = BlockchainError>>,
+    block: Arc<dyn SyncBlock<ChainSpecT, Error = BlockchainError>>,
     pending: bool,
     total_difficulty: Option<U256>,
     transaction_detail_flag: bool,

--- a/crates/edr_provider/src/requests/eth/transactions.rs
+++ b/crates/edr_provider/src/requests/eth/transactions.rs
@@ -58,7 +58,8 @@ pub fn handle_get_transaction_by_block_spec_and_index<
         // Pending block requested
         Ok(None) => {
             let result = data.mine_pending_block()?;
-            let block: Arc<dyn SyncBlock<Error = BlockchainError>> = Arc::new(result.block);
+            let block: Arc<dyn SyncBlock<ChainSpecT, Error = BlockchainError>> =
+                Arc::new(result.block);
             Some((block, true))
         }
         // Matching Hardhat behavior in returning None for invalid block hash or number.
@@ -128,7 +129,7 @@ pub fn handle_get_transaction_receipt<LoggerErrorT: Debug, TimerT: Clone + TimeS
 }
 
 fn transaction_from_block(
-    block: Arc<dyn SyncBlock<Error = BlockchainError>>,
+    block: Arc<dyn SyncBlock<ChainSpecT, Error = BlockchainError>>,
     transaction_index: usize,
     is_pending: bool,
 ) -> Option<TransactionAndBlock> {
@@ -151,7 +152,7 @@ pub fn transaction_to_rpc_result<LoggerErrorT: Debug>(
 ) -> Result<edr_rpc_eth::Transaction, ProviderError<LoggerErrorT>> {
     fn gas_price_for_post_eip1559(
         signed_transaction: &transaction::Signed,
-        block: Option<&Arc<dyn SyncBlock<Error = BlockchainError>>>,
+        block: Option<&Arc<dyn SyncBlock<ChainSpecT, Error = BlockchainError>>>,
     ) -> U256 {
         let max_fee_per_gas = signed_transaction
             .max_fee_per_gas()

--- a/crates/edr_provider/src/subscribe.rs
+++ b/crates/edr_provider/src/subscribe.rs
@@ -1,6 +1,6 @@
 use dyn_clone::DynClone;
 use edr_eth::{filter::LogOutput, B256, U256};
-use edr_evm::{blockchain::BlockchainError, BlockAndTotalDifficulty};
+use edr_evm::{blockchain::BlockchainError, chain_spec::L1ChainSpec, BlockAndTotalDifficulty};
 
 /// Subscription event.
 #[derive(Clone, Debug)]
@@ -13,7 +13,7 @@ pub struct SubscriptionEvent {
 #[derive(Clone, Debug)]
 pub enum SubscriptionEventData {
     Logs(Vec<LogOutput>),
-    NewHeads(BlockAndTotalDifficulty<BlockchainError>),
+    NewHeads(BlockAndTotalDifficulty<L1ChainSpec, BlockchainError>),
     NewPendingTransactions(B256),
 }
 

--- a/crates/edr_provider/src/test_utils.rs
+++ b/crates/edr_provider/src/test_utils.rs
@@ -13,12 +13,13 @@ use edr_eth::{
 };
 use edr_evm::{
     alloy_primitives::U160,
-    blockchain::{Blockchain, ForkedBlockchain},
+    blockchain::{Blockchain as _, ForkedBlockchain},
+    chain_spec::L1ChainSpec,
     state::IrregularState,
     Block, BlockBuilder, CfgEnv, CfgEnvWithHandlerCfg, DebugContext, ExecutionResultWithContext,
-    RandomHashGenerator, RemoteBlock,
+    IntoRemoteBlock, RandomHashGenerator,
 };
-use edr_rpc_eth::{client::EthRpcClient, spec::EthRpcSpec};
+use edr_rpc_eth::client::EthRpcClient;
 
 use super::*;
 use crate::{config::MiningConfig, requests::hardhat::rpc_types::ForkConfig};
@@ -140,16 +141,17 @@ pub async fn run_full_block(url: String, block_number: u64, chain_id: u64) -> an
 
     let replay_block = {
         let rpc_client =
-            EthRpcClient::<EthRpcSpec>::new(&url, default_config.cache_dir.clone(), None)?;
+            EthRpcClient::<L1ChainSpec>::new(&url, default_config.cache_dir.clone(), None)?;
 
         let block = rpc_client
             .get_block_by_number_with_transaction_data(PreEip1898BlockSpec::Number(block_number))
             .await?;
 
-        RemoteBlock::new(block, Arc::new(rpc_client), runtime.clone())?
+        block.into_remote_block(Arc::new(rpc_client), runtime.clone())?
     };
 
-    let rpc_client = EthRpcClient::<EthRpcSpec>::new(&url, default_config.cache_dir.clone(), None)?;
+    let rpc_client =
+        EthRpcClient::<L1ChainSpec>::new(&url, default_config.cache_dir.clone(), None)?;
     let mut irregular_state = IrregularState::default();
     let state_root_generator = Arc::new(parking_lot::Mutex::new(RandomHashGenerator::with_seed(
         edr_defaults::STATE_ROOT_HASH_SEED,
@@ -206,7 +208,7 @@ pub async fn run_full_block(url: String, block_number: u64, chain_id: u64) -> an
         blockchain.state_at_block_number(block_number - 1, irregular_state.state_overrides())?;
 
     for transaction in replay_block.transactions() {
-        let debug_context: Option<DebugContext<'_, _, (), _>> = None;
+        let debug_context: Option<DebugContext<'_, L1ChainSpec, _, (), _>> = None;
         let ExecutionResultWithContext {
             result,
             evm_context: _,

--- a/crates/edr_rpc_eth/src/client.rs
+++ b/crates/edr_rpc_eth/src/client.rs
@@ -146,7 +146,7 @@ impl<RpcSpecT: RpcSpec> EthRpcClient<RpcSpecT> {
     pub async fn get_block_by_hash(
         &self,
         hash: B256,
-    ) -> Result<Option<RpcSpecT::Block<B256>>, RpcClientError> {
+    ) -> Result<Option<RpcSpecT::RpcBlock<B256>>, RpcClientError> {
         self.inner
             .call(RequestMethod::GetBlockByHash(hash, false))
             .await
@@ -169,7 +169,7 @@ impl<RpcSpecT: RpcSpec> EthRpcClient<RpcSpecT> {
     pub async fn get_block_by_hash_with_transaction_data(
         &self,
         hash: B256,
-    ) -> Result<Option<RpcSpecT::Block<RpcSpecT::Transaction>>, RpcClientError> {
+    ) -> Result<Option<RpcSpecT::RpcBlock<RpcSpecT::RpcTransaction>>, RpcClientError> {
         self.inner
             .call(RequestMethod::GetBlockByHash(hash, true))
             .await
@@ -180,11 +180,11 @@ impl<RpcSpecT: RpcSpec> EthRpcClient<RpcSpecT> {
     pub async fn get_block_by_number(
         &self,
         spec: PreEip1898BlockSpec,
-    ) -> Result<Option<RpcSpecT::Block<B256>>, RpcClientError> {
+    ) -> Result<Option<RpcSpecT::RpcBlock<B256>>, RpcClientError> {
         self.inner
             .call_with_resolver(
                 RequestMethod::GetBlockByNumber(spec, false),
-                |block: &Option<RpcSpecT::Block<B256>>| {
+                |block: &Option<RpcSpecT::RpcBlock<B256>>| {
                     block.as_ref().and_then(GetBlockNumber::number)
                 },
             )
@@ -196,11 +196,11 @@ impl<RpcSpecT: RpcSpec> EthRpcClient<RpcSpecT> {
     pub async fn get_block_by_number_with_transaction_data(
         &self,
         spec: PreEip1898BlockSpec,
-    ) -> Result<RpcSpecT::Block<RpcSpecT::Transaction>, RpcClientError> {
+    ) -> Result<RpcSpecT::RpcBlock<RpcSpecT::RpcTransaction>, RpcClientError> {
         self.inner
             .call_with_resolver(
                 RequestMethod::GetBlockByNumber(spec, true),
-                |block: &RpcSpecT::Block<RpcSpecT::Transaction>| block.number(),
+                |block: &RpcSpecT::RpcBlock<RpcSpecT::RpcTransaction>| block.number(),
             )
             .await
     }
@@ -242,7 +242,7 @@ impl<RpcSpecT: RpcSpec> EthRpcClient<RpcSpecT> {
     pub async fn get_transaction_by_hash(
         &self,
         tx_hash: B256,
-    ) -> Result<Option<RpcSpecT::Transaction>, RpcClientError> {
+    ) -> Result<Option<RpcSpecT::RpcTransaction>, RpcClientError> {
         self.inner
             .call(RequestMethod::GetTransactionByHash(tx_hash))
             .await

--- a/crates/edr_rpc_eth/src/spec.rs
+++ b/crates/edr_rpc_eth/src/spec.rs
@@ -2,13 +2,13 @@ use serde::{de::DeserializeOwned, Serialize};
 
 /// Trait for specifying Ethereum-based JSON-RPC method types.
 pub trait RpcSpec {
-    /// Type representing a block
-    type Block<Data>: GetBlockNumber + DeserializeOwned + Serialize
+    /// Type representing an RPC block
+    type RpcBlock<Data>: GetBlockNumber + DeserializeOwned + Serialize
     where
         Data: Default + DeserializeOwned + Serialize;
 
-    /// Type representing the transaction.
-    type Transaction: Default + DeserializeOwned + Serialize;
+    /// Type representing an RPC transaction.
+    type RpcTransaction: Default + DeserializeOwned + Serialize;
 }
 
 pub trait GetBlockNumber {
@@ -20,6 +20,6 @@ pub trait GetBlockNumber {
 pub struct EthRpcSpec;
 
 impl RpcSpec for EthRpcSpec {
-    type Block<Data> = crate::block::Block<Data> where Data: Default + DeserializeOwned + Serialize;
-    type Transaction = crate::transaction::Transaction;
+    type RpcBlock<Data> = crate::block::Block<Data> where Data: Default + DeserializeOwned + Serialize;
+    type RpcTransaction = crate::transaction::Transaction;
 }

--- a/crates/edr_rpc_eth/src/spec.rs
+++ b/crates/edr_rpc_eth/src/spec.rs
@@ -1,7 +1,7 @@
 use serde::{de::DeserializeOwned, Serialize};
 
 /// Trait for specifying Ethereum-based JSON-RPC method types.
-pub trait RpcSpec {
+pub trait RpcSpec: Sized {
     /// Type representing an RPC block
     type RpcBlock<Data>: GetBlockNumber + DeserializeOwned + Serialize
     where


### PR DESCRIPTION
This PR adds a `trait ChainSpec` to `edr_evm` that allows specification of chain-specific internal/engine types. For now, we only deal with with L1 Ethereum.

Future work will implement a block builder and miner for Optimism and abstract that using a trait.

I used three traits `IntoRemoteBlock`, `EthRpcBlock`, and `EthRpcTransaction` to access the values that are required for state and blockchain implementations. I don't think this is particularly elegant, especially the `IntoRemoteBlock` but I wasn't sure what better way to abstract them. 

I'm open to suggestions for how I might be better able to abstract the information that needs to be retrieved from `ChainSpec::RpcBlock`. For now I stuck with this design, as it's hard to predict what this will look like with more chain types. As it stands, it is relatively easy to change the API in the future; e.g. if another chain type requires access to more properties of the RPC block or transaction.