### PR TITLE
refactor: Solidity test runner progress callback completion

### DIFF
--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -461,6 +461,15 @@ export interface TestContract {
    */
   libraries: Array<string>
 }
+/**
+ * Executes Solidity tests.
+ *
+ * The function will return as soon as test execution is started.
+ * The progress callback will be called with the results of each test suite.
+ * It is up to the caller to track how many times the callback is called to
+ * know when all tests are done.
+ */
+export function runSolidityTests(test_suites: Array<TestSuite>, gas_report: boolean, progress_callback: (result: SuiteResult) => void): void
 export interface SubscriptionEvent {
   filterId: bigint
   result: any
@@ -541,13 +550,6 @@ export class Response {
   get json(): string
   get solidityTrace(): RawTrace | null
   get traces(): Array<RawTrace>
-}
-/** Executes solidity tests. */
-export class SolidityTestRunner {
-  /**Creates a new instance of the SolidityTestRunner. The callback function will be called with suite results as they finish. */
-  constructor(gasReport: boolean, resultsCallback: (...args: any[]) => any)
-  /**Runs the given test suites. */
-  runTests(testSuites: Array<TestSuite>): Promise<Array<SuiteResult>>
 }
 export class RawTrace {
   trace(): Array<TracingMessage | TracingStep | TracingMessageResult>

--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -469,7 +469,7 @@ export interface TestContract {
  * It is up to the caller to track how many times the callback is called to
  * know when all tests are done.
  */
-export function runSolidityTests(test_suites: Array<TestSuite>, gas_report: boolean, progress_callback: (result: SuiteResult) => void): void
+export function runSolidityTests(testSuites: Array<TestSuite>, gasReport: boolean, progressCallback: (result: SuiteResult) => void): void
 export interface SubscriptionEvent {
   filterId: bigint
   result: any

--- a/crates/edr_napi/index.js
+++ b/crates/edr_napi/index.js
@@ -310,7 +310,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { SpecId, EdrContext, MineOrdering, Provider, Response, SuccessReason, ExceptionalHalt, TestStatus, SolidityTestRunner, RawTrace } = nativeBinding
+const { SpecId, EdrContext, MineOrdering, Provider, Response, SuccessReason, ExceptionalHalt, TestStatus, runSolidityTests, RawTrace } = nativeBinding
 
 module.exports.SpecId = SpecId
 module.exports.EdrContext = EdrContext
@@ -320,5 +320,5 @@ module.exports.Response = Response
 module.exports.SuccessReason = SuccessReason
 module.exports.ExceptionalHalt = ExceptionalHalt
 module.exports.TestStatus = TestStatus
-module.exports.SolidityTestRunner = SolidityTestRunner
+module.exports.runSolidityTests = runSolidityTests
 module.exports.RawTrace = RawTrace

--- a/crates/edr_napi/src/solidity_tests.rs
+++ b/crates/edr_napi/src/solidity_tests.rs
@@ -28,13 +28,11 @@ use crate::solidity_tests::{
 /// know when all tests are done.
 // False positive from Clippy. The function is exposed through the FFI.
 #[allow(dead_code)]
-#[napi(
-    ts_args_type = "test_suites: Array<TestSuite>, gas_report: boolean, progress_callback: (result: SuiteResult) => void"
-)]
+#[napi]
 pub fn run_solidity_tests(
     test_suites: Vec<TestSuite>,
     gas_report: bool,
-    progress_callback: JsFunction,
+    #[napi(ts_arg_type = "(result: SuiteResult) => void")] progress_callback: JsFunction,
 ) -> napi::Result<()> {
     let results_callback_fn: ThreadsafeFunction<_, ErrorStrategy::Fatal> = progress_callback
         .create_threadsafe_function(

--- a/crates/edr_napi/src/solidity_tests.rs
+++ b/crates/edr_napi/src/solidity_tests.rs
@@ -12,7 +12,7 @@ use napi::{
     },
     tokio,
     tokio::runtime,
-    Env, JsFunction,
+    JsFunction,
 };
 use napi_derive::napi;
 
@@ -20,87 +20,59 @@ use crate::solidity_tests::{
     runner::build_runner, test_results::SuiteResult, test_suite::TestSuite,
 };
 
-/// Executes solidity tests.
-#[napi]
-pub struct SolidityTestRunner {
-    /// The callback to call with the results as they become available.
-    results_callback_fn: ThreadsafeFunction<SuiteResult>,
+/// Executes Solidity tests.
+///
+/// The function will return as soon as test execution is started.
+/// The progress callback will be called with the results of each test suite.
+/// It is up to the caller to track how many times the callback is called to
+/// know when all tests are done.
+// False positive from Clippy. The function is exposed through the FFI.
+#[allow(dead_code)]
+#[napi(
+    ts_args_type = "test_suites: Array<TestSuite>, gas_report: boolean, progress_callback: (result: SuiteResult) => void"
+)]
+pub fn run_solidity_tests(
+    test_suites: Vec<TestSuite>,
     gas_report: bool,
-}
+    progress_callback: JsFunction,
+) -> napi::Result<()> {
+    let results_callback_fn: ThreadsafeFunction<_, ErrorStrategy::Fatal> = progress_callback
+        .create_threadsafe_function(
+            // Unbounded queue size
+            0,
+            |ctx: ThreadSafeCallContext<SuiteResult>| Ok(vec![ctx.value]),
+        )?;
 
-// The callback has to be passed in the constructor because it's not `Send`.
-#[napi]
-impl SolidityTestRunner {
-    #[doc = "Creates a new instance of the SolidityTestRunner. The callback function will be called with suite results as they finish."]
-    #[napi(constructor)]
-    pub fn new(env: Env, gas_report: bool, results_callback: JsFunction) -> napi::Result<Self> {
-        let mut results_callback_fn: ThreadsafeFunction<_, ErrorStrategy::CalleeHandled> =
-            results_callback.create_threadsafe_function(
-                // Unbounded queue size
-                0,
-                |ctx: ThreadSafeCallContext<SuiteResult>| Ok(vec![ctx.value]),
-            )?;
+    let test_suites = test_suites
+        .into_iter()
+        .map(|item| Ok((item.id.try_into()?, item.contract.try_into()?)))
+        .collect::<Result<Vec<_>, napi::Error>>()?;
+    let runner = build_runner(test_suites, gas_report)?;
 
-        // Allow the event loop to exit before the function is destroyed
-        results_callback_fn.unref(&env)?;
+    let (tx_results, mut rx_results) =
+        tokio::sync::mpsc::unbounded_channel::<(String, forge::result::SuiteResult)>();
 
-        Ok(Self {
-            results_callback_fn,
-            gas_report,
-        })
-    }
+    let runtime = runtime::Handle::current();
+    runtime.spawn(async move {
+        while let Some(name_and_suite_result) = rx_results.recv().await {
+            let callback_arg = name_and_suite_result.into();
+            // Blocking mode won't block in our case because the function was created with
+            // unlimited queue size https://github.com/nodejs/node-addon-api/blob/main/doc/threadsafe_function.md#blockingcall--nonblockingcall
+            let call_status =
+                results_callback_fn.call(callback_arg, ThreadsafeFunctionCallMode::Blocking);
+            // This should always succeed since we're using an unbounded queue. We add an
+            // assertion for completeness.
+            assert!(
+                matches!(call_status, napi::Status::Ok),
+                "Failed to call callback with status {call_status:?}"
+            );
+        }
+    });
 
-    #[doc = "Runs the given test suites."]
-    #[napi]
-    pub async fn run_tests(&self, test_suites: Vec<TestSuite>) -> napi::Result<Vec<SuiteResult>> {
-        let test_suites = test_suites
-            .into_iter()
-            .map(|item| Ok((item.id.try_into()?, item.contract.try_into()?)))
-            .collect::<Result<Vec<_>, napi::Error>>()?;
-        let runner = build_runner(test_suites, self.gas_report)?;
+    // Returns immediately after test suite execution is started
+    runner.test_hardhat(Arc::new(EverythingFilter), tx_results);
 
-        let (tx_results, mut rx_results) =
-            tokio::sync::mpsc::unbounded_channel::<(String, forge::result::SuiteResult)>();
-        let (tx_end_result, rx_end_result) = tokio::sync::oneshot::channel();
-
-        let callback_fn = self.results_callback_fn.clone();
-        let runtime = runtime::Handle::current();
-        runtime.spawn(async move {
-            let mut results = Vec::<(String, forge::result::SuiteResult)>::new();
-
-            while let Some(name_and_suite_result) = rx_results.recv().await {
-                results.push(name_and_suite_result.clone());
-                // Blocking mode won't block in our case because the function was created with
-                // unlimited queue size https://github.com/nodejs/node-addon-api/blob/main/doc/threadsafe_function.md#blockingcall--nonblockingcall
-                let call_status = callback_fn.call(
-                    Ok(name_and_suite_result.into()),
-                    ThreadsafeFunctionCallMode::Blocking,
-                );
-                // This should always succeed since we're using an unbounded queue. We add an
-                // assertion for completeness.
-                assert!(
-                    matches!(call_status, napi::Status::Ok),
-                    "Failed to call callback with status {call_status:?}"
-                );
-            }
-
-            let js_suite_results = results
-                .into_iter()
-                .map(Into::into)
-                .collect::<Vec<SuiteResult>>();
-            tx_end_result
-                .send(js_suite_results)
-                .expect("Failed to send end result");
-        });
-
-        runner.test_hardhat(Arc::new(EverythingFilter), tx_results);
-
-        let results = rx_end_result.await.map_err(|_err| {
-            napi::Error::new(napi::Status::GenericFailure, "Failed to receive end result")
-        })?;
-
-        Ok(results)
-    }
+    Ok(())
 }
 
 struct EverythingFilter;


### PR DESCRIPTION
# Problem

The Solidity test runner interface that is exposed from Rust looks like this currently (config options are WIP):

```tsx
/** Executes solidity tests. */
export class SolidityTestRunner {
  /**Creates a new instance of the SolidityTestRunner. The callback function will be called with suite results as they finish. */
  constructor(gasReport: boolean, resultsCallback: (SuiteResult) => void)
  /**Runs the given test suites. */
  runTests(testSuites: Array<TestSuite>): Promise<Array<SuiteResult>>
}
```

The `SolidityTestRunner`  makes no guarantees about when the progress callbacks are called. The only guarantee is that the callback will be scheduled to be called for each test suite as soon as the test suite finished executing. The scheduling is done by the NodeJS event loop and it can happen after the promise returned by `runTests` is resolved.

Normally NodeJS won’t exit as long as there are callbacks scheduled to be called by the event loop, but this can be overridden by calling `process.exit()` . So given code like this:

```tsx
const testRunner = new SolidityTestsRunner(/* gasReport: */ false, () => { console.log("callback") })
const results = await testRunner.run()

// ...

process.exit()
```

It’s possible that the progress callback is never invoked. 

As it turns out, the Hardhat CLI [calls](https://github.com/NomicFoundation/hardhat/blob/739d593d46123c6584de10c7bc5fce10bae4b9e2/packages/hardhat-core/src/internal/cli/cli.ts#L475) `process.exit` after all plugins have finished executing, which leads to progress reports not being printed sometimes in the Solidity tests plugin.

# Solution

The `process.exit` call in Hardhat is probably there for a good reason, so I can see two solutions to this problem:

1. Make `runTests` return nothing, and have the callee accumulate results through the progress callback that receive each `SuiteResult` as it’s ready.
2. Make the promise returned by  `runTests`  only resolve after the callbacks have finished executing (as opposed to the current behavior which is to resolve after all test suites have finished executing).

I prefer the first solution, because it’s simpler on the Rust side and it gives full flexibility on the JS side where it’s easy to keep track of when all test suites have finished. E.g. one could promisify it as follows:

```tsx
const testSuites: TestSuite[] = [...];

const results: Array<SuiteResult> = await new Promise((resolve) => {
  const gasReport = false;
  const resultsFromCallback: Array<SuiteResult> = [];

  runSolidityTests(testSuites, gasReport, (result: SuiteResult) => {
    resultsFromCallback.push(result);
    if (resultsFromCallback.length === testSuites.length) {
      resolve(resultsFromCallback);
    }
  });
});

// Calling `process.exit` here is no problem, because the promise only resolves 
// after all callbacks have fired.
```

And this could be modified to support event subscriptions or async progress callbacks without modifications on the Rust side.

## Interface

The previous object-oriented interface had to be abandoned, because of lifetime issues with the JS progress callback once the `runTests` method was changed to return immediately after test execution started.

For background, we first wanted to have a single function to call to execute Solidity tests, but we also wanted to have this function return all the results. This meant the function had to be async. But the `JsFunction` callback passed into Rust is not `Send` which means it cannot be passed as argument into a napi-rs async function. As a workaround we added a `SolidityTestRunner` class, passed the `JsFunction` into its sync constructor and then added an async method to the class.

But because we held on the `JsFunction` in the `SolidityTestRunner`, we needed another workaround to let the event loop exit before the object is GC-ed by calling `unref` on the thread safe function wrapper for the `JsFunction`. When I changed the `runTest` method in this PR to return immediately after test execution started, this `unref` workaround was causing problems as the lifetime of the `SolidityTestRunner` object and the callback no longer aligned when called like this:

```js
new Promise((resolve) => {
  const results = []

  const runner = new SolidityTestRunner((suiteResult) => {
    results.push(suiteResult)
    if (results.length === testSuites.length) {
       resolve(results)
    }
  })

  runner.runTests(testSuites)
})
```

With the `unref` workaround, the code above would panic with "thread safe function is closed" message and without the `unref` workaround there would be a noticeable delay between finishing test execution and the interpreter exiting. So I went back to the original design to just have a single free-standing function to run Solidity tests as the lifetimes are naturally aligned this way:

```ts
/**
 * Executes Solidity tests.
 *
 * The function will return as soon as test execution is started.
 * The progress callback will be called with the results of each test suite.
 * It is up to the caller to track how many times the callback is called to
 * know when all tests are done.
 */
export function runSolidityTests(test_suites: Array<TestSuite>, gas_report: boolean, progress_callback: (result: SuiteResult) => void): void
```

See full diff in `crates/edr_napi/index.d.ts`. 

An alternative to the free standing function could be keeping the `SolidityTestRunner` and have `runTests` take the callback as argument, but I don't think having a `SolidityTestRunner` object is warranted (sans async workaround) as it'd have no other methods and it'd achieve the same operation with two calls instead of one. So it'd be just ceremony.

# Considerations

- The promise result from `runTests` was originally introduced to make the JS interface more ergonomic, but it looks like it adds significantly more complexity on the Rust side than it saves on the JS side.
