### PR TITLE
build: upgrade revm to v12

### DIFF
--- a/.changeset/thick-impalas-sparkle.md
+++ b/.changeset/thick-impalas-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Fixed a bug in the JSON-RPC where we previously allowed a null value for storage keys of an access list

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,14 +64,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f76ecab54890cdea1e4808fc0891c7e6cfcf71fe1a9fe26810c7280ef768f4ed"
+checksum = "d32a3e14fa0d152d00bd8daf605eb74ad397efb0f54bd7155585823dddb4401e"
 dependencies = [
  "alloy-primitives 0.7.7",
  "alloy-rlp",
  "alloy-serde",
  "c-kzg",
+ "k256",
  "once_cell",
  "serde",
 ]
@@ -156,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9416c52959e66ead795a11f4a86c248410e9e368a0765710e57055b8a1774dd6"
+checksum = "15c5b9057acc02aee1b8aac2b5a0729cb0f73d080082c111313e5d1f92a96630"
 dependencies = [
  "alloy-primitives 0.7.7",
  "serde",
@@ -1986,7 +1987,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -2915,8 +2916,9 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "11.0.0"
-source = "git+https://github.com/NomicFoundation/revm?rev=be50b38#be50b38d386419595d82563f8e1cd2f62612ffc7"
+version = "12.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6cfb48bce8ca2113e157bdbddbd5eeb09daac1c903d79ec17085897c38c7c91"
 dependencies = [
  "auto_impl",
  "cfg-if",
@@ -2929,8 +2931,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "7.0.0"
-source = "git+https://github.com/NomicFoundation/revm?rev=be50b38#be50b38d386419595d82563f8e1cd2f62612ffc7"
+version = "8.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6b0daddea06fc6da5346acc39b32a357bbe3579e9e3d94117d9ae125cd596fc"
 dependencies = [
  "revm-primitives",
  "serde",
@@ -2938,8 +2941,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "9.0.0"
-source = "git+https://github.com/NomicFoundation/revm?rev=be50b38#be50b38d386419595d82563f8e1cd2f62612ffc7"
+version = "9.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef55228211251d7b6c7707c3ee13bb70dea4d2fd81ec4034521e4fe31010b2ea"
 dependencies = [
  "aurora-engine-modexp",
  "c-kzg",
@@ -2956,8 +2960,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "6.0.0"
-source = "git+https://github.com/NomicFoundation/revm?rev=be50b38#be50b38d386419595d82563f8e1cd2f62612ffc7"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc4311037ee093ec50ec734e1424fcb3e12d535c6cef683b75d1c064639630c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives 0.7.7",

--- a/crates/edr_eth/Cargo.toml
+++ b/crates/edr_eth/Cargo.toml
@@ -15,8 +15,7 @@ itertools = { version = "0.10.5", default-features = false, features = ["use_all
 k256 = { version = "0.13.1", default-features = false, features = ["arithmetic", "ecdsa", "pkcs8", ] }
 log = { version = "0.4.17", default-features = false }
 once_cell = { version = "1.18.0", default-features = false, features = ["alloc", "race", "std"] }
-# revm-primitives = { version = "5.0", default-features = false, features = ["c-kzg", "hashbrown"] }
-revm-primitives = { git = "https://github.com/NomicFoundation/revm", rev = "be50b38", version = "6.0", default-features = false, features = ["c-kzg", "hashbrown"] }
+revm-primitives = { version = "7.0", default-features = false, features = ["c-kzg", "hashbrown"] }
 serde = { version = "1.0.147", default-features = false, features = ["derive"], optional = true }
 sha2 = { version = "0.10.8", default-features = false }
 sha3 = { version = "0.10.8", default-features = false }

--- a/crates/edr_evm/Cargo.toml
+++ b/crates/edr_evm/Cargo.toml
@@ -19,8 +19,7 @@ parking_lot = { version = "0.12.1", default-features = false }
 edr_defaults = { version = "0.3.5", path = "../edr_defaults" }
 edr_eth = { version = "0.3.5", path = "../edr_eth", features = ["rand", "serde"] }
 edr_rpc_eth = { version = "0.3.5", path = "../edr_rpc_eth" }
-# revm = { version = "10.0", default-features = false, features = ["c-kzg", "dev", "serde", "std"] }
-revm = { git = "https://github.com/NomicFoundation/revm", rev = "be50b38", version = "11.0", default-features = false, features = ["c-kzg", "dev", "serde", "std"] }
+revm = { version = "12.0", default-features = false, features = ["c-kzg", "dev", "serde", "std"] }
 rpds = { version = "1.1.0", default-features = false, features = ["std"] }
 serde = { version = "1.0.158", default-features = false, features = ["std"] }
 serde_json = { version = "1.0.94", default-features = false, features = ["std"] }

--- a/crates/edr_provider/Cargo.toml
+++ b/crates/edr_provider/Cargo.toml
@@ -20,8 +20,7 @@ lazy_static = { version = "1.4.0", default-features = false }
 log = { version = "0.4.20", default-features = false }
 parking_lot = { version = "0.12.1", default-features = false }
 rand = { version = "0.8.5", default-features = false }
-# revm-precompile = { version = "8.0", default-features = false, features = ["c-kzg", "secp256r1", "std"] }
-revm-precompile = { git = "https://github.com/NomicFoundation/revm", rev = "be50b38", version = "9.0", default-features = false, features = ["c-kzg", "secp256r1", "std"] }
+revm-precompile = { version = "9.1", default-features = false, features = ["c-kzg", "secp256r1", "std"] }
 rpds = { version = "1.1.0", default-features = false, features = ["std"] }
 serde = { version = "1.0.147", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.89" }

--- a/hardhat-tests/test/internal/hardhat-network/provider/modules/eth/hardforks.ts
+++ b/hardhat-tests/test/internal/hardhat-network/provider/modules/eth/hardforks.ts
@@ -532,39 +532,6 @@ describe("Eth module - hardfork dependant tests", function () {
             );
             assert.deepEqual(tx.accessList, accessList);
           });
-
-          it("Should accept access lists with null storageKeys", async function () {
-            const accessList = [
-              {
-                address: "0x1234567890123456789012345678901234567890",
-                storageKeys: null,
-              },
-            ];
-            const [sender] = await this.provider.send("eth_accounts");
-            const txHash = await this.provider.send("eth_sendTransaction", [
-              {
-                from: sender,
-                to: sender,
-                accessList,
-              },
-            ]);
-
-            const tx = await this.provider.send("eth_getTransactionByHash", [
-              txHash,
-            ]);
-
-            assert.equal(tx.type, numberToRpcQuantity(1));
-            assert.equal(
-              tx.chainId,
-              numberToRpcQuantity(this.common.chainId())
-            );
-            assert.deepEqual(tx.accessList, [
-              {
-                address: "0x1234567890123456789012345678901234567890",
-                storageKeys: [],
-              },
-            ]);
-          });
         });
       });
 


### PR DESCRIPTION
This voids the need for a fork on `main`.