### PR TITLE
ci: remove path restrictions for EDR jobs

### DIFF
--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -4,21 +4,9 @@ on:
   push:
     branches:
       - main
-    paths:
-      - ".github/workflows/edr-ci.yml"
-      - "rust-toolchain"
-      - "Cargo.lock"
-      - "Cargo.toml"
-      - "crates/**"
   pull_request:
     branches:
       - "**"
-    paths:
-      - ".github/workflows/edr-ci.yml"
-      - "rust-toolchain"
-      - "Cargo.lock"
-      - "Cargo.toml"
-      - "crates/**"
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
These path restrictions made sense when EDR was part of the Hardhat repo, but now that the EDR has its own repo, they are just a potential source of errors.