### PR TITLE
refactor: remove verbosity config

### DIFF
--- a/crates/edr_napi/src/solidity_tests/config.rs
+++ b/crates/edr_napi/src/solidity_tests/config.rs
@@ -48,7 +48,6 @@ impl SolidityTestsConfig {
             sender: DEFAULT_SENDER,
             initial_balance: U256::from(0xffffffffffffffffffffffffu128),
             ffi: false,
-            verbosity: 0,
             memory_limit: 1 << 27, // 2**27 = 128MiB = 134_217_728 bytes
             ..EvmOpts::default()
         };

--- a/crates/edr_napi/src/solidity_tests/runner.rs
+++ b/crates/edr_napi/src/solidity_tests/runner.rs
@@ -75,6 +75,7 @@ pub(super) fn build_runner(
         revert_decoder,
         fork: None,
         coverage: false,
+        trace: false,
         debug: false,
         test_options,
         isolation: false,

--- a/crates/foundry/common/src/evm.rs
+++ b/crates/foundry/common/src/evm.rs
@@ -1,6 +1,6 @@
 //! cli arguments for configuring the evm settings
 use alloy_primitives::{Address, B256, U256};
-use clap::{ArgAction, Parser};
+use clap::Parser;
 use eyre::ContextCompat;
 use foundry_config::{
     figment::{
@@ -104,20 +104,6 @@ pub struct EvmArgs {
     #[serde(skip)]
     pub always_use_create_2_factory: bool,
 
-    /// Verbosity of the EVM.
-    ///
-    /// Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
-    ///
-    /// Verbosity levels:
-    /// - 2: Print logs for all tests
-    /// - 3: Print execution traces for failing tests
-    /// - 4: Print execution traces for all tests, and setup traces for failing
-    ///   tests
-    /// - 5: Print execution and setup traces for all tests
-    #[arg(long, short, verbatim_doc_comment, action = ArgAction::Count)]
-    #[serde(skip)]
-    pub verbosity: u8,
-
     /// Sets the number of assumed available compute units per second for this
     /// provider
     ///
@@ -169,11 +155,6 @@ impl Provider for EvmArgs {
         let value = Value::serialize(self)?;
         let error = InvalidType(value.to_actual(), "map".into());
         let mut dict = value.into_dict().ok_or(error)?;
-
-        if self.verbosity > 0 {
-            // need to merge that manually otherwise `from_occurrences` does not work
-            dict.insert("verbosity".to_string(), self.verbosity.into());
-        }
 
         if self.ffi {
             dict.insert("ffi".to_string(), self.ffi.into());

--- a/crates/foundry/config/README.md
+++ b/crates/foundry/config/README.md
@@ -88,7 +88,6 @@ model_checker = { contracts = { 'a.sol' = [
     'assert',
     'outOfBounds',
 ], timeout = 10000 }
-verbosity = 0
 eth_rpc_url = "https://example.com/"
 # Setting this option enables decoding of error traces from mainnet deployed / verfied contracts via etherscan
 etherscan_api_key = "YOURETHERSCANAPIKEY"

--- a/crates/foundry/config/src/lib.rs
+++ b/crates/foundry/config/src/lib.rs
@@ -211,8 +211,6 @@ pub struct Config {
     pub optimizer_details: Option<OptimizerDetails>,
     /// Model checker settings.
     pub model_checker: Option<ModelCheckerSettings>,
-    /// verbosity to use
-    pub verbosity: u8,
     /// url of the rpc server that should be used for any rpc calls
     pub eth_rpc_url: Option<String>,
     /// JWT secret that should be used for any rpc calls
@@ -2111,7 +2109,6 @@ impl Default for Config {
             eth_rpc_url: None,
             eth_rpc_jwt: None,
             etherscan_api_key: None,
-            verbosity: 0,
             remappings: vec![],
             auto_detect_remappings: true,
             libraries: vec![],
@@ -3795,7 +3792,6 @@ mod tests {
                 out = "some-out"
                 cache = true
                 eth_rpc_url = "https://example.com/"
-                verbosity = 3
                 remappings = ["ds-test=lib/ds-test/"]
                 via_ir = true
                 rpc_storage_caching = { chains = [1, "optimism", 999999], endpoints = "all"}
@@ -3824,7 +3820,6 @@ mod tests {
                     cache: true,
                     eth_rpc_url: Some("https://example.com/".to_string()),
                     remappings: vec![Remapping::from_str("ds-test=lib/ds-test/").unwrap().into()],
-                    verbosity: 3,
                     via_ir: true,
                     rpc_storage_caching: StorageCachingConfig {
                         chains: CachedChains::Chains(vec![
@@ -3939,7 +3934,6 @@ mod tests {
                 src = 'src'
                 test = 'test'
                 tx_origin = '0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38'
-                verbosity = 0
                 via_ir = false
                 
                 [profile.default.rpc_storage_caching]
@@ -4148,7 +4142,6 @@ mod tests {
                 [profile.default]
                 src = "mysrc"
                 out = "myout"
-                verbosity = 3
             "#,
             )?;
 
@@ -4158,7 +4151,6 @@ mod tests {
                 Config {
                     src: "mysrc".into(),
                     out: "myout".into(),
-                    verbosity: 3,
                     ..Config::default()
                 }
             );
@@ -4170,7 +4162,6 @@ mod tests {
                 Config {
                     src: "other-src".into(),
                     out: "myout".into(),
-                    verbosity: 3,
                     ..Config::default()
                 }
             );
@@ -4192,7 +4183,6 @@ mod tests {
                 [profile.default]
                 src = "mysrc"
                 out = "myout"
-                verbosity = 3
                 evm_version = 'berlin'
 
                 [profile.other]

--- a/crates/foundry/evm/core/src/opts.rs
+++ b/crates/foundry/evm/core/src/opts.rs
@@ -53,9 +53,6 @@ pub struct EvmOpts {
     /// non-broadcasting scripts.
     pub always_use_create_2_factory: bool,
 
-    /// Verbosity mode of EVM output as number of occurrences.
-    pub verbosity: u8,
-
     /// The memory limit per EVM execution in bytes.
     /// If this limit is exceeded, a `MemoryLimitOOG` result is thrown.
     pub memory_limit: u64,

--- a/crates/foundry/forge/src/multi_runner.rs
+++ b/crates/foundry/forge/src/multi_runner.rs
@@ -77,6 +77,8 @@ pub struct MultiContractRunner {
     pub fork: Option<CreateFork>,
     /// Whether to collect coverage info
     pub coverage: bool,
+    /// Whether to collect traces
+    pub trace: bool,
     /// Whether to collect debug info
     pub debug: bool,
     /// Settings related to fuzz and/or invariant tests
@@ -303,7 +305,7 @@ impl MultiContractRunner {
             .inspectors(|stack| {
                 stack
                     .cheatcodes(Arc::new(cheats_config))
-                    .trace(self.evm_opts.verbosity >= 3 || self.debug)
+                    .trace(self.trace || self.debug)
                     .debug(self.debug)
                     .coverage(self.coverage)
                     .enable_isolation(self.isolation)
@@ -359,7 +361,7 @@ impl MultiContractRunner {
             .inspectors(|stack| {
                 stack
                     .cheatcodes(Arc::new(cheats_config))
-                    .trace(self.evm_opts.verbosity >= 3 || self.debug)
+                    .trace(self.trace || self.debug)
                     .debug(self.debug)
                     .coverage(self.coverage)
                     .enable_isolation(self.isolation)
@@ -411,6 +413,8 @@ pub struct MultiContractRunnerBuilder {
     pub coverage: bool,
     /// Whether or not to collect debug info
     pub debug: bool,
+    /// Whether or not to collect traces
+    pub trace: bool,
     /// Whether to enable call isolation
     pub isolation: bool,
     /// Settings related to fuzz and/or invariant tests
@@ -426,6 +430,7 @@ impl MultiContractRunnerBuilder {
             evm_spec: None,
             fork: None,
             coverage: false,
+            trace: false,
             debug: false,
             isolation: false,
             test_options: None,
@@ -464,6 +469,11 @@ impl MultiContractRunnerBuilder {
 
     pub fn set_debug(mut self, enable: bool) -> Self {
         self.debug = enable;
+        self
+    }
+
+    pub fn set_trace(mut self, enable: bool) -> Self {
+        self.trace = enable;
         self
     }
 
@@ -556,6 +566,7 @@ impl MultiContractRunnerBuilder {
             cheats_config_opts: Arc::new(cheats_config_opts),
             coverage: self.coverage,
             debug: self.debug,
+            trace: self.trace,
             test_options: self.test_options.unwrap_or_default(),
             isolation: self.isolation,
             output: Some(output),

--- a/crates/foundry/forge/tests/it/test_helpers.rs
+++ b/crates/foundry/forge/tests/it/test_helpers.rs
@@ -129,7 +129,6 @@ impl ForgeTestProfile {
             sender: CALLER,
             initial_balance: U256::MAX,
             ffi: true,
-            verbosity: 3,
             memory_limit: 1 << 26,
             ..Default::default()
         }
@@ -196,6 +195,7 @@ impl ForgeTestData {
     pub fn base_runner(&self) -> MultiContractRunnerBuilder {
         init_tracing();
         let mut runner = MultiContractRunnerBuilder::new(self.config.clone())
+            .set_trace(true)
             .sender(self.evm_opts.sender)
             .with_test_options(self.test_opts.clone());
         if self.profile.is_cancun() {
@@ -245,8 +245,7 @@ impl ForgeTestData {
 
     /// Builds a tracing runner
     pub fn tracing_runner(&self) -> MultiContractRunner {
-        let mut opts = self.evm_opts.clone();
-        opts.verbosity = 5;
+        let opts = self.evm_opts.clone();
         self.base_runner()
             .build(
                 self.project.root(),

--- a/crates/foundry/testdata/foundry.toml
+++ b/crates/foundry/testdata/foundry.toml
@@ -39,7 +39,6 @@ sparse_mode = false
 src = "./"
 test = "./"
 tx_origin = "0x00a329c0648769a73afac7f9381e08fb43dbea72"
-verbosity = 3
 via_ir = false
 fs_permissions = [{ access = "read-write", path = "./" }]
 


### PR DESCRIPTION
I broke out this change from a larger PR coming to expose Solidity test config options to JS through the ffi.

The [verbosity config](https://book.getfoundry.sh/reference/config/testing#verbosity) in Foundry controls the level of detail displayed to the user, but it's also used internally to determine what info to collect. Since displaying info to the user will be the responsibility of Hardhat, this PR removes the verbosity config and replaces it with a boolean flag whether to enable tracing. This is sufficient to preserve previous functionality.