### PR TITLE
ci: remove path checks for benchmarks

### DIFF
--- a/.github/workflows/edr-benchmark.yml
+++ b/.github/workflows/edr-benchmark.yml
@@ -4,21 +4,9 @@ on:
   push:
     branches:
       - main
-    paths:
-      - ".github/workflows/edr-benchmark.yml"
-      - "rust-toolchain"
-      - "Cargo.lock"
-      - "Cargo.toml"
-      - "crates/**"
   pull_request:
     branches:
       - "**"
-    paths:
-      - ".github/workflows/edr-benchmark.yml"
-      - "rust-toolchain"
-      - "Cargo.lock"
-      - "Cargo.toml"
-      - "crates/**"
   workflow_dispatch:
 
 defaults:


### PR DESCRIPTION
These path restrictions made sense when EDR was part of the Hardhat repo, but they can cause problems now that the EDR has its own repo (e.g. they wouldn't run if the Hardhat version was changed).