### PR TITLE
feat: solidity test runner config

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,9 @@ MIT License
 
 Copyright (c) 2021 Nomic Foundation. The solidity tests feature of this work 
 is based on and modifies Foundry, which is licensed under the MIT license, 
-copyright (c) 2021 Georgios Konstantopoulos.
+copyright (c) 2021 Georgios Konstantopoulos. Documentation for the solidity 
+tests feature is based on Foundry Book which is copyright (c) 2021 Oliver 
+Nordbjerg.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -372,6 +372,285 @@ export interface ContractData {
    */
   deployedBytecode?: string
 }
+/**
+ * Solidity test runner configuration arguments exposed through the ffi.
+ * Docs based on https://book.getfoundry.sh/reference/config/testing
+ */
+export interface SolidityTestRunnerConfigArgs {
+  /**
+   * The absolute path to the project root directory.
+   * Relative paths in cheat codes are resolved against this path.
+   */
+  projectRoot: string
+  /** Configures the permissions of cheat codes that access the file system. */
+  fsPermissions?: Array<PathPermission>
+  /** Whether to collect traces. Defaults to false. */
+  trace?: boolean
+  /** Whether to collect debug info. Defaults to false. */
+  debug?: boolean
+  /** Address labels for traces. Defaults to none. */
+  labels?: Array<AddressLabel>
+  /**
+   * Whether to enable isolation of calls. In isolation mode all top-level
+   * calls are executed as a separate transaction in a separate EVM
+   * context, enabling more precise gas accounting and transaction state
+   * changes.
+   * Defaults to false.
+   */
+  isolate?: boolean
+  /**
+   * Whether or not to enable the ffi cheatcode.
+   * Warning: Enabling this cheatcode has security implications, as it allows
+   * tests to execute arbitrary programs on your computer.
+   * Defaults to false.
+   */
+  ffi?: boolean
+  /**
+   * The value of `msg.sender` in tests as hex string.
+   * Defaults to `0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38`.
+   */
+  sender?: Buffer
+  /**
+   * The value of `tx.origin` in tests as hex string.
+   * Defaults to `0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38`.
+   */
+  txOrigin?: Buffer
+  /**
+   * The initial balance of the sender in tests.
+   * Defaults to `0xffffffffffffffffffffffff`.
+   */
+  initialBalance?: bigint
+  /**
+   * The value of `block.number` in tests.
+   * Defaults to `1`.
+   */
+  blockNumber?: bigint
+  /**
+   * The value of the `chainid` opcode in tests.
+   * Defaults to `31337`.
+   */
+  chainId?: bigint
+  /**
+   * The gas limit for each test case.
+   * Defaults to `9_223_372_036_854_775_807` (`i64::MAX`).
+   */
+  gasLimit?: bigint
+  /**
+   * The price of gas (in wei) in tests.
+   * Defaults to `0`.
+   */
+  gasPrice?: bigint
+  /**
+   * The base fee per gas (in wei) in tests.
+   * Defaults to `0`.
+   */
+  blockBaseFeePerGas?: bigint
+  /**
+   * The value of `block.coinbase` in tests.
+   * Defaults to `0x0000000000000000000000000000000000000000`.
+   */
+  blockCoinbase?: Buffer
+  /**
+   * The value of `block.timestamp` in tests.
+   * Defaults to 1.
+   */
+  blockTimestamp?: bigint
+  /**
+   * The value of `block.difficulty` in tests.
+   * Defaults to 0.
+   */
+  blockDifficulty?: bigint
+  /**
+   * The `block.gaslimit` value during EVM execution.
+   * Defaults to none.
+   */
+  blockGasLimit?: bigint
+  /**
+   * Whether to disable the block gas limit.
+   * Defaults to false.
+   */
+  disableBlockGasLimit?: boolean
+  /**
+   * The memory limit of the EVM in bytes.
+   * Defaults to 33_554_432 (2^25 = 32MiB).
+   */
+  memoryLimit?: bigint
+  /**
+   * If set to true, then block data from RPC endpoints in tests will not be
+   * cached. Otherwise, the data is cached to
+   * `$HOME/.foundry/cache/<chain id>/<block number>`.
+   * Defaults to false.
+   */
+  noStorageCaching?: boolean
+  /**
+   * If set, all tests are ran in fork mode using this url or remote name.
+   * Defaults to none.
+   */
+  ethRpcUrl?: string
+  /** Pins the block number for the global state fork. */
+  forkBlockNumber?: bigint
+  /**
+   * Map of RPC endpoints from chain name to RPC urls for fork cheat codes,
+   * e.g. `{ "optimism": "https://optimism.alchemyapi.io/v2/..." }`
+   */
+  rpcEndpoints?: Record<string, string>
+  /** What RPC endpoints are cached. Defaults to all. */
+  rpcStorageCaching?: StorageCachingConfig
+  /**
+   * The number of seconds to wait before `vm.prompt` reverts with a timeout.
+   * Defaults to 120.
+   */
+  promptTimeout?: number
+  /** Fuzz testing configuration. */
+  fuzz?: FuzzConfigArgs
+  /**
+   * Invariant testing configuration.
+   * If an invariant config setting is not set, but a corresponding fuzz
+   * config value is set, then the fuzz config value will be used.
+   */
+  invariant?: InvariantConfigArgs
+}
+/** Fuzz testing configuration */
+export interface FuzzConfigArgs {
+  /** Path where fuzz failures are recorded and replayed. */
+  failurePersistDir: string
+  /** Name of the file to record fuzz failures, defaults to `failures`. */
+  failurePersistFile?: string
+  /**
+   * The amount of fuzz runs to perform for each fuzz test case. Higher
+   * values gives more confidence in results at the cost of testing
+   * speed.
+   * Defaults to 256.
+   */
+  runs?: number
+  /**
+   * The maximum number of combined inputs that may be rejected before the
+   * test as a whole aborts. “Global” filters apply to the whole test
+   * case. If the test case is rejected, the whole thing is regenerated.
+   * Defaults to 65536.
+   */
+  maxTestRejects?: number
+  /**
+   * Hexadecimal string.
+   * Optional seed for the fuzzing RNG algorithm.
+   * Defaults to None.
+   */
+  seed?: string
+  /**
+   * Integer between 0 and 100.
+   * The weight of the dictionary. A higher dictionary weight will bias the
+   * fuzz inputs towards “interesting” values, e.g. boundary values like
+   * type(uint256).max or contract addresses from your environment.
+   * Defaults to 40.
+   */
+  dictionaryWeight?: number
+  /**
+   * The flag indicating whether to include values from storage.
+   * Defaults to true.
+   */
+  includeStorage?: boolean
+  /**
+   * The flag indicating whether to include push bytes values.
+   * Defaults to true.
+   */
+  includePushBytes?: boolean
+}
+/** Invariant testing configuration. */
+export interface InvariantConfigArgs {
+  /** Path where invariant failures are recorded and replayed. */
+  failurePersistDir?: string
+  /**
+   * The number of runs that must execute for each invariant test group.
+   * Defaults to 256.
+   */
+  runs?: number
+  /**
+   * The number of calls executed to attempt to break invariants in one run.
+   * Defaults to 500.
+   */
+  depth?: number
+  /**
+   * Fails the invariant fuzzing if a revert occurs.
+   * Defaults to false.
+   */
+  failOnRevert?: boolean
+  /**
+   * Overrides unsafe external calls when running invariant tests, useful for
+   * e.g. performing reentrancy checks.
+   * Defaults to false.
+   */
+  callOverride?: boolean
+  /**
+   * Integer between 0 and 100.
+   * The weight of the dictionary. A higher dictionary weight will bias the
+   * fuzz inputs towards “interesting” values, e.g. boundary values like
+   * type(uint256).max or contract addresses from your environment.
+   * Defaults to 40.
+   */
+  dictionaryWeight?: number
+  /**
+   * The flag indicating whether to include values from storage.
+   * Defaults to true.
+   */
+  includeStorage?: boolean
+  /**
+   * The flag indicating whether to include push bytes values.
+   * Defaults to true.
+   */
+  includePushBytes?: boolean
+  /**
+   * The maximum number of attempts to shrink a failed the sequence. Shrink
+   * process is disabled if set to 0.
+   * Defaults to 5000.
+   */
+  shrinkRunLimit?: number
+}
+/** Settings to configure caching of remote */
+export interface StorageCachingConfig {
+  /**
+   * Chains to cache. Either all or none or a list of chain names, e.g.
+   * ["optimism", "mainnet"].
+   */
+  chains: CachedChains | Array<string>
+  /** Endpoints to cache. Either all or remote or a regex. */
+  endpoints: CachedEndpoints | string
+}
+/** What chains to cache */
+export const enum CachedChains {
+  /** Cache all chains */
+  All = 0,
+  /** Don't cache anything */
+  None = 1
+}
+/** What endpoints to enable caching for */
+export const enum CachedEndpoints {
+  /** Cache all endpoints */
+  All = 0,
+  /** Only cache non-local host endpoints */
+  Remote = 1
+}
+/** Represents an access permission to a single path */
+export interface PathPermission {
+  /** Permission level to access the `path` */
+  access: FsAccessPermission
+  /** The targeted path guarded by the permission */
+  path: string
+}
+/** Determines the status of file system access */
+export const enum FsAccessPermission {
+  /** FS access is allowed with `read` + `write` permission */
+  ReadWrite = 0,
+  /** Only reading is allowed */
+  Read = 1,
+  /** Only writing is allowed */
+  Write = 2
+}
+export interface AddressLabel {
+  /** The address to label */
+  address: Buffer
+  /** The label to assign to the address */
+  label: string
+}
 /** See [forge::result::SuiteResult] */
 export interface SuiteResult {
   /**
@@ -468,8 +747,9 @@ export interface BaseCounterExample {
  * The progress callback will be called with the results of each test suite.
  * It is up to the caller to track how many times the callback is called to
  * know when all tests are done.
+ * The error callback is called if an invalid configuration value is provided.
  */
-export function runSolidityTests(artifacts: Array<Artifact>, testSuites: Array<ArtifactId>, gasReport: boolean, progressCallback: (result: SuiteResult) => void): void
+export function runSolidityTests(artifacts: Array<Artifact>, testSuites: Array<ArtifactId>, configArgs: SolidityTestRunnerConfigArgs, progressCallback: (result: SuiteResult) => void, errorCallback: (error: Error) => void): void
 export interface SubscriptionEvent {
   filterId: bigint
   result: any

--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -483,7 +483,7 @@ export interface SolidityTestRunnerConfigArgs {
    */
   noStorageCaching?: boolean
   /**
-   * If set, all tests are ran in fork mode using this url or remote name.
+   * If set, all tests are run in fork mode using this url or remote name.
    * Defaults to none.
    */
   ethRpcUrl?: string

--- a/crates/edr_napi/index.js
+++ b/crates/edr_napi/index.js
@@ -310,7 +310,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { SpecId, EdrContext, MineOrdering, Provider, Response, SuccessReason, ExceptionalHalt, TestStatus, runSolidityTests, RawTrace } = nativeBinding
+const { SpecId, EdrContext, MineOrdering, Provider, Response, SuccessReason, ExceptionalHalt, CachedChains, CachedEndpoints, FsAccessPermission, TestStatus, runSolidityTests, RawTrace } = nativeBinding
 
 module.exports.SpecId = SpecId
 module.exports.EdrContext = EdrContext
@@ -319,6 +319,9 @@ module.exports.Provider = Provider
 module.exports.Response = Response
 module.exports.SuccessReason = SuccessReason
 module.exports.ExceptionalHalt = ExceptionalHalt
+module.exports.CachedChains = CachedChains
+module.exports.CachedEndpoints = CachedEndpoints
+module.exports.FsAccessPermission = FsAccessPermission
 module.exports.TestStatus = TestStatus
 module.exports.runSolidityTests = runSolidityTests
 module.exports.RawTrace = RawTrace

--- a/crates/edr_napi/src/solidity_tests/config.rs
+++ b/crates/edr_napi/src/solidity_tests/config.rs
@@ -1,21 +1,691 @@
-use std::{collections::HashMap, path::PathBuf};
+use std::{collections::HashMap, fmt::Debug, path::PathBuf};
 
-use alloy_primitives::{address, Address};
+use alloy_primitives::{address, hex, Address, B256};
 use edr_eth::U256;
 use forge::{
+    fork::CreateFork,
     inspectors::cheatcodes::CheatsConfigOptions,
     opts::{Env as EvmEnv, EvmOpts},
 };
-use foundry_config::{
-    cache::StorageCachingConfig, FsPermissions, FuzzConfig, GasLimit, InvariantConfig, RpcEndpoint,
-    RpcEndpoints,
+use foundry_config::{FsPermissions, FuzzConfig, InvariantConfig, RpcEndpoint, RpcEndpoints};
+use napi::{
+    bindgen_prelude::{BigInt, Buffer},
+    Either, Status,
 };
+use napi_derive::napi;
+
+use crate::cast::TryCast;
+
+/// Default address for `tx.origin` for Foundry
+///
+/// `0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38`
+const DEFAULT_SENDER: Address = address!("1804c8AB1F12E6bbf3894d4083f33e07309d1f38");
+
+/// Solidity test runner configuration arguments exposed through the ffi.
+/// Docs based on https://book.getfoundry.sh/reference/config/testing
+#[napi(object)]
+#[derive(Clone)]
+pub struct SolidityTestRunnerConfigArgs {
+    /// The absolute path to the project root directory.
+    /// Relative paths in cheat codes are resolved against this path.
+    pub project_root: String,
+    /// Configures the permissions of cheat codes that access the file system.
+    pub fs_permissions: Option<Vec<PathPermission>>,
+    /// Whether to collect traces. Defaults to false.
+    pub trace: Option<bool>,
+    /// Whether to collect debug info. Defaults to false.
+    pub debug: Option<bool>,
+    /// Address labels for traces. Defaults to none.
+    pub labels: Option<Vec<AddressLabel>>,
+    /// Whether to enable isolation of calls. In isolation mode all top-level
+    /// calls are executed as a separate transaction in a separate EVM
+    /// context, enabling more precise gas accounting and transaction state
+    /// changes.
+    /// Defaults to false.
+    pub isolate: Option<bool>,
+    /// Whether or not to enable the ffi cheatcode.
+    /// Warning: Enabling this cheatcode has security implications, as it allows
+    /// tests to execute arbitrary programs on your computer.
+    /// Defaults to false.
+    pub ffi: Option<bool>,
+    /// The value of `msg.sender` in tests as hex string.
+    /// Defaults to `0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38`.
+    pub sender: Option<Buffer>,
+    /// The value of `tx.origin` in tests as hex string.
+    /// Defaults to `0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38`.
+    pub tx_origin: Option<Buffer>,
+    /// The initial balance of the sender in tests.
+    /// Defaults to `0xffffffffffffffffffffffff`.
+    pub initial_balance: Option<BigInt>,
+    /// The value of `block.number` in tests.
+    /// Defaults to `1`.
+    pub block_number: Option<BigInt>,
+    /// The value of the `chainid` opcode in tests.
+    /// Defaults to `31337`.
+    pub chain_id: Option<BigInt>,
+    /// The gas limit for each test case.
+    /// Defaults to `9_223_372_036_854_775_807` (`i64::MAX`).
+    pub gas_limit: Option<BigInt>,
+    /// The price of gas (in wei) in tests.
+    /// Defaults to `0`.
+    pub gas_price: Option<BigInt>,
+    /// The base fee per gas (in wei) in tests.
+    /// Defaults to `0`.
+    pub block_base_fee_per_gas: Option<BigInt>,
+    /// The value of `block.coinbase` in tests.
+    /// Defaults to `0x0000000000000000000000000000000000000000`.
+    pub block_coinbase: Option<Buffer>,
+    /// The value of `block.timestamp` in tests.
+    /// Defaults to 1.
+    pub block_timestamp: Option<BigInt>,
+    /// The value of `block.difficulty` in tests.
+    /// Defaults to 0.
+    pub block_difficulty: Option<BigInt>,
+    /// The `block.gaslimit` value during EVM execution.
+    /// Defaults to none.
+    pub block_gas_limit: Option<BigInt>,
+    /// Whether to disable the block gas limit.
+    /// Defaults to false.
+    pub disable_block_gas_limit: Option<bool>,
+    /// The memory limit of the EVM in bytes.
+    /// Defaults to 33_554_432 (2^25 = 32MiB).
+    pub memory_limit: Option<BigInt>,
+    // TODO https://github.com/NomicFoundation/edr/issues/591
+    /// If set to true, then block data from RPC endpoints in tests will not be
+    /// cached. Otherwise, the data is cached to
+    /// `$HOME/.foundry/cache/<chain id>/<block number>`.
+    /// Defaults to false.
+    pub no_storage_caching: Option<bool>,
+    /// If set, all tests are ran in fork mode using this url or remote name.
+    /// Defaults to none.
+    pub eth_rpc_url: Option<String>,
+    /// Pins the block number for the global state fork.
+    pub fork_block_number: Option<BigInt>,
+    /// Map of RPC endpoints from chain name to RPC urls for fork cheat codes,
+    /// e.g. `{ "optimism": "https://optimism.alchemyapi.io/v2/..." }`
+    pub rpc_endpoints: Option<HashMap<String, String>>,
+    /// What RPC endpoints are cached. Defaults to all.
+    pub rpc_storage_caching: Option<StorageCachingConfig>,
+    /// The number of seconds to wait before `vm.prompt` reverts with a timeout.
+    /// Defaults to 120.
+    pub prompt_timeout: Option<u32>,
+    /// Fuzz testing configuration.
+    pub fuzz: Option<FuzzConfigArgs>,
+    /// Invariant testing configuration.
+    /// If an invariant config setting is not set, but a corresponding fuzz
+    /// config value is set, then the fuzz config value will be used.
+    pub invariant: Option<InvariantConfigArgs>,
+}
+
+impl Debug for SolidityTestRunnerConfigArgs {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SolidityTestRunnerConfigArgs")
+            .field("project_root", &self.project_root)
+            .field("fs_permissions", &self.fs_permissions)
+            .field("trace", &self.trace)
+            .field("debug", &self.debug)
+            .field("ffi", &self.ffi)
+            .field("sender", &self.sender.as_ref().map(hex::encode))
+            .field("tx_origin", &self.tx_origin.as_ref().map(hex::encode))
+            .field("initial_balance", &self.initial_balance)
+            .field("block_number", &self.block_number)
+            .field("chain_id", &self.chain_id)
+            .field("gas_limit", &self.gas_limit)
+            .field("gas_price", &self.gas_price)
+            .field("block_base_fee_per_gas", &self.block_base_fee_per_gas)
+            .field(
+                "block_coinbase",
+                &self.block_coinbase.as_ref().map(hex::encode),
+            )
+            .field("block_timestamp", &self.block_timestamp)
+            .field("block_difficulty", &self.block_difficulty)
+            .field("block_gas_limit", &self.block_gas_limit)
+            .field("memory_limit", &self.memory_limit)
+            .field("eth_rpc_url", &self.eth_rpc_url)
+            .field("no_storage_caching", &self.no_storage_caching)
+            .field("rpc_endpoints", &self.rpc_endpoints)
+            .field("rpc_storage_caching", &self.rpc_storage_caching)
+            .field("prompt_timeout", &self.prompt_timeout)
+            .field("fuzz", &self.fuzz)
+            .field("invariant", &self.invariant)
+            .finish()
+    }
+}
+
+impl TryFrom<SolidityTestRunnerConfigArgs> for SolidityTestRunnerConfig {
+    type Error = napi::Error;
+
+    fn try_from(value: SolidityTestRunnerConfigArgs) -> Result<Self, Self::Error> {
+        let SolidityTestRunnerConfigArgs {
+            project_root,
+            fs_permissions,
+            trace,
+            debug,
+            labels,
+            isolate,
+            ffi,
+            sender,
+            tx_origin,
+            initial_balance,
+            block_number,
+            chain_id,
+            gas_limit,
+            gas_price,
+            block_base_fee_per_gas,
+            block_coinbase,
+            block_timestamp,
+            block_difficulty,
+            block_gas_limit,
+            disable_block_gas_limit,
+            memory_limit,
+            eth_rpc_url,
+            no_storage_caching,
+            fork_block_number,
+            rpc_endpoints,
+            rpc_storage_caching,
+            prompt_timeout,
+            fuzz,
+            invariant,
+        } = value;
+
+        let invariant: InvariantConfig = fuzz
+            .as_ref()
+            .map(|f| invariant.unwrap_or_default().defaults_from_fuzz(f))
+            .map(TryFrom::try_from)
+            .transpose()?
+            .unwrap_or_default();
+
+        let fuzz: FuzzConfig = fuzz.map(TryFrom::try_from).transpose()?.unwrap_or_default();
+
+        let cheats_config_options = CheatsConfigOptions {
+            rpc_endpoints: rpc_endpoints
+                .map(|endpoints| {
+                    RpcEndpoints::new(
+                        endpoints
+                            .into_iter()
+                            .map(|(chain, url)| (chain, RpcEndpoint::Url(url))),
+                    )
+                })
+                .unwrap_or_default(),
+            rpc_storage_caching: rpc_storage_caching
+                .map(TryFrom::try_from)
+                .transpose()?
+                .unwrap_or_default(),
+            unchecked_cheatcode_artifacts: false,
+            fs_permissions: FsPermissions::new(
+                fs_permissions
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(Into::into),
+            ),
+            prompt_timeout: prompt_timeout.map_or(120, Into::into),
+            labels: labels
+                .unwrap_or_default()
+                .into_iter()
+                .map(|AddressLabel { address, label }| Ok((address.try_cast()?, label)))
+                .collect::<Result<_, napi::Error>>()?,
+        };
+
+        let mut evm_opts = SolidityTestRunnerConfig::default_evm_opts();
+
+        if let Some(gas_limit) = gas_limit {
+            evm_opts.env.gas_limit = gas_limit.try_cast()?;
+        }
+
+        evm_opts.env.chain_id = chain_id.map(TryCast::try_cast).transpose()?;
+
+        evm_opts.env.gas_price = gas_price.map(TryCast::try_cast).transpose()?;
+
+        if let Some(block_base_fee_per_gas) = block_base_fee_per_gas {
+            evm_opts.env.block_base_fee_per_gas = block_base_fee_per_gas.try_cast()?;
+        }
+
+        if let Some(tx_origin) = tx_origin {
+            evm_opts.env.tx_origin = tx_origin.try_cast()?;
+        }
+
+        if let Some(block_number) = block_number {
+            evm_opts.env.block_number = block_number.try_cast()?;
+        }
+
+        if let Some(block_difficulty) = block_difficulty {
+            evm_opts.env.block_difficulty = block_difficulty.try_cast()?;
+        }
+
+        evm_opts.env.block_gas_limit = block_gas_limit.map(TryCast::try_cast).transpose()?;
+
+        if let Some(block_timestamp) = block_timestamp {
+            evm_opts.env.block_timestamp = block_timestamp.try_cast()?;
+        }
+
+        if let Some(block_coinbase) = block_coinbase {
+            evm_opts.env.block_coinbase = block_coinbase.try_cast()?;
+        }
+
+        evm_opts.fork_url = eth_rpc_url;
+
+        evm_opts.fork_block_number = fork_block_number.map(TryCast::try_cast).transpose()?;
+
+        if let Some(no_storage_caching) = no_storage_caching {
+            evm_opts.no_storage_caching = no_storage_caching;
+        }
+
+        if let Some(isolate) = isolate {
+            evm_opts.isolate = isolate;
+        }
+
+        if let Some(ffi) = ffi {
+            evm_opts.ffi = ffi;
+        }
+
+        if let Some(sender) = sender {
+            evm_opts.sender = sender.try_cast()?;
+        }
+
+        if let Some(initial_balance) = initial_balance {
+            evm_opts.initial_balance = initial_balance.try_cast()?;
+        }
+
+        if let Some(memory_limit) = memory_limit {
+            evm_opts.memory_limit = memory_limit.try_cast()?;
+        }
+
+        if let Some(disable_block_gas_limit) = disable_block_gas_limit {
+            evm_opts.disable_block_gas_limit = disable_block_gas_limit;
+        }
+
+        Ok(SolidityTestRunnerConfig {
+            project_root: project_root.into(),
+            debug: debug.unwrap_or_default(),
+            trace: trace.unwrap_or_default(),
+            cheats_config_options,
+            evm_opts,
+            fuzz,
+            invariant,
+        })
+    }
+}
+
+/// Fuzz testing configuration
+#[napi(object)]
+#[derive(Clone, Default, Debug)]
+pub struct FuzzConfigArgs {
+    /// Path where fuzz failures are recorded and replayed.
+    pub failure_persist_dir: String,
+    /// Name of the file to record fuzz failures, defaults to `failures`.
+    pub failure_persist_file: Option<String>,
+    /// The amount of fuzz runs to perform for each fuzz test case. Higher
+    /// values gives more confidence in results at the cost of testing
+    /// speed.
+    /// Defaults to 256.
+    pub runs: Option<u32>,
+    /// The maximum number of combined inputs that may be rejected before the
+    /// test as a whole aborts. “Global” filters apply to the whole test
+    /// case. If the test case is rejected, the whole thing is regenerated.
+    /// Defaults to 65536.
+    pub max_test_rejects: Option<u32>,
+    /// Hexadecimal string.
+    /// Optional seed for the fuzzing RNG algorithm.
+    /// Defaults to None.
+    pub seed: Option<String>,
+    /// Integer between 0 and 100.
+    /// The weight of the dictionary. A higher dictionary weight will bias the
+    /// fuzz inputs towards “interesting” values, e.g. boundary values like
+    /// type(uint256).max or contract addresses from your environment.
+    /// Defaults to 40.
+    pub dictionary_weight: Option<u32>,
+    /// The flag indicating whether to include values from storage.
+    /// Defaults to true.
+    pub include_storage: Option<bool>,
+    /// The flag indicating whether to include push bytes values.
+    /// Defaults to true.
+    pub include_push_bytes: Option<bool>,
+}
+
+impl TryFrom<FuzzConfigArgs> for FuzzConfig {
+    type Error = napi::Error;
+
+    fn try_from(value: FuzzConfigArgs) -> Result<Self, Self::Error> {
+        let FuzzConfigArgs {
+            failure_persist_dir,
+            failure_persist_file,
+            runs,
+            max_test_rejects,
+            seed,
+            dictionary_weight,
+            include_storage,
+            include_push_bytes,
+        } = value;
+
+        let mut fuzz = FuzzConfig::default();
+
+        fuzz.failure_persist_dir = Some(failure_persist_dir.into());
+
+        fuzz.failure_persist_file = Some(failure_persist_file.unwrap_or("failures".to_string()));
+
+        if let Some(runs) = runs {
+            fuzz.runs = runs;
+        }
+
+        if let Some(max_test_rejects) = max_test_rejects {
+            fuzz.max_test_rejects = max_test_rejects;
+        }
+
+        fuzz.seed = seed
+            .map(|s| {
+                s.parse().map_err(|_| {
+                    napi::Error::new(Status::InvalidArg, format!("Invalid seed value: {s}"))
+                })
+            })
+            .transpose()?;
+
+        if let Some(dictionary_weight) = dictionary_weight {
+            fuzz.dictionary.dictionary_weight = dictionary_weight;
+        }
+
+        if let Some(include_storage) = include_storage {
+            fuzz.dictionary.include_storage = include_storage;
+        }
+
+        if let Some(include_push_bytes) = include_push_bytes {
+            fuzz.dictionary.include_push_bytes = include_push_bytes;
+        }
+
+        Ok(fuzz)
+    }
+}
+
+/// Invariant testing configuration.
+#[napi(object)]
+#[derive(Clone, Default, Debug)]
+pub struct InvariantConfigArgs {
+    /// Path where invariant failures are recorded and replayed.
+    pub failure_persist_dir: Option<String>,
+    /// The number of runs that must execute for each invariant test group.
+    /// Defaults to 256.
+    pub runs: Option<u32>,
+    /// The number of calls executed to attempt to break invariants in one run.
+    /// Defaults to 500.
+    pub depth: Option<u32>,
+    /// Fails the invariant fuzzing if a revert occurs.
+    /// Defaults to false.
+    pub fail_on_revert: Option<bool>,
+    /// Overrides unsafe external calls when running invariant tests, useful for
+    /// e.g. performing reentrancy checks.
+    /// Defaults to false.
+    pub call_override: Option<bool>,
+    /// Integer between 0 and 100.
+    /// The weight of the dictionary. A higher dictionary weight will bias the
+    /// fuzz inputs towards “interesting” values, e.g. boundary values like
+    /// type(uint256).max or contract addresses from your environment.
+    /// Defaults to 40.
+    pub dictionary_weight: Option<u32>,
+    /// The flag indicating whether to include values from storage.
+    /// Defaults to true.
+    pub include_storage: Option<bool>,
+    /// The flag indicating whether to include push bytes values.
+    /// Defaults to true.
+    pub include_push_bytes: Option<bool>,
+    /// The maximum number of attempts to shrink a failed the sequence. Shrink
+    /// process is disabled if set to 0.
+    /// Defaults to 5000.
+    pub shrink_run_limit: Option<u32>,
+}
+
+impl InvariantConfigArgs {
+    /// Fill in fields from the fuzz config if they are not set.
+    fn defaults_from_fuzz(mut self, fuzz: &FuzzConfigArgs) -> Self {
+        let FuzzConfigArgs {
+            failure_persist_dir,
+            runs,
+            dictionary_weight,
+            include_storage,
+            include_push_bytes,
+            // These aren't used in the invariant config.
+            failure_persist_file: _,
+            max_test_rejects: _,
+            seed: _,
+        } = fuzz;
+
+        if self.failure_persist_dir.is_none() {
+            self.failure_persist_dir = Some(failure_persist_dir.clone());
+        }
+
+        if self.runs.is_none() {
+            self.runs = *runs;
+        }
+
+        if self.dictionary_weight.is_none() {
+            self.dictionary_weight = *dictionary_weight;
+        }
+
+        if self.include_storage.is_none() {
+            self.include_storage = *include_storage;
+        }
+
+        if self.include_push_bytes.is_none() {
+            self.include_push_bytes = *include_push_bytes;
+        }
+
+        self
+    }
+}
+
+impl From<InvariantConfigArgs> for InvariantConfig {
+    fn from(value: InvariantConfigArgs) -> Self {
+        let InvariantConfigArgs {
+            failure_persist_dir,
+            runs,
+            depth,
+            fail_on_revert,
+            call_override,
+            dictionary_weight,
+            include_storage,
+            include_push_bytes,
+            shrink_run_limit,
+        } = value;
+
+        let mut invariant = InvariantConfig::default();
+
+        invariant.failure_persist_dir = failure_persist_dir.map(PathBuf::from);
+
+        if let Some(runs) = runs {
+            invariant.runs = runs;
+        }
+
+        if let Some(depth) = depth {
+            invariant.depth = depth;
+        }
+
+        if let Some(fail_on_revert) = fail_on_revert {
+            invariant.fail_on_revert = fail_on_revert;
+        }
+
+        if let Some(call_override) = call_override {
+            invariant.call_override = call_override;
+        }
+
+        if let Some(dictionary_weight) = dictionary_weight {
+            invariant.dictionary.dictionary_weight = dictionary_weight;
+        }
+
+        if let Some(include_storage) = include_storage {
+            invariant.dictionary.include_storage = include_storage;
+        }
+
+        if let Some(include_push_bytes) = include_push_bytes {
+            invariant.dictionary.include_push_bytes = include_push_bytes;
+        }
+
+        if let Some(shrink_run_limit) = shrink_run_limit {
+            invariant.shrink_run_limit = shrink_run_limit.try_into().expect("u32 fits into usize");
+        }
+
+        invariant
+    }
+}
+
+/// Settings to configure caching of remote
+#[napi(object)]
+#[derive(Clone, Debug)]
+pub struct StorageCachingConfig {
+    /// Chains to cache. Either all or none or a list of chain names, e.g.
+    /// ["optimism", "mainnet"].
+    pub chains: Either<CachedChains, Vec<String>>,
+    /// Endpoints to cache. Either all or remote or a regex.
+    pub endpoints: Either<CachedEndpoints, String>,
+}
+
+impl Default for StorageCachingConfig {
+    fn default() -> Self {
+        Self {
+            chains: Either::A(CachedChains::default()),
+            endpoints: Either::A(CachedEndpoints::default()),
+        }
+    }
+}
+
+impl TryFrom<StorageCachingConfig> for foundry_config::cache::StorageCachingConfig {
+    type Error = napi::Error;
+
+    fn try_from(value: StorageCachingConfig) -> Result<Self, Self::Error> {
+        let chains = match value.chains {
+            Either::A(chains) => chains.into(),
+            Either::B(chains) => {
+                let chains = chains
+                    .into_iter()
+                    .map(|c| {
+                        c.parse()
+                            .map_err(|c| napi::Error::new(Status::InvalidArg, c))
+                    })
+                    .collect::<Result<_, _>>()?;
+                foundry_config::cache::CachedChains::Chains(chains)
+            }
+        };
+        let endpoints = match value.endpoints {
+            Either::A(endpoints) => endpoints.into(),
+            Either::B(regex) => {
+                let regex = regex.parse().map_err(|_err| {
+                    napi::Error::new(Status::InvalidArg, format!("Invalid regex: {regex}"))
+                })?;
+                foundry_config::cache::CachedEndpoints::Pattern(regex)
+            }
+        };
+        Ok(Self { chains, endpoints })
+    }
+}
+
+/// What chains to cache
+#[napi]
+#[derive(Debug, Default)]
+pub enum CachedChains {
+    /// Cache all chains
+    #[default]
+    All,
+    /// Don't cache anything
+    None,
+}
+
+impl From<CachedChains> for foundry_config::cache::CachedChains {
+    fn from(value: CachedChains) -> Self {
+        match value {
+            CachedChains::All => foundry_config::cache::CachedChains::All,
+            CachedChains::None => foundry_config::cache::CachedChains::None,
+        }
+    }
+}
+
+/// What endpoints to enable caching for
+#[napi]
+#[derive(Debug, Default)]
+pub enum CachedEndpoints {
+    /// Cache all endpoints
+    #[default]
+    All,
+    /// Only cache non-local host endpoints
+    Remote,
+}
+
+impl From<CachedEndpoints> for foundry_config::cache::CachedEndpoints {
+    fn from(value: CachedEndpoints) -> Self {
+        match value {
+            CachedEndpoints::All => foundry_config::cache::CachedEndpoints::All,
+            CachedEndpoints::Remote => foundry_config::cache::CachedEndpoints::Remote,
+        }
+    }
+}
+
+/// Represents an access permission to a single path
+#[napi(object)]
+#[derive(Clone, Debug)]
+pub struct PathPermission {
+    /// Permission level to access the `path`
+    pub access: FsAccessPermission,
+    /// The targeted path guarded by the permission
+    pub path: String,
+}
+
+impl From<PathPermission> for foundry_config::fs_permissions::PathPermission {
+    fn from(value: PathPermission) -> Self {
+        let PathPermission { access, path } = value;
+        Self {
+            access: access.into(),
+            path: path.into(),
+        }
+    }
+}
+
+/// Determines the status of file system access
+#[napi]
+#[derive(Debug)]
+pub enum FsAccessPermission {
+    /// FS access is allowed with `read` + `write` permission
+    ReadWrite,
+    /// Only reading is allowed
+    Read,
+    /// Only writing is allowed
+    Write,
+}
+
+impl From<FsAccessPermission> for foundry_config::fs_permissions::FsAccessPermission {
+    fn from(value: FsAccessPermission) -> Self {
+        match value {
+            FsAccessPermission::ReadWrite => {
+                foundry_config::fs_permissions::FsAccessPermission::ReadWrite
+            }
+            FsAccessPermission::Read => foundry_config::fs_permissions::FsAccessPermission::Read,
+            FsAccessPermission::Write => foundry_config::fs_permissions::FsAccessPermission::Write,
+        }
+    }
+}
+
+#[napi(object)]
+#[derive(Clone)]
+pub struct AddressLabel {
+    /// The address to label
+    pub address: Buffer,
+    /// The label to assign to the address
+    pub label: String,
+}
+
+impl Debug for AddressLabel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AddressLabel")
+            .field("address", &hex::encode(&self.address))
+            .field("label", &self.label)
+            .finish()
+    }
+}
 
 /// Solidity tests configuration
 #[derive(Clone, Debug)]
-pub(super) struct SolidityTestsConfig {
-    /// Project root directory
+pub(super) struct SolidityTestRunnerConfig {
+    /// Project root directory.
     pub project_root: PathBuf,
+    /// Whether to enable debug mode.
+    pub debug: bool,
+    /// Whether to enable trace mode.
+    pub trace: bool,
     /// Cheats configuration options
     pub cheats_config_options: CheatsConfigOptions,
     /// EVM options
@@ -26,64 +696,78 @@ pub(super) struct SolidityTestsConfig {
     pub invariant: InvariantConfig,
 }
 
-/// Default address for tx.origin for Foundry
-///
-/// `0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38`
-const DEFAULT_SENDER: Address = address!("1804c8AB1F12E6bbf3894d4083f33e07309d1f38");
-
-impl SolidityTestsConfig {
-    /// Create a new `SolidityTestsConfig` instance
-    pub fn new(gas_report: bool) -> Self {
-        // Matches Foundry config defaults
-        let gas_limit: GasLimit = i64::MAX.into();
-        let evm_opts = EvmOpts {
+impl SolidityTestRunnerConfig {
+    /// The default evm options for the Solidity test runner.
+    pub fn default_evm_opts() -> EvmOpts {
+        EvmOpts {
             env: EvmEnv {
-                gas_limit: gas_limit.into(),
-                chain_id: None,
+                gas_limit: i64::MAX.try_into().expect("max i64 fits into u64"),
+                chain_id: Some(31337),
+                gas_price: Some(0),
+                block_base_fee_per_gas: 0,
                 tx_origin: DEFAULT_SENDER,
                 block_number: 1,
+                block_difficulty: 0,
+                block_prevrandao: B256::default(),
+                block_gas_limit: None,
                 block_timestamp: 1,
-                ..Default::default()
+                block_coinbase: Address::default(),
+                code_size_limit: None,
             },
+            fork_url: None,
+            fork_block_number: None,
+            fork_retries: None,
+            fork_retry_backoff: None,
+            compute_units_per_second: None,
+            no_rpc_rate_limit: false,
             sender: DEFAULT_SENDER,
             initial_balance: U256::from(0xffffffffffffffffffffffffu128),
             ffi: false,
-            memory_limit: 1 << 27, // 2**27 = 128MiB = 134_217_728 bytes
-            ..EvmOpts::default()
-        };
-
-        // Matches Foundry config defaults
-        let mut fuzz = FuzzConfig::new("cache/fuzz".into());
-        let mut invariant = InvariantConfig::new("cache/invariant".into());
-        if !gas_report {
-            fuzz.gas_report_samples = 0;
-            invariant.gas_report_samples = 0;
+            always_use_create_2_factory: false,
+            memory_limit: 1 << 25, // 2**25 = 32MiB
+            isolate: false,
+            no_storage_caching: false,
+            disable_block_gas_limit: false,
         }
-        let project_root = PathBuf::from(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../crates/foundry/testdata"
-        ));
+    }
 
-        // Matches Foundry config defaults
-        let cheats_config_options = CheatsConfigOptions {
-            rpc_endpoints: RpcEndpoints::new([(
-                "alchemy",
-                RpcEndpoint::Url("${ALCHEMY_URL}".to_string()),
-            )]),
-            unchecked_cheatcode_artifacts: false,
-            prompt_timeout: 0,
-            rpc_storage_caching: StorageCachingConfig::default(),
-            // Hardhat doesn't support loading artifacts from disk
-            fs_permissions: FsPermissions::new(vec![]),
-            labels: HashMap::default(),
-        };
+    pub async fn get_fork(&self) -> Result<Option<CreateFork>, napi::Error> {
+        if let Some(fork_url) = self.evm_opts.fork_url.as_ref() {
+            let evm_env = self
+                .evm_opts
+                .fork_evm_env(fork_url)
+                .await
+                .map_err(|e| {
+                    napi::Error::new(
+                        Status::GenericFailure,
+                        format!("Failed to get fork config: {e:?}"),
+                    )
+                })?
+                .0;
 
-        Self {
-            project_root,
-            cheats_config_options,
-            evm_opts,
-            fuzz,
-            invariant,
+            let enable_caching = self.enable_caching(fork_url, evm_env.cfg.chain_id);
+
+            Ok(Some(CreateFork {
+                url: fork_url.clone(),
+                enable_caching,
+                env: evm_env,
+                evm_opts: self.evm_opts.clone(),
+            }))
+        } else {
+            Ok(None)
         }
+    }
+
+    /// Whether caching should be enabled for the given chain id
+    fn enable_caching(&self, endpoint: &str, chain_id: impl Into<u64>) -> bool {
+        !self.evm_opts.no_storage_caching
+            && self
+                .cheats_config_options
+                .rpc_storage_caching
+                .enable_for_chain_id(chain_id.into())
+            && self
+                .cheats_config_options
+                .rpc_storage_caching
+                .enable_for_endpoint(endpoint)
     }
 }

--- a/crates/edr_napi/src/solidity_tests/config.rs
+++ b/crates/edr_napi/src/solidity_tests/config.rs
@@ -16,7 +16,7 @@ use napi_derive::napi;
 
 use crate::cast::TryCast;
 
-/// Default address for `tx.origin` for Foundry
+/// Default address of `tx.origin` in Foundry
 ///
 /// `0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38`
 const DEFAULT_SENDER: Address = address!("1804c8AB1F12E6bbf3894d4083f33e07309d1f38");

--- a/crates/edr_napi/src/solidity_tests/config.rs
+++ b/crates/edr_napi/src/solidity_tests/config.rs
@@ -96,7 +96,7 @@ pub struct SolidityTestRunnerConfigArgs {
     /// `$HOME/.foundry/cache/<chain id>/<block number>`.
     /// Defaults to false.
     pub no_storage_caching: Option<bool>,
-    /// If set, all tests are ran in fork mode using this url or remote name.
+    /// If set, all tests are run in fork mode using this url or remote name.
     /// Defaults to none.
     pub eth_rpc_url: Option<String>,
     /// Pins the block number for the global state fork.

--- a/crates/edr_napi/src/solidity_tests/runner.rs
+++ b/crates/edr_napi/src/solidity_tests/runner.rs
@@ -29,8 +29,6 @@ pub(super) async fn build_runner(
         invariant,
     } = config;
 
-    dbg!(&fuzz);
-
     let test_options = TestOptionsBuilder::default()
         .fuzz(fuzz)
         .invariant(invariant)

--- a/crates/edr_napi/src/solidity_tests/runner.rs
+++ b/crates/edr_napi/src/solidity_tests/runner.rs
@@ -8,22 +8,28 @@ use forge::{
 };
 use foundry_common::ContractsByArtifact;
 
-use crate::solidity_tests::config::SolidityTestsConfig;
+use crate::solidity_tests::config::{SolidityTestRunnerConfig, SolidityTestRunnerConfigArgs};
 
-pub(super) fn build_runner(
+pub(super) async fn build_runner(
     known_contracts: &ContractsByArtifact,
     test_suites: Vec<foundry_common::ArtifactId>,
-    gas_report: bool,
+    config_args: SolidityTestRunnerConfigArgs,
 ) -> napi::Result<MultiContractRunner> {
-    let config = SolidityTestsConfig::new(gas_report);
+    let config: SolidityTestRunnerConfig = config_args.try_into()?;
 
-    let SolidityTestsConfig {
+    let fork = config.get_fork().await?;
+
+    let SolidityTestRunnerConfig {
+        debug,
+        trace,
         evm_opts,
         project_root,
         cheats_config_options,
         fuzz,
         invariant,
     } = config;
+
+    dbg!(&fuzz);
 
     let test_options = TestOptionsBuilder::default()
         .fuzz(fuzz)
@@ -62,6 +68,7 @@ pub(super) fn build_runner(
         .collect::<napi::Result<DeployableContracts>>()?;
 
     let sender = Some(evm_opts.sender);
+    let isolate = evm_opts.isolate;
     let evm_env = evm_opts.local_evm_env();
 
     Ok(MultiContractRunner {
@@ -73,12 +80,12 @@ pub(super) fn build_runner(
         evm_spec: SpecId::CANCUN,
         sender,
         revert_decoder,
-        fork: None,
+        fork,
         coverage: false,
-        trace: false,
-        debug: false,
+        trace,
+        debug,
         test_options,
-        isolation: false,
+        isolation: isolate,
         output: None,
     })
 }

--- a/crates/edr_napi/test/solidity-tests.ts
+++ b/crates/edr_napi/test/solidity-tests.ts
@@ -6,7 +6,32 @@ import {
   SuiteResult,
   runSolidityTests,
   Artifact,
+  SolidityTestRunnerConfigArgs,
 } from "..";
+
+// This throws an error if the tests fail
+async function executeSolidityTests(
+  artifacts: Array<Artifact>,
+  testSuites: Array<ArtifactId>,
+  configArgs: SolidityTestRunnerConfigArgs,
+): Promise<Array<SuiteResult>> {
+  return await new Promise((resolve, reject) => {
+    const resultsFromCallback: Array<SuiteResult> = [];
+
+    runSolidityTests(
+      artifacts,
+      testSuites,
+      configArgs,
+      (result: SuiteResult) => {
+        resultsFromCallback.push(result);
+        if (resultsFromCallback.length === artifacts.length) {
+          resolve(resultsFromCallback);
+        }
+      },
+      reject,
+    );
+  });
+}
 
 describe("Solidity Tests", () => {
   it("executes basic tests", async function () {
@@ -14,26 +39,13 @@ describe("Solidity Tests", () => {
       loadContract("./artifacts/SetupConsistencyCheck.json"),
       loadContract("./artifacts/PaymentFailureTest.json"),
     ];
-
     // All artifacts are test suites.
     const testSuites = artifacts.map((artifact) => artifact.id);
+    const config = {
+      projectRoot: __dirname,
+    };
 
-    const results: Array<SuiteResult> = await new Promise((resolve, reject) => {
-      const resultsFromCallback: Array<SuiteResult> = [];
-
-      runSolidityTests(
-        artifacts,
-        testSuites,
-        { projectRoot: __dirname },
-        (result: SuiteResult) => {
-          resultsFromCallback.push(result);
-          if (resultsFromCallback.length === artifacts.length) {
-            resolve(resultsFromCallback);
-          }
-        },
-        reject,
-      );
-    });
+    const results = await executeSolidityTests(artifacts, testSuites, config);
 
     assert.equal(results.length, artifacts.length);
 
@@ -49,6 +61,25 @@ describe("Solidity Tests", () => {
         assert.fail("Unexpected test suite name: " + res.id.name);
       }
     }
+  });
+
+  it("throws errors", async function () {
+    const artifacts = [
+      loadContract("./artifacts/SetupConsistencyCheck.json"),
+      loadContract("./artifacts/PaymentFailureTest.json"),
+    ];
+    // All artifacts are test suites.
+    const testSuites = artifacts.map((artifact) => artifact.id);
+    const config = {
+      projectRoot: __dirname,
+      // Memory limit is too large
+      memoryLimit: 2n ** 65n,
+    };
+
+    await assert.isRejected(
+      executeSolidityTests(artifacts, testSuites, config),
+      Error,
+    );
   });
 });
 

--- a/crates/edr_napi/test/solidity-tests.ts
+++ b/crates/edr_napi/test/solidity-tests.ts
@@ -18,20 +18,20 @@ describe("Solidity Tests", () => {
     // All artifacts are test suites.
     const testSuites = artifacts.map((artifact) => artifact.id);
 
-    const results: Array<SuiteResult> = await new Promise((resolve) => {
-      const gasReport = false;
+    const results: Array<SuiteResult> = await new Promise((resolve, reject) => {
       const resultsFromCallback: Array<SuiteResult> = [];
 
       runSolidityTests(
         artifacts,
         testSuites,
-        gasReport,
+        { projectRoot: __dirname },
         (result: SuiteResult) => {
           resultsFromCallback.push(result);
           if (resultsFromCallback.length === artifacts.length) {
             resolve(resultsFromCallback);
           }
         },
+        reject,
       );
     });
 

--- a/crates/foundry/cheatcodes/src/config.rs
+++ b/crates/foundry/cheatcodes/src/config.rs
@@ -57,19 +57,19 @@ pub struct CheatsConfig {
 pub struct CheatsConfigOptions {
     /// Multiple rpc endpoints and their aliases
     pub rpc_endpoints: RpcEndpoints,
+    /// RPC storage caching settings determines what chains and endpoints to
+    /// cache
+    pub rpc_storage_caching: StorageCachingConfig,
     /// Whether to enable safety checks for `vm.getCode` and
     /// `vm.getDeployedCode` invocations. If disabled, it is possible to
     /// access artifacts which were not recompiled or cached.
     pub unchecked_cheatcode_artifacts: bool,
-    /// Sets a timeout in seconds for vm.prompt cheatcodes
-    pub prompt_timeout: u64,
-    /// RPC storage caching settings determines what chains and endpoints to
-    /// cache
-    pub rpc_storage_caching: StorageCachingConfig,
     /// Configures the permissions of cheat codes that touch the file system.
     ///
     /// This includes what operations can be executed (read, write)
     pub fs_permissions: FsPermissions,
+    /// Sets a timeout in seconds for vm.prompt cheatcodes
+    pub prompt_timeout: u64,
     /// Address labels
     pub labels: HashMap<Address, String>,
 }

--- a/crates/foundry/config/src/fuzz.rs
+++ b/crates/foundry/config/src/fuzz.rs
@@ -40,7 +40,7 @@ impl Default for FuzzConfig {
             max_test_rejects: 65536,
             seed: None,
             dictionary: FuzzDictionaryConfig::default(),
-            gas_report_samples: 256,
+            gas_report_samples: 0,
             failure_persist_dir: None,
             failure_persist_file: None,
         }
@@ -56,7 +56,7 @@ impl FuzzConfig {
             max_test_rejects: 65536,
             seed: None,
             dictionary: FuzzDictionaryConfig::default(),
-            gas_report_samples: 256,
+            gas_report_samples: 0,
             failure_persist_dir: Some(cache_dir),
             failure_persist_file: Some("failures".to_string()),
         }

--- a/crates/foundry/config/src/invariant.rs
+++ b/crates/foundry/config/src/invariant.rs
@@ -42,7 +42,7 @@ impl Default for InvariantConfig {
     fn default() -> Self {
         InvariantConfig {
             runs: 256,
-            depth: 15,
+            depth: 500,
             fail_on_revert: false,
             call_override: false,
             dictionary: FuzzDictionaryConfig {
@@ -63,7 +63,7 @@ impl InvariantConfig {
     pub fn new(cache_dir: PathBuf) -> Self {
         InvariantConfig {
             runs: 256,
-            depth: 15,
+            depth: 500,
             fail_on_revert: false,
             call_override: false,
             dictionary: FuzzDictionaryConfig {

--- a/crates/tools/js/benchmark/solidity-tests.js
+++ b/crates/tools/js/benchmark/solidity-tests.js
@@ -47,8 +47,6 @@ async function setupForgeStdRepo() {
 }
 
 async function runForgeStdTests(forgeStdRepoPath) {
-  const gasReport = false;
-
   const start = performance.now();
 
   const artifactsDir = path.join(forgeStdRepoPath, "artifacts");
@@ -67,17 +65,29 @@ async function runForgeStdTests(forgeStdRepoPath) {
     )
     .map((a) => a.id);
 
-  const results = await new Promise((resolve) => {
+  const results = await new Promise((resolve, reject) => {
     const resultsFromCallback = [];
+    const configs = {
+      projectRoot: forgeStdRepoPath,
+      fuzz: {
+        failurePersistDir: path.join(forgeStdRepoPath, "failures"),
+      },
+    };
 
-    runSolidityTests(artifacts, testSuiteIds, gasReport, (result) => {
-      console.error(`${result.id.name} took ${elapsedSec(start)} seconds`);
+    runSolidityTests(
+      artifacts,
+      testSuiteIds,
+      configs,
+      (result) => {
+        console.error(`${result.id.name} took ${elapsedSec(start)} seconds`);
 
-      resultsFromCallback.push(result);
-      if (resultsFromCallback.length === artifacts.length) {
-        resolve(resultsFromCallback);
-      }
-    });
+        resultsFromCallback.push(result);
+        if (resultsFromCallback.length === artifacts.length) {
+          resolve(resultsFromCallback);
+        }
+      },
+      reject,
+    );
   });
   console.error("elapsed (s)", elapsedSec(start));
 

--- a/hardhat-solidity-tests/src/index.ts
+++ b/hardhat-solidity-tests/src/index.ts
@@ -52,13 +52,15 @@ task("test:solidity").setAction(async (_: any, hre: any) => {
     }
   }
 
-  await new Promise<void>((resolve) => {
-    const gasReport = false;
+  await new Promise<void>((resolve, reject) => {
+    const config = {
+      projectRoot: hre.config.paths.root,
+    };
 
     runSolidityTests(
       artifacts,
       testSuiteIds,
-      gasReport,
+      config,
       (suiteResult: SuiteResult) => {
         for (const testResult of suiteResult.testResults) {
           let name = suiteResult.id.name + " | " + testResult.name;
@@ -84,6 +86,7 @@ task("test:solidity").setAction(async (_: any, hre: any) => {
           resolve();
         }
       },
+      reject,
     );
   });
 


### PR DESCRIPTION
## Config Options

This PR exposes Solidity test runner config options to TypeScript from Rust through NAPI-RS.

The basis of the config options are the Foundry testing configuration options documented [here.](https://book.getfoundry.sh/reference/config/testing) There were some additional config options not covered there that are needed to construct a test runner. These are exposed based on the [Foundry config struct](https://github.com/NomicFoundation/edr/blob/103f3b12f73621867983cc58893ec5a8d212dc28/crates/foundry/config/src/lib.rs) that contains all configuration options (including build and deployment options which we don't need).

The following Foundry testing options are not exposed:

- [verbosity](https://book.getfoundry.sh/reference/config/testing#verbosity)
    - This controls the CLI output verbosity which is out of scope for EDR.
- [etherscan_api_key](https://book.getfoundry.sh/reference/config/testing#etherscan_api_key)
    - This is used for verifying deployed contracts and identifying unknown contracts in traces in fork mode. Both are out of scope for the EDR Solidity tests effort.
- [threads](https://book.getfoundry.sh/reference/config/testing#threads)
    - Number of logical cores to use for parallel test execution.
    - Not yet supported by forked Foundry version.
- [show_progress](https://book.getfoundry.sh/reference/config/testing#show_progress)
    - Whether to show test execution progress.
    - Not yet supported by forked Foundry version and probably out of scope for EDR.
- [names](https://book.getfoundry.sh/reference/config/testing#names)
    - Print compiled contract names.
    - Build-related, out of scope for EDR.
- [sizes](https://book.getfoundry.sh/reference/config/testing#sizes)
    - Print compiled contract sizes.
    - Build-related, out of scope for EDR.
- [gas_reports](https://book.getfoundry.sh/reference/config/testing#gas_reports)
    - Specifies the contracts to print gas reports for.
    - Displaying info to the user is Hardhat’s responsibility, so this is out of scope for EDR.
    - How to expose data for gas reporting is a separate issue
- [match-test, no-match-test, match-contract, no-match-contract, match-path, no-match-path](https://book.getfoundry.sh/reference/config/testing#match-test)
    - Only run test methods matching the above specifiers
    - Selecting which contracts to run is the responsibility of Hardhat, so these config options are out of scope for EDR.

## Error Callback

In addition to the config options, this PR brings another change to the Solidity test runner interface: an error callback. 

The reason for introducing this error callback is that building a test runner is async now to resolve forked EVM parameters, but the JS interface is sync and returns results with a progress callback. If we want to be able to propagate errors encountered while building a test runner we have two options:

1. Make the test runner async. This is possible, but we'd need to create a test runner class that takes the progress callback as argument first and then give it an async method for reasons explained in https://github.com/NomicFoundation/edr/pull/563. 
2. Expose an error callback.

The second option is simpler and composes well with the `Promise` wrapper on the TS-side (just have to pass the `reject` arg of the promise as the error callback), so I went with this option.