### PR TITLE
refactor: remove `ProjectPathsConfig` from `MultiContractRunner`

### DIFF
--- a/crates/edr_napi/src/solidity_tests/config.rs
+++ b/crates/edr_napi/src/solidity_tests/config.rs
@@ -15,8 +15,8 @@ use foundry_config::{
 /// Solidity tests configuration
 #[derive(Clone, Debug)]
 pub(super) struct SolidityTestsConfig {
-    /// Project paths configuration
-    pub project_paths_config: ProjectPathsConfig,
+    /// Project root directory
+    pub project_root: PathBuf,
     /// Cheats configuration options
     pub cheats_config_options: CheatsConfigOptions,
     /// EVM options
@@ -67,7 +67,8 @@ impl SolidityTestsConfig {
         ));
 
         // TODO https://github.com/NomicFoundation/edr/issues/487
-        let project_paths_config = ProjectPathsConfig::builder().build_with_root(project_root);
+        let project_paths_config: ProjectPathsConfig<foundry_compilers::Solc> =
+            ProjectPathsConfig::builder().build_with_root(project_root.clone());
 
         let artifacts: PathBuf = project_paths_config
             .artifacts
@@ -89,7 +90,7 @@ impl SolidityTestsConfig {
         };
 
         Self {
-            project_paths_config,
+            project_root,
             cheats_config_options,
             evm_opts,
             fuzz,

--- a/crates/edr_napi/src/solidity_tests/runner.rs
+++ b/crates/edr_napi/src/solidity_tests/runner.rs
@@ -17,7 +17,7 @@ pub(super) fn build_runner(
 
     let SolidityTestsConfig {
         evm_opts,
-        project_paths_config,
+        project_root,
         cheats_config_options,
         fuzz,
         invariant,
@@ -36,7 +36,7 @@ pub(super) fn build_runner(
     let evm_env = evm_opts.local_evm_env();
 
     Ok(MultiContractRunner {
-        project_paths_config: Arc::new(project_paths_config),
+        project_root,
         cheats_config_opts: Arc::new(cheats_config_options),
         contracts: test_suites.into_iter().collect(),
         evm_opts,

--- a/crates/foundry/cheatcodes/src/fs.rs
+++ b/crates/foundry/cheatcodes/src/fs.rs
@@ -89,7 +89,7 @@ impl Cheatcode for isFileCall {
 impl Cheatcode for projectRootCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {} = self;
-        Ok(state.config.root.display().to_string().abi_encode())
+        Ok(state.config.project_root.display().to_string().abi_encode())
     }
 }
 
@@ -547,7 +547,7 @@ fn ffi(state: &Cheatcodes, input: &[String]) -> Result<FfiResult> {
     debug!(target: "cheatcodes", ?cmd, "invoking ffi");
 
     let output = cmd
-        .current_dir(&state.config.root)
+        .current_dir(&state.config.project_root)
         .output()
         .map_err(|err| fmt_err!("failed to execute command {cmd:?}: {err}"))?;
 
@@ -612,7 +612,7 @@ mod tests {
     fn cheats() -> Cheatcodes {
         let config = CheatsConfig {
             ffi: true,
-            root: PathBuf::from(&env!("CARGO_MANIFEST_DIR")),
+            project_root: PathBuf::from(&env!("CARGO_MANIFEST_DIR")),
             ..Default::default()
         };
         Cheatcodes {

--- a/crates/foundry/cheatcodes/src/utils.rs
+++ b/crates/foundry/cheatcodes/src/utils.rs
@@ -142,7 +142,7 @@ mod tests {
     fn cheats() -> Cheatcodes {
         let config = CheatsConfig {
             ffi: true,
-            root: PathBuf::from(&env!("CARGO_MANIFEST_DIR")),
+            project_root: PathBuf::from(&env!("CARGO_MANIFEST_DIR")),
             ..Default::default()
         };
         Cheatcodes {

--- a/crates/foundry/forge/tests/it/repros.rs
+++ b/crates/foundry/forge/tests/it/repros.rs
@@ -315,7 +315,7 @@ test_repro!(6538);
 
 // https://github.com/foundry-rs/foundry/issues/6554
 test_repro!(6554; |config| {
-    let path = config.runner.project_paths_config.root.join("out/default/Issue6554.t.sol");
+    let path = config.runner.project_root.join("out/default/Issue6554.t.sol");
 
     let cheats_config_opts = Arc::get_mut(&mut config.runner.cheats_config_opts).unwrap();
     cheats_config_opts.fs_permissions.add(PathPermission::read_write(path));


### PR DESCRIPTION
I've decided to split this out from a larger change coming to remove the dependence of the Solidity test runner on the Foundry project format for https://github.com/NomicFoundation/edr/issues/487