### PR TITLE
fix: accept missing mix hashes in remote blocks

### DIFF
--- a/.changeset/modern-ways-wash.md
+++ b/.changeset/modern-ways-wash.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Fixed a problem that prevented forking chains without mix hash fields in their blocks

--- a/crates/edr_evm/src/block/remote.rs
+++ b/crates/edr_evm/src/block/remote.rs
@@ -79,6 +79,8 @@ impl RemoteBlock {
             gas_used: block.gas_used,
             timestamp: block.timestamp,
             extra_data: block.extra_data,
+            // TODO don't accept remote blocks with missing mix hash,
+            // see https://github.com/NomicFoundation/edr/issues/518
             mix_hash: block.mix_hash.unwrap_or_default(),
             nonce: block.nonce.ok_or(CreationError::MissingNonce)?,
             base_fee_per_gas: block.base_fee_per_gas,

--- a/crates/edr_evm/src/block/remote.rs
+++ b/crates/edr_evm/src/block/remote.rs
@@ -79,7 +79,7 @@ impl RemoteBlock {
             gas_used: block.gas_used,
             timestamp: block.timestamp,
             extra_data: block.extra_data,
-            mix_hash: block.mix_hash.ok_or(CreationError::MissingMixHash)?,
+            mix_hash: block.mix_hash.unwrap_or_default(),
             nonce: block.nonce.ok_or(CreationError::MissingNonce)?,
             base_fee_per_gas: block.base_fee_per_gas,
             withdrawals_root: block.withdrawals_root,


### PR DESCRIPTION
See https://github.com/NomicFoundation/hardhat/discussions/5266#discussioncomment-9776377

I didn't add a test for this because neither Infura nor Alchemy support that creditcoin chain, and I don't think we should use public RPC URLs in our tests, since they don't tend to be very robust.