### PR TITLE
ci: check that index.d.ts is up to date

### DIFF
--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -180,3 +180,26 @@ jobs:
 
       - name: Run prettier
         run: pnpm run prettier
+
+  edr-napi-typings-file:
+    name: Check that edr_napi typings file is up to date
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - name: Install Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+          cache: pnpm
+
+      - name: Install package
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Build edr_napi
+        run: cd crates/edr_napi && pnpm build
+
+      - name: Check that there are no uncommitted changes
+        run: git diff --exit-code


### PR DESCRIPTION
Check that `index.d.ts` has no changes after running `pnpm build`.

The failing job should start working after https://github.com/NomicFoundation/edr/pull/552 is merged.