### PR TITLE
refactor: Port the `VmTraceDecoder` from Hardhat

### DIFF
--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -426,7 +426,7 @@ export interface CreateMessageTrace {
   depth: number
   code: Uint8Array
   steps: Array<EvmStep | PrecompileMessageTrace | CallMessageTrace | CreateMessageTrace>
-  bytecode?: any
+  bytecode?: Bytecode
   numberOfSubtraces: number
   deployedContract?: Uint8Array | undefined
 }
@@ -438,7 +438,7 @@ export interface CallMessageTrace {
   depth: number
   code: Uint8Array
   steps: Array<EvmStep | PrecompileMessageTrace | CallMessageTrace | CreateMessageTrace>
-  bytecode?: any
+  bytecode?: Bytecode
   numberOfSubtraces: number
   calldata: Uint8Array
   address: Uint8Array

--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -707,6 +707,11 @@ export function isPush(opcode: Opcode): boolean
 export function isJump(opcode: Opcode): boolean
 export function isCall(opcode: Opcode): boolean
 export function isCreate(opcode: Opcode): boolean
+export interface ContractAndFunctionName {
+  contractName: string
+  functionName: string | undefined
+}
+export function initializeVmTraceDecoder(vmTraceDecoder: VmTraceDecoder, tracingConfig: any): void
 export interface TracingMessage {
   /** Sender address */
   readonly caller: Buffer
@@ -847,6 +852,13 @@ export class Exit {
   get kind(): ExitCode
   isError(): boolean
   getReason(): string
+}
+export class VmTraceDecoder {
+  constructor(contractsIdentifier: ContractsIdentifier)
+  addBytecode(bytecode: Bytecode): void
+  getBytecodeForCall(code: Uint8Array, isCreate: boolean): Bytecode | undefined
+  tryToDecodeMessageTrace(messageTrace: PrecompileMessageTrace | CreateMessageTrace | CallMessageTrace): PrecompileMessageTrace | CreateMessageTrace | CallMessageTrace
+  getContractAndFunctionNamesForCall(code: Uint8Array, calldata: Uint8Array | undefined): ContractAndFunctionName
 }
 export type VMTracer = VmTracer
 /** N-API bindings for the Rust port of `VMTracer` from Hardhat. */

--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -425,10 +425,10 @@ export interface CreateMessageTrace {
   gasUsed: bigint
   depth: number
   code: Uint8Array
-  steps: Array<EvmStep | PrecompileMessageTrace | CreateMessageTrace | CallMessageTrace>
+  steps: Array<EvmStep | PrecompileMessageTrace | CallMessageTrace | CreateMessageTrace>
   bytecode?: any
   numberOfSubtraces: number
-  deployedContract: Uint8Array | undefined
+  deployedContract?: Uint8Array | undefined
 }
 export interface CallMessageTrace {
   value: bigint
@@ -437,7 +437,7 @@ export interface CallMessageTrace {
   gasUsed: bigint
   depth: number
   code: Uint8Array
-  steps: Array<EvmStep | PrecompileMessageTrace | CreateMessageTrace | CallMessageTrace>
+  steps: Array<EvmStep | PrecompileMessageTrace | CallMessageTrace | CreateMessageTrace>
   bytecode?: any
   numberOfSubtraces: number
   calldata: Uint8Array
@@ -857,7 +857,7 @@ export class VmTraceDecoder {
   constructor(contractsIdentifier: ContractsIdentifier)
   addBytecode(bytecode: Bytecode): void
   getBytecodeForCall(code: Uint8Array, isCreate: boolean): Bytecode | undefined
-  tryToDecodeMessageTrace(messageTrace: PrecompileMessageTrace | CreateMessageTrace | CallMessageTrace): PrecompileMessageTrace | CreateMessageTrace | CallMessageTrace
+  tryToDecodeMessageTrace(messageTrace: PrecompileMessageTrace | CallMessageTrace | CreateMessageTrace): PrecompileMessageTrace | CallMessageTrace | CreateMessageTrace
   getContractAndFunctionNamesForCall(code: Uint8Array, calldata: Uint8Array | undefined): ContractAndFunctionName
 }
 export type VMTracer = VmTracer
@@ -866,7 +866,7 @@ export class VmTracer {
   constructor()
   /** Observes a trace, collecting information about the execution of the EVM. */
   observe(trace: RawTrace): void
-  getLastTopLevelMessageTrace(): PrecompileMessageTrace | CreateMessageTrace | CallMessageTrace | undefined
+  getLastTopLevelMessageTrace(): PrecompileMessageTrace | CallMessageTrace | CreateMessageTrace | undefined
   getLastError(): Error | undefined
 }
 export class RawTrace {

--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -846,7 +846,6 @@ export class Contract {
 export class ContractsIdentifier {
   constructor(enableCache?: boolean | undefined | null)
   addBytecode(bytecode: Bytecode): void
-  getBytecodeForCall(code: Uint8Array, isCreate: boolean): Bytecode | undefined
 }
 export class Exit {
   get kind(): ExitCode
@@ -856,7 +855,6 @@ export class Exit {
 export class VmTraceDecoder {
   constructor(contractsIdentifier: ContractsIdentifier)
   addBytecode(bytecode: Bytecode): void
-  getBytecodeForCall(code: Uint8Array, isCreate: boolean): Bytecode | undefined
   tryToDecodeMessageTrace(messageTrace: PrecompileMessageTrace | CallMessageTrace | CreateMessageTrace): PrecompileMessageTrace | CallMessageTrace | CreateMessageTrace
   getContractAndFunctionNamesForCall(code: Uint8Array, calldata: Uint8Array | undefined): ContractAndFunctionName
 }

--- a/crates/edr_napi/index.js
+++ b/crates/edr_napi/index.js
@@ -310,7 +310,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { SpecId, EdrContext, MineOrdering, Provider, Response, SuccessReason, ExceptionalHalt, createModelsAndDecodeBytecodes, linkHexStringBytecode, SourceFile, SourceLocation, ContractFunctionType, ContractFunctionVisibility, ContractFunction, CustomError, Instruction, JumpType, jumpTypeToString, Bytecode, ContractType, Contract, ContractsIdentifier, Exit, ExitCode, Opcode, opcodeToString, isPush, isJump, isCall, isCreate, VmTracer, RawTrace } = nativeBinding
+const { SpecId, EdrContext, MineOrdering, Provider, Response, SuccessReason, ExceptionalHalt, createModelsAndDecodeBytecodes, linkHexStringBytecode, SourceFile, SourceLocation, ContractFunctionType, ContractFunctionVisibility, ContractFunction, CustomError, Instruction, JumpType, jumpTypeToString, Bytecode, ContractType, Contract, ContractsIdentifier, Exit, ExitCode, Opcode, opcodeToString, isPush, isJump, isCall, isCreate, VmTraceDecoder, initializeVmTraceDecoder, VmTracer, RawTrace } = nativeBinding
 
 module.exports.SpecId = SpecId
 module.exports.EdrContext = EdrContext
@@ -342,5 +342,7 @@ module.exports.isPush = isPush
 module.exports.isJump = isJump
 module.exports.isCall = isCall
 module.exports.isCreate = isCreate
+module.exports.VmTraceDecoder = VmTraceDecoder
+module.exports.initializeVmTraceDecoder = initializeVmTraceDecoder
 module.exports.VmTracer = VmTracer
 module.exports.RawTrace = RawTrace

--- a/crates/edr_napi/src/trace.rs
+++ b/crates/edr_napi/src/trace.rs
@@ -25,6 +25,7 @@ mod contracts_identifier;
 mod exit;
 mod message_trace;
 mod opcodes;
+mod vm_trace_decoder;
 mod vm_tracer;
 
 #[napi(object)]

--- a/crates/edr_napi/src/trace/compiler.rs
+++ b/crates/edr_napi/src/trace/compiler.rs
@@ -11,7 +11,7 @@ use edr_solidity::{
 use indexmap::IndexMap;
 use napi::{
     bindgen_prelude::{ClassInstance, Uint8Array},
-    Either, Env,
+    Env,
 };
 use napi_derive::napi;
 

--- a/crates/edr_napi/src/trace/compiler.rs
+++ b/crates/edr_napi/src/trace/compiler.rs
@@ -26,7 +26,7 @@ use super::{
 use crate::utils::ClassInstanceRef;
 
 #[napi]
-fn create_models_and_decode_bytecodes(
+pub fn create_models_and_decode_bytecodes(
     solc_version: String,
     compiler_input: serde_json::Value,
     compiler_output: serde_json::Value,
@@ -35,12 +35,21 @@ fn create_models_and_decode_bytecodes(
     let compiler_input: CompilerInput = serde_json::from_value(compiler_input)?;
     let compiler_output: CompilerOutput = serde_json::from_value(compiler_output)?;
 
+    create_models_and_decode_bytecodes_inner(solc_version, &compiler_input, &compiler_output, env)
+}
+
+pub fn create_models_and_decode_bytecodes_inner(
+    solc_version: String,
+    compiler_input: &CompilerInput,
+    compiler_output: &CompilerOutput,
+    env: Env,
+) -> napi::Result<Vec<ClassInstance<Bytecode>>> {
     let mut file_id_to_source_file = HashMap::new();
     let mut contract_id_to_contract = IndexMap::new();
 
     create_sources_model_from_ast(
-        &compiler_output,
-        &compiler_input,
+        compiler_output,
+        compiler_input,
         &mut file_id_to_source_file,
         &mut contract_id_to_contract,
         env,
@@ -48,13 +57,13 @@ fn create_models_and_decode_bytecodes(
 
     let bytecodes = decode_bytecodes(
         solc_version,
-        &compiler_output,
+        compiler_output,
         &file_id_to_source_file,
         &contract_id_to_contract,
         env,
     )?;
 
-    correct_selectors(&bytecodes, &compiler_output, env)?;
+    correct_selectors(&bytecodes, compiler_output, env)?;
 
     Ok(bytecodes)
 }
@@ -691,10 +700,9 @@ fn correct_selectors(
             let selector = hex::decode(hex_selector)
                 .map_err(|e| napi::Error::from_reason(format!("Failed to decode hex: {e:?}")))?;
 
-            let contract_function =
-                contract.get_function_from_selector(selector.clone().into(), env)?;
+            let contract_function = contract.get_function_from_selector_inner(&selector);
 
-            if let Either::A(_) = contract_function {
+            if contract_function.is_some() {
                 continue;
             }
 

--- a/crates/edr_napi/src/trace/contracts_identifier.rs
+++ b/crates/edr_napi/src/trace/contracts_identifier.rs
@@ -296,6 +296,38 @@ impl ContractsIdentifier {
             None => Ok(Either::B(())),
         }
     }
+
+    pub fn get_bytecode_for_call_inner(
+        &mut self,
+        code: Uint8Array,
+        is_create: bool,
+        env: Env,
+    ) -> napi::Result<Either<Rc<ClassInstanceRef<Bytecode>>, Undefined>> {
+        let mut normalized_code = code.clone();
+        normalize_library_runtime_bytecode_if_necessary(&mut normalized_code);
+
+        let normalized_code_hex = hex::encode(normalized_code.as_ref());
+        if self.enable_cache {
+            let cached = self.cache.get(&normalized_code_hex);
+
+            if let Some(cached) = cached {
+                return Ok(Either::A(cached.clone()));
+            }
+        }
+
+        let result = self.search_bytecode(is_create, normalized_code, None, None, None, env)?;
+
+        if self.enable_cache {
+            if let Some(result) = &result {
+                self.cache.insert(normalized_code_hex, result.clone());
+            }
+        }
+
+        match result {
+            Some(bytecode) => Ok(Either::A(bytecode)),
+            None => Ok(Either::B(())),
+        }
+    }
 }
 
 fn normalize_library_runtime_bytecode_if_necessary(code: &mut Uint8Array) {

--- a/crates/edr_napi/src/trace/contracts_identifier.rs
+++ b/crates/edr_napi/src/trace/contracts_identifier.rs
@@ -3,8 +3,8 @@ use std::{collections::HashMap, rc::Rc};
 use edr_eth::Address;
 use edr_evm::hex;
 use napi::{
-    bindgen_prelude::{ClassInstance, Uint8Array, Undefined},
-    Either, Env, JsObject,
+    bindgen_prelude::{ClassInstance, Uint8Array},
+    Either, Env,
 };
 use napi_derive::napi;
 

--- a/crates/edr_napi/src/trace/message_trace.rs
+++ b/crates/edr_napi/src/trace/message_trace.rs
@@ -27,6 +27,10 @@ pub struct PrecompileMessageTrace {
     pub calldata: Uint8Array,
 }
 
+// NOTE: Because of the hack below for `deployed_contract`, now the `CallMessageTrace`
+// is a strict superset of `CreateMessageTrace`, so we need to take care to keep
+// the order consistent from most-specific to least-specific in the `Either{3,4}` type
+// when converting to or from N-API.
 #[napi(object)]
 pub struct CreateMessageTrace {
     // `BaseMessageTrace`
@@ -37,16 +41,21 @@ pub struct CreateMessageTrace {
     pub depth: u32,
     // `BaseEvmMessageTrace`
     pub code: Uint8Array,
-    pub steps: Vec<Either4<EvmStep, PrecompileMessageTrace, CreateMessageTrace, CallMessageTrace>>,
+    pub steps: Vec<Either4<EvmStep, PrecompileMessageTrace, CallMessageTrace, CreateMessageTrace>>,
     // TODO: Will be later filled on the JS side but we should port to ContractsIdentifier in Rust
     // This is explicitly `any` on the JS side to side-step the type-checking until we port
     #[napi(ts_type = "any")]
     pub bytecode: Option<Object>,
     pub number_of_subtraces: u32,
     // `CreateMessageTrace`
-    // NOTE: we can't use Option<T> as this is converted to an optional property,
-    // which is not backwards compatible with the current JS interface
-    pub deployed_contract: Either<Uint8Array, Undefined>,
+    // HACK: It seems that `Either<Uint8Array, Undefined>` means exactly what we
+    // want (a required property but can be explicitly `undefined`) but internally
+    // the napi-rs treats an encountered `Undefined` like a missing property
+    // and it throws a validation error. While not 100% backwards compatible, we
+    // work around using an optional type.
+    // See https://github.com/napi-rs/napi-rs/issues/1986 for context on the PR
+    // that introduced this behavior.
+    pub deployed_contract: Option<Either<Uint8Array, Undefined>>,
 }
 
 #[napi(object)]
@@ -59,7 +68,7 @@ pub struct CallMessageTrace {
     pub depth: u32,
     // `BaseEvmMessageTrace`
     pub code: Uint8Array,
-    pub steps: Vec<Either4<EvmStep, PrecompileMessageTrace, CreateMessageTrace, CallMessageTrace>>,
+    pub steps: Vec<Either4<EvmStep, PrecompileMessageTrace, CallMessageTrace, CreateMessageTrace>>,
     // TODO: Will be later filled on the JS side but we should port to ContractsIdentifier in Rust
     // This is explicitly `any` on the JS side to side-step the type-checking until we port
     #[napi(ts_type = "any")]
@@ -79,7 +88,7 @@ pub struct CallMessageTrace {
 pub fn message_trace_step_to_napi(
     value: edr_solidity::message_trace::MessageTraceStep,
     env: Env,
-) -> napi::Result<Either4<EvmStep, PrecompileMessageTrace, CreateMessageTrace, CallMessageTrace>> {
+) -> napi::Result<Either4<EvmStep, PrecompileMessageTrace, CallMessageTrace, CreateMessageTrace>> {
     Ok(match value {
         edr_solidity::message_trace::MessageTraceStep::Evm(step) => {
             Either4::A(EvmStep { pc: step.pc as u32 })
@@ -90,8 +99,8 @@ pub fn message_trace_step_to_napi(
             let owned = msg.borrow().clone();
             match message_trace_to_napi(owned, env)? {
                 Either3::A(precompile) => Either4::B(precompile),
-                Either3::B(create) => Either4::C(create),
-                Either3::C(call) => Either4::D(call),
+                Either3::B(call) => Either4::C(call),
+                Either3::C(create) => Either4::D(create),
             }
         }
     })
@@ -102,7 +111,7 @@ pub fn message_trace_step_to_napi(
 pub fn message_trace_to_napi(
     value: edr_solidity::message_trace::MessageTrace,
     env: Env,
-) -> napi::Result<Either3<PrecompileMessageTrace, CreateMessageTrace, CallMessageTrace>> {
+) -> napi::Result<Either3<PrecompileMessageTrace, CallMessageTrace, CreateMessageTrace>> {
     Ok(match value {
         edr_solidity::message_trace::MessageTrace::Precompile(precompile) => {
             Either3::A(PrecompileMessageTrace {
@@ -119,34 +128,7 @@ pub fn message_trace_to_napi(
                 calldata: Uint8Array::from(precompile.calldata.as_ref()),
             })
         }
-        edr_solidity::message_trace::MessageTrace::Create(create) => {
-            Either3::B(CreateMessageTrace {
-                value: BigInt {
-                    sign_bit: false,
-                    words: create.base.base.value.as_limbs().to_vec(),
-                },
-                return_data: Uint8Array::from(create.base.base.return_data.as_ref()),
-                exit: Exit(create.base.base.exit.into()).into_instance(env)?,
-                gas_used: BigInt::from(create.base.base.gas_used),
-                depth: create.base.base.depth as u32,
-                code: Uint8Array::from(create.base.code.as_ref()),
-                steps: create
-                    .base
-                    .steps
-                    .into_iter()
-                    .map(|step| message_trace_step_to_napi(step, env))
-                    .collect::<napi::Result<Vec<_>>>()?,
-                // NOTE: We specifically use None as that will be later filled on the JS side
-                bytecode: None,
-
-                number_of_subtraces: create.base.number_of_subtraces,
-                deployed_contract: match create.deployed_contract {
-                    Some(contract) => Either::A(Uint8Array::from(contract.as_ref())),
-                    None => Either::B(()),
-                },
-            })
-        }
-        edr_solidity::message_trace::MessageTrace::Call(call) => Either3::C(CallMessageTrace {
+        edr_solidity::message_trace::MessageTrace::Call(call) => Either3::B(CallMessageTrace {
             value: BigInt {
                 sign_bit: false,
                 words: call.base.base.value.as_limbs().to_vec(),
@@ -170,5 +152,31 @@ pub fn message_trace_to_napi(
             calldata: Uint8Array::from(call.calldata.as_ref()),
             code_address: Uint8Array::from(call.code_address.as_slice()),
         }),
+        edr_solidity::message_trace::MessageTrace::Create(create) => {
+            Either3::C(CreateMessageTrace {
+                value: BigInt {
+                    sign_bit: false,
+                    words: create.base.base.value.as_limbs().to_vec(),
+                },
+                return_data: Uint8Array::from(create.base.base.return_data.as_ref()),
+                exit: Exit(create.base.base.exit.into()).into_instance(env)?,
+                gas_used: BigInt::from(create.base.base.gas_used),
+                depth: create.base.base.depth as u32,
+                code: Uint8Array::from(create.base.code.as_ref()),
+                steps: create
+                    .base
+                    .steps
+                    .into_iter()
+                    .map(|step| message_trace_step_to_napi(step, env))
+                    .collect::<napi::Result<Vec<_>>>()?,
+                // NOTE: We specifically use None as that will be later filled on the JS side
+                bytecode: None,
+
+                number_of_subtraces: create.base.number_of_subtraces,
+                deployed_contract: create
+                    .deployed_contract
+                    .map(|contract| Either::A(Uint8Array::from(contract.as_ref()))),
+            })
+        }
     })
 }

--- a/crates/edr_napi/src/trace/message_trace.rs
+++ b/crates/edr_napi/src/trace/message_trace.rs
@@ -41,9 +41,7 @@ pub struct CreateMessageTrace {
     // `BaseEvmMessageTrace`
     pub code: Uint8Array,
     pub steps: Vec<Either4<EvmStep, PrecompileMessageTrace, CallMessageTrace, CreateMessageTrace>>,
-    // TODO: Will be later filled on the JS side but we should port to ContractsIdentifier in Rust
-    // This is explicitly `any` on the JS side to side-step the type-checking until we port
-    #[napi(ts_type = "any")]
+    #[napi(ts_type = "Bytecode")]
     pub bytecode: Option<Object>,
     pub number_of_subtraces: u32,
     // `CreateMessageTrace`
@@ -68,9 +66,7 @@ pub struct CallMessageTrace {
     // `BaseEvmMessageTrace`
     pub code: Uint8Array,
     pub steps: Vec<Either4<EvmStep, PrecompileMessageTrace, CallMessageTrace, CreateMessageTrace>>,
-    // TODO: Will be later filled on the JS side but we should port to ContractsIdentifier in Rust
-    // This is explicitly `any` on the JS side to side-step the type-checking until we port
-    #[napi(ts_type = "any")]
+    #[napi(ts_type = "Bytecode")]
     pub bytecode: Option<Object>,
     pub number_of_subtraces: u32,
     // `CallMessageTrace`

--- a/crates/edr_napi/src/trace/message_trace.rs
+++ b/crates/edr_napi/src/trace/message_trace.rs
@@ -1,7 +1,7 @@
 //! Bridging type for the existing `MessageTrace` interface in Hardhat.
 
 use napi::{
-    bindgen_prelude::{BigInt, ClassInstance, Either3, Either4, Uint8Array, Undefined},
+    bindgen_prelude::{BigInt, ClassInstance, Either3, Either4, Object, Uint8Array, Undefined},
     Either, Env,
 };
 use napi_derive::napi;
@@ -40,7 +40,8 @@ pub struct CreateMessageTrace {
     pub steps: Vec<Either4<EvmStep, PrecompileMessageTrace, CreateMessageTrace, CallMessageTrace>>,
     // TODO: Will be later filled on the JS side but we should port to ContractsIdentifier in Rust
     // This is explicitly `any` on the JS side to side-step the type-checking until we port
-    pub bytecode: Option<Value>,
+    #[napi(ts_type = "any")]
+    pub bytecode: Option<Object>,
     pub number_of_subtraces: u32,
     // `CreateMessageTrace`
     // NOTE: we can't use Option<T> as this is converted to an optional property,
@@ -61,7 +62,8 @@ pub struct CallMessageTrace {
     pub steps: Vec<Either4<EvmStep, PrecompileMessageTrace, CreateMessageTrace, CallMessageTrace>>,
     // TODO: Will be later filled on the JS side but we should port to ContractsIdentifier in Rust
     // This is explicitly `any` on the JS side to side-step the type-checking until we port
-    pub bytecode: Option<Value>,
+    #[napi(ts_type = "any")]
+    pub bytecode: Option<Object>,
     pub number_of_subtraces: u32,
     // `CallMessageTrace`
     pub calldata: Uint8Array,

--- a/crates/edr_napi/src/trace/message_trace.rs
+++ b/crates/edr_napi/src/trace/message_trace.rs
@@ -5,7 +5,6 @@ use napi::{
     Either, Env,
 };
 use napi_derive::napi;
-use serde_json::Value;
 
 use super::exit::Exit;
 
@@ -27,10 +26,10 @@ pub struct PrecompileMessageTrace {
     pub calldata: Uint8Array,
 }
 
-// NOTE: Because of the hack below for `deployed_contract`, now the `CallMessageTrace`
-// is a strict superset of `CreateMessageTrace`, so we need to take care to keep
-// the order consistent from most-specific to least-specific in the `Either{3,4}` type
-// when converting to or from N-API.
+// NOTE: Because of the hack below for `deployed_contract`, now the
+// `CallMessageTrace` is a strict superset of `CreateMessageTrace`, so we need
+// to take care to keep the order consistent from most-specific to
+// least-specific in the `Either{3,4}` type when converting to or from N-API.
 #[napi(object)]
 pub struct CreateMessageTrace {
     // `BaseMessageTrace`

--- a/crates/edr_napi/src/trace/model.rs
+++ b/crates/edr_napi/src/trace/model.rs
@@ -535,12 +535,19 @@ impl Contract {
         selector: Uint8Array,
         env: Env,
     ) -> napi::Result<Either<JsObject, Undefined>> {
-        let selector_hex = hex::encode(&*selector);
-
-        match self.selector_hex_to_function.get(&selector_hex) {
+        match self.get_function_from_selector_inner(selector.as_ref()) {
             Some(func) => func.as_object(env).map(Either::A),
             None => Ok(Either::B(())),
         }
+    }
+
+    pub fn get_function_from_selector_inner(
+        &self,
+        selector: &[u8],
+    ) -> Option<&Rc<ClassInstanceRef<ContractFunction>>> {
+        let selector_hex = hex::encode(selector);
+
+        self.selector_hex_to_function.get(&selector_hex)
     }
 
     /// We compute selectors manually, which is particularly hard. We do this

--- a/crates/edr_napi/src/trace/vm_trace_decoder.rs
+++ b/crates/edr_napi/src/trace/vm_trace_decoder.rs
@@ -1,0 +1,273 @@
+use edr_solidity::artifacts::BuildInfo;
+use napi::{
+    bindgen_prelude::{ClassInstance, Either3, Either4, Uint8Array, Undefined},
+    Either, Env, JsObject,
+};
+use napi_derive::napi;
+use serde::{Deserialize, Serialize};
+
+use crate::{trace::model::ContractFunctionType, utils::ClassInstanceRef};
+
+use super::{
+    compiler::create_models_and_decode_bytecodes_inner,
+    contracts_identifier::ContractsIdentifier,
+    message_trace::{CallMessageTrace, CreateMessageTrace, PrecompileMessageTrace},
+    model::Bytecode,
+};
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TracingConfig {
+    pub build_infos: Option<Vec<BuildInfo>>,
+    pub ignore_contracts: Option<bool>,
+}
+
+#[napi]
+pub struct VmTraceDecoder {
+    contracts_identifier: ClassInstanceRef<ContractsIdentifier>,
+}
+
+#[napi]
+impl VmTraceDecoder {
+    #[napi(constructor)]
+    pub fn new(
+        contracts_identifier: ClassInstance<ContractsIdentifier>,
+        env: Env,
+    ) -> napi::Result<Self> {
+        let contracts_identifier = ClassInstanceRef::from_obj(contracts_identifier, env)?;
+
+        Ok(Self {
+            contracts_identifier,
+        })
+    }
+
+    #[napi]
+    pub fn add_bytecode(
+        &mut self,
+        bytecode: ClassInstance<Bytecode>,
+        env: Env,
+    ) -> napi::Result<()> {
+        self.contracts_identifier
+            .borrow_mut(env)?
+            .add_bytecode(bytecode, env)
+    }
+
+    #[napi(ts_return_type = "Bytecode | undefined")]
+    pub fn get_bytecode_for_call(
+        &mut self,
+        code: Uint8Array,
+        is_create: bool,
+        env: Env,
+    ) -> napi::Result<Either<JsObject, Undefined>> {
+        self.contracts_identifier
+            .borrow_mut(env)?
+            .get_bytecode_for_call(code, is_create, env)
+    }
+
+    #[napi]
+    pub fn try_to_decode_message_trace(
+        &self,
+        message_trace: Either3<PrecompileMessageTrace, CreateMessageTrace, CallMessageTrace>,
+        env: Env,
+    ) -> napi::Result<Either3<PrecompileMessageTrace, CreateMessageTrace, CallMessageTrace>> {
+        match message_trace {
+            precompile @ Either3::A(..) => Ok(precompile),
+            // NOTE: The branches below are the same with the difference of `is_create`
+            Either3::B(mut create) => {
+                let is_create = true;
+
+                let bytecode = self
+                    .contracts_identifier
+                    .borrow_mut(env)?
+                    .get_bytecode_for_call(create.code.clone(), is_create, env)?;
+
+                let steps: Vec<_> = create
+                    .steps
+                    .into_iter()
+                    .map(|step| {
+                        let trace = match step {
+                            Either4::A(step) => return Ok(Either4::A(step)),
+                            Either4::B(precompile) => Either3::A(precompile),
+                            Either4::C(create) => Either3::B(create),
+                            Either4::D(call) => Either3::C(call),
+                        };
+
+                        Ok(match self.try_to_decode_message_trace(trace, env)? {
+                            Either3::A(precompile) => Either4::B(precompile),
+                            Either3::B(create) => Either4::C(create),
+                            Either3::C(call) => Either4::D(call),
+                        })
+                    })
+                    .collect::<napi::Result<_>>()?;
+
+                match bytecode {
+                    Either::A(bytecode) => {
+                        create.bytecode = Some(bytecode);
+                    }
+                    Either::B(()) => {
+                        create.bytecode = None;
+                    }
+                }
+                create.steps = steps;
+
+                Ok(Either3::B(create))
+            }
+            Either3::C(mut call) => {
+                let is_create = false;
+
+                let bytecode = self
+                    .contracts_identifier
+                    .borrow_mut(env)?
+                    .get_bytecode_for_call(call.code.clone(), is_create, env)?;
+
+                let steps: Vec<_> = call
+                    .steps
+                    .into_iter()
+                    .map(|step| {
+                        let trace = match step {
+                            Either4::A(step) => return Ok(Either4::A(step)),
+                            Either4::B(precompile) => Either3::A(precompile),
+                            Either4::C(create) => Either3::B(create),
+                            Either4::D(call) => Either3::C(call),
+                        };
+
+                        Ok(match self.try_to_decode_message_trace(trace, env)? {
+                            Either3::A(precompile) => Either4::B(precompile),
+                            Either3::B(create) => Either4::C(create),
+                            Either3::C(call) => Either4::D(call),
+                        })
+                    })
+                    .collect::<napi::Result<_>>()?;
+
+                match bytecode {
+                    Either::A(bytecode) => {
+                        call.bytecode = Some(bytecode);
+                    }
+                    Either::B(()) => {
+                        call.bytecode = None;
+                    }
+                }
+                call.steps = steps;
+
+                Ok(Either3::C(call))
+            }
+        }
+    }
+
+    #[napi]
+    pub fn get_contract_and_function_names_for_call(
+        &self,
+        code: Uint8Array,
+        calldata: Either<Uint8Array, Undefined>,
+        env: Env,
+    ) -> napi::Result<ContractAndFunctionName> {
+        let is_create = matches!(calldata, Either::B(()));
+        let bytecode = self
+            .contracts_identifier
+            .borrow_mut(env)?
+            .get_bytecode_for_call_inner(code, is_create, env)?;
+
+        let contract = match bytecode {
+            Either::A(bytecode) => Some(bytecode.borrow(env)?.contract.clone()),
+            Either::B(()) => None,
+        };
+        let contract = contract.as_ref().map(|c| c.borrow(env)).transpose()?;
+
+        let contract_name = contract.as_ref().map_or_else(
+            || UNRECOGNIZED_CONTRACT_NAME.to_string(),
+            |c| c.name.clone(),
+        );
+
+        if is_create {
+            Ok(ContractAndFunctionName {
+                contract_name,
+                function_name: Either::B(()),
+            })
+        } else {
+            match contract {
+                None => Ok(ContractAndFunctionName {
+                    contract_name,
+                    function_name: Either::A("".to_string()),
+                }),
+                Some(contract) => {
+                    let calldata = match calldata {
+                        Either::A(calldata) => calldata,
+                        Either::B(_) => {
+                            unreachable!("calldata should be Some if is_create is false")
+                        }
+                    };
+
+                    let selector = &calldata.get(..4).unwrap_or(&calldata[..]);
+
+                    let func = contract.get_function_from_selector_inner(selector);
+
+                    let function_name = match func {
+                        Some(func) => {
+                            let func = func.borrow(env)?;
+                            match func.r#type {
+                                ContractFunctionType::FALLBACK => {
+                                    FALLBACK_FUNCTION_NAME.to_string()
+                                }
+                                ContractFunctionType::RECEIVE => RECEIVE_FUNCTION_NAME.to_string(),
+                                _ => func.name.clone(),
+                            }
+                        }
+                        None => UNRECOGNIZED_FUNCTION_NAME.to_string(),
+                    };
+
+                    Ok(ContractAndFunctionName {
+                        contract_name,
+                        function_name: Either::A(function_name),
+                    })
+                }
+            }
+        }
+    }
+}
+
+const UNRECOGNIZED_CONTRACT_NAME: &str = "<UnrecognizedContract>";
+const UNRECOGNIZED_FUNCTION_NAME: &str = "<unrecognized-selector>";
+const FALLBACK_FUNCTION_NAME: &str = "<fallback>";
+const RECEIVE_FUNCTION_NAME: &str = "<receive>";
+
+#[napi(object)]
+pub struct ContractAndFunctionName {
+    pub contract_name: String,
+    pub function_name: Either<String, Undefined>,
+}
+
+#[napi(catch_unwind)]
+pub fn initialize_vm_trace_decoder(
+    mut vm_trace_decoder: ClassInstance<VmTraceDecoder>,
+    tracing_config: serde_json::Value,
+    env: Env,
+) -> napi::Result<()> {
+    let config = serde_json::from_value::<TracingConfig>(tracing_config).map_err(|e| {
+        napi::Error::from_reason(format!("Failed to deserialize tracing config: {e:?}"))
+    })?;
+
+    let Some(build_infos) = config.build_infos else {
+        return Ok(());
+    };
+
+    for build_info in &build_infos {
+        let bytecodes = create_models_and_decode_bytecodes_inner(
+            build_info.solc_version.clone(),
+            &build_info.input,
+            &build_info.output,
+            env,
+        )?;
+
+        for bytecode in bytecodes {
+            if config.ignore_contracts == Some(true)
+                && bytecode.contract.borrow(env)?.name.starts_with("Ignored")
+            {
+                continue;
+            }
+
+            vm_trace_decoder.add_bytecode(bytecode, env)?;
+        }
+    }
+
+    Ok(())
+}

--- a/crates/edr_napi/src/trace/vm_trace_decoder.rs
+++ b/crates/edr_napi/src/trace/vm_trace_decoder.rs
@@ -6,14 +6,13 @@ use napi::{
 use napi_derive::napi;
 use serde::{Deserialize, Serialize};
 
-use crate::{trace::model::ContractFunctionType, utils::ClassInstanceRef};
-
 use super::{
     compiler::create_models_and_decode_bytecodes_inner,
     contracts_identifier::ContractsIdentifier,
     message_trace::{CallMessageTrace, CreateMessageTrace, PrecompileMessageTrace},
     model::Bytecode,
 };
+use crate::{trace::model::ContractFunctionType, utils::ClassInstanceRef};
 
 #[derive(Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/crates/edr_napi/src/trace/vm_tracer.rs
+++ b/crates/edr_napi/src/trace/vm_tracer.rs
@@ -37,7 +37,7 @@ impl VMTracer {
         &self,
         env: Env,
     ) -> napi::Result<
-        Either4<PrecompileMessageTrace, CreateMessageTrace, CallMessageTrace, Undefined>,
+        Either4<PrecompileMessageTrace, CallMessageTrace, CreateMessageTrace, Undefined>,
     > {
         Ok(
             match self
@@ -52,8 +52,8 @@ impl VMTracer {
                 .transpose()?
             {
                 Some(Either3::A(precompile)) => Either4::A(precompile),
-                Some(Either3::B(create)) => Either4::B(create),
-                Some(Either3::C(call)) => Either4::C(call),
+                Some(Either3::B(call)) => Either4::B(call),
+                Some(Either3::C(create)) => Either4::C(create),
                 None => Either4::D(()),
             },
         )

--- a/crates/edr_solidity/src/artifacts.rs
+++ b/crates/edr_solidity/src/artifacts.rs
@@ -13,12 +13,13 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BuildInfo {
-    _format: String,
-    id: String,
-    solc_version: String,
-    solc_long_version: String,
-    input: CompilerInput,
-    output: CompilerOutput,
+    #[serde(rename = "_format")]
+    pub _format: String,
+    pub id: String,
+    pub solc_version: String,
+    pub solc_long_version: String,
+    pub input: CompilerInput,
+    pub output: CompilerOutput,
 }
 
 /// References: of source name -> library name -> link references.

--- a/hardhat-tests/test/internal/hardhat-network/stack-traces/test.ts
+++ b/hardhat-tests/test/internal/hardhat-network/stack-traces/test.ts
@@ -673,7 +673,7 @@ async function runDeploymentTransactionTest(
     gas: tx.gas !== undefined ? BigInt(tx.gas) : undefined,
   });
 
-  if (!("deployedContract" in trace)) {
+  if ("precompile" in trace || "calldata" in trace) {
     assert.fail("Expected trace to be a deployment trace");
   }
 

--- a/patches/gen-hardhat-patches.sh
+++ b/patches/gen-hardhat-patches.sh
@@ -28,6 +28,8 @@ COMMITS=(
   dd34257cec2ceddc4e7065aa9147378d8f75da98
   # refactor: Re-use the ContractsIdentifier from EDR
   0bdc767826aba3b7ae2c4de02687d1743fb05813
+  # refactor: Port the VmTraceDecoder from Hardhat
+  137cfb33a8868329ae4d3d3903f4c7bf8838a50f
 )
 
 for commit in "${COMMITS[@]}"; do

--- a/patches/hardhat@2.22.6.patch
+++ b/patches/hardhat@2.22.6.patch
@@ -2657,38 +2657,144 @@ index 8aa9ffe76723470f68ffd824d9cac39de6494962..a13cd7177df2df7f7f3ae0abcdbd9db3
 \ No newline at end of file
 +{"version":3,"file":"solidityTracer.js","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/solidityTracer.ts"],"names":[],"mappings":";;;AAAA,sEAA+D;AAE/D,yDAAqD;AAGrD,qDAI0B;AAC1B,iHAGwD;AACxD,mDAayB;AAGzB,iEAIgC;AAEhC,MAAa,cAAc;IAA3B;QACU,mBAAc,GAAG,IAAI,8BAAa,EAAE,CAAC;IAyN/C,CAAC;IAvNQ,aAAa,CAClB,wBAAsC;QAEtC,IAAI,CAAC,wBAAwB,CAAC,IAAI,CAAC,OAAO,EAAE,EAAE;YAC5C,OAAO,EAAE,CAAC;SACX;QAED,IAAI,IAAA,iCAAiB,EAAC,wBAAwB,CAAC,EAAE;YAC/C,OAAO,IAAI,CAAC,+BAA+B,CAAC,wBAAwB,CAAC,CAAC;SACvE;QAED,IAAI,IAAA,oCAAoB,EAAC,wBAAwB,CAAC,EAAE;YAClD,OAAO,IAAI,CAAC,2BAA2B,CAAC,wBAAwB,CAAC,CAAC;SACnE;QAED,IAAI,IAAA,kCAAkB,EAAC,wBAAwB,CAAC,EAAE;YAChD,OAAO,IAAI,CAAC,yBAAyB,CAAC,wBAAwB,CAAC,CAAC;SACjE;QAED,OAAO,IAAI,CAAC,iCAAiC,CAAC,wBAAwB,CAAC,CAAC;IAC1E,CAAC;IAEO,yBAAyB,CAC/B,KAA8B;QAE9B,MAAM,aAAa,GACjB,IAAI,CAAC,cAAc,CAAC,6BAA6B,CAAC,KAAK,CAAC,CAAC;QAE3D,IAAI,aAAa,KAAK,SAAS,EAAE;YAC/B,OAAO,aAAa,CAAC;SACtB;QAED,OAAO,IAAI,CAAC,kBAAkB,CAAC,KAAK,CAAC,CAAC;IACxC,CAAC;IAEO,iCAAiC,CACvC,KAAsB;QAEtB,MAAM,QAAQ,GAAG,IAAI,CAAC,gBAAgB,CAAC,KAAK,CAAC,CAAC;QAE9C,IAAI,QAAQ,KAAK,SAAS,EAAE;YAC1B,yFAAyF;YACzF,8DAA8D;YAC9D,IACE,QAAQ,CAAC,IAAI,CAAC,OAAO,EAAE;gBACvB,IAAA,6BAAW,EAAC,KAAK,CAAC,UAAU,EAAE,QAAQ,CAAC,UAAU,CAAC,EAClD;gBACA,IAAI,iBAA0C,CAAC;gBAE/C,IAAI,IAAA,6BAAa,EAAC,KAAK,CAAC,EAAE;oBACxB,iBAAiB,GAAG;wBAClB,IAAI,EAAE,0CAAmB,CAAC,mCAAmC;qBAC9D,CAAC;iBACH;qBAAM;oBACL,iBAAiB,GAAG;wBAClB,IAAI,EAAE,0CAAmB,CAAC,qCAAqC;wBAC/D,OAAO,EAAE,KAAK,CAAC,OAAO;qBACvB,CAAC;iBACH;gBAED,OAAO,CAAC,iBAAiB,EAAE,GAAG,IAAI,CAAC,aAAa,CAAC,QAAQ,CAAC,CAAC,CAAC;aAC7D;SACF;QAED,IAAI,KAAK,CAAC,IAAI,CAAC,IAAI,8CAAsC,EAAE;YACzD,OAAO;gBACL;oBACE,IAAI,EAAE,0CAAmB,CAAC,wBAAwB;iBACnD;aACF,CAAC;SACH;QAED,MAAM,oBAAoB,GAAG,KAAK,CAAC,IAAI,CAAC,IAAI,oCAA4B,CAAC;QAEzE,IAAI,IAAA,6BAAa,EAAC,KAAK,CAAC,EAAE;YACxB,OAAO;gBACL;oBACE,IAAI,EAAE,0CAAmB,CAAC,yBAAyB;oBACnD,OAAO,EAAE,IAAI,wBAAU,CAAC,KAAK,CAAC,UAAU,CAAC;oBACzC,oBAAoB;iBACrB;aACF,CAAC;SACH;QAED,OAAO;YACL;gBACE,IAAI,EAAE,0CAAmB,CAAC,2BAA2B;gBACrD,OAAO,EAAE,KAAK,CAAC,OAAO;gBACtB,OAAO,EAAE,IAAI,wBAAU,CAAC,KAAK,CAAC,UAAU,CAAC;gBACzC,oBAAoB;aACrB;SACF,CAAC;IACJ,CAAC;IAEO,2BAA2B,CACjC,KAAgC;QAEhC,MAAM,aAAa,GACjB,IAAI,CAAC,cAAc,CAAC,+BAA+B,CAAC,KAAK,CAAC,CAAC;QAE7D,IAAI,aAAa,KAAK,SAAS,EAAE;YAC/B,OAAO,aAAa,CAAC;SACtB;QAED,OAAO,IAAI,CAAC,kBAAkB,CAAC,KAAK,CAAC,CAAC;IACxC,CAAC;IAEO,+BAA+B,CACrC,KAA6B;QAE7B,OAAO;YACL;gBACE,IAAI,EAAE,0CAAmB,CAAC,gBAAgB;gBAC1C,UAAU,EAAE,KAAK,CAAC,UAAU;aAC7B;SACF,CAAC;IACJ,CAAC;IAEO,kBAAkB,CACxB,KAA6B;QAE7B,MAAM,UAAU,GAAG,IAAI,CAAC,qBAAqB,CAAC,KAAK,CAAC,CAAC;QAErD,IAAI,IAAA,8EAA+B,EAAC,UAAU,EAAE,KAAK,CAAC,EAAE;YACtD,OAAO,IAAA,+DAAgB,EAAC,UAAU,EAAE,KAAK,CAAC,CAAC;SAC5C;QAED,OAAO,UAAU,CAAC;IACpB,CAAC;IAEO,qBAAqB,CAC3B,KAA6B;QAE7B,MAAM,UAAU,GAAuB,EAAE,CAAC;QAE1C,IAAI,aAAa,GAAG,CAAC,CAAC;QAEtB,+DAA+D;QAC/D,IAAI,kBAAkB,GAAG,KAAK,CAAC;QAE/B,MAAM,iBAAiB,GAAkB,EAAE,CAAC;QAE5C,IAAI,kBAA8C,CAAC;QAEnD,KAAK,IAAI,SAAS,GAAG,CAAC,EAAE,SAAS,GAAG,KAAK,CAAC,KAAK,CAAC,MAAM,EAAE,SAAS,EAAE,EAAE;YACnE,MAAM,IAAI,GAAG,KAAK,CAAC,KAAK,CAAC,SAAS,CAAC,CAAC;YACpC,MAAM,QAAQ,GAAG,KAAK,CAAC,KAAK,CAAC,SAAS,GAAG,CAAC,CAAC,CAAC;YAE5C,IAAI,IAAA,yBAAS,EAAC,IAAI,CAAC,EAAE;gBACnB,MAAM,IAAI,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,IAAI,CAAC,EAAE,CAAC,CAAC;gBAEpD,IACE,IAAI,CAAC,QAAQ,mCAA2B;oBACxC,QAAQ,KAAK,SAAS,EACtB;oBACA,MAAM,WAAW,GAAG,QAAmB,CAAC,CAAC,yCAAyC;oBAClF,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,WAAW,CAAC,EAAE,CAAC,CAAC;oBAE/D,IAAI,QAAQ,KAAK,SAAS,IAAI,QAAQ,CAAC,MAAM,6BAAoB,EAAE;wBACjE,UAAU,CAAC,IAAI,CACb,IAAA,sDAAqC,EAAC,KAAK,CAAC,QAAQ,EAAE,IAAI,CAAC,CAC5D,CAAC;wBACF,IAAI,QAAQ,CAAC,QAAQ,KAAK,SAAS,EAAE;4BACnC,kBAAkB,GAAG,IAAI,CAAC;yBAC3B;wBACD,iBAAiB,CAAC,IAAI,CAAC,QAAQ,CAAC,CAAC;qBAClC;iBACF;qBAAM,IAAI,IAAI,CAAC,QAAQ,oCAA4B,EAAE;oBACpD,UAAU,CAAC,GAAG,EAAE,CAAC;oBACjB,iBAAiB,CAAC,GAAG,EAAE,CAAC;iBACzB;aACF;iBAAM;gBACL,aAAa,IAAI,CAAC,CAAC;gBAEnB,uEAAuE;gBACvE,IAAI,aAAa,GAAG,KAAK,CAAC,iBAAiB,EAAE;oBAC3C,SAAS;iBACV;gBAED,MAAM,eAAe,GAAG,IAAI,CAAC,aAAa,CAAC,IAAI,CAAC,CAAC;gBAEjD,kBAAkB,GAAG;oBACnB,YAAY,EAAE,IAAI;oBAClB,SAAS;oBACT,UAAU,EAAE,eAAe;iBAC5B,CAAC;aACH;SACF;QAED,MAAM,2BAA2B,GAAG,IAAI,CAAC,cAAc,CAAC,iBAAiB,CACvE,KAAK,EACL,UAAU,EACV,iBAAiB,EACjB,kBAAkB,EAClB,kBAAkB,CACnB,CAAC;QAEF,OAAO,IAAI,CAAC,cAAc,CAAC,qBAAqB,CAC9C,2BAA2B,CAC5B,CAAC;IACJ,CAAC;IAEO,gBAAgB,CAAC,KAAsB;QAC7C,IAAI,KAAK,CAAC,iBAAiB,GAAG,CAAC,EAAE;YAC/B,OAAO,SAAS,CAAC;SAClB;QAED,IAAI,CAAC,GAAG,KAAK,CAAC,KAAK,CAAC,MAAM,GAAG,CAAC,CAAC;QAE/B,OAAO,IAAA,yBAAS,EAAC,KAAK,CAAC,KAAK,CAAC,CAAC,CAAC,CAAC,EAAE;YAChC,CAAC,IAAI,CAAC,CAAC;SACR;QAED,OAAO,KAAK,CAAC,KAAK,CAAC,CAAC,CAAiB,CAAC;IACxC,CAAC;CACF;AA1ND,wCA0NC"}
 \ No newline at end of file
+diff --git a/internal/hardhat-network/stack-traces/vm-trace-decoder.d.ts b/internal/hardhat-network/stack-traces/vm-trace-decoder.d.ts
+index 9ab9469708c0ddcded9aed839acf9c5f0c260543..4d0acc22312db19e8b3b731d6bb9063c778d81c8 100644
+--- a/internal/hardhat-network/stack-traces/vm-trace-decoder.d.ts
++++ b/internal/hardhat-network/stack-traces/vm-trace-decoder.d.ts
+@@ -1,17 +1,5 @@
+-/// <reference types="node" />
++import { VmTraceDecoder } from "@nomicfoundation/edr";
+ import { TracingConfig } from "../provider/node-types";
+-import { ContractsIdentifier } from "./contracts-identifier";
+-import { MessageTrace } from "./message-trace";
+-import { Bytecode } from "./model";
+-export declare class VmTraceDecoder {
+-    private readonly _contractsIdentifier;
+-    constructor(_contractsIdentifier: ContractsIdentifier);
+-    getContractAndFunctionNamesForCall(code: Buffer, calldata?: Buffer): {
+-        contractName: string;
+-        functionName?: string;
+-    };
+-    tryToDecodeMessageTrace(messageTrace: MessageTrace): MessageTrace;
+-    addBytecode(bytecode: Bytecode): void;
+-}
+-export declare function initializeVmTraceDecoder(vmTraceDecoder: VmTraceDecoder, tracingConfig: TracingConfig): void;
++declare function initializeVmTraceDecoderWrapper(vmTraceDecoder: VmTraceDecoder, tracingConfig: TracingConfig): void;
++export { VmTraceDecoder, initializeVmTraceDecoderWrapper as initializeVmTraceDecoder, };
+ //# sourceMappingURL=vm-trace-decoder.d.ts.map
+\ No newline at end of file
+diff --git a/internal/hardhat-network/stack-traces/vm-trace-decoder.d.ts.map b/internal/hardhat-network/stack-traces/vm-trace-decoder.d.ts.map
+index 708695c850760ec2fa7c4dacb8fcc2bc4556bade..00ae430c09396a2254d98bc104d514ef7ffe5c2c 100644
+--- a/internal/hardhat-network/stack-traces/vm-trace-decoder.d.ts.map
++++ b/internal/hardhat-network/stack-traces/vm-trace-decoder.d.ts.map
+@@ -1 +1 @@
+-{"version":3,"file":"vm-trace-decoder.d.ts","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/vm-trace-decoder.ts"],"names":[],"mappings":";AAGA,OAAO,EAAE,aAAa,EAAE,MAAM,wBAAwB,CAAC;AAEvD,OAAO,EAAE,mBAAmB,EAAE,MAAM,wBAAwB,CAAC;AAC7D,OAAO,EAIL,YAAY,EACb,MAAM,iBAAiB,CAAC;AACzB,OAAO,EAAE,QAAQ,EAAwB,MAAM,SAAS,CAAC;AAUzD,qBAAa,cAAc;IACb,OAAO,CAAC,QAAQ,CAAC,oBAAoB;gBAApB,oBAAoB,EAAE,mBAAmB;IAE/D,kCAAkC,CACvC,IAAI,EAAE,MAAM,EACZ,QAAQ,CAAC,EAAE,MAAM,GAChB;QAAE,YAAY,EAAE,MAAM,CAAC;QAAC,YAAY,CAAC,EAAE,MAAM,CAAA;KAAE;IAyC3C,uBAAuB,CAAC,YAAY,EAAE,YAAY,GAAG,YAAY;IAiBjE,WAAW,CAAC,QAAQ,EAAE,QAAQ;CAGtC;AAED,wBAAgB,wBAAwB,CACtC,cAAc,EAAE,cAAc,EAC9B,aAAa,EAAE,aAAa,QAyC7B"}
+\ No newline at end of file
++{"version":3,"file":"vm-trace-decoder.d.ts","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/vm-trace-decoder.ts"],"names":[],"mappings":"AAEA,OAAO,EAAE,cAAc,EAA4B,MAAM,sBAAsB,CAAC;AAEhF,OAAO,EAAE,aAAa,EAAE,MAAM,wBAAwB,CAAC;AAIvD,iBAAS,+BAA+B,CACtC,cAAc,EAAE,cAAc,EAC9B,aAAa,EAAE,aAAa,QAoB7B;AAED,OAAO,EACL,cAAc,EACd,+BAA+B,IAAI,wBAAwB,GAC5D,CAAC"}
+\ No newline at end of file
 diff --git a/internal/hardhat-network/stack-traces/vm-trace-decoder.js b/internal/hardhat-network/stack-traces/vm-trace-decoder.js
-index 4d344963203e4ddb9e0ce4eddc2c08797847547b..0f78fe89d0d4028a04b3a5bae38d45f65e6ab939 100644
+index 4d344963203e4ddb9e0ce4eddc2c08797847547b..2ab199eb81dc6e8cee8b8b27437bd7f29f134539 100644
 --- a/internal/hardhat-network/stack-traces/vm-trace-decoder.js
 +++ b/internal/hardhat-network/stack-traces/vm-trace-decoder.js
-@@ -9,7 +9,6 @@ const debug_1 = __importDefault(require("debug"));
+@@ -6,78 +6,13 @@ Object.defineProperty(exports, "__esModule", { value: true });
+ exports.initializeVmTraceDecoder = exports.VmTraceDecoder = void 0;
+ const chalk_1 = __importDefault(require("chalk"));
+ const debug_1 = __importDefault(require("debug"));
++const edr_1 = require("@nomicfoundation/edr");
++Object.defineProperty(exports, "VmTraceDecoder", { enumerable: true, get: function () { return edr_1.VmTraceDecoder; } });
  const reporter_1 = require("../../sentry/reporter");
- const compiler_to_model_1 = require("./compiler-to-model");
- const message_trace_1 = require("./message-trace");
+-const compiler_to_model_1 = require("./compiler-to-model");
+-const message_trace_1 = require("./message-trace");
 -const model_1 = require("./model");
- const solidity_stack_trace_1 = require("./solidity-stack-trace");
+-const solidity_stack_trace_1 = require("./solidity-stack-trace");
  const log = (0, debug_1.default)("hardhat:core:hardhat-network:node");
- class VmTraceDecoder {
-@@ -36,9 +35,9 @@ class VmTraceDecoder {
-                 const func = bytecode.contract.getFunctionFromSelector(calldata.slice(0, 4));
-                 const functionName = func === undefined
-                     ? solidity_stack_trace_1.UNRECOGNIZED_FUNCTION_NAME
+-class VmTraceDecoder {
+-    constructor(_contractsIdentifier) {
+-        this._contractsIdentifier = _contractsIdentifier;
+-    }
+-    getContractAndFunctionNamesForCall(code, calldata) {
+-        const isCreate = calldata === undefined;
+-        const bytecode = this._contractsIdentifier.getBytecodeForCall(code, isCreate);
+-        const contractName = bytecode?.contract.name ?? solidity_stack_trace_1.UNRECOGNIZED_CONTRACT_NAME;
+-        if (isCreate) {
+-            return {
+-                contractName,
+-            };
+-        }
+-        else {
+-            if (bytecode === undefined) {
+-                return {
+-                    contractName,
+-                    functionName: "",
+-                };
+-            }
+-            else {
+-                const func = bytecode.contract.getFunctionFromSelector(calldata.slice(0, 4));
+-                const functionName = func === undefined
+-                    ? solidity_stack_trace_1.UNRECOGNIZED_FUNCTION_NAME
 -                    : func.type === model_1.ContractFunctionType.FALLBACK
-+                    : func.type === 2 /* ContractFunctionType.FALLBACK */
-                         ? solidity_stack_trace_1.FALLBACK_FUNCTION_NAME
+-                        ? solidity_stack_trace_1.FALLBACK_FUNCTION_NAME
 -                        : func.type === model_1.ContractFunctionType.RECEIVE
-+                        : func.type === 3 /* ContractFunctionType.RECEIVE */
-                             ? solidity_stack_trace_1.RECEIVE_FUNCTION_NAME
-                             : func.name;
-                 return {
+-                            ? solidity_stack_trace_1.RECEIVE_FUNCTION_NAME
+-                            : func.name;
+-                return {
+-                    contractName,
+-                    functionName,
+-                };
+-            }
+-        }
+-    }
+-    tryToDecodeMessageTrace(messageTrace) {
+-        if ((0, message_trace_1.isPrecompileTrace)(messageTrace)) {
+-            return messageTrace;
+-        }
+-        return {
+-            ...messageTrace,
+-            bytecode: this._contractsIdentifier.getBytecodeForCall(messageTrace.code, (0, message_trace_1.isCreateTrace)(messageTrace)),
+-            steps: messageTrace.steps.map((s) => (0, message_trace_1.isEvmStep)(s) ? s : this.tryToDecodeMessageTrace(s)),
+-        };
+-    }
+-    addBytecode(bytecode) {
+-        this._contractsIdentifier.addBytecode(bytecode);
+-    }
+-}
+-exports.VmTraceDecoder = VmTraceDecoder;
+-function initializeVmTraceDecoder(vmTraceDecoder, tracingConfig) {
+-    if (tracingConfig.buildInfos === undefined) {
+-        return;
+-    }
++function initializeVmTraceDecoderWrapper(vmTraceDecoder, tracingConfig) {
+     try {
+-        for (const buildInfo of tracingConfig.buildInfos) {
+-            const bytecodes = (0, compiler_to_model_1.createModelsAndDecodeBytecodes)(buildInfo.solcVersion, buildInfo.input, buildInfo.output);
+-            for (const bytecode of bytecodes) {
+-                if (tracingConfig.ignoreContracts === true &&
+-                    bytecode.contract.name.startsWith("Ignored")) {
+-                    continue;
+-                }
+-                vmTraceDecoder.addBytecode(bytecode);
+-            }
+-        }
++        (0, edr_1.initializeVmTraceDecoder)(vmTraceDecoder, tracingConfig);
+     }
+     catch (error) {
+         console.warn(chalk_1.default.yellow("The Hardhat Network tracing engine could not be initialized. Run Hardhat with --verbose to learn more."));
+@@ -87,5 +22,5 @@ function initializeVmTraceDecoder(vmTraceDecoder, tracingConfig) {
+         }
+     }
+ }
+-exports.initializeVmTraceDecoder = initializeVmTraceDecoder;
++exports.initializeVmTraceDecoder = initializeVmTraceDecoderWrapper;
+ //# sourceMappingURL=vm-trace-decoder.js.map
+\ No newline at end of file
 diff --git a/internal/hardhat-network/stack-traces/vm-trace-decoder.js.map b/internal/hardhat-network/stack-traces/vm-trace-decoder.js.map
-index 445c3d5dd155afa63e92ca1bc586e86b2edc2f1e..dc762aedbfaaa335080d1335d0afe771be636cf9 100644
+index 445c3d5dd155afa63e92ca1bc586e86b2edc2f1e..109dc83807b6535e6ac313eed7f3dbefe6130a9e 100644
 --- a/internal/hardhat-network/stack-traces/vm-trace-decoder.js.map
 +++ b/internal/hardhat-network/stack-traces/vm-trace-decoder.js.map
 @@ -1 +1 @@
 -{"version":3,"file":"vm-trace-decoder.js","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/vm-trace-decoder.ts"],"names":[],"mappings":";;;;;;AAAA,kDAA0B;AAC1B,kDAA0B;AAC1B,oDAAiD;AAEjD,2DAAqE;AAErE,mDAKyB;AACzB,mCAAyD;AACzD,iEAKgC;AAEhC,MAAM,GAAG,GAAG,IAAA,eAAK,EAAC,mCAAmC,CAAC,CAAC;AAEvD,MAAa,cAAc;IACzB,YAA6B,oBAAyC;QAAzC,yBAAoB,GAApB,oBAAoB,CAAqB;IAAG,CAAC;IAEnE,kCAAkC,CACvC,IAAY,EACZ,QAAiB;QAEjB,MAAM,QAAQ,GAAG,QAAQ,KAAK,SAAS,CAAC;QACxC,MAAM,QAAQ,GAAG,IAAI,CAAC,oBAAoB,CAAC,kBAAkB,CAC3D,IAAI,EACJ,QAAQ,CACT,CAAC;QAEF,MAAM,YAAY,GAAG,QAAQ,EAAE,QAAQ,CAAC,IAAI,IAAI,iDAA0B,CAAC;QAE3E,IAAI,QAAQ,EAAE;YACZ,OAAO;gBACL,YAAY;aACb,CAAC;SACH;aAAM;YACL,IAAI,QAAQ,KAAK,SAAS,EAAE;gBAC1B,OAAO;oBACL,YAAY;oBACZ,YAAY,EAAE,EAAE;iBACjB,CAAC;aACH;iBAAM;gBACL,MAAM,IAAI,GAAG,QAAQ,CAAC,QAAQ,CAAC,uBAAuB,CACpD,QAAQ,CAAC,KAAK,CAAC,CAAC,EAAE,CAAC,CAAC,CACrB,CAAC;gBAEF,MAAM,YAAY,GAChB,IAAI,KAAK,SAAS;oBAChB,CAAC,CAAC,iDAA0B;oBAC5B,CAAC,CAAC,IAAI,CAAC,IAAI,KAAK,4BAAoB,CAAC,QAAQ;wBAC7C,CAAC,CAAC,6CAAsB;wBACxB,CAAC,CAAC,IAAI,CAAC,IAAI,KAAK,4BAAoB,CAAC,OAAO;4BAC5C,CAAC,CAAC,4CAAqB;4BACvB,CAAC,CAAC,IAAI,CAAC,IAAI,CAAC;gBAEhB,OAAO;oBACL,YAAY;oBACZ,YAAY;iBACb,CAAC;aACH;SACF;IACH,CAAC;IAEM,uBAAuB,CAAC,YAA0B;QACvD,IAAI,IAAA,iCAAiB,EAAC,YAAY,CAAC,EAAE;YACnC,OAAO,YAAY,CAAC;SACrB;QAED,OAAO;YACL,GAAG,YAAY;YACf,QAAQ,EAAE,IAAI,CAAC,oBAAoB,CAAC,kBAAkB,CACpD,YAAY,CAAC,IAAI,EACjB,IAAA,6BAAa,EAAC,YAAY,CAAC,CAC5B;YACD,KAAK,EAAE,YAAY,CAAC,KAAK,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,EAAE,CAClC,IAAA,yBAAS,EAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,IAAI,CAAC,uBAAuB,CAAC,CAAC,CAAC,CACnD;SACF,CAAC;IACJ,CAAC;IAEM,WAAW,CAAC,QAAkB;QACnC,IAAI,CAAC,oBAAoB,CAAC,WAAW,CAAC,QAAQ,CAAC,CAAC;IAClD,CAAC;CACF;AAnED,wCAmEC;AAED,SAAgB,wBAAwB,CACtC,cAA8B,EAC9B,aAA4B;IAE5B,IAAI,aAAa,CAAC,UAAU,KAAK,SAAS,EAAE;QAC1C,OAAO;KACR;IAED,IAAI;QACF,KAAK,MAAM,SAAS,IAAI,aAAa,CAAC,UAAU,EAAE;YAChD,MAAM,SAAS,GAAG,IAAA,kDAA8B,EAC9C,SAAS,CAAC,WAAW,EACrB,SAAS,CAAC,KAAK,EACf,SAAS,CAAC,MAAM,CACjB,CAAC;YAEF,KAAK,MAAM,QAAQ,IAAI,SAAS,EAAE;gBAChC,IACE,aAAa,CAAC,eAAe,KAAK,IAAI;oBACtC,QAAQ,CAAC,QAAQ,CAAC,IAAI,CAAC,UAAU,CAAC,SAAS,CAAC,EAC5C;oBACA,SAAS;iBACV;gBAED,cAAc,CAAC,WAAW,CAAC,QAAQ,CAAC,CAAC;aACtC;SACF;KACF;IAAC,OAAO,KAAK,EAAE;QACd,OAAO,CAAC,IAAI,CACV,eAAK,CAAC,MAAM,CACV,wGAAwG,CACzG,CACF,CAAC;QAEF,GAAG,CACD,kIAAkI,EAClI,KAAK,CACN,CAAC;QAEF,IAAI,KAAK,YAAY,KAAK,EAAE;YAC1B,mBAAQ,CAAC,WAAW,CAAC,KAAK,CAAC,CAAC;SAC7B;KACF;AACH,CAAC;AA3CD,4DA2CC"}
 \ No newline at end of file
-+{"version":3,"file":"vm-trace-decoder.js","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/vm-trace-decoder.ts"],"names":[],"mappings":";;;;;;AAAA,kDAA0B;AAC1B,kDAA0B;AAC1B,oDAAiD;AAEjD,2DAAqE;AAErE,mDAKyB;AAEzB,iEAKgC;AAEhC,MAAM,GAAG,GAAG,IAAA,eAAK,EAAC,mCAAmC,CAAC,CAAC;AAEvD,MAAa,cAAc;IACzB,YAA6B,oBAAyC;QAAzC,yBAAoB,GAApB,oBAAoB,CAAqB;IAAG,CAAC;IAEnE,kCAAkC,CACvC,IAAY,EACZ,QAAiB;QAEjB,MAAM,QAAQ,GAAG,QAAQ,KAAK,SAAS,CAAC;QACxC,MAAM,QAAQ,GAAG,IAAI,CAAC,oBAAoB,CAAC,kBAAkB,CAC3D,IAAI,EACJ,QAAQ,CACT,CAAC;QAEF,MAAM,YAAY,GAAG,QAAQ,EAAE,QAAQ,CAAC,IAAI,IAAI,iDAA0B,CAAC;QAE3E,IAAI,QAAQ,EAAE;YACZ,OAAO;gBACL,YAAY;aACb,CAAC;SACH;aAAM;YACL,IAAI,QAAQ,KAAK,SAAS,EAAE;gBAC1B,OAAO;oBACL,YAAY;oBACZ,YAAY,EAAE,EAAE;iBACjB,CAAC;aACH;iBAAM;gBACL,MAAM,IAAI,GAAG,QAAQ,CAAC,QAAQ,CAAC,uBAAuB,CACpD,QAAQ,CAAC,KAAK,CAAC,CAAC,EAAE,CAAC,CAAC,CACrB,CAAC;gBAEF,MAAM,YAAY,GAChB,IAAI,KAAK,SAAS;oBAChB,CAAC,CAAC,iDAA0B;oBAC5B,CAAC,CAAC,IAAI,CAAC,IAAI,0CAAkC;wBAC7C,CAAC,CAAC,6CAAsB;wBACxB,CAAC,CAAC,IAAI,CAAC,IAAI,yCAAiC;4BAC5C,CAAC,CAAC,4CAAqB;4BACvB,CAAC,CAAC,IAAI,CAAC,IAAI,CAAC;gBAEhB,OAAO;oBACL,YAAY;oBACZ,YAAY;iBACb,CAAC;aACH;SACF;IACH,CAAC;IAEM,uBAAuB,CAAC,YAA0B;QACvD,IAAI,IAAA,iCAAiB,EAAC,YAAY,CAAC,EAAE;YACnC,OAAO,YAAY,CAAC;SACrB;QAED,OAAO;YACL,GAAG,YAAY;YACf,QAAQ,EAAE,IAAI,CAAC,oBAAoB,CAAC,kBAAkB,CACpD,YAAY,CAAC,IAAI,EACjB,IAAA,6BAAa,EAAC,YAAY,CAAC,CAC5B;YACD,KAAK,EAAE,YAAY,CAAC,KAAK,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,EAAE,CAClC,IAAA,yBAAS,EAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,IAAI,CAAC,uBAAuB,CAAC,CAAC,CAAC,CACnD;SACF,CAAC;IACJ,CAAC;IAEM,WAAW,CAAC,QAAkB;QACnC,IAAI,CAAC,oBAAoB,CAAC,WAAW,CAAC,QAAQ,CAAC,CAAC;IAClD,CAAC;CACF;AAnED,wCAmEC;AAED,SAAgB,wBAAwB,CACtC,cAA8B,EAC9B,aAA4B;IAE5B,IAAI,aAAa,CAAC,UAAU,KAAK,SAAS,EAAE;QAC1C,OAAO;KACR;IAED,IAAI;QACF,KAAK,MAAM,SAAS,IAAI,aAAa,CAAC,UAAU,EAAE;YAChD,MAAM,SAAS,GAAG,IAAA,kDAA8B,EAC9C,SAAS,CAAC,WAAW,EACrB,SAAS,CAAC,KAAK,EACf,SAAS,CAAC,MAAM,CACjB,CAAC;YAEF,KAAK,MAAM,QAAQ,IAAI,SAAS,EAAE;gBAChC,IACE,aAAa,CAAC,eAAe,KAAK,IAAI;oBACtC,QAAQ,CAAC,QAAQ,CAAC,IAAI,CAAC,UAAU,CAAC,SAAS,CAAC,EAC5C;oBACA,SAAS;iBACV;gBAED,cAAc,CAAC,WAAW,CAAC,QAAQ,CAAC,CAAC;aACtC;SACF;KACF;IAAC,OAAO,KAAK,EAAE;QACd,OAAO,CAAC,IAAI,CACV,eAAK,CAAC,MAAM,CACV,wGAAwG,CACzG,CACF,CAAC;QAEF,GAAG,CACD,kIAAkI,EAClI,KAAK,CACN,CAAC;QAEF,IAAI,KAAK,YAAY,KAAK,EAAE;YAC1B,mBAAQ,CAAC,WAAW,CAAC,KAAK,CAAC,CAAC;SAC7B;KACF;AACH,CAAC;AA3CD,4DA2CC"}
++{"version":3,"file":"vm-trace-decoder.js","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/vm-trace-decoder.ts"],"names":[],"mappings":";;;;;;AAAA,kDAA0B;AAC1B,kDAA0B;AAC1B,8CAAgF;AA+B9E,+FA/BO,oBAAc,OA+BP;AA9BhB,oDAAiD;AAGjD,MAAM,GAAG,GAAG,IAAA,eAAK,EAAC,mCAAmC,CAAC,CAAC;AAEvD,SAAS,+BAA+B,CACtC,cAA8B,EAC9B,aAA4B;IAE5B,IAAI;QACF,IAAA,8BAAwB,EAAC,cAAc,EAAE,aAAa,CAAC,CAAC;KACzD;IAAC,OAAO,KAAK,EAAE;QACd,OAAO,CAAC,IAAI,CACV,eAAK,CAAC,MAAM,CACV,wGAAwG,CACzG,CACF,CAAC;QAEF,GAAG,CACD,kIAAkI,EAClI,KAAK,CACN,CAAC;QAEF,IAAI,KAAK,YAAY,KAAK,EAAE;YAC1B,mBAAQ,CAAC,WAAW,CAAC,KAAK,CAAC,CAAC;SAC7B;KACF;AACH,CAAC;AAIoC,mEAAwB"}
 \ No newline at end of file
 diff --git a/internal/hardhat-network/stack-traces/vm-tracer.d.ts b/internal/hardhat-network/stack-traces/vm-tracer.d.ts
 index b70c116300e0b3c2da6b458fc8126de65717eb8b..966c475a4c2b7a8ed3b0b19c6a17cfa8b1268841 100644
@@ -5062,6 +5168,144 @@ index e0602c17fb8c0c48b740d5e6bb8925cfaba67740..54329f2587d8cb398d7567840ce7295f
 diff --git a/src/internal/hardhat-network/stack-traces/source-maps.ts b/src/internal/hardhat-network/stack-traces/source-maps.ts
 deleted file mode 100644
 index 8ff03b3c7337cb0da035004844c850bf89745669..0000000000000000000000000000000000000000
+diff --git a/src/internal/hardhat-network/stack-traces/vm-trace-decoder.ts b/src/internal/hardhat-network/stack-traces/vm-trace-decoder.ts
+index 738427290fa82e7e861ae984c4785eaedbe8e2fb..3c19f367cba0a87de065531df95f2e8d83ee2bac 100644
+--- a/src/internal/hardhat-network/stack-traces/vm-trace-decoder.ts
++++ b/src/internal/hardhat-network/stack-traces/vm-trace-decoder.ts
+@@ -1,121 +1,17 @@
+ import chalk from "chalk";
+ import debug from "debug";
++import { VmTraceDecoder, initializeVmTraceDecoder } from "@nomicfoundation/edr";
+ import { Reporter } from "../../sentry/reporter";
+ import { TracingConfig } from "../provider/node-types";
+-import { createModelsAndDecodeBytecodes } from "./compiler-to-model";
+-import { ContractsIdentifier } from "./contracts-identifier";
+-import {
+-  isCreateTrace,
+-  isEvmStep,
+-  isPrecompileTrace,
+-  MessageTrace,
+-} from "./message-trace";
+-import { Bytecode, ContractFunctionType } from "./model";
+-import {
+-  FALLBACK_FUNCTION_NAME,
+-  RECEIVE_FUNCTION_NAME,
+-  UNRECOGNIZED_CONTRACT_NAME,
+-  UNRECOGNIZED_FUNCTION_NAME,
+-} from "./solidity-stack-trace";
+ 
+ const log = debug("hardhat:core:hardhat-network:node");
+ 
+-export class VmTraceDecoder {
+-  constructor(private readonly _contractsIdentifier: ContractsIdentifier) {}
+-
+-  public getContractAndFunctionNamesForCall(
+-    code: Buffer,
+-    calldata?: Buffer
+-  ): { contractName: string; functionName?: string } {
+-    const isCreate = calldata === undefined;
+-    const bytecode = this._contractsIdentifier.getBytecodeForCall(
+-      code,
+-      isCreate
+-    );
+-
+-    const contractName = bytecode?.contract.name ?? UNRECOGNIZED_CONTRACT_NAME;
+-
+-    if (isCreate) {
+-      return {
+-        contractName,
+-      };
+-    } else {
+-      if (bytecode === undefined) {
+-        return {
+-          contractName,
+-          functionName: "",
+-        };
+-      } else {
+-        const func = bytecode.contract.getFunctionFromSelector(
+-          calldata.slice(0, 4)
+-        );
+-
+-        const functionName: string =
+-          func === undefined
+-            ? UNRECOGNIZED_FUNCTION_NAME
+-            : func.type === ContractFunctionType.FALLBACK
+-            ? FALLBACK_FUNCTION_NAME
+-            : func.type === ContractFunctionType.RECEIVE
+-            ? RECEIVE_FUNCTION_NAME
+-            : func.name;
+-
+-        return {
+-          contractName,
+-          functionName,
+-        };
+-      }
+-    }
+-  }
+-
+-  public tryToDecodeMessageTrace(messageTrace: MessageTrace): MessageTrace {
+-    if (isPrecompileTrace(messageTrace)) {
+-      return messageTrace;
+-    }
+-
+-    return {
+-      ...messageTrace,
+-      bytecode: this._contractsIdentifier.getBytecodeForCall(
+-        messageTrace.code,
+-        isCreateTrace(messageTrace)
+-      ),
+-      steps: messageTrace.steps.map((s) =>
+-        isEvmStep(s) ? s : this.tryToDecodeMessageTrace(s)
+-      ),
+-    };
+-  }
+-
+-  public addBytecode(bytecode: Bytecode) {
+-    this._contractsIdentifier.addBytecode(bytecode);
+-  }
+-}
+-
+-export function initializeVmTraceDecoder(
++function initializeVmTraceDecoderWrapper(
+   vmTraceDecoder: VmTraceDecoder,
+   tracingConfig: TracingConfig
+ ) {
+-  if (tracingConfig.buildInfos === undefined) {
+-    return;
+-  }
+-
+   try {
+-    for (const buildInfo of tracingConfig.buildInfos) {
+-      const bytecodes = createModelsAndDecodeBytecodes(
+-        buildInfo.solcVersion,
+-        buildInfo.input,
+-        buildInfo.output
+-      );
+-
+-      for (const bytecode of bytecodes) {
+-        if (
+-          tracingConfig.ignoreContracts === true &&
+-          bytecode.contract.name.startsWith("Ignored")
+-        ) {
+-          continue;
+-        }
+-
+-        vmTraceDecoder.addBytecode(bytecode);
+-      }
+-    }
++    initializeVmTraceDecoder(vmTraceDecoder, tracingConfig);
+   } catch (error) {
+     console.warn(
+       chalk.yellow(
+@@ -133,3 +29,8 @@ export function initializeVmTraceDecoder(
+     }
+   }
+ }
++
++export {
++  VmTraceDecoder,
++  initializeVmTraceDecoderWrapper as initializeVmTraceDecoder,
++};
 diff --git a/src/internal/hardhat-network/stack-traces/vm-tracer.ts b/src/internal/hardhat-network/stack-traces/vm-tracer.ts
 index 520573ab34cbc0d421af7ddccd2ff90f46f345e9..6785ccae843cc9f04a5056ef3bd02a3955c386e7 100644
 --- a/src/internal/hardhat-network/stack-traces/vm-tracer.ts

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
 
 patchedDependencies:
   hardhat@2.22.6:
-    hash: 2xv63rgn6ejog2ah3azyw26aiy
+    hash: j3gfe5ig7g6ydi26uensdojdca
     path: patches/hardhat@2.22.6.patch
 
 importers:
@@ -66,7 +66,7 @@ importers:
         version: 4.4.1
       hardhat:
         specifier: 2.22.6
-        version: 2.22.6(patch_hash=2xv63rgn6ejog2ah3azyw26aiy)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.0.4))(typescript@5.0.4)
+        version: 2.22.6(patch_hash=j3gfe5ig7g6ydi26uensdojdca)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.0.4))(typescript@5.0.4)
       lodash:
         specifier: ^4.17.11
         version: 4.17.21
@@ -186,7 +186,7 @@ importers:
         version: 7.0.1
       hardhat:
         specifier: 2.22.6
-        version: 2.22.6(patch_hash=2xv63rgn6ejog2ah3azyw26aiy)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.0.4))(typescript@5.0.4)
+        version: 2.22.6(patch_hash=j3gfe5ig7g6ydi26uensdojdca)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.0.4))(typescript@5.0.4)
       mocha:
         specifier: ^10.0.0
         version: 10.3.0
@@ -216,10 +216,10 @@ importers:
     devDependencies:
       '@defi-wonderland/smock':
         specifier: ^2.4.0
-        version: 2.4.0(@ethersproject/abi@5.7.0)(@ethersproject/abstract-provider@5.7.0)(@ethersproject/abstract-signer@5.7.0)(@nomiclabs/hardhat-ethers@2.2.3(ethers@5.7.2)(hardhat@2.22.6(patch_hash=2xv63rgn6ejog2ah3azyw26aiy)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4)))(ethers@5.7.2)(hardhat@2.22.6(patch_hash=2xv63rgn6ejog2ah3azyw26aiy)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4))
+        version: 2.4.0(@ethersproject/abi@5.7.0)(@ethersproject/abstract-provider@5.7.0)(@ethersproject/abstract-signer@5.7.0)(@nomiclabs/hardhat-ethers@2.2.3(ethers@5.7.2)(hardhat@2.22.6(patch_hash=j3gfe5ig7g6ydi26uensdojdca)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4)))(ethers@5.7.2)(hardhat@2.22.6(patch_hash=j3gfe5ig7g6ydi26uensdojdca)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4))
       '@nomiclabs/hardhat-ethers':
         specifier: ^2.2.3
-        version: 2.2.3(ethers@5.7.2)(hardhat@2.22.6(patch_hash=2xv63rgn6ejog2ah3azyw26aiy)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4))
+        version: 2.2.3(ethers@5.7.2)(hardhat@2.22.6(patch_hash=j3gfe5ig7g6ydi26uensdojdca)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4))
       chai:
         specifier: ^4.3.6
         version: 4.4.1
@@ -228,7 +228,7 @@ importers:
         version: 5.7.2
       hardhat:
         specifier: 2.22.6
-        version: 2.22.6(patch_hash=2xv63rgn6ejog2ah3azyw26aiy)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.0.4))(typescript@5.0.4)
+        version: 2.22.6(patch_hash=j3gfe5ig7g6ydi26uensdojdca)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.0.4))(typescript@5.0.4)
       mocha:
         specifier: ^10.0.0
         version: 10.3.0
@@ -3082,16 +3082,16 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@defi-wonderland/smock@2.4.0(@ethersproject/abi@5.7.0)(@ethersproject/abstract-provider@5.7.0)(@ethersproject/abstract-signer@5.7.0)(@nomiclabs/hardhat-ethers@2.2.3(ethers@5.7.2)(hardhat@2.22.6(patch_hash=2xv63rgn6ejog2ah3azyw26aiy)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4)))(ethers@5.7.2)(hardhat@2.22.6(patch_hash=2xv63rgn6ejog2ah3azyw26aiy)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4))':
+  '@defi-wonderland/smock@2.4.0(@ethersproject/abi@5.7.0)(@ethersproject/abstract-provider@5.7.0)(@ethersproject/abstract-signer@5.7.0)(@nomiclabs/hardhat-ethers@2.2.3(ethers@5.7.2)(hardhat@2.22.6(patch_hash=j3gfe5ig7g6ydi26uensdojdca)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4)))(ethers@5.7.2)(hardhat@2.22.6(patch_hash=j3gfe5ig7g6ydi26uensdojdca)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4))':
     dependencies:
       '@ethersproject/abi': 5.7.0
       '@ethersproject/abstract-provider': 5.7.0
       '@ethersproject/abstract-signer': 5.7.0
       '@nomicfoundation/ethereumjs-util': 9.0.4
-      '@nomiclabs/hardhat-ethers': 2.2.3(ethers@5.7.2)(hardhat@2.22.6(patch_hash=2xv63rgn6ejog2ah3azyw26aiy)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4))
+      '@nomiclabs/hardhat-ethers': 2.2.3(ethers@5.7.2)(hardhat@2.22.6(patch_hash=j3gfe5ig7g6ydi26uensdojdca)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4))
       diff: 5.0.0
       ethers: 5.7.2
-      hardhat: 2.22.6(patch_hash=2xv63rgn6ejog2ah3azyw26aiy)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.0.4))(typescript@5.0.4)
+      hardhat: 2.22.6(patch_hash=j3gfe5ig7g6ydi26uensdojdca)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.0.4))(typescript@5.0.4)
       lodash.isequal: 4.5.0
       lodash.isequalwith: 4.4.0
       rxjs: 7.8.1
@@ -3602,10 +3602,10 @@ snapshots:
       '@nomicfoundation/solidity-analyzer-win32-ia32-msvc': 0.1.1
       '@nomicfoundation/solidity-analyzer-win32-x64-msvc': 0.1.1
 
-  '@nomiclabs/hardhat-ethers@2.2.3(ethers@5.7.2)(hardhat@2.22.6(patch_hash=2xv63rgn6ejog2ah3azyw26aiy)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4))':
+  '@nomiclabs/hardhat-ethers@2.2.3(ethers@5.7.2)(hardhat@2.22.6(patch_hash=j3gfe5ig7g6ydi26uensdojdca)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4))':
     dependencies:
       ethers: 5.7.2
-      hardhat: 2.22.6(patch_hash=2xv63rgn6ejog2ah3azyw26aiy)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.0.4))(typescript@5.0.4)
+      hardhat: 2.22.6(patch_hash=j3gfe5ig7g6ydi26uensdojdca)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.0.4))(typescript@5.0.4)
 
   '@scure/base@1.1.5': {}
 
@@ -4872,7 +4872,7 @@ snapshots:
 
   hard-rejection@2.1.0: {}
 
-  hardhat@2.22.6(patch_hash=2xv63rgn6ejog2ah3azyw26aiy)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.0.4))(typescript@5.0.4):
+  hardhat@2.22.6(patch_hash=j3gfe5ig7g6ydi26uensdojdca)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.0.4))(typescript@5.0.4):
     dependencies:
       '@ethersproject/abi': 5.7.0
       '@metamask/eth-sig-util': 4.0.1


### PR DESCRIPTION
This ports of `VmTraceDecoder` from Hardhat; what's left now is the error inferrer and finally solidity stack trace logic :partying_face: 

What's more interesting, however, is the fix for the `MessageTrace` and others:
1. There's a `napi-rs` bug that incorrectly validates and converts an object that has a required property but can be explicitly undefined, e.g. `deployedContract: Bytecode | undefined`. That's the case for `CreateMessageTrace` and so this is worked around using an optional property, however...
2. With this, the `CallMessageTrace` is a strict superset of `CreateMessageTrace`. We need to be careful with the type order when using the N-API type `Either` to always attempt converting and validating the most specific type first, otherwise we may incorrectly convert into a less specific type, skipping some additional properties it may have.

Link to the companion commit: https://github.com/nomicFoundation/hardhat/commit/137cfb33a8868329ae4d3d3903f4c7bf8838a50f