### PR TITLE
improvement: add chain id to error message

### DIFF
--- a/crates/edr_evm/src/blockchain.rs
+++ b/crates/edr_evm/src/blockchain.rs
@@ -55,12 +55,14 @@ pub enum BlockchainError {
         expected: B256,
     },
     /// Missing hardfork activation history
-    #[error("No known hardfork for execution on historical block {block_number} (relative to fork block number {fork_block_number}). The node was not configured with a hardfork activation history.")]
+    #[error("No known hardfork for execution on historical block {block_number} (relative to fork block number {fork_block_number}) in chain with id {chain_id}. The node was not configured with a hardfork activation history.")]
     MissingHardforkActivations {
         /// Block number
         block_number: u64,
         /// Fork block number
         fork_block_number: u64,
+        /// Chain id
+        chain_id: u64,
     },
     /// Missing withdrawals for post-Shanghai blockchain
     #[error("Missing withdrawals for post-Shanghai blockchain")]

--- a/crates/edr_evm/src/blockchain/forked.rs
+++ b/crates/edr_evm/src/blockchain/forked.rs
@@ -432,6 +432,7 @@ impl Blockchain for ForkedBlockchain {
                     Err(BlockchainError::MissingHardforkActivations {
                         block_number,
                         fork_block_number: self.fork_block_number,
+                        chain_id: self.remote_chain_id,
                     })
                 }
             })


### PR DESCRIPTION
This error is a bit better if it includes the remote chain id, because then adding it to the default hardfork histories (as done in https://github.com/NomicFoundation/hardhat/pull/5394) will be easier.