### PR TITLE
ci: make release workflow more robust

### DIFF
--- a/.github/workflows/edr-npm-release.yml
+++ b/.github/workflows/edr-npm-release.yml
@@ -87,13 +87,13 @@ jobs:
       run:
         working-directory: ./crates/edr_napi
     steps:
+      - uses: actions/checkout@v4
       - name: Check number of targets
         shell: bash
         run: |
           echo "Number of build jobs: ${{ strategy.job-total }}"
           echo "Expected number of build jobs: $NUMBER_OF_TARGETS"
           test ${{ strategy.job-total }} -eq "$NUMBER_OF_TARGETS"
-      - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2
         with:
           version: 9

--- a/.github/workflows/edr-npm-release.yml
+++ b/.github/workflows/edr-npm-release.yml
@@ -413,9 +413,11 @@ jobs:
       - name: Check number of artifacts
         shell: bash
         run: |
-          NUMBER_OF_ARTIFACTS=$(ls -1q ./crates/edr_napi/artifacts/*.node | wc -l)
-          echo "Number of artifacts: $NUMBER_OF_ARTIFACTS"
-          echo "Expected number of artifacts: $NUMBER_OF_TARGETS"
+          tree artifacts
+          # get number of artifacts with unique names
+          NUMBER_OF_ARTIFACTS=$(ls -1q artifacts/*/*.node | xargs -n 1 basename | sort | uniq | wc -l)
+          echo "Number of unique artifacts: $NUMBER_OF_ARTIFACTS"
+          echo "Expected number of unique artifacts: $NUMBER_OF_TARGETS"
           test "$NUMBER_OF_ARTIFACTS" -eq "$NUMBER_OF_TARGETS"
       - name: Install sponge
         run: |

--- a/.github/workflows/edr-npm-release.yml
+++ b/.github/workflows/edr-npm-release.yml
@@ -305,9 +305,15 @@ jobs:
             pnpm testNoBuild
             ls -la
   test-linux-aarch64-musl-binding:
-    name: Test bindings on aarch64-unknown-linux-musl - node@lts
+    name: Test bindings on aarch64-unknown-linux-musl - node@${{ matrix.node }}
     needs:
       - build
+    strategy:
+      fail-fast: false
+      matrix:
+        node:
+          - "18"
+          - "20"
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -335,7 +341,7 @@ jobs:
       - name: Setup and run tests
         uses: addnab/docker-run-action@v3
         with:
-          image: node:lts-alpine
+          image: node:${{ matrix.node }}-alpine
           options: "--platform linux/arm64 -v ${{ github.workspace }}:/build -w /build/crates/edr_napi -e CI=1"
           run: |
             wget -qO- 'https://unpkg.com/@pnpm/self-installer' | node

--- a/.github/workflows/edr-npm-release.yml
+++ b/.github/workflows/edr-npm-release.yml
@@ -88,6 +88,7 @@ jobs:
         working-directory: ./crates/edr_napi
     steps:
       - name: Check number of targets
+        shell: bash
         run: |
           echo "Number of build jobs: ${{ strategy.job-total }}"
           echo "Expected number of build jobs: $NUMBER_OF_TARGETS"
@@ -410,6 +411,7 @@ jobs:
         with:
           path: ./crates/edr_napi/artifacts
       - name: Check number of artifacts
+        shell: bash
         run: |
           NUMBER_OF_ARTIFACTS=$(ls -1q ./crates/edr_napi/artifacts/*.node | wc -l)
           echo "Number of artifacts: $NUMBER_OF_ARTIFACTS"

--- a/.github/workflows/edr-npm-release.yml
+++ b/.github/workflows/edr-npm-release.yml
@@ -88,7 +88,10 @@ jobs:
         working-directory: ./crates/edr_napi
     steps:
       - name: Check number of targets
-        run: test ${{ strategy.job-total }} -eq "$NUMBER_OF_TARGETS"
+        run: |
+          echo "Number of build jobs: ${{ strategy.job-total }}"
+          echo "Expected number of build jobs: $NUMBER_OF_TARGETS"
+          test ${{ strategy.job-total }} -eq "$NUMBER_OF_TARGETS"
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2
         with:
@@ -407,7 +410,11 @@ jobs:
         with:
           path: ./crates/edr_napi/artifacts
       - name: Check number of artifacts
-        run: test $(ls -1q ./crates/edr_napi/artifacts/*.node | wc -l) -eq "$NUMBER_OF_TARGETS"
+        run: |
+          NUMBER_OF_ARTIFACTS=$(ls -1q ./crates/edr_napi/artifacts/*.node | wc -l)
+          echo "Number of artifacts: $NUMBER_OF_ARTIFACTS"
+          echo "Expected number of artifacts: $NUMBER_OF_TARGETS"
+          test "$NUMBER_OF_ARTIFACTS" -eq "$NUMBER_OF_TARGETS"
       - name: Install sponge
         run: |
           sudo apt-get update

--- a/.github/workflows/edr-npm-release.yml
+++ b/.github/workflows/edr-npm-release.yml
@@ -4,6 +4,7 @@ env:
   DEBUG: napi:*
   APP_NAME: edr
   MACOSX_DEPLOYMENT_TARGET: "10.13"
+  NUMBER_OF_TARGETS: 7
 permissions:
   contents: write
   id-token: write
@@ -86,6 +87,8 @@ jobs:
       run:
         working-directory: ./crates/edr_napi
     steps:
+      - name: Check number of targets
+        run: test ${{ strategy.job-total }} -eq "$NUMBER_OF_TARGETS"
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2
         with:
@@ -403,6 +406,8 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           path: ./crates/edr_napi/artifacts
+      - name: Check number of artifacts
+        run: test $(ls -1q ./crates/edr_napi/artifacts/*.node | wc -l) -eq "$NUMBER_OF_TARGETS"
       - name: Install sponge
         run: |
           sudo apt-get update

--- a/.github/workflows/edr-npm-release.yml
+++ b/.github/workflows/edr-npm-release.yml
@@ -154,6 +154,8 @@ jobs:
         settings:
           - host: macos-12
             target: x86_64-apple-darwin
+          - host: macos-14
+            target: aarch64-apple-darwin
           - host: windows-2022
             target: x86_64-pc-windows-msvc
         node:


### PR DESCRIPTION
The main change here is a couple of new steps, checking that the number of build jobs and the number of unique generated artifacts are the ones we expect.

There surely are better ways to do this, but this seems like a simple way to get it done. These are the relevant changes:
- Added a workflow-scoped `NUMBER_OF_TARGETS` variable. Its current value is 7.
- Added a check that the number of build jobs matches that number.
- Added a check that the number of _unique_ generated artifacts is the expected one.

The last item is the one that catches the problem we had before. I double checked this by temporarily setting the OSes to `macos-latest` again. This generated 6 unique artifacts, and was caught by that step.

I included two unrelated changes here, fixing some things I noticed while working on this:
- I added an entry to the matrix in the `test-macOS-windows-binding` job, which tests the `aarch64-apple-darwin` build in macos 14. We didn't have this before because there were no Apple ARM runners up until recently (in fact, the introduction of these runners is what caused the issue that motivates this PR).
- I noticed that the `test-linux-aarch64-musl-binding` job was testing the bindings in `node@lts`, while the rest of the tests where using node 18 and 20. I'm not sure if there was a reason for this, but I modified it to be consistent with the other tests.

---

Closes https://github.com/NomicFoundation/edr/issues/421