### PR TITLE
refactor: Port ErrorInferrer and SolidityTracer from Hardhat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1153,6 +1153,8 @@ dependencies = [
 name = "edr_napi"
 version = "0.3.5"
 dependencies = [
+ "alloy-dyn-abi",
+ "alloy-json-abi",
  "alloy-sol-types 0.5.4",
  "ansi_term",
  "crossbeam-channel",
@@ -1174,6 +1176,7 @@ dependencies = [
  "openssl-sys",
  "parking_lot 0.12.1",
  "rand",
+ "semver 1.0.22",
  "serde",
  "serde_json",
  "strum",

--- a/crates/edr_napi/Cargo.toml
+++ b/crates/edr_napi/Cargo.toml
@@ -8,8 +8,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 alloy-dyn-abi = { version = "0.7.6", default-features = false }
-alloy-sol-types = { version = "0.5.1", default-features = false, features = ["std"] }
 alloy-json-abi = { version = "0.7.4", default-features = false }
+alloy-sol-types = { version = "0.5.1", default-features = false, features = ["std"] }
 ansi_term = { version = "0.12.1", default-features = false }
 crossbeam-channel = { version = "0.5.6", default-features = false }
 itertools = { version = "0.12.0", default-features = false }

--- a/crates/edr_napi/Cargo.toml
+++ b/crates/edr_napi/Cargo.toml
@@ -8,6 +8,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 alloy-sol-types = { version = "0.5.1", default-features = false, features = ["std"] }
+alloy-json-abi = { version = "0.7.4", default-features = false}
+alloy-dyn-abi = { version = "0.7.6", default-features = false}
 ansi_term = { version = "0.12.1", default-features = false }
 crossbeam-channel = { version = "0.5.6", default-features = false }
 itertools = { version = "0.12.0", default-features = false }
@@ -32,6 +34,7 @@ tracing-subscriber = { version = "0.3.18", default-features = false, features = 
 parking_lot = { version = "0.12.1", default-features = false }
 lazy_static = { version = "1.4.0", features = [] }
 rand = { version = "0.8.4", optional = true }
+semver = "1.0.22"
 serde = { version = "1.0.189", features = ["derive"] }
 strum = { version = "0.26.0", features = ["derive"] }
 mimalloc = { version = "0.1.39", default-features = false, features = ["local_dynamic_tls"] }

--- a/crates/edr_napi/Cargo.toml
+++ b/crates/edr_napi/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
+alloy-dyn-abi = { version = "0.7.6", default-features = false }
 alloy-sol-types = { version = "0.5.1", default-features = false, features = ["std"] }
-alloy-json-abi = { version = "0.7.4", default-features = false}
-alloy-dyn-abi = { version = "0.7.6", default-features = false}
+alloy-json-abi = { version = "0.7.4", default-features = false }
 ansi_term = { version = "0.12.1", default-features = false }
 crossbeam-channel = { version = "0.5.6", default-features = false }
 itertools = { version = "0.12.0", default-features = false }

--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -778,7 +778,7 @@ export interface PrecompileErrorStackTraceEntry {
 }
 export interface RevertErrorStackTraceEntry {
   type: StackTraceEntryType.REVERT_ERROR
-  message: ReturnData
+  returnData: Uint8Array
   sourceReference: SourceReference
   isInvalidOpcodeError: boolean
 }
@@ -837,14 +837,14 @@ export interface DirectLibraryCallErrorStackTraceEntry {
 }
 export interface UnrecognizedCreateErrorStackTraceEntry {
   type: StackTraceEntryType.UNRECOGNIZED_CREATE_ERROR
-  message: ReturnData
+  returnData: Uint8Array
   sourceReference?: undefined
   isInvalidOpcodeError: boolean
 }
 export interface UnrecognizedContractErrorStackTraceEntry {
   type: StackTraceEntryType.UNRECOGNIZED_CONTRACT_ERROR
   address: Uint8Array
-  message: ReturnData
+  returnData: Uint8Array
   sourceReference?: undefined
   isInvalidOpcodeError: boolean
 }

--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -387,7 +387,12 @@ export interface SourceMap {
   location: SourceMapLocation
   jumpType: JumpType
 }
-export function sourceLocationToSourceReference(bytecode: Bytecode, location: SourceLocation | undefined): SourceReference | undefined
+export interface SubmessageData {
+  messageTrace: PrecompileMessageTrace | CallMessageTrace | CreateMessageTrace
+  stacktrace: SolidityStackTrace
+  stepIndex: number
+}
+export function instructionToCallstackStackTraceEntry(bytecode: Bytecode, inst: Instruction): CallstackEntryStackTraceEntry | InternalFunctionCallStackEntry
 /** Represents the exit code of the EVM. */
 export const enum ExitCode {
   /** Execution was successful. */
@@ -785,10 +790,6 @@ export interface CustomErrorStackTraceEntry {
   message: string
   sourceReference: SourceReference
 }
-export interface UnmappedSolc063RevertErrorStackTraceEntry {
-  type: StackTraceEntryType.UNMAPPED_SOLC_0_6_3_REVERT_ERROR
-  sourceReference?: SourceReference
-}
 export interface FunctionNotPayableErrorStackTraceEntry {
   type: StackTraceEntryType.FUNCTION_NOT_PAYABLE_ERROR
   value: bigint
@@ -847,6 +848,10 @@ export interface UnrecognizedContractErrorStackTraceEntry {
 }
 export interface OtherExecutionErrorStackTraceEntry {
   type: StackTraceEntryType.OTHER_EXECUTION_ERROR
+  sourceReference?: SourceReference
+}
+export interface UnmappedSolc063RevertErrorStackTraceEntry {
+  type: StackTraceEntryType.UNMAPPED_SOLC_0_6_3_REVERT_ERROR
   sourceReference?: SourceReference
 }
 export interface ContractTooLargeErrorStackTraceEntry {
@@ -1003,7 +1008,50 @@ export class ContractsIdentifier {
   addBytecode(bytecode: Bytecode): void
 }
 export class ErrorInferrer {
+  static inferBeforeTracingCallMessage(trace: CallMessageTrace): SolidityStackTrace | undefined
+  static inferBeforeTracingCreateMessage(trace: CreateMessageTrace): SolidityStackTrace | undefined
+  static inferAfterTracing(trace: CallMessageTrace | CreateMessageTrace, stacktrace: SolidityStackTrace, functionJumpdests: Array<Instruction>, jumpedIntoFunction: boolean, lastSubmessageData: SubmessageData | undefined): SolidityStackTrace | undefined
   static filterRedundantFrames(stacktrace: SolidityStackTrace): SolidityStackTrace
+  static checkContractTooLarge(trace: CallMessageTrace | CreateMessageTrace): SolidityStackTrace | undefined
+  /** Check if the last call/create that was done failed. */
+  static checkFailedLastCall(trace: CallMessageTrace | CreateMessageTrace, stacktrace: SolidityStackTrace): SolidityStackTrace | undefined
+  /** Check if the trace reverted with a panic error. */
+  static checkPanic(trace: CallMessageTrace | CreateMessageTrace, stacktrace: SolidityStackTrace, lastInstruction: Instruction): SolidityStackTrace | undefined
+  static checkCustomErrors(trace: CallMessageTrace | CreateMessageTrace, stacktrace: SolidityStackTrace, lastInstruction: Instruction): SolidityStackTrace | undefined
+  static checkSolidity063UnmappedRevert(trace: CallMessageTrace | CreateMessageTrace, stacktrace: SolidityStackTrace): SolidityStackTrace | undefined
+  static checkNonContractCalled(trace: CallMessageTrace | CreateMessageTrace, stacktrace: SolidityStackTrace): SolidityStackTrace | undefined
+  /** Check if the last submessage can be used to generate the stack trace. */
+  static checkLastSubmessage(trace: CallMessageTrace | CreateMessageTrace, stacktrace: SolidityStackTrace, lastSubmessageData: SubmessageData | undefined): SolidityStackTrace | undefined
+  /** Check if the execution stopped with a revert or an invalid opcode. */
+  static checkRevertOrInvalidOpcode(trace: CallMessageTrace | CreateMessageTrace, stacktrace: SolidityStackTrace, lastInstruction: Instruction, functionJumpdests: Array<Instruction>, jumpedIntoFunction: boolean): SolidityStackTrace | undefined
+  /** Check last instruction to try to infer the error. */
+  static checkLastInstruction(trace: CallMessageTrace | CreateMessageTrace, stacktrace: SolidityStackTrace, functionJumpdests: Array<Instruction>, jumpedIntoFunction: boolean): SolidityStackTrace | undefined
+  static fixInitialModifier(trace: CallMessageTrace | CreateMessageTrace, stacktrace: SolidityStackTrace): SolidityStackTrace
+  static callInstructionToCallFailedToExecuteStackTraceEntry(bytecode: Bytecode, callInst: Instruction): CallFailedErrorStackTraceEntry
+  static getEntryBeforeFailureInModifier(trace: CallMessageTrace | CreateMessageTrace, functionJumpdests: Array<Instruction>): CallstackEntryStackTraceEntry | InternalFunctionCallStackEntry
+  static failsRightAfterCall(trace: CallMessageTrace | CreateMessageTrace, callSubtraceStepIndex: number): boolean
+  static isSubtraceErrorPropagated(trace: CallMessageTrace | CreateMessageTrace, callSubtraceStepIndex: number): boolean
+  static isContractCallRunOutOfGasError(trace: CallMessageTrace | CreateMessageTrace, callStepIndex: number): boolean
+  static isProxyErrorPropagated(trace: CallMessageTrace | CreateMessageTrace, callSubtraceStepIndex: number): boolean
+  static otherExecutionErrorStacktrace(trace: CallMessageTrace | CreateMessageTrace, stacktrace: SolidityStackTrace): SolidityStackTrace
+  static getFunctionStartSourceReference(trace: CallMessageTrace | CreateMessageTrace, func: ContractFunction): SourceReference
+  static getFallbackStartSourceReference(trace: CallMessageTrace): SourceReference
+  /** Returns a source reference pointing to the constructor if it exists, or to the contract otherwise. */
+  static getConstructorStartSourceReference(trace: CreateMessageTrace): SourceReference
+  static getContractStartWithoutFunctionSourceReference(trace: CallMessageTrace | CreateMessageTrace): SourceReference
+  static getLastSourceReference(trace: CallMessageTrace | CreateMessageTrace): SourceReference | undefined
+  static hasFailedInsideTheFallbackFunction(trace: CallMessageTrace): boolean
+  static hasFailedInsideTheReceiveFunction(trace: CallMessageTrace): boolean
+  static instructionWithinFunctionToRevertStackTraceEntry(trace: CallMessageTrace | CreateMessageTrace, inst: Instruction): RevertErrorStackTraceEntry
+  static instructionWithinFunctionToUnmappedSolc063RevertErrorStackTraceEntry(trace: CallMessageTrace | CreateMessageTrace, inst: Instruction): UnmappedSolc063RevertErrorStackTraceEntry
+  static instructionWithinFunctionToPanicStackTraceEntry(trace: CallMessageTrace | CreateMessageTrace, inst: Instruction, errorCode: bigint): PanicErrorStackTraceEntry
+  static instructionWithinFunctionToCustomErrorStackTraceEntry(trace: CallMessageTrace | CreateMessageTrace, inst: Instruction, message: string): CustomErrorStackTraceEntry
+  static solidity063MaybeUnmappedRevert(trace: CallMessageTrace | CreateMessageTrace): boolean
+  static solidity063GetFrameForUnmappedRevertBeforeFunction(trace: CallMessageTrace): UnmappedSolc063RevertErrorStackTraceEntry | undefined
+  static solidity063GetFrameForUnmappedRevertWithinFunction(trace: CallMessageTrace | CreateMessageTrace): UnmappedSolc063RevertErrorStackTraceEntry | undefined
+  static solidity063CorrectLineNumber(revertFrame: UnmappedSolc063RevertErrorStackTraceEntry): UnmappedSolc063RevertErrorStackTraceEntry
+  static getOtherErrorBeforeCalledFunctionStackTraceEntry(trace: CallMessageTrace): OtherExecutionErrorStackTraceEntry
+  static isPanicReturnData(returnData: Uint8Array): boolean
 }
 export class Exit {
   get kind(): ExitCode
@@ -1014,7 +1062,6 @@ export class ReturnData {
   readonly value: Uint8Array
   constructor(value: Uint8Array)
   isEmpty(): boolean
-  matchesSelector(selector: Uint8Array): boolean
   isErrorReturnData(): boolean
   isPanicReturnData(): boolean
   decodeError(): string

--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -412,6 +412,8 @@ export const enum ExitCode {
   /** Create collision. */
   CREATE_COLLISION = 7
 }
+export function stackTraceMayRequireAdjustments(stacktrace: SolidityStackTrace, decodedTrace: CallMessageTrace | CreateMessageTrace): boolean
+export function adjustStackTrace(stacktrace: SolidityStackTrace, decodedTrace: CallMessageTrace | CreateMessageTrace): SolidityStackTrace
 export interface EvmStep {
   pc: number
 }

--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -1017,9 +1017,6 @@ export class ErrorInferrer {
   static checkContractTooLarge(trace: CallMessageTrace | CreateMessageTrace): SolidityStackTrace | undefined
   /** Check if the last call/create that was done failed. */
   static checkFailedLastCall(trace: CallMessageTrace | CreateMessageTrace, stacktrace: SolidityStackTrace): SolidityStackTrace | undefined
-  /** Check if the trace reverted with a panic error. */
-  static checkPanic(trace: CallMessageTrace | CreateMessageTrace, stacktrace: SolidityStackTrace, lastInstruction: Instruction): SolidityStackTrace | undefined
-  static checkCustomErrors(trace: CallMessageTrace | CreateMessageTrace, stacktrace: SolidityStackTrace, lastInstruction: Instruction): SolidityStackTrace | undefined
   static checkSolidity063UnmappedRevert(trace: CallMessageTrace | CreateMessageTrace, stacktrace: SolidityStackTrace): SolidityStackTrace | undefined
   static checkNonContractCalled(trace: CallMessageTrace | CreateMessageTrace, stacktrace: SolidityStackTrace): SolidityStackTrace | undefined
   /** Check if the last submessage can be used to generate the stack trace. */
@@ -1028,32 +1025,7 @@ export class ErrorInferrer {
   static checkRevertOrInvalidOpcode(trace: CallMessageTrace | CreateMessageTrace, stacktrace: SolidityStackTrace, lastInstruction: Instruction, functionJumpdests: Array<Instruction>, jumpedIntoFunction: boolean): SolidityStackTrace | undefined
   /** Check last instruction to try to infer the error. */
   static checkLastInstruction(trace: CallMessageTrace | CreateMessageTrace, stacktrace: SolidityStackTrace, functionJumpdests: Array<Instruction>, jumpedIntoFunction: boolean): SolidityStackTrace | undefined
-  static fixInitialModifier(trace: CallMessageTrace | CreateMessageTrace, stacktrace: SolidityStackTrace): SolidityStackTrace
-  static callInstructionToCallFailedToExecuteStackTraceEntry(bytecode: Bytecode, callInst: Instruction): CallFailedErrorStackTraceEntry
-  static getEntryBeforeFailureInModifier(trace: CallMessageTrace | CreateMessageTrace, functionJumpdests: Array<Instruction>): CallstackEntryStackTraceEntry | InternalFunctionCallStackEntry
-  static failsRightAfterCall(trace: CallMessageTrace | CreateMessageTrace, callSubtraceStepIndex: number): boolean
-  static isSubtraceErrorPropagated(trace: CallMessageTrace | CreateMessageTrace, callSubtraceStepIndex: number): boolean
-  static isContractCallRunOutOfGasError(trace: CallMessageTrace | CreateMessageTrace, callStepIndex: number): boolean
-  static isProxyErrorPropagated(trace: CallMessageTrace | CreateMessageTrace, callSubtraceStepIndex: number): boolean
   static otherExecutionErrorStacktrace(trace: CallMessageTrace | CreateMessageTrace, stacktrace: SolidityStackTrace): SolidityStackTrace
-  static getFunctionStartSourceReference(trace: CallMessageTrace | CreateMessageTrace, func: ContractFunction): SourceReference
-  static getFallbackStartSourceReference(trace: CallMessageTrace): SourceReference
-  /** Returns a source reference pointing to the constructor if it exists, or to the contract otherwise. */
-  static getConstructorStartSourceReference(trace: CreateMessageTrace): SourceReference
-  static getContractStartWithoutFunctionSourceReference(trace: CallMessageTrace | CreateMessageTrace): SourceReference
-  static getLastSourceReference(trace: CallMessageTrace | CreateMessageTrace): SourceReference | undefined
-  static hasFailedInsideTheFallbackFunction(trace: CallMessageTrace): boolean
-  static hasFailedInsideTheReceiveFunction(trace: CallMessageTrace): boolean
-  static instructionWithinFunctionToRevertStackTraceEntry(trace: CallMessageTrace | CreateMessageTrace, inst: Instruction): RevertErrorStackTraceEntry
-  static instructionWithinFunctionToUnmappedSolc063RevertErrorStackTraceEntry(trace: CallMessageTrace | CreateMessageTrace, inst: Instruction): UnmappedSolc063RevertErrorStackTraceEntry
-  static instructionWithinFunctionToPanicStackTraceEntry(trace: CallMessageTrace | CreateMessageTrace, inst: Instruction, errorCode: bigint): PanicErrorStackTraceEntry
-  static instructionWithinFunctionToCustomErrorStackTraceEntry(trace: CallMessageTrace | CreateMessageTrace, inst: Instruction, message: string): CustomErrorStackTraceEntry
-  static solidity063MaybeUnmappedRevert(trace: CallMessageTrace | CreateMessageTrace): boolean
-  static solidity063GetFrameForUnmappedRevertBeforeFunction(trace: CallMessageTrace): UnmappedSolc063RevertErrorStackTraceEntry | undefined
-  static solidity063GetFrameForUnmappedRevertWithinFunction(trace: CallMessageTrace | CreateMessageTrace): UnmappedSolc063RevertErrorStackTraceEntry | undefined
-  static solidity063CorrectLineNumber(revertFrame: UnmappedSolc063RevertErrorStackTraceEntry): UnmappedSolc063RevertErrorStackTraceEntry
-  static getOtherErrorBeforeCalledFunctionStackTraceEntry(trace: CallMessageTrace): OtherExecutionErrorStackTraceEntry
-  static isPanicReturnData(returnData: Uint8Array): boolean
 }
 export class Exit {
   get kind(): ExitCode

--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -1016,6 +1016,11 @@ export class ReturnData {
   decodeError(): string
   decodePanic(): bigint
 }
+export class SolidityTracer {
+  
+  constructor()
+  getLastSubtrace(trace: CallMessageTrace | CreateMessageTrace): PrecompileMessageTrace | CallMessageTrace | CreateMessageTrace | undefined
+}
 export class VmTraceDecoder {
   constructor(contractsIdentifier: ContractsIdentifier)
   addBytecode(bytecode: Bytecode): void

--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -387,6 +387,7 @@ export interface SourceMap {
   location: SourceMapLocation
   jumpType: JumpType
 }
+export function sourceLocationToSourceReference(bytecode: Bytecode, location: SourceLocation | undefined): SourceReference | undefined
 /** Represents the exit code of the EVM. */
 export const enum ExitCode {
   /** Execution was successful. */
@@ -1000,6 +1001,9 @@ export class Contract {
 export class ContractsIdentifier {
   constructor(enableCache?: boolean | undefined | null)
   addBytecode(bytecode: Bytecode): void
+}
+export class ErrorInferrer {
+  static filterRedundantFrames(stacktrace: SolidityStackTrace): SolidityStackTrace
 }
 export class Exit {
   get kind(): ExitCode

--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -1010,22 +1010,12 @@ export class ContractsIdentifier {
   addBytecode(bytecode: Bytecode): void
 }
 export class ErrorInferrer {
-  static inferBeforeTracingCallMessage(trace: CallMessageTrace): SolidityStackTrace | undefined
-  static inferBeforeTracingCreateMessage(trace: CreateMessageTrace): SolidityStackTrace | undefined
-  static inferAfterTracing(trace: CallMessageTrace | CreateMessageTrace, stacktrace: SolidityStackTrace, functionJumpdests: Array<Instruction>, jumpedIntoFunction: boolean, lastSubmessageData: SubmessageData | undefined): SolidityStackTrace | undefined
-  static filterRedundantFrames(stacktrace: SolidityStackTrace): SolidityStackTrace
-  static checkContractTooLarge(trace: CallMessageTrace | CreateMessageTrace): SolidityStackTrace | undefined
-  /** Check if the last call/create that was done failed. */
-  static checkFailedLastCall(trace: CallMessageTrace | CreateMessageTrace, stacktrace: SolidityStackTrace): SolidityStackTrace | undefined
-  static checkSolidity063UnmappedRevert(trace: CallMessageTrace | CreateMessageTrace, stacktrace: SolidityStackTrace): SolidityStackTrace | undefined
-  static checkNonContractCalled(trace: CallMessageTrace | CreateMessageTrace, stacktrace: SolidityStackTrace): SolidityStackTrace | undefined
-  /** Check if the last submessage can be used to generate the stack trace. */
-  static checkLastSubmessage(trace: CallMessageTrace | CreateMessageTrace, stacktrace: SolidityStackTrace, lastSubmessageData: SubmessageData | undefined): SolidityStackTrace | undefined
-  /** Check if the execution stopped with a revert or an invalid opcode. */
-  static checkRevertOrInvalidOpcode(trace: CallMessageTrace | CreateMessageTrace, stacktrace: SolidityStackTrace, lastInstruction: Instruction, functionJumpdests: Array<Instruction>, jumpedIntoFunction: boolean): SolidityStackTrace | undefined
-  /** Check last instruction to try to infer the error. */
-  static checkLastInstruction(trace: CallMessageTrace | CreateMessageTrace, stacktrace: SolidityStackTrace, functionJumpdests: Array<Instruction>, jumpedIntoFunction: boolean): SolidityStackTrace | undefined
-  static otherExecutionErrorStacktrace(trace: CallMessageTrace | CreateMessageTrace, stacktrace: SolidityStackTrace): SolidityStackTrace
+  
+  constructor()
+  inferBeforeTracingCallMessage(trace: CallMessageTrace): SolidityStackTrace | undefined
+  inferBeforeTracingCreateMessage(trace: CreateMessageTrace): SolidityStackTrace | undefined
+  inferAfterTracing(trace: CallMessageTrace | CreateMessageTrace, stacktrace: SolidityStackTrace, functionJumpdests: Array<Instruction>, jumpedIntoFunction: boolean, lastSubmessageData: SubmessageData | undefined): SolidityStackTrace
+  filterRedundantFrames(stacktrace: SolidityStackTrace): SolidityStackTrace
 }
 export class Exit {
   get kind(): ExitCode

--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -412,8 +412,6 @@ export const enum ExitCode {
   /** Create collision. */
   CREATE_COLLISION = 7
 }
-export function stackTraceMayRequireAdjustments(stacktrace: SolidityStackTrace, decodedTrace: CallMessageTrace | CreateMessageTrace): boolean
-export function adjustStackTrace(stacktrace: SolidityStackTrace, decodedTrace: CallMessageTrace | CreateMessageTrace): SolidityStackTrace
 export interface EvmStep {
   pc: number
 }
@@ -1034,7 +1032,7 @@ export class ReturnData {
 export class SolidityTracer {
   
   constructor()
-  getLastSubtrace(trace: CallMessageTrace | CreateMessageTrace): PrecompileMessageTrace | CallMessageTrace | CreateMessageTrace | undefined
+  getStackTrace(trace: PrecompileMessageTrace | CallMessageTrace | CreateMessageTrace): SolidityStackTrace
 }
 export class VmTraceDecoder {
   constructor(contractsIdentifier: ContractsIdentifier)

--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -392,7 +392,6 @@ export interface SubmessageData {
   stacktrace: SolidityStackTrace
   stepIndex: number
 }
-export function instructionToCallstackStackTraceEntry(bytecode: Bytecode, inst: Instruction): CallstackEntryStackTraceEntry | InternalFunctionCallStackEntry
 /** Represents the exit code of the EVM. */
 export const enum ExitCode {
   /** Execution was successful. */
@@ -1006,14 +1005,6 @@ export class Contract {
 export class ContractsIdentifier {
   constructor(enableCache?: boolean | undefined | null)
   addBytecode(bytecode: Bytecode): void
-}
-export class ErrorInferrer {
-  
-  constructor()
-  inferBeforeTracingCallMessage(trace: CallMessageTrace): SolidityStackTrace | undefined
-  inferBeforeTracingCreateMessage(trace: CreateMessageTrace): SolidityStackTrace | undefined
-  inferAfterTracing(trace: CallMessageTrace | CreateMessageTrace, stacktrace: SolidityStackTrace, functionJumpdests: Array<Instruction>, jumpedIntoFunction: boolean, lastSubmessageData: SubmessageData | undefined): SolidityStackTrace
-  filterRedundantFrames(stacktrace: SolidityStackTrace): SolidityStackTrace
 }
 export class Exit {
   get kind(): ExitCode

--- a/crates/edr_napi/index.js
+++ b/crates/edr_napi/index.js
@@ -310,7 +310,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { SpecId, EdrContext, MineOrdering, Provider, Response, SuccessReason, ExceptionalHalt, createModelsAndDecodeBytecodes, linkHexStringBytecode, SourceFile, SourceLocation, ContractFunctionType, ContractFunctionVisibility, ContractFunction, CustomError, Instruction, JumpType, jumpTypeToString, Bytecode, ContractType, Contract, ContractsIdentifier, Exit, ExitCode, Opcode, opcodeToString, isPush, isJump, isCall, isCreate, ReturnData, StackTraceEntryType, stackTraceEntryTypeToString, FALLBACK_FUNCTION_NAME, RECEIVE_FUNCTION_NAME, CONSTRUCTOR_FUNCTION_NAME, UNRECOGNIZED_FUNCTION_NAME, UNKNOWN_FUNCTION_NAME, PRECOMPILE_FUNCTION_NAME, UNRECOGNIZED_CONTRACT_NAME, SolidityTracer, VmTraceDecoder, initializeVmTraceDecoder, VmTracer, RawTrace } = nativeBinding
+const { SpecId, EdrContext, MineOrdering, Provider, Response, SuccessReason, ExceptionalHalt, createModelsAndDecodeBytecodes, linkHexStringBytecode, SourceFile, SourceLocation, ContractFunctionType, ContractFunctionVisibility, ContractFunction, CustomError, Instruction, JumpType, jumpTypeToString, Bytecode, ContractType, Contract, ContractsIdentifier, ErrorInferrer, sourceLocationToSourceReference, Exit, ExitCode, Opcode, opcodeToString, isPush, isJump, isCall, isCreate, ReturnData, StackTraceEntryType, stackTraceEntryTypeToString, FALLBACK_FUNCTION_NAME, RECEIVE_FUNCTION_NAME, CONSTRUCTOR_FUNCTION_NAME, UNRECOGNIZED_FUNCTION_NAME, UNKNOWN_FUNCTION_NAME, PRECOMPILE_FUNCTION_NAME, UNRECOGNIZED_CONTRACT_NAME, SolidityTracer, VmTraceDecoder, initializeVmTraceDecoder, VmTracer, RawTrace } = nativeBinding
 
 module.exports.SpecId = SpecId
 module.exports.EdrContext = EdrContext
@@ -334,6 +334,8 @@ module.exports.Bytecode = Bytecode
 module.exports.ContractType = ContractType
 module.exports.Contract = Contract
 module.exports.ContractsIdentifier = ContractsIdentifier
+module.exports.ErrorInferrer = ErrorInferrer
+module.exports.sourceLocationToSourceReference = sourceLocationToSourceReference
 module.exports.Exit = Exit
 module.exports.ExitCode = ExitCode
 module.exports.Opcode = Opcode

--- a/crates/edr_napi/index.js
+++ b/crates/edr_napi/index.js
@@ -310,7 +310,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { SpecId, EdrContext, MineOrdering, Provider, Response, SuccessReason, ExceptionalHalt, createModelsAndDecodeBytecodes, linkHexStringBytecode, SourceFile, SourceLocation, ContractFunctionType, ContractFunctionVisibility, ContractFunction, CustomError, Instruction, JumpType, jumpTypeToString, Bytecode, ContractType, Contract, ContractsIdentifier, ErrorInferrer, instructionToCallstackStackTraceEntry, Exit, ExitCode, Opcode, opcodeToString, isPush, isJump, isCall, isCreate, ReturnData, StackTraceEntryType, stackTraceEntryTypeToString, FALLBACK_FUNCTION_NAME, RECEIVE_FUNCTION_NAME, CONSTRUCTOR_FUNCTION_NAME, UNRECOGNIZED_FUNCTION_NAME, UNKNOWN_FUNCTION_NAME, PRECOMPILE_FUNCTION_NAME, UNRECOGNIZED_CONTRACT_NAME, SolidityTracer, VmTraceDecoder, initializeVmTraceDecoder, VmTracer, RawTrace } = nativeBinding
+const { SpecId, EdrContext, MineOrdering, Provider, Response, SuccessReason, ExceptionalHalt, createModelsAndDecodeBytecodes, linkHexStringBytecode, SourceFile, SourceLocation, ContractFunctionType, ContractFunctionVisibility, ContractFunction, CustomError, Instruction, JumpType, jumpTypeToString, Bytecode, ContractType, Contract, ContractsIdentifier, ErrorInferrer, instructionToCallstackStackTraceEntry, Exit, ExitCode, stackTraceMayRequireAdjustments, adjustStackTrace, Opcode, opcodeToString, isPush, isJump, isCall, isCreate, ReturnData, StackTraceEntryType, stackTraceEntryTypeToString, FALLBACK_FUNCTION_NAME, RECEIVE_FUNCTION_NAME, CONSTRUCTOR_FUNCTION_NAME, UNRECOGNIZED_FUNCTION_NAME, UNKNOWN_FUNCTION_NAME, PRECOMPILE_FUNCTION_NAME, UNRECOGNIZED_CONTRACT_NAME, SolidityTracer, VmTraceDecoder, initializeVmTraceDecoder, VmTracer, RawTrace } = nativeBinding
 
 module.exports.SpecId = SpecId
 module.exports.EdrContext = EdrContext
@@ -338,6 +338,8 @@ module.exports.ErrorInferrer = ErrorInferrer
 module.exports.instructionToCallstackStackTraceEntry = instructionToCallstackStackTraceEntry
 module.exports.Exit = Exit
 module.exports.ExitCode = ExitCode
+module.exports.stackTraceMayRequireAdjustments = stackTraceMayRequireAdjustments
+module.exports.adjustStackTrace = adjustStackTrace
 module.exports.Opcode = Opcode
 module.exports.opcodeToString = opcodeToString
 module.exports.isPush = isPush

--- a/crates/edr_napi/index.js
+++ b/crates/edr_napi/index.js
@@ -310,7 +310,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { SpecId, EdrContext, MineOrdering, Provider, Response, SuccessReason, ExceptionalHalt, createModelsAndDecodeBytecodes, linkHexStringBytecode, SourceFile, SourceLocation, ContractFunctionType, ContractFunctionVisibility, ContractFunction, CustomError, Instruction, JumpType, jumpTypeToString, Bytecode, ContractType, Contract, ContractsIdentifier, ErrorInferrer, instructionToCallstackStackTraceEntry, Exit, ExitCode, stackTraceMayRequireAdjustments, adjustStackTrace, Opcode, opcodeToString, isPush, isJump, isCall, isCreate, ReturnData, StackTraceEntryType, stackTraceEntryTypeToString, FALLBACK_FUNCTION_NAME, RECEIVE_FUNCTION_NAME, CONSTRUCTOR_FUNCTION_NAME, UNRECOGNIZED_FUNCTION_NAME, UNKNOWN_FUNCTION_NAME, PRECOMPILE_FUNCTION_NAME, UNRECOGNIZED_CONTRACT_NAME, SolidityTracer, VmTraceDecoder, initializeVmTraceDecoder, VmTracer, RawTrace } = nativeBinding
+const { SpecId, EdrContext, MineOrdering, Provider, Response, SuccessReason, ExceptionalHalt, createModelsAndDecodeBytecodes, linkHexStringBytecode, SourceFile, SourceLocation, ContractFunctionType, ContractFunctionVisibility, ContractFunction, CustomError, Instruction, JumpType, jumpTypeToString, Bytecode, ContractType, Contract, ContractsIdentifier, ErrorInferrer, instructionToCallstackStackTraceEntry, Exit, ExitCode, Opcode, opcodeToString, isPush, isJump, isCall, isCreate, ReturnData, StackTraceEntryType, stackTraceEntryTypeToString, FALLBACK_FUNCTION_NAME, RECEIVE_FUNCTION_NAME, CONSTRUCTOR_FUNCTION_NAME, UNRECOGNIZED_FUNCTION_NAME, UNKNOWN_FUNCTION_NAME, PRECOMPILE_FUNCTION_NAME, UNRECOGNIZED_CONTRACT_NAME, SolidityTracer, VmTraceDecoder, initializeVmTraceDecoder, VmTracer, RawTrace } = nativeBinding
 
 module.exports.SpecId = SpecId
 module.exports.EdrContext = EdrContext
@@ -338,8 +338,6 @@ module.exports.ErrorInferrer = ErrorInferrer
 module.exports.instructionToCallstackStackTraceEntry = instructionToCallstackStackTraceEntry
 module.exports.Exit = Exit
 module.exports.ExitCode = ExitCode
-module.exports.stackTraceMayRequireAdjustments = stackTraceMayRequireAdjustments
-module.exports.adjustStackTrace = adjustStackTrace
 module.exports.Opcode = Opcode
 module.exports.opcodeToString = opcodeToString
 module.exports.isPush = isPush

--- a/crates/edr_napi/index.js
+++ b/crates/edr_napi/index.js
@@ -310,7 +310,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { SpecId, EdrContext, MineOrdering, Provider, Response, SuccessReason, ExceptionalHalt, createModelsAndDecodeBytecodes, linkHexStringBytecode, SourceFile, SourceLocation, ContractFunctionType, ContractFunctionVisibility, ContractFunction, CustomError, Instruction, JumpType, jumpTypeToString, Bytecode, ContractType, Contract, ContractsIdentifier, ErrorInferrer, instructionToCallstackStackTraceEntry, Exit, ExitCode, Opcode, opcodeToString, isPush, isJump, isCall, isCreate, ReturnData, StackTraceEntryType, stackTraceEntryTypeToString, FALLBACK_FUNCTION_NAME, RECEIVE_FUNCTION_NAME, CONSTRUCTOR_FUNCTION_NAME, UNRECOGNIZED_FUNCTION_NAME, UNKNOWN_FUNCTION_NAME, PRECOMPILE_FUNCTION_NAME, UNRECOGNIZED_CONTRACT_NAME, SolidityTracer, VmTraceDecoder, initializeVmTraceDecoder, VmTracer, RawTrace } = nativeBinding
+const { SpecId, EdrContext, MineOrdering, Provider, Response, SuccessReason, ExceptionalHalt, createModelsAndDecodeBytecodes, linkHexStringBytecode, SourceFile, SourceLocation, ContractFunctionType, ContractFunctionVisibility, ContractFunction, CustomError, Instruction, JumpType, jumpTypeToString, Bytecode, ContractType, Contract, ContractsIdentifier, Exit, ExitCode, Opcode, opcodeToString, isPush, isJump, isCall, isCreate, ReturnData, StackTraceEntryType, stackTraceEntryTypeToString, FALLBACK_FUNCTION_NAME, RECEIVE_FUNCTION_NAME, CONSTRUCTOR_FUNCTION_NAME, UNRECOGNIZED_FUNCTION_NAME, UNKNOWN_FUNCTION_NAME, PRECOMPILE_FUNCTION_NAME, UNRECOGNIZED_CONTRACT_NAME, SolidityTracer, VmTraceDecoder, initializeVmTraceDecoder, VmTracer, RawTrace } = nativeBinding
 
 module.exports.SpecId = SpecId
 module.exports.EdrContext = EdrContext
@@ -334,8 +334,6 @@ module.exports.Bytecode = Bytecode
 module.exports.ContractType = ContractType
 module.exports.Contract = Contract
 module.exports.ContractsIdentifier = ContractsIdentifier
-module.exports.ErrorInferrer = ErrorInferrer
-module.exports.instructionToCallstackStackTraceEntry = instructionToCallstackStackTraceEntry
 module.exports.Exit = Exit
 module.exports.ExitCode = ExitCode
 module.exports.Opcode = Opcode

--- a/crates/edr_napi/index.js
+++ b/crates/edr_napi/index.js
@@ -310,7 +310,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { SpecId, EdrContext, MineOrdering, Provider, Response, SuccessReason, ExceptionalHalt, createModelsAndDecodeBytecodes, linkHexStringBytecode, SourceFile, SourceLocation, ContractFunctionType, ContractFunctionVisibility, ContractFunction, CustomError, Instruction, JumpType, jumpTypeToString, Bytecode, ContractType, Contract, ContractsIdentifier, ErrorInferrer, sourceLocationToSourceReference, Exit, ExitCode, Opcode, opcodeToString, isPush, isJump, isCall, isCreate, ReturnData, StackTraceEntryType, stackTraceEntryTypeToString, FALLBACK_FUNCTION_NAME, RECEIVE_FUNCTION_NAME, CONSTRUCTOR_FUNCTION_NAME, UNRECOGNIZED_FUNCTION_NAME, UNKNOWN_FUNCTION_NAME, PRECOMPILE_FUNCTION_NAME, UNRECOGNIZED_CONTRACT_NAME, SolidityTracer, VmTraceDecoder, initializeVmTraceDecoder, VmTracer, RawTrace } = nativeBinding
+const { SpecId, EdrContext, MineOrdering, Provider, Response, SuccessReason, ExceptionalHalt, createModelsAndDecodeBytecodes, linkHexStringBytecode, SourceFile, SourceLocation, ContractFunctionType, ContractFunctionVisibility, ContractFunction, CustomError, Instruction, JumpType, jumpTypeToString, Bytecode, ContractType, Contract, ContractsIdentifier, ErrorInferrer, instructionToCallstackStackTraceEntry, Exit, ExitCode, Opcode, opcodeToString, isPush, isJump, isCall, isCreate, ReturnData, StackTraceEntryType, stackTraceEntryTypeToString, FALLBACK_FUNCTION_NAME, RECEIVE_FUNCTION_NAME, CONSTRUCTOR_FUNCTION_NAME, UNRECOGNIZED_FUNCTION_NAME, UNKNOWN_FUNCTION_NAME, PRECOMPILE_FUNCTION_NAME, UNRECOGNIZED_CONTRACT_NAME, SolidityTracer, VmTraceDecoder, initializeVmTraceDecoder, VmTracer, RawTrace } = nativeBinding
 
 module.exports.SpecId = SpecId
 module.exports.EdrContext = EdrContext
@@ -335,7 +335,7 @@ module.exports.ContractType = ContractType
 module.exports.Contract = Contract
 module.exports.ContractsIdentifier = ContractsIdentifier
 module.exports.ErrorInferrer = ErrorInferrer
-module.exports.sourceLocationToSourceReference = sourceLocationToSourceReference
+module.exports.instructionToCallstackStackTraceEntry = instructionToCallstackStackTraceEntry
 module.exports.Exit = Exit
 module.exports.ExitCode = ExitCode
 module.exports.Opcode = Opcode

--- a/crates/edr_napi/index.js
+++ b/crates/edr_napi/index.js
@@ -310,7 +310,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { SpecId, EdrContext, MineOrdering, Provider, Response, SuccessReason, ExceptionalHalt, createModelsAndDecodeBytecodes, linkHexStringBytecode, SourceFile, SourceLocation, ContractFunctionType, ContractFunctionVisibility, ContractFunction, CustomError, Instruction, JumpType, jumpTypeToString, Bytecode, ContractType, Contract, ContractsIdentifier, Exit, ExitCode, Opcode, opcodeToString, isPush, isJump, isCall, isCreate, ReturnData, StackTraceEntryType, stackTraceEntryTypeToString, FALLBACK_FUNCTION_NAME, RECEIVE_FUNCTION_NAME, CONSTRUCTOR_FUNCTION_NAME, UNRECOGNIZED_FUNCTION_NAME, UNKNOWN_FUNCTION_NAME, PRECOMPILE_FUNCTION_NAME, UNRECOGNIZED_CONTRACT_NAME, VmTraceDecoder, initializeVmTraceDecoder, VmTracer, RawTrace } = nativeBinding
+const { SpecId, EdrContext, MineOrdering, Provider, Response, SuccessReason, ExceptionalHalt, createModelsAndDecodeBytecodes, linkHexStringBytecode, SourceFile, SourceLocation, ContractFunctionType, ContractFunctionVisibility, ContractFunction, CustomError, Instruction, JumpType, jumpTypeToString, Bytecode, ContractType, Contract, ContractsIdentifier, Exit, ExitCode, Opcode, opcodeToString, isPush, isJump, isCall, isCreate, ReturnData, StackTraceEntryType, stackTraceEntryTypeToString, FALLBACK_FUNCTION_NAME, RECEIVE_FUNCTION_NAME, CONSTRUCTOR_FUNCTION_NAME, UNRECOGNIZED_FUNCTION_NAME, UNKNOWN_FUNCTION_NAME, PRECOMPILE_FUNCTION_NAME, UNRECOGNIZED_CONTRACT_NAME, SolidityTracer, VmTraceDecoder, initializeVmTraceDecoder, VmTracer, RawTrace } = nativeBinding
 
 module.exports.SpecId = SpecId
 module.exports.EdrContext = EdrContext
@@ -352,6 +352,7 @@ module.exports.UNRECOGNIZED_FUNCTION_NAME = UNRECOGNIZED_FUNCTION_NAME
 module.exports.UNKNOWN_FUNCTION_NAME = UNKNOWN_FUNCTION_NAME
 module.exports.PRECOMPILE_FUNCTION_NAME = PRECOMPILE_FUNCTION_NAME
 module.exports.UNRECOGNIZED_CONTRACT_NAME = UNRECOGNIZED_CONTRACT_NAME
+module.exports.SolidityTracer = SolidityTracer
 module.exports.VmTraceDecoder = VmTraceDecoder
 module.exports.initializeVmTraceDecoder = initializeVmTraceDecoder
 module.exports.VmTracer = VmTracer

--- a/crates/edr_napi/src/trace.rs
+++ b/crates/edr_napi/src/trace.rs
@@ -22,6 +22,7 @@ mod model;
 mod source_map;
 
 mod contracts_identifier;
+mod error_inferrer;
 mod exit;
 mod message_trace;
 mod opcodes;

--- a/crates/edr_napi/src/trace.rs
+++ b/crates/edr_napi/src/trace.rs
@@ -24,6 +24,7 @@ mod source_map;
 mod contracts_identifier;
 mod error_inferrer;
 mod exit;
+mod mapped_inlined_internal_functions_heuristics;
 mod message_trace;
 mod opcodes;
 mod return_data;

--- a/crates/edr_napi/src/trace.rs
+++ b/crates/edr_napi/src/trace.rs
@@ -27,6 +27,7 @@ mod message_trace;
 mod opcodes;
 mod return_data;
 mod solidity_stack_trace;
+mod solidity_tracer;
 mod vm_trace_decoder;
 mod vm_tracer;
 

--- a/crates/edr_napi/src/trace/compiler.rs
+++ b/crates/edr_napi/src/trace/compiler.rs
@@ -326,14 +326,8 @@ fn process_function_definition_ast_node(
 
     let param_types = matching_function_abi
         .as_ref()
-        .and_then(|matching_function_abi| {
-            matching_function_abi.inputs.as_ref().map(|inputs| {
-                inputs
-                    .iter()
-                    .map(|input| input["type"].as_str().unwrap())
-                    .collect::<Vec<_>>()
-            })
-        });
+        .and_then(|abi| abi.inputs.as_ref())
+        .cloned();
 
     let contract_func = ContractFunction {
         name: node["name"].as_str().unwrap().to_string(),
@@ -343,7 +337,7 @@ fn process_function_definition_ast_node(
         visibility: Some(visibility),
         is_payable: Some(node["stateMutability"].as_str().unwrap() == "payable"),
         selector: selector.map(Uint8Array::from),
-        param_types: Some(param_types.into_iter().map(Into::into).collect()),
+        param_types,
     }
     .into_instance(env)?;
     let contract_func = Rc::new(ClassInstanceRef::from_obj(contract_func, env)?);
@@ -414,13 +408,8 @@ fn process_variable_declaration_ast_node(
 
     let param_types = getter_abi
         .as_ref()
-        .and_then(|getter_abi| getter_abi.inputs.as_ref())
-        .map(|inputs| {
-            inputs
-                .iter()
-                .map(|input| input["type"].as_str().unwrap())
-                .collect::<Vec<_>>()
-        });
+        .and_then(|abi| abi.inputs.as_ref())
+        .cloned();
 
     let contract_func = ContractFunction {
         name: node["name"].as_str().unwrap().to_string(),
@@ -432,7 +421,7 @@ fn process_variable_declaration_ast_node(
         selector: Some(Uint8Array::from(
             get_public_variable_selector_from_declaration_ast_node(node)?,
         )),
-        param_types: Some(param_types.into_iter().map(Into::into).collect()),
+        param_types,
     }
     .into_instance(env)?;
     let contract_func = Rc::new(ClassInstanceRef::from_obj(contract_func, env)?);

--- a/crates/edr_napi/src/trace/error_inferrer.rs
+++ b/crates/edr_napi/src/trace/error_inferrer.rs
@@ -1,32 +1,294 @@
 use std::collections::HashSet;
 
+use alloy_dyn_abi::{DynSolValue, JsonAbiExt};
+use edr_evm::hex;
 use napi::{
-    bindgen_prelude::{Either24, Undefined},
+    bindgen_prelude::{BigInt, Either24, Either3, Either4, Uint8Array, Undefined},
     Either, Env,
 };
 use napi_derive::napi;
+use semver::{Version, VersionReq};
 
-use crate::trace::{
-    model::ContractFunctionType,
-    solidity_stack_trace::{
-        ReturndataSizeErrorStackTraceEntry, CONSTRUCTOR_FUNCTION_NAME, FALLBACK_FUNCTION_NAME,
-        RECEIVE_FUNCTION_NAME,
+use crate::{
+    trace::{
+        model::{ContractFunctionType, Instruction, JumpType},
+        solidity_stack_trace::{
+            ContractCallRunOutOfGasError, ContractTooLargeErrorStackTraceEntry,
+            DirectLibraryCallErrorStackTraceEntry,
+            FallbackNotPayableAndNoReceiveErrorStackTraceEntry,
+            FunctionNotPayableErrorStackTraceEntry, MissingFallbackOrReceiveErrorStackTraceEntry,
+            OtherExecutionErrorStackTraceEntry, ReturndataSizeErrorStackTraceEntry,
+            RevertErrorStackTraceEntry, StackTraceEntryTypeConst,
+            UnrecognizedFunctionWithoutFallbackErrorStackTraceEntry, CONSTRUCTOR_FUNCTION_NAME,
+            FALLBACK_FUNCTION_NAME, RECEIVE_FUNCTION_NAME,
+        },
     },
+    utils::ClassInstanceRef,
 };
 
 use super::{
-    model::{Bytecode, SourceLocation},
+    exit::ExitCode,
+    message_trace::{CallMessageTrace, CreateMessageTrace, EvmStep, PrecompileMessageTrace},
+    model::{Bytecode, ContractFunction, ContractType, SourceLocation},
+    opcodes::Opcode,
+    return_data::ReturnData,
     solidity_stack_trace::{
-        CallstackEntryStackTraceEntry, SolidityStackTrace, SolidityStackTraceEntryExt,
-        SourceReference,
+        CallFailedErrorStackTraceEntry, CallstackEntryStackTraceEntry, CustomErrorStackTraceEntry,
+        FallbackNotPayableErrorStackTraceEntry, InternalFunctionCallStackEntry,
+        InvalidParamsErrorStackTraceEntry, NonContractAccountCalledErrorStackTraceEntry,
+        PanicErrorStackTraceEntry, SolidityStackTrace, SolidityStackTraceEntry,
+        SolidityStackTraceEntryExt, SourceReference, UnmappedSolc063RevertErrorStackTraceEntry,
     },
 };
+
+trait AsEitherRef {
+    type Left;
+    type Right;
+
+    fn as_ref(&self) -> Either<&Self::Left, &Self::Right>;
+}
+
+impl<A, B> AsEitherRef for Either<A, B> {
+    type Left = A;
+    type Right = B;
+
+    fn as_ref(&self) -> Either<&A, &B> {
+        match self {
+            Either::A(ref a) => Either::A(a),
+            Either::B(ref b) => Either::B(b),
+        }
+    }
+}
+
+pub enum ModifiedStackTrace {
+    Yes(SolidityStackTrace),
+    No(SolidityStackTrace),
+}
+
+impl ModifiedStackTrace {
+    pub fn into_inner(self) -> SolidityStackTrace {
+        match self {
+            ModifiedStackTrace::No(stack) | ModifiedStackTrace::Yes(stack) => stack,
+        }
+    }
+}
+
+trait IntoEither<T> {
+    fn into_either(self) -> Either<T, Undefined>;
+}
+
+impl<T> IntoEither<T> for Option<T> {
+    fn into_either(self) -> Either<T, Undefined> {
+        match self {
+            Some(a) => Either::A(a),
+            None => Either::B(()),
+        }
+    }
+}
+
+trait IntoOption<T> {
+    fn into_option(self) -> Option<T>;
+}
+
+impl<T> IntoOption<T> for Either<T, Undefined> {
+    fn into_option(self) -> Option<T> {
+        match self {
+            Either::A(a) => Some(a),
+            Either::B(_) => None,
+        }
+    }
+}
+
+const FIRST_SOLC_VERSION_CREATE_PARAMS_VALIDATION: Version = Version::new(0, 5, 9);
+const FIRST_SOLC_VERSION_RECEIVE_FUNCTION: Version = Version::new(0, 6, 0);
+const FIRST_SOLC_VERSION_WITH_UNMAPPED_REVERTS: &str = "0.6.3";
+
+#[napi(object)]
+pub struct SubmessageData {
+    pub message_trace: Either3<PrecompileMessageTrace, CallMessageTrace, CreateMessageTrace>,
+    pub stacktrace: SolidityStackTrace,
+    pub step_index: u32,
+}
 
 #[napi]
 pub struct ErrorInferrer;
 
 #[napi]
 impl ErrorInferrer {
+    #[napi]
+    pub fn infer_before_tracing_call_message(
+        trace: CallMessageTrace,
+        env: Env,
+    ) -> napi::Result<Either<SolidityStackTrace, Undefined>> {
+        if Self::is_direct_library_call(&trace, env)? {
+            return Ok(Either::A(Self::get_direct_library_call_error_stack_trace(
+                &trace, env,
+            )?));
+        }
+
+        let bytecode = trace
+            .bytecode
+            .as_ref()
+            .expect("The TS code type-checks this to always have bytecode");
+        let contract = bytecode.contract.borrow(env)?;
+
+        let called_function = contract.get_function_from_selector_inner(
+            trace.calldata.get(..4).unwrap_or(&trace.calldata[..]),
+        );
+
+        if let Some(called_function) = called_function {
+            let called_function = called_function.borrow(env)?;
+
+            if Self::is_function_not_payable_error(&trace, &called_function, env)? {
+                return Ok(Either::A(vec![FunctionNotPayableErrorStackTraceEntry {
+                    type_: StackTraceEntryTypeConst,
+                    source_reference: Self::get_function_start_source_reference_inner(
+                        Either::A(&trace),
+                        &called_function,
+                        env,
+                    )?,
+                    value: trace.value,
+                }
+                .into()]));
+            }
+        }
+
+        let called_function = called_function.map(|x| x.borrow(env)).transpose()?;
+        let called_function = called_function.as_deref();
+
+        if Self::is_missing_function_and_fallback_error(&trace, called_function, env)? {
+            let source_reference =
+                Self::get_contract_start_without_function_source_reference_inner(
+                    Either::A(&trace),
+                    env,
+                )?;
+
+            if Self::empty_calldata_and_no_receive(&trace, env)? {
+                return Ok(Either::A(vec![
+                    MissingFallbackOrReceiveErrorStackTraceEntry {
+                        type_: StackTraceEntryTypeConst,
+                        source_reference,
+                    }
+                    .into(),
+                ]));
+            }
+
+            return Ok(Either::A(vec![
+                UnrecognizedFunctionWithoutFallbackErrorStackTraceEntry {
+                    type_: StackTraceEntryTypeConst,
+                    source_reference,
+                }
+                .into(),
+            ]));
+        }
+
+        if Self::is_fallback_not_payable_error(&trace, called_function, env)? {
+            let source_reference = Self::get_fallback_start_source_reference_inner(&trace, env)?;
+
+            if Self::empty_calldata_and_no_receive(&trace, env)? {
+                return Ok(Either::A(vec![
+                    FallbackNotPayableAndNoReceiveErrorStackTraceEntry {
+                        type_: StackTraceEntryTypeConst,
+                        source_reference,
+                        value: trace.value,
+                    }
+                    .into(),
+                ]));
+            }
+
+            return Ok(Either::A(vec![FallbackNotPayableErrorStackTraceEntry {
+                type_: StackTraceEntryTypeConst,
+                source_reference,
+                value: trace.value,
+            }
+            .into()]));
+        }
+
+        Ok(Either::B(()))
+    }
+
+    #[napi]
+    pub fn infer_before_tracing_create_message(
+        trace: CreateMessageTrace,
+        env: Env,
+    ) -> napi::Result<Either<SolidityStackTrace, Undefined>> {
+        if Self::is_constructor_not_payable_error(&trace, env)? {
+            return Ok(Either::A(vec![FunctionNotPayableErrorStackTraceEntry {
+                type_: StackTraceEntryTypeConst,
+                source_reference: Self::get_constructor_start_source_reference_inner(&trace, env)?,
+                value: trace.value,
+            }
+            .into()]));
+        }
+
+        if Self::is_constructor_invalid_arguments_error(&trace, env)? {
+            return Ok(Either::A(vec![InvalidParamsErrorStackTraceEntry {
+                type_: StackTraceEntryTypeConst,
+                source_reference: Self::get_constructor_start_source_reference_inner(&trace, env)?,
+            }
+            .into()]));
+        }
+
+        Ok(Either::B(()))
+    }
+
+    #[napi]
+    pub fn infer_after_tracing(
+        trace: Either<CallMessageTrace, CreateMessageTrace>,
+        stacktrace: SolidityStackTrace,
+        function_jumpdests: Vec<&Instruction>,
+        jumped_into_function: bool,
+        last_submessage_data: Either<SubmessageData, Undefined>,
+        env: Env,
+    ) -> napi::Result<Either<SolidityStackTrace, Undefined>> {
+        macro_rules! propagate_stacktrace {
+            ($stacktrace:ident, $res: ident) => {
+                let $stacktrace = match $res {
+                    ModifiedStackTrace::Yes(stacktrace) => return Ok(Either::A(stacktrace)),
+                    ModifiedStackTrace::No(stacktrace) => stacktrace,
+                };
+            };
+        }
+        // FIXME: Calling these in JS somehow works, because it seems that it's
+        // copying the values around between passes?
+        // We need to make this work in Rust as well; if we stop needing
+        // to export return data from the trace objects, then we can make this
+        // clonable and just clone it here
+        // OR: we probably need to wrap all of these frames in Rc and clone it
+        // this way
+        let trace = trace.as_ref();
+
+        let res = Self::check_last_submessage_inner(trace, stacktrace, last_submessage_data, env)?;
+        propagate_stacktrace!(stacktrace, res);
+
+        let res = Self::check_failed_last_call_inner(trace, stacktrace, env)?;
+        propagate_stacktrace!(stacktrace, res);
+
+        let res = Self::check_last_instruction_inner(
+            trace,
+            stacktrace,
+            function_jumpdests.clone(),
+            jumped_into_function,
+            env,
+        )?;
+        propagate_stacktrace!(stacktrace, res);
+
+        let res = Self::check_non_contract_called_inner(trace, stacktrace, env)?;
+        propagate_stacktrace!(stacktrace, res);
+
+        let res = Self::check_solidity_0_6_3_unmapped_revert_inner(trace, stacktrace, env)?;
+        propagate_stacktrace!(stacktrace, res);
+
+        // NOTE: We added the stacktrace for context threading here
+        let res = Self::check_contract_too_large_inner(trace, stacktrace, env)?;
+        propagate_stacktrace!(stacktrace, res);
+
+        let res = Self::other_execution_error_stacktrace_inner(trace, stacktrace, env)?;
+        let res = Either::A(res);
+
+        Ok(res)
+    }
+
     #[napi]
     pub fn filter_redundant_frames(
         stacktrace: SolidityStackTrace,
@@ -106,39 +368,2936 @@ impl ErrorInferrer {
             .map(|(_, frame)| frame)
             .collect())
     }
+
+    // Heuristics
+
+    #[napi]
+    pub fn check_contract_too_large(
+        trace: Either<CallMessageTrace, CreateMessageTrace>,
+        env: Env,
+    ) -> napi::Result<Either<SolidityStackTrace, Undefined>> {
+        Ok(match trace {
+            Either::B(create @ CreateMessageTrace { .. })
+                if create.exit.kind() == ExitCode::CODESIZE_EXCEEDS_MAXIMUM =>
+            {
+                Either::A(vec![ContractTooLargeErrorStackTraceEntry {
+                    type_: StackTraceEntryTypeConst,
+                    source_reference: Some(Self::get_constructor_start_source_reference_inner(
+                        &create, env,
+                    )?),
+                }
+                .into()])
+            }
+
+            _ => Either::B(()),
+        })
+    }
+
+    pub fn check_contract_too_large_inner(
+        trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+        stacktrace: SolidityStackTrace,
+        env: Env,
+    ) -> napi::Result<ModifiedStackTrace> {
+        Ok(match trace {
+            Either::B(create @ CreateMessageTrace { .. })
+                if create.exit.kind() == ExitCode::CODESIZE_EXCEEDS_MAXIMUM =>
+            {
+                ModifiedStackTrace::Yes(vec![ContractTooLargeErrorStackTraceEntry {
+                    type_: StackTraceEntryTypeConst,
+                    source_reference: Some(Self::get_constructor_start_source_reference_inner(
+                        create, env,
+                    )?),
+                }
+                .into()])
+            }
+
+            _ => ModifiedStackTrace::No(stacktrace),
+        })
+    }
+
+    /// Check if the last call/create that was done failed.
+    #[napi]
+    pub fn check_failed_last_call(
+        trace: Either<CallMessageTrace, CreateMessageTrace>,
+        stacktrace: SolidityStackTrace,
+        env: Env,
+    ) -> napi::Result<Either<SolidityStackTrace, Undefined>> {
+        let (bytecode, steps) = match &trace {
+            Either::A(call) => (&call.bytecode, &call.steps),
+            Either::B(create) => (&create.bytecode, &create.steps),
+        };
+
+        let bytecode = bytecode.as_ref().expect("JS code asserts");
+
+        for step_index in (0..steps.len() - 1).rev() {
+            let (step, next_step) = match &steps[step_index..][..2] {
+                &[Either4::A(ref step), ref next_step] => (step, next_step),
+                _ => return Ok(Either::B(())),
+            };
+
+            let inst = bytecode.get_instruction_inner(step.pc)?;
+            let inst = inst.borrow(env)?;
+
+            if let (Opcode::CALL | Opcode::CREATE, Either4::A(EvmStep { .. })) =
+                (inst.opcode, next_step)
+            {
+                if Self::is_call_failed_error(trace.as_ref(), step_index as u32, &inst, env)? {
+                    let mut stacktrace = stacktrace;
+                    stacktrace.push(
+                        Self::call_instruction_to_call_failed_to_execute_stack_trace_entry(
+                            bytecode, &inst, env,
+                        )?
+                        .into(),
+                    );
+
+                    return Ok(Either::A(Self::fix_initial_modifier_inner(
+                        trace.as_ref(),
+                        stacktrace,
+                        env,
+                    )?));
+                }
+            }
+        }
+
+        Ok(Either::B(()))
+    }
+
+    /// Check if the last call/create that was done failed.
+    pub fn check_failed_last_call_inner(
+        trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+        stacktrace: SolidityStackTrace,
+        env: Env,
+    ) -> napi::Result<ModifiedStackTrace> {
+        let (bytecode, steps) = match &trace {
+            Either::A(call) => (&call.bytecode, &call.steps),
+            Either::B(create) => (&create.bytecode, &create.steps),
+        };
+
+        let bytecode = bytecode.as_ref().expect("JS code asserts");
+
+        for step_index in (0..steps.len() - 1).rev() {
+            let (step, next_step) = match &steps[step_index..][..2] {
+                &[Either4::A(ref step), ref next_step] => (step, next_step),
+                _ => return Ok(ModifiedStackTrace::No(stacktrace)),
+            };
+
+            let inst = bytecode.get_instruction_inner(step.pc)?;
+            let inst = inst.borrow(env)?;
+
+            if let (Opcode::CALL | Opcode::CREATE, Either4::A(EvmStep { .. })) =
+                (inst.opcode, next_step)
+            {
+                if Self::is_call_failed_error(trace, step_index as u32, &inst, env)? {
+                    let mut stacktrace = stacktrace;
+                    stacktrace.push(
+                        Self::call_instruction_to_call_failed_to_execute_stack_trace_entry(
+                            bytecode, &inst, env,
+                        )?
+                        .into(),
+                    );
+
+                    return Ok(ModifiedStackTrace::Yes(Self::fix_initial_modifier_inner(
+                        trace, stacktrace, env,
+                    )?));
+                }
+            }
+        }
+
+        Ok(ModifiedStackTrace::No(stacktrace))
+    }
+
+    /// Check if the trace reverted with a panic error.
+    #[napi]
+    pub fn check_panic(
+        trace: Either<CallMessageTrace, CreateMessageTrace>,
+        stacktrace: SolidityStackTrace,
+        last_instruction: &Instruction,
+        env: Env,
+    ) -> napi::Result<Either<SolidityStackTrace, Undefined>> {
+        Self::check_panic_inner(trace.as_ref(), stacktrace, last_instruction, env)
+    }
+
+    /// Check if the trace reverted with a panic error.
+    pub fn check_panic_inner(
+        trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+        mut stacktrace: SolidityStackTrace,
+        last_instruction: &Instruction,
+        env: Env,
+    ) -> napi::Result<Either<SolidityStackTrace, Undefined>> {
+        let return_data = ReturnData::new(
+            match &trace {
+                Either::A(call) => &call.return_data,
+                Either::B(create) => &create.return_data,
+            }
+            .clone(),
+        );
+
+        if !return_data.is_panic_return_data() {
+            return Ok(Either::B(()));
+        }
+
+        // If the last frame is an internal function, it means that the trace
+        // jumped there to return the panic. If that's the case, we remove that
+        // frame.
+        if let Some(Either24::W(InternalFunctionCallStackEntry { .. })) = stacktrace.last() {
+            stacktrace.pop();
+        }
+
+        // if the error comes from a call to a zero-initialized function,
+        // we remove the last frame, which represents the call, to avoid
+        // having duplicated frames
+        let error_code = return_data.decode_panic()?;
+        let (panic_error_code, lossless) = error_code.get_i64();
+        if let (0x51, false) = (panic_error_code, lossless) {
+            stacktrace.pop();
+        }
+
+        stacktrace.push(
+            Self::instruction_within_function_to_panic_stack_trace_entry_inner(
+                trace,
+                last_instruction,
+                error_code,
+                env,
+            )?
+            .into(),
+        );
+
+        Self::fix_initial_modifier_inner(trace, stacktrace, env).map(Either::A)
+    }
+
+    /// Check if the trace reverted with a panic error.
+    pub fn check_panic_inner_modified_opt(
+        trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+        mut stacktrace: SolidityStackTrace,
+        last_instruction: &Instruction,
+        env: Env,
+    ) -> napi::Result<ModifiedStackTrace> {
+        let return_data = ReturnData::new(
+            match &trace {
+                Either::A(call) => &call.return_data,
+                Either::B(create) => &create.return_data,
+            }
+            .clone(),
+        );
+
+        if !return_data.is_panic_return_data() {
+            return Ok(ModifiedStackTrace::No(stacktrace));
+        }
+
+        // If the last frame is an internal function, it means that the trace
+        // jumped there to return the panic. If that's the case, we remove that
+        // frame.
+        if let Some(Either24::W(InternalFunctionCallStackEntry { .. })) = stacktrace.last() {
+            stacktrace.pop();
+        }
+
+        // if the error comes from a call to a zero-initialized function,
+        // we remove the last frame, which represents the call, to avoid
+        // having duplicated frames
+        let error_code = return_data.decode_panic()?;
+        let (panic_error_code, lossless) = error_code.get_i64();
+        if let (0x51, false) = (panic_error_code, lossless) {
+            stacktrace.pop();
+        }
+
+        stacktrace.push(
+            Self::instruction_within_function_to_panic_stack_trace_entry_inner(
+                trace,
+                last_instruction,
+                error_code,
+                env,
+            )?
+            .into(),
+        );
+
+        Self::fix_initial_modifier_inner(trace, stacktrace, env).map(ModifiedStackTrace::Yes)
+    }
+
+    #[napi]
+    pub fn check_custom_errors(
+        trace: Either<CallMessageTrace, CreateMessageTrace>,
+        stacktrace: SolidityStackTrace,
+        last_instruction: &Instruction,
+        env: Env,
+    ) -> napi::Result<Either<SolidityStackTrace, Undefined>> {
+        Self::check_custom_errors_inner(trace.as_ref(), stacktrace, last_instruction, env)
+    }
+
+    pub fn check_custom_errors_inner(
+        trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+        stacktrace: SolidityStackTrace,
+        last_instruction: &Instruction,
+        env: Env,
+    ) -> napi::Result<Either<SolidityStackTrace, Undefined>> {
+        let (bytecode, return_data) = match &trace {
+            Either::A(call) => (&call.bytecode, &call.return_data),
+            Either::B(create) => (&create.bytecode, &create.return_data),
+        };
+
+        let bytecode = bytecode.as_ref().expect("JS code asserts");
+        let contract = bytecode.contract.borrow(env)?;
+
+        let return_data = ReturnData::new(return_data.clone());
+
+        if return_data.is_empty() || return_data.is_error_return_data() {
+            // if there is no return data, or if it's a Error(string),
+            // then it can't be a custom error
+            return Ok(Either::B(()));
+        }
+
+        let raw_return_data = hex::encode(&*return_data.value);
+        let mut error_message = format!(
+            "reverted with an unrecognized custom error (return data: 0x{raw_return_data})",
+        );
+
+        for custom_error in &contract.custom_errors {
+            let custom_error = custom_error.borrow(env)?;
+
+            if return_data.matches_selector(&*custom_error.selector) {
+                // if the return data matches a custom error in the called contract,
+                // we format the message using the returnData and the custom error instance
+                let decoded = custom_error
+                    .decode_error_data(&return_data.value)
+                    .map_err(|e| {
+                        napi::Error::from_reason(format!("Error decoding custom error: {e}"))
+                    })?;
+
+                let params = decoded
+                    .body
+                    .iter()
+                    .map(format_dyn_sol_value)
+                    .collect::<Vec<_>>();
+
+                error_message = format!(
+                    "reverted with custom error '{name}({params})'",
+                    name = custom_error.name,
+                    params = params.join(", ")
+                );
+
+                break;
+            }
+        }
+        drop(contract);
+
+        let mut stacktrace = stacktrace;
+        stacktrace.push(
+            Self::instruction_within_function_to_custom_error_stack_trace_entry_inner(
+                trace,
+                last_instruction,
+                error_message,
+                env,
+            )?
+            .into(),
+        );
+
+        Self::fix_initial_modifier_inner(trace, stacktrace, env).map(Either::A)
+    }
+
+    pub fn check_custom_errors_inner_modified_opt(
+        trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+        stacktrace: SolidityStackTrace,
+        last_instruction: &Instruction,
+        env: Env,
+    ) -> napi::Result<ModifiedStackTrace> {
+        let (bytecode, return_data) = match &trace {
+            Either::A(call) => (&call.bytecode, &call.return_data),
+            Either::B(create) => (&create.bytecode, &create.return_data),
+        };
+
+        let bytecode = bytecode.as_ref().expect("JS code asserts");
+        let contract = bytecode.contract.borrow(env)?;
+
+        let return_data = ReturnData::new(return_data.clone());
+
+        if return_data.is_empty() || return_data.is_error_return_data() {
+            // if there is no return data, or if it's a Error(string),
+            // then it can't be a custom error
+            return Ok(ModifiedStackTrace::No(stacktrace));
+        }
+
+        let raw_return_data = hex::encode(&*return_data.value);
+        let mut error_message = format!(
+            "reverted with an unrecognized custom error (return data: 0x{raw_return_data})",
+        );
+
+        for custom_error in &contract.custom_errors {
+            let custom_error = custom_error.borrow(env)?;
+
+            if return_data.matches_selector(&*custom_error.selector) {
+                // if the return data matches a custom error in the called contract,
+                // we format the message using the returnData and the custom error instance
+                let decoded = custom_error
+                    .decode_error_data(&return_data.value)
+                    .map_err(|e| {
+                        napi::Error::from_reason(format!("Error decoding custom error: {e}"))
+                    })?;
+
+                let params = decoded
+                    .body
+                    .iter()
+                    .map(format_dyn_sol_value)
+                    .collect::<Vec<_>>();
+
+                error_message = format!(
+                    "reverted with custom error '{name}({params})'",
+                    name = custom_error.name,
+                    params = params.join(", ")
+                );
+
+                break;
+            }
+        }
+        drop(contract);
+
+        let mut stacktrace = stacktrace;
+        stacktrace.push(
+            Self::instruction_within_function_to_custom_error_stack_trace_entry_inner(
+                trace,
+                last_instruction,
+                error_message,
+                env,
+            )?
+            .into(),
+        );
+
+        Self::fix_initial_modifier_inner(trace, stacktrace, env).map(ModifiedStackTrace::Yes)
+    }
+
+    #[napi]
+    pub fn check_solidity_0_6_3_unmapped_revert(
+        trace: Either<CallMessageTrace, CreateMessageTrace>,
+        mut stacktrace: SolidityStackTrace,
+        env: Env,
+    ) -> napi::Result<Either<SolidityStackTrace, Undefined>> {
+        if Self::solidity_0_6_3_maybe_unmapped_revert_inner(trace.as_ref(), env)? {
+            let revert_frame =
+                Self::solidity_0_6_3_get_frame_for_unmapped_revert_within_function(trace, env)?;
+
+            if let Either::A(revert_frame) = revert_frame {
+                stacktrace.push(revert_frame.into());
+
+                return Ok(Either::A(stacktrace));
+            }
+
+            return Ok(Either::A(stacktrace));
+        }
+
+        Ok(Either::B(()))
+    }
+
+    pub fn check_solidity_0_6_3_unmapped_revert_inner(
+        trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+        mut stacktrace: SolidityStackTrace,
+        env: Env,
+    ) -> napi::Result<ModifiedStackTrace> {
+        if Self::solidity_0_6_3_maybe_unmapped_revert_inner(trace, env)? {
+            let revert_frame =
+                Self::solidity_0_6_3_get_frame_for_unmapped_revert_within_function_inner(
+                    trace, env,
+                )?;
+
+            if let Either::A(revert_frame) = revert_frame {
+                stacktrace.push(revert_frame.into());
+
+                return Ok(ModifiedStackTrace::Yes(stacktrace));
+            }
+
+            return Ok(ModifiedStackTrace::Yes(stacktrace));
+        }
+
+        Ok(ModifiedStackTrace::No(stacktrace))
+    }
+
+    #[napi(catch_unwind)]
+    pub fn check_non_contract_called(
+        trace: Either<CallMessageTrace, CreateMessageTrace>,
+        mut stacktrace: SolidityStackTrace,
+        env: Env,
+    ) -> napi::Result<Either<SolidityStackTrace, Undefined>> {
+        if Self::is_called_non_contract_account_error(trace.as_ref(), env)? {
+            let source_reference = Self::get_last_source_reference_inner(trace.as_ref(), env)?;
+
+            // We are sure this is not undefined because there was at least a call instruction
+            let source_reference = match source_reference {
+                Either::A(source_reference) => source_reference,
+                Either::B(_) => panic!("Expected source reference to be defined"),
+            };
+
+            let non_contract_called_frame = NonContractAccountCalledErrorStackTraceEntry {
+                type_: StackTraceEntryTypeConst,
+                source_reference,
+            };
+
+            stacktrace.push(non_contract_called_frame.into());
+
+            Ok(Either::A(stacktrace))
+        } else {
+            Ok(Either::B(()))
+        }
+    }
+
+    pub fn check_non_contract_called_inner(
+        trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+        mut stacktrace: SolidityStackTrace,
+        env: Env,
+    ) -> napi::Result<ModifiedStackTrace> {
+        if Self::is_called_non_contract_account_error(trace, env)? {
+            let source_reference = Self::get_last_source_reference_inner(trace, env)?;
+
+            // We are sure this is not undefined because there was at least a call instruction
+            let source_reference = match source_reference {
+                Either::A(source_reference) => source_reference,
+                Either::B(_) => panic!("Expected source reference to be defined"),
+            };
+
+            let non_contract_called_frame = NonContractAccountCalledErrorStackTraceEntry {
+                type_: StackTraceEntryTypeConst,
+                source_reference,
+            };
+
+            stacktrace.push(non_contract_called_frame.into());
+
+            Ok(ModifiedStackTrace::Yes(stacktrace))
+        } else {
+            Ok(ModifiedStackTrace::No(stacktrace))
+        }
+    }
+
+    /// Check if the last submessage can be used to generate the stack trace.
+    #[napi]
+    pub fn check_last_submessage(
+        trace: Either<CallMessageTrace, CreateMessageTrace>,
+        mut stacktrace: SolidityStackTrace,
+        last_submessage_data: Either<SubmessageData, Undefined>,
+        env: Env,
+    ) -> napi::Result<Either<SolidityStackTrace, Undefined>> {
+        let (bytecode, steps) = match &trace {
+            Either::A(call) => (&call.bytecode, &call.steps),
+            Either::B(create) => (&create.bytecode, &create.steps),
+        };
+
+        let bytecode = bytecode.as_ref().expect("JS code asserts");
+
+        let last_submessage_data = match last_submessage_data {
+            Either::A(last_submessage_data) => last_submessage_data,
+            Either::B(()) => return Ok(Either::B(())),
+        };
+
+        // get the instruction before the submessage and add it to the stack trace
+        let call_step = match steps.get(last_submessage_data.step_index as usize - 1) {
+            Some(Either4::A(call_step)) => call_step,
+            _ => panic!("This should not happen: MessageTrace should be preceded by a EVM step"),
+        };
+
+        let call_inst = bytecode.get_instruction_inner(call_step.pc)?;
+        let call_inst = call_inst.borrow(env)?;
+        let call_stack_frame =
+            instruction_to_callstack_stack_trace_entry(bytecode, &call_inst, env)?;
+
+        let (call_stack_frame_source_reference, call_stack_frame) = match call_stack_frame {
+            Either::A(frame) => (frame.source_reference.clone(), frame.into()),
+            Either::B(frame) => (frame.source_reference.clone(), frame.into()),
+        };
+
+        let last_message_failed = match last_submessage_data.message_trace {
+            Either3::A(ref precompile) => precompile.exit.is_error(),
+            Either3::B(ref call) => call.exit.is_error(),
+            Either3::C(ref create) => create.exit.is_error(),
+        };
+        if last_message_failed {
+            // add the call/create that generated the message to the stack trace
+
+            stacktrace.push(call_stack_frame);
+
+            if Self::is_subtrace_error_propagated_inner(
+                trace.as_ref(),
+                last_submessage_data.step_index,
+                env,
+            )? || Self::is_proxy_error_propagated_inner(
+                trace.as_ref(),
+                last_submessage_data.step_index,
+                env,
+            )? {
+                stacktrace.extend(last_submessage_data.stacktrace);
+
+                if Self::is_contract_call_run_out_of_gas_error_inner(
+                    trace.as_ref(),
+                    last_submessage_data.step_index,
+                    env,
+                )? {
+                    let last_frame = match stacktrace.pop() {
+                        Some(frame) => frame,
+                        _ => panic!("Expected inferred stack trace to have at least one frame"),
+                    };
+
+                    stacktrace.push(
+                        ContractCallRunOutOfGasError {
+                            type_: StackTraceEntryTypeConst,
+                            source_reference: last_frame.source_reference().cloned(),
+                        }
+                        .into(),
+                    );
+                }
+
+                return Self::fix_initial_modifier_inner(trace.as_ref(), stacktrace, env)
+                    .map(Either::A);
+            }
+        } else {
+            let is_return_data_size_error = Self::fails_right_after_call_inner(
+                trace.as_ref(),
+                last_submessage_data.step_index,
+                env,
+            )?;
+            if is_return_data_size_error {
+                stacktrace.push(
+                    ReturndataSizeErrorStackTraceEntry {
+                        type_: StackTraceEntryTypeConst,
+                        source_reference: call_stack_frame_source_reference,
+                    }
+                    .into(),
+                );
+
+                return Self::fix_initial_modifier_inner(trace.as_ref(), stacktrace, env)
+                    .map(Either::A);
+            }
+        }
+
+        Ok(Either::B(()))
+    }
+
+    /// Check if the last submessage can be used to generate the stack trace.
+    fn check_last_submessage_inner(
+        trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+        mut stacktrace: SolidityStackTrace,
+        last_submessage_data: Either<SubmessageData, Undefined>,
+        env: Env,
+    ) -> napi::Result<ModifiedStackTrace> {
+        let (bytecode, steps) = match &trace {
+            Either::A(call) => (&call.bytecode, &call.steps),
+            Either::B(create) => (&create.bytecode, &create.steps),
+        };
+
+        let bytecode = bytecode.as_ref().expect("JS code asserts");
+
+        let last_submessage_data = match last_submessage_data {
+            Either::A(last_submessage_data) => last_submessage_data,
+            Either::B(()) => return Ok(ModifiedStackTrace::No(stacktrace)),
+        };
+
+        // get the instruction before the submessage and add it to the stack trace
+        let call_step = match steps.get(last_submessage_data.step_index as usize - 1) {
+            Some(Either4::A(call_step)) => call_step,
+            _ => panic!("This should not happen: MessageTrace should be preceded by a EVM step"),
+        };
+
+        let call_inst = bytecode.get_instruction_inner(call_step.pc)?;
+        let call_inst = call_inst.borrow(env)?;
+        let call_stack_frame =
+            instruction_to_callstack_stack_trace_entry(bytecode, &call_inst, env)?;
+
+        let (call_stack_frame_source_reference, call_stack_frame) = match call_stack_frame {
+            Either::A(frame) => (frame.source_reference.clone(), frame.into()),
+            Either::B(frame) => (frame.source_reference.clone(), frame.into()),
+        };
+
+        let last_message_failed = match last_submessage_data.message_trace {
+            Either3::A(ref precompile) => precompile.exit.is_error(),
+            Either3::B(ref call) => call.exit.is_error(),
+            Either3::C(ref create) => create.exit.is_error(),
+        };
+        if last_message_failed {
+            // add the call/create that generated the message to the stack trace
+
+            stacktrace.push(call_stack_frame);
+
+            if Self::is_subtrace_error_propagated_inner(
+                trace,
+                last_submessage_data.step_index,
+                env,
+            )? || Self::is_proxy_error_propagated_inner(
+                trace,
+                last_submessage_data.step_index,
+                env,
+            )? {
+                stacktrace.extend(last_submessage_data.stacktrace);
+
+                if Self::is_contract_call_run_out_of_gas_error_inner(
+                    trace,
+                    last_submessage_data.step_index,
+                    env,
+                )? {
+                    let last_frame = match stacktrace.pop() {
+                        Some(frame) => frame,
+                        _ => panic!("Expected inferred stack trace to have at least one frame"),
+                    };
+
+                    stacktrace.push(
+                        ContractCallRunOutOfGasError {
+                            type_: StackTraceEntryTypeConst,
+                            source_reference: last_frame.source_reference().cloned(),
+                        }
+                        .into(),
+                    );
+                }
+
+                return Self::fix_initial_modifier_inner(trace, stacktrace, env)
+                    .map(ModifiedStackTrace::Yes);
+            }
+        } else {
+            let is_return_data_size_error =
+                Self::fails_right_after_call_inner(trace, last_submessage_data.step_index, env)?;
+            if is_return_data_size_error {
+                stacktrace.push(
+                    ReturndataSizeErrorStackTraceEntry {
+                        type_: StackTraceEntryTypeConst,
+                        source_reference: call_stack_frame_source_reference,
+                    }
+                    .into(),
+                );
+
+                return Self::fix_initial_modifier_inner(trace, stacktrace, env)
+                    .map(ModifiedStackTrace::Yes);
+            }
+        }
+
+        Ok(ModifiedStackTrace::No(stacktrace))
+    }
+
+    /// Check if the execution stopped with a revert or an invalid opcode.
+    #[napi]
+    pub fn check_revert_or_invalid_opcode(
+        trace: Either<CallMessageTrace, CreateMessageTrace>,
+        stacktrace: SolidityStackTrace,
+        last_instruction: &Instruction,
+        function_jumpdests: Vec<&Instruction>,
+        jumped_into_function: bool,
+        env: Env,
+    ) -> napi::Result<Either<SolidityStackTrace, Undefined>> {
+        match last_instruction.opcode {
+            Opcode::REVERT | Opcode::INVALID => {}
+            _ => return Ok(Either::B(())),
+        }
+
+        let (bytecode, return_data) = match &trace {
+            Either::A(call) => (&call.bytecode, &call.return_data),
+            Either::B(create) => (&create.bytecode, &create.return_data),
+        };
+        let bytecode = bytecode.as_ref().expect("JS code asserts");
+
+        let mut inferred_stacktrace = stacktrace;
+
+        if let Some(location) = &last_instruction.location {
+            if jumped_into_function || matches!(trace, Either::B(CreateMessageTrace { .. })) {
+                // There should always be a function here, but that's not the case with optimizations.
+                //
+                // If this is a create trace, we already checked args and nonpayable failures before
+                // calling this function.
+                //
+                // If it's a call trace, we already jumped into a function. But optimizations can happen.
+                let location = location.borrow(env)?;
+                let failing_function = location.get_containing_function_inner(env)?;
+
+                // If the failure is in a modifier we add an entry with the function/constructor
+                match failing_function.into_option() {
+                    Some(func) if func.borrow(env)?.r#type == ContractFunctionType::MODIFIER => {
+                        let frame = Self::get_entry_before_failure_in_modifier_inner(
+                            trace.as_ref(),
+                            function_jumpdests,
+                            env,
+                        )?;
+
+                        inferred_stacktrace.push(match frame {
+                            Either::A(frame) => frame.into(),
+                            Either::B(frame) => frame.into(),
+                        });
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        let panic_stacktrace = Self::check_panic_inner_modified_opt(
+            trace.as_ref(),
+            inferred_stacktrace,
+            last_instruction,
+            env,
+        )?;
+        let inferred_stacktrace = match panic_stacktrace {
+            ModifiedStackTrace::Yes(stacktrace) => return Ok(Either::A(stacktrace)),
+            ModifiedStackTrace::No(stacktrace) => stacktrace,
+        };
+
+        let custom_error_stacktrace = Self::check_custom_errors_inner_modified_opt(
+            trace.as_ref(),
+            inferred_stacktrace,
+            last_instruction,
+            env,
+        )?;
+        let mut inferred_stacktrace = match custom_error_stacktrace {
+            ModifiedStackTrace::Yes(stacktrace) => return Ok(Either::A(stacktrace)),
+            ModifiedStackTrace::No(stacktrace) => stacktrace,
+        };
+
+        if let Some(location) = &last_instruction.location {
+            if jumped_into_function || matches!(trace, Either::B(CreateMessageTrace { .. })) {
+                let location = location.borrow(env)?;
+                let failing_function = location.get_containing_function_inner(env)?;
+
+                if failing_function.into_option().is_some() {
+                    let frame =
+                        Self::instruction_within_function_to_revert_stack_trace_entry_inner(
+                            trace.as_ref(),
+                            last_instruction,
+                            env,
+                        )?;
+
+                    inferred_stacktrace.push(frame.into());
+                } else {
+                    let message = ReturnData::new(return_data.clone()).into_instance(env)?;
+                    let is_invalid_opcode_error = last_instruction.opcode == Opcode::INVALID;
+
+                    match &trace {
+                        Either::A(CallMessageTrace { calldata, .. }) => {
+                            let contract = bytecode.contract.borrow(env)?;
+
+                            // This is here because of the optimizations
+                            let function_selector = contract.get_function_from_selector_inner(
+                                calldata.get(..4).unwrap_or(&calldata[..]),
+                            );
+
+                            // in general this shouldn't happen, but it does when viaIR is enabled,
+                            // "optimizerSteps": "u" is used, and the called function is fallback or
+                            // receive
+                            let Some(function_selector) = function_selector else {
+                                return Ok(Either::B(()));
+                            };
+
+                            let function = function_selector.borrow(env)?;
+
+                            let frame = RevertErrorStackTraceEntry {
+                                type_: StackTraceEntryTypeConst,
+                                source_reference: Self::get_function_start_source_reference_inner(
+                                    trace.as_ref(),
+                                    &function,
+                                    env,
+                                )?,
+                                message,
+                                is_invalid_opcode_error,
+                            };
+
+                            inferred_stacktrace.push(frame.into());
+                        }
+                        Either::B(trace @ CreateMessageTrace { .. }) => {
+                            // This is here because of the optimizations
+                            let frame = RevertErrorStackTraceEntry {
+                                type_: StackTraceEntryTypeConst,
+                                source_reference:
+                                    Self::get_constructor_start_source_reference_inner(trace, env)?,
+                                message,
+                                is_invalid_opcode_error,
+                            };
+
+                            inferred_stacktrace.push(frame.into());
+                        }
+                    }
+                }
+
+                return Self::fix_initial_modifier_inner(trace.as_ref(), inferred_stacktrace, env)
+                    .map(Either::A);
+            }
+        }
+
+        // If the revert instruction is not mapped but there is return data,
+        // we add the frame anyway, sith the best sourceReference we can get
+        if last_instruction.location.is_none() && !return_data.is_empty() {
+            let revert_frame = RevertErrorStackTraceEntry {
+                type_: StackTraceEntryTypeConst,
+                source_reference: Self::get_contract_start_without_function_source_reference_inner(
+                    trace.as_ref(),
+                    env,
+                )?,
+                message: ReturnData::new(return_data.clone()).into_instance(env)?,
+                is_invalid_opcode_error: last_instruction.opcode == Opcode::INVALID,
+            };
+
+            inferred_stacktrace.push(revert_frame.into());
+
+            return Self::fix_initial_modifier_inner(trace.as_ref(), inferred_stacktrace, env)
+                .map(Either::A);
+        }
+
+        Ok(Either::B(()))
+    }
+
+    /// Check if the execution stopped with a revert or an invalid opcode.
+    pub fn check_revert_or_invalid_opcode_modified_opt(
+        trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+        stacktrace: SolidityStackTrace,
+        last_instruction: &Instruction,
+        function_jumpdests: Vec<&Instruction>,
+        jumped_into_function: bool,
+        env: Env,
+    ) -> napi::Result<ModifiedStackTrace> {
+        match last_instruction.opcode {
+            Opcode::REVERT | Opcode::INVALID => {}
+            _ => return Ok(ModifiedStackTrace::No(stacktrace)),
+        }
+
+        let (bytecode, return_data) = match &trace {
+            Either::A(call) => (&call.bytecode, &call.return_data),
+            Either::B(create) => (&create.bytecode, &create.return_data),
+        };
+        let bytecode = bytecode.as_ref().expect("JS code asserts");
+
+        let mut inferred_stacktrace = stacktrace;
+
+        if let Some(location) = &last_instruction.location {
+            if jumped_into_function || matches!(trace, Either::B(CreateMessageTrace { .. })) {
+                // There should always be a function here, but that's not the case with optimizations.
+                //
+                // If this is a create trace, we already checked args and nonpayable failures before
+                // calling this function.
+                //
+                // If it's a call trace, we already jumped into a function. But optimizations can happen.
+                let location = location.borrow(env)?;
+                let failing_function = location.get_containing_function_inner(env)?;
+
+                // If the failure is in a modifier we add an entry with the function/constructor
+                match failing_function.into_option() {
+                    Some(func) if func.borrow(env)?.r#type == ContractFunctionType::MODIFIER => {
+                        let frame = Self::get_entry_before_failure_in_modifier_inner(
+                            trace,
+                            function_jumpdests,
+                            env,
+                        )?;
+
+                        inferred_stacktrace.push(match frame {
+                            Either::A(frame) => frame.into(),
+                            Either::B(frame) => frame.into(),
+                        });
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        let panic_stacktrace = Self::check_panic_inner_modified_opt(
+            trace,
+            inferred_stacktrace,
+            last_instruction,
+            env,
+        )?;
+        let inferred_stacktrace = match panic_stacktrace {
+            yes @ ModifiedStackTrace::Yes(..) => return Ok(yes),
+            ModifiedStackTrace::No(stacktrace) => stacktrace,
+        };
+
+        let custom_error_stacktrace = Self::check_custom_errors_inner_modified_opt(
+            trace,
+            inferred_stacktrace,
+            last_instruction,
+            env,
+        )?;
+        let mut inferred_stacktrace = match custom_error_stacktrace {
+            yes @ ModifiedStackTrace::Yes(..) => return Ok(yes),
+            ModifiedStackTrace::No(stacktrace) => stacktrace,
+        };
+
+        if let Some(location) = &last_instruction.location {
+            if jumped_into_function || matches!(trace, Either::B(CreateMessageTrace { .. })) {
+                let location = location.borrow(env)?;
+                let failing_function = location.get_containing_function_inner(env)?;
+
+                if failing_function.into_option().is_some() {
+                    let frame =
+                        Self::instruction_within_function_to_revert_stack_trace_entry_inner(
+                            trace,
+                            last_instruction,
+                            env,
+                        )?;
+
+                    inferred_stacktrace.push(frame.into());
+                } else {
+                    let message = ReturnData::new(return_data.clone()).into_instance(env)?;
+                    let is_invalid_opcode_error = last_instruction.opcode == Opcode::INVALID;
+
+                    match &trace {
+                        Either::A(CallMessageTrace { calldata, .. }) => {
+                            let contract = bytecode.contract.borrow(env)?;
+
+                            // This is here because of the optimizations
+                            let function_selector = contract.get_function_from_selector_inner(
+                                calldata.get(..4).unwrap_or(&calldata[..]),
+                            );
+
+                            // in general this shouldn't happen, but it does when viaIR is enabled,
+                            // "optimizerSteps": "u" is used, and the called function is fallback or
+                            // receive
+                            let Some(function_selector) = function_selector else {
+                                return Ok(ModifiedStackTrace::No(inferred_stacktrace));
+                            };
+
+                            let function = function_selector.borrow(env)?;
+
+                            let frame = RevertErrorStackTraceEntry {
+                                type_: StackTraceEntryTypeConst,
+                                source_reference: Self::get_function_start_source_reference_inner(
+                                    trace, &function, env,
+                                )?,
+                                message,
+                                is_invalid_opcode_error,
+                            };
+
+                            inferred_stacktrace.push(frame.into());
+                        }
+                        Either::B(trace @ CreateMessageTrace { .. }) => {
+                            // This is here because of the optimizations
+                            let frame = RevertErrorStackTraceEntry {
+                                type_: StackTraceEntryTypeConst,
+                                source_reference:
+                                    Self::get_constructor_start_source_reference_inner(trace, env)?,
+                                message,
+                                is_invalid_opcode_error,
+                            };
+
+                            inferred_stacktrace.push(frame.into());
+                        }
+                    }
+                }
+
+                return Self::fix_initial_modifier_inner(trace, inferred_stacktrace, env)
+                    .map(ModifiedStackTrace::Yes);
+            }
+        }
+
+        // If the revert instruction is not mapped but there is return data,
+        // we add the frame anyway, sith the best sourceReference we can get
+        if last_instruction.location.is_none() && !return_data.is_empty() {
+            let revert_frame = RevertErrorStackTraceEntry {
+                type_: StackTraceEntryTypeConst,
+                source_reference: Self::get_contract_start_without_function_source_reference_inner(
+                    trace, env,
+                )?,
+                message: ReturnData::new(return_data.clone()).into_instance(env)?,
+                is_invalid_opcode_error: last_instruction.opcode == Opcode::INVALID,
+            };
+
+            inferred_stacktrace.push(revert_frame.into());
+
+            return Self::fix_initial_modifier_inner(trace, inferred_stacktrace, env)
+                .map(ModifiedStackTrace::Yes);
+        }
+
+        Ok(ModifiedStackTrace::No(inferred_stacktrace))
+    }
+
+    /// Check last instruction to try to infer the error.
+    #[napi]
+    pub fn check_last_instruction(
+        trace: Either<CallMessageTrace, CreateMessageTrace>,
+        stacktrace: SolidityStackTrace,
+        function_jumpdests: Vec<&Instruction>,
+        jumped_into_function: bool,
+        env: Env,
+    ) -> napi::Result<Either<SolidityStackTrace, Undefined>> {
+        let (bytecode, steps) = match &trace {
+            Either::A(call) => (&call.bytecode, &call.steps),
+            Either::B(create) => (&create.bytecode, &create.steps),
+        };
+        let bytecode = bytecode.as_ref().expect("JS code asserts");
+
+        if steps.is_empty() {
+            return Ok(Either::B(()));
+        }
+
+        let last_step = match steps.last() {
+            Some(Either4::A(step)) => step,
+            _ => panic!("This should not happen: MessageTrace ends with a subtrace"),
+        };
+
+        let last_instruction = bytecode.get_instruction_inner(last_step.pc)?;
+
+        let revert_or_invalid_stacktrace = Self::check_revert_or_invalid_opcode_modified_opt(
+            trace.as_ref(),
+            stacktrace,
+            &*last_instruction.borrow(env)?,
+            function_jumpdests,
+            jumped_into_function,
+            env,
+        )?;
+        if let ModifiedStackTrace::Yes(stacktrace) = revert_or_invalid_stacktrace {
+            return Ok(Either::A(stacktrace));
+        }
+
+        let (Either::A(trace @ CallMessageTrace { ref calldata, .. }), false) =
+            (&trace, jumped_into_function)
+        else {
+            return Ok(Either::B(()));
+        };
+
+        let last_instruction = last_instruction.borrow(env)?;
+
+        if Self::has_failed_inside_the_fallback_function_inner(trace, env)?
+            || Self::has_failed_inside_the_receive_function_inner(trace, env)?
+        {
+            let frame = Self::instruction_within_function_to_revert_stack_trace_entry_inner(
+                Either::A(trace),
+                &last_instruction,
+                env,
+            )?;
+
+            return Ok(Either::A(vec![frame.into()]));
+        }
+
+        // Sometimes we do fail inside of a function but there's no jump into
+        if let Some(location) = &last_instruction.location {
+            let location = location.borrow(env)?;
+            let failing_function = location.get_containing_function_inner(env)?;
+
+            if let Some(failing_function) = failing_function.into_option() {
+                let failing_function = failing_function.borrow(env)?;
+
+                let frame = RevertErrorStackTraceEntry {
+                    type_: StackTraceEntryTypeConst,
+                    source_reference: Self::get_function_start_source_reference_inner(
+                        Either::A(trace),
+                        &failing_function,
+                        env,
+                    )?,
+                    message: ReturnData::new(trace.return_data.clone()).into_instance(env)?,
+                    is_invalid_opcode_error: last_instruction.opcode == Opcode::INVALID,
+                };
+
+                return Ok(Either::A(vec![frame.into()]));
+            }
+        }
+
+        let contract = bytecode.contract.borrow(env)?;
+
+        let selector = calldata.get(..4).unwrap_or(&calldata[..]);
+        let calldata = &calldata.get(4..).unwrap_or(&[]);
+
+        let called_function = contract.get_function_from_selector_inner(selector);
+
+        if let Some(called_function) = called_function {
+            let called_function = called_function.borrow(env)?;
+
+            let abi = called_function.to_alloy().map_err(|e| {
+                napi::Error::from_reason(format!("Error converting to alloy ABI: {e}"))
+            })?;
+
+            let is_valid_calldata = match &called_function.param_types {
+                Some(_) => abi.abi_decode_input(calldata, true).is_ok(),
+                // if we don't know the param types, we just assume that the call is valid
+                None => true,
+            };
+
+            if !is_valid_calldata {
+                let frame = InvalidParamsErrorStackTraceEntry {
+                    type_: StackTraceEntryTypeConst,
+                    source_reference: Self::get_function_start_source_reference_inner(
+                        Either::A(trace),
+                        &called_function,
+                        env,
+                    )?,
+                };
+
+                return Ok(Either::A(vec![frame.into()]));
+            }
+        }
+
+        if Self::solidity_0_6_3_maybe_unmapped_revert_inner(Either::A(trace), env)? {
+            let revert_frame =
+                Self::solidity_0_6_3_get_frame_for_unmapped_revert_before_function_inner(
+                    trace, env,
+                )?;
+
+            if let Some(revert_frame) = revert_frame.into_option() {
+                return Ok(Either::A(vec![revert_frame.into()]));
+            }
+        }
+
+        let frame =
+            Self::get_other_error_before_called_function_stack_trace_entry_inner(trace, env)?;
+
+        Ok(Either::A(vec![frame.into()]))
+    }
+
+    pub fn check_last_instruction_inner(
+        trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+        stacktrace: SolidityStackTrace,
+        function_jumpdests: Vec<&Instruction>,
+        jumped_into_function: bool,
+        env: Env,
+    ) -> napi::Result<ModifiedStackTrace> {
+        let (bytecode, steps) = match &trace {
+            Either::A(call) => (&call.bytecode, &call.steps),
+            Either::B(create) => (&create.bytecode, &create.steps),
+        };
+        let bytecode = bytecode.as_ref().expect("JS code asserts");
+
+        if steps.is_empty() {
+            return Ok(ModifiedStackTrace::No(stacktrace));
+        }
+
+        let last_step = match steps.last() {
+            Some(Either4::A(step)) => step,
+            _ => panic!("This should not happen: MessageTrace ends with a subtrace"),
+        };
+
+        let last_instruction = bytecode.get_instruction_inner(last_step.pc)?;
+
+        let revert_or_invalid_stacktrace = Self::check_revert_or_invalid_opcode_modified_opt(
+            trace,
+            stacktrace,
+            &*last_instruction.borrow(env)?,
+            function_jumpdests,
+            jumped_into_function,
+            env,
+        )?;
+        let stacktrace = match revert_or_invalid_stacktrace {
+            yes @ ModifiedStackTrace::Yes(..) => return Ok(yes),
+            ModifiedStackTrace::No(stacktrace) => stacktrace,
+        };
+
+        let (Either::A(trace @ CallMessageTrace { ref calldata, .. }), false) =
+            (&trace, jumped_into_function)
+        else {
+            return Ok(ModifiedStackTrace::No(stacktrace));
+        };
+
+        let last_instruction = last_instruction.borrow(env)?;
+
+        if Self::has_failed_inside_the_fallback_function_inner(trace, env)?
+            || Self::has_failed_inside_the_receive_function_inner(trace, env)?
+        {
+            let frame = Self::instruction_within_function_to_revert_stack_trace_entry_inner(
+                Either::A(trace),
+                &last_instruction,
+                env,
+            )?;
+
+            return Ok(ModifiedStackTrace::Yes(vec![frame.into()]));
+        }
+
+        // Sometimes we do fail inside of a function but there's no jump into
+        if let Some(location) = &last_instruction.location {
+            let location = location.borrow(env)?;
+            let failing_function = location.get_containing_function_inner(env)?;
+
+            if let Some(failing_function) = failing_function.into_option() {
+                let failing_function = failing_function.borrow(env)?;
+
+                let frame = RevertErrorStackTraceEntry {
+                    type_: StackTraceEntryTypeConst,
+                    source_reference: Self::get_function_start_source_reference_inner(
+                        Either::A(trace),
+                        &failing_function,
+                        env,
+                    )?,
+                    message: ReturnData::new(trace.return_data.clone()).into_instance(env)?,
+                    is_invalid_opcode_error: last_instruction.opcode == Opcode::INVALID,
+                };
+
+                return Ok(ModifiedStackTrace::Yes(vec![frame.into()]));
+            }
+        }
+
+        let contract = bytecode.contract.borrow(env)?;
+
+        let selector = calldata.get(..4).unwrap_or(&calldata[..]);
+        let calldata = &calldata.get(4..).unwrap_or(&[]);
+
+        let called_function = contract.get_function_from_selector_inner(selector);
+
+        if let Some(called_function) = called_function {
+            let called_function = called_function.borrow(env)?;
+
+            let abi = called_function.to_alloy().map_err(|e| {
+                napi::Error::from_reason(format!("Error converting to alloy ABI: {e}"))
+            })?;
+
+            let is_valid_calldata = match &called_function.param_types {
+                Some(_) => abi.abi_decode_input(calldata, true).is_ok(),
+                // if we don't know the param types, we just assume that the call is valid
+                None => true,
+            };
+
+            if !is_valid_calldata {
+                let frame = InvalidParamsErrorStackTraceEntry {
+                    type_: StackTraceEntryTypeConst,
+                    source_reference: Self::get_function_start_source_reference_inner(
+                        Either::A(trace),
+                        &called_function,
+                        env,
+                    )?,
+                };
+
+                return Ok(ModifiedStackTrace::Yes(vec![frame.into()]));
+            }
+        }
+
+        if Self::solidity_0_6_3_maybe_unmapped_revert_inner(Either::A(trace), env)? {
+            let revert_frame =
+                Self::solidity_0_6_3_get_frame_for_unmapped_revert_before_function_inner(
+                    trace, env,
+                )?;
+
+            if let Some(revert_frame) = revert_frame.into_option() {
+                return Ok(ModifiedStackTrace::Yes(vec![revert_frame.into()]));
+            }
+        }
+
+        let frame =
+            Self::get_other_error_before_called_function_stack_trace_entry_inner(trace, env)?;
+
+        Ok(ModifiedStackTrace::Yes(vec![frame.into()]))
+    }
+
+    // Helpers
+
+    #[napi]
+    pub fn fix_initial_modifier(
+        trace: Either<CallMessageTrace, CreateMessageTrace>,
+        stacktrace: SolidityStackTrace,
+        env: Env,
+    ) -> napi::Result<SolidityStackTrace> {
+        Self::fix_initial_modifier_inner(trace.as_ref(), stacktrace, env)
+    }
+
+    fn fix_initial_modifier_inner(
+        trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+        mut stacktrace: SolidityStackTrace,
+        env: Env,
+    ) -> napi::Result<SolidityStackTrace> {
+        if let Some(Either24::A(CallstackEntryStackTraceEntry {
+            function_type: ContractFunctionType::MODIFIER,
+            ..
+        })) = stacktrace.first()
+        {
+            let entry_before_initial_modifier =
+                Self::get_entry_before_initial_modifier_callstack_entry(trace, env)?;
+
+            stacktrace.insert(0, entry_before_initial_modifier);
+        }
+
+        Ok(stacktrace)
+    }
+
+    fn get_entry_before_initial_modifier_callstack_entry(
+        trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+        env: Env,
+    ) -> napi::Result<SolidityStackTraceEntry> {
+        let trace = match trace {
+            Either::B(create) => {
+                return Ok(CallstackEntryStackTraceEntry {
+                    type_: StackTraceEntryTypeConst,
+                    source_reference: Self::get_constructor_start_source_reference_inner(
+                        create, env,
+                    )?,
+                    function_type: ContractFunctionType::CONSTRUCTOR,
+                }
+                .into())
+            }
+            Either::A(call) => call,
+        };
+
+        let bytecode = trace.bytecode.as_ref().expect("JS code asserts");
+        let contract = bytecode.contract.borrow(env)?;
+
+        let called_function = contract.get_function_from_selector_inner(
+            trace.calldata.get(..4).unwrap_or(&trace.calldata[..]),
+        );
+
+        let called_function = called_function.map(|x| x.borrow(env)).transpose()?;
+        let called_function = called_function.as_deref();
+
+        let source_reference = match called_function {
+            Some(called_function) => Self::get_function_start_source_reference_inner(
+                Either::A(trace),
+                called_function,
+                env,
+            )?,
+            None => Self::get_fallback_start_source_reference_inner(trace, env)?,
+        };
+
+        let function_type = match called_function {
+            Some(_) => ContractFunctionType::FUNCTION,
+            None => ContractFunctionType::FALLBACK,
+        };
+
+        Ok(CallstackEntryStackTraceEntry {
+            type_: StackTraceEntryTypeConst,
+            source_reference,
+            function_type,
+        }
+        .into())
+    }
+
+    #[napi(catch_unwind)]
+    pub fn call_instruction_to_call_failed_to_execute_stack_trace_entry(
+        bytecode: &Bytecode,
+        call_inst: &Instruction,
+        env: Env,
+    ) -> napi::Result<CallFailedErrorStackTraceEntry> {
+        let location = call_inst
+            .location
+            .as_ref()
+            .map(|l| l.borrow(env))
+            .transpose()?;
+        let location = location.as_deref();
+
+        let source_reference = source_location_to_source_reference(bytecode, location, env)?;
+        let source_reference = source_reference.expect("Expected source reference to be defined");
+
+        // Calls only happen within functions
+        Ok(CallFailedErrorStackTraceEntry {
+            type_: StackTraceEntryTypeConst,
+            source_reference,
+        })
+    }
+
+    #[napi(catch_unwind)]
+    pub fn get_entry_before_failure_in_modifier(
+        trace: Either<CallMessageTrace, CreateMessageTrace>,
+        function_jumpdests: Vec<&Instruction>,
+        env: Env,
+    ) -> napi::Result<Either<CallstackEntryStackTraceEntry, InternalFunctionCallStackEntry>> {
+        Self::get_entry_before_failure_in_modifier_inner(trace.as_ref(), function_jumpdests, env)
+    }
+
+    pub fn get_entry_before_failure_in_modifier_inner(
+        trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+        function_jumpdests: Vec<&Instruction>,
+        env: Env,
+    ) -> napi::Result<Either<CallstackEntryStackTraceEntry, InternalFunctionCallStackEntry>> {
+        let bytecode = match &trace {
+            Either::A(call) => &call.bytecode,
+            Either::B(create) => &create.bytecode,
+        };
+        let bytecode = bytecode.as_ref().expect("JS code asserts");
+
+        // If there's a jumpdest, this modifier belongs to the last function that it represents
+        if let Some(last_jumpdest) = function_jumpdests.last() {
+            let entry = instruction_to_callstack_stack_trace_entry(bytecode, last_jumpdest, env)?;
+
+            return Ok(entry);
+        }
+
+        let trace = match trace {
+            Either::A(_call) => unreachable!("This shouldn't happen: a call trace has no functionJumpdest but has already jumped into a function"),
+            Either::B(create) => create,
+        };
+
+        // If there's no jump dest, we point to the constructor.
+        Ok(Either::A(CallstackEntryStackTraceEntry {
+            type_: StackTraceEntryTypeConst,
+            source_reference: Self::get_constructor_start_source_reference_inner(trace, env)?,
+            function_type: ContractFunctionType::CONSTRUCTOR,
+        }))
+    }
+
+    #[napi]
+    pub fn fails_right_after_call(
+        trace: Either<CallMessageTrace, CreateMessageTrace>,
+        call_subtrace_step_index: u32,
+        env: Env,
+    ) -> napi::Result<bool> {
+        Self::fails_right_after_call_inner(trace.as_ref(), call_subtrace_step_index, env)
+    }
+
+    fn fails_right_after_call_inner(
+        trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+        call_subtrace_step_index: u32,
+        env: Env,
+    ) -> napi::Result<bool> {
+        let (bytecode, steps) = match &trace {
+            Either::A(call) => (&call.bytecode, &call.steps),
+            Either::B(create) => (&create.bytecode, &create.steps),
+        };
+
+        let bytecode = bytecode.as_ref().expect("JS code asserts");
+
+        let Some(Either4::A(last_step)) = steps.last() else {
+            return Ok(false);
+        };
+
+        let last_inst = bytecode.get_instruction_inner(last_step.pc)?;
+        let last_inst = last_inst.borrow(env)?;
+        if last_inst.opcode != Opcode::REVERT {
+            return Ok(false);
+        }
+
+        let call_opcode_step = steps.get(call_subtrace_step_index as usize - 1);
+        let call_opcode_step = match call_opcode_step {
+            Some(Either4::A(step)) => step,
+            _ => panic!("JS code asserts this is always an EvmStep"),
+        };
+        let call_inst = bytecode.get_instruction_inner(call_opcode_step.pc)?;
+        let call_inst = call_inst.borrow(env)?;
+
+        // Calls are always made from within functions
+        let call_inst_location = call_inst
+            .location
+            .as_ref()
+            .expect("Expected call instruction location to be defined");
+        let call_inst_location = call_inst_location.borrow(env)?;
+
+        Self::is_last_location(
+            trace,
+            call_subtrace_step_index + 1,
+            &call_inst_location,
+            env,
+        )
+    }
+
+    fn is_call_failed_error(
+        trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+        inst_index: u32,
+        call_instruction: &Instruction,
+        env: Env,
+    ) -> napi::Result<bool> {
+        let call_location = match &call_instruction.location {
+            Some(location) => location.borrow(env)?,
+            None => panic!("Expected call location to be defined"),
+        };
+
+        Self::is_last_location(trace, inst_index, &call_location, env)
+    }
+
+    fn is_last_location(
+        trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+        from_step: u32,
+        location: &SourceLocation,
+        env: Env,
+    ) -> napi::Result<bool> {
+        let (bytecode, steps) = match &trace {
+            Either::A(call) => (&call.bytecode, &call.steps),
+            Either::B(create) => (&create.bytecode, &create.steps),
+        };
+
+        let bytecode = bytecode.as_ref().expect("JS code asserts");
+
+        for step in steps.iter().skip(from_step as usize) {
+            let step = match step {
+                Either4::A(step) => step,
+                _ => return Ok(false),
+            };
+
+            let step_inst = bytecode.get_instruction_inner(step.pc)?;
+            let step_inst = step_inst.borrow(env)?;
+
+            if let Some(step_inst_location) = &step_inst.location {
+                let step_inst_location = step_inst_location.borrow(env)?;
+
+                if !step_inst_location.equals(location, env) {
+                    return Ok(false);
+                }
+            }
+        }
+
+        Ok(true)
+    }
+
+    #[napi]
+    pub fn is_subtrace_error_propagated(
+        trace: Either<CallMessageTrace, CreateMessageTrace>,
+        call_subtrace_step_index: u32,
+        env: Env,
+    ) -> napi::Result<bool> {
+        Self::is_subtrace_error_propagated_inner(trace.as_ref(), call_subtrace_step_index, env)
+    }
+
+    pub fn is_subtrace_error_propagated_inner(
+        trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+        call_subtrace_step_index: u32,
+        env: Env,
+    ) -> napi::Result<bool> {
+        let (return_data, exit, steps) = match &trace {
+            Either::A(call) => (&call.return_data, call.exit.kind(), &call.steps),
+            Either::B(create) => (&create.return_data, create.exit.kind(), &create.steps),
+        };
+
+        let (call_return_data, call_exit) = match steps.get(call_subtrace_step_index as usize) {
+            None | Some(Either4::A(_)) => panic!("Expected call to be a message trace"),
+            Some(Either4::B(precompile)) => (&precompile.return_data, precompile.exit.kind()),
+            Some(Either4::C(call)) => (&call.return_data, call.exit.kind()),
+            Some(Either4::D(create)) => (&create.return_data, create.exit.kind()),
+        };
+
+        if return_data.as_ref() != call_return_data.as_ref() {
+            return Ok(false);
+        }
+
+        if exit == ExitCode::OUT_OF_GAS && call_exit == ExitCode::OUT_OF_GAS {
+            return Ok(true);
+        }
+
+        // If the return data is not empty, and it's still the same, we assume it
+        // is being propagated
+        if return_data.len() > 0 {
+            return Ok(true);
+        }
+
+        Self::fails_right_after_call_inner(trace, call_subtrace_step_index, env)
+    }
+
+    #[napi(catch_unwind)]
+    pub fn is_contract_call_run_out_of_gas_error(
+        trace: Either<CallMessageTrace, CreateMessageTrace>,
+        call_step_index: u32,
+        env: Env,
+    ) -> napi::Result<bool> {
+        Self::is_contract_call_run_out_of_gas_error_inner(trace.as_ref(), call_step_index, env)
+    }
+
+    pub fn is_contract_call_run_out_of_gas_error_inner(
+        trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+        call_step_index: u32,
+        env: Env,
+    ) -> napi::Result<bool> {
+        let (steps, return_data, exit_code) = match &trace {
+            Either::A(call) => (&call.steps, &call.return_data, call.exit.kind()),
+            Either::B(create) => (&create.steps, &create.return_data, create.exit.kind()),
+        };
+
+        if return_data.len() > 0 {
+            return Ok(false);
+        }
+
+        if exit_code != ExitCode::REVERT {
+            return Ok(false);
+        }
+
+        let call_exit = match steps.get(call_step_index as usize) {
+            None | Some(Either4::A(_)) => panic!("Expected call to be a message trace"),
+            Some(Either4::B(precompile)) => precompile.exit.kind(),
+            Some(Either4::C(call)) => call.exit.kind(),
+            Some(Either4::D(create)) => create.exit.kind(),
+        };
+
+        if call_exit != ExitCode::OUT_OF_GAS {
+            return Ok(false);
+        }
+
+        Self::fails_right_after_call_inner(trace, call_step_index, env)
+    }
+
+    #[napi]
+    pub fn is_proxy_error_propagated(
+        trace: Either<CallMessageTrace, CreateMessageTrace>,
+        call_subtrace_step_index: u32,
+        env: Env,
+    ) -> napi::Result<bool> {
+        Self::is_proxy_error_propagated_inner(trace.as_ref(), call_subtrace_step_index, env)
+    }
+
+    pub fn is_proxy_error_propagated_inner(
+        trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+        call_subtrace_step_index: u32,
+        env: Env,
+    ) -> napi::Result<bool> {
+        let trace = match &trace {
+            Either::A(call) => call,
+            Either::B(_) => return Ok(false),
+        };
+
+        let bytecode = trace.bytecode.as_ref().expect("JS code asserts");
+
+        let call_step = match trace.steps.get(call_subtrace_step_index as usize - 1) {
+            Some(Either4::A(step)) => step,
+            _ => return Ok(false),
+        };
+
+        let call_inst = bytecode.get_instruction_inner(call_step.pc)?;
+        let call_inst = call_inst.borrow(env)?;
+
+        if call_inst.opcode != Opcode::DELEGATECALL {
+            return Ok(false);
+        }
+
+        let subtrace = match trace.steps.get(call_subtrace_step_index as usize) {
+            None | Some(Either4::A(_) | Either4::B(_)) => return Ok(false),
+            Some(Either4::C(call)) => Either::A(call),
+            Some(Either4::D(create)) => Either::B(create),
+        };
+
+        let (subtrace_bytecode, subtrace_return_data) = match &subtrace {
+            Either::A(call) => (&call.bytecode, &call.return_data),
+            Either::B(create) => (&create.bytecode, &create.return_data),
+        };
+        let subtrace_bytecode = match subtrace_bytecode {
+            Some(bytecode) => bytecode,
+            // If we can't recognize the implementation we'd better don't consider it as such
+            None => return Ok(false),
+        };
+
+        if subtrace_bytecode.contract.borrow(env)?.r#type == ContractType::LIBRARY {
+            return Ok(false);
+        }
+
+        if trace.return_data.as_ref() != subtrace_return_data.as_ref() {
+            return Ok(false);
+        }
+
+        for step in trace
+            .steps
+            .iter()
+            .skip(call_subtrace_step_index as usize + 1)
+        {
+            let step = match step {
+                Either4::A(step) => step,
+                _ => return Ok(false),
+            };
+
+            let inst = subtrace_bytecode.get_instruction_inner(step.pc)?;
+            let inst = inst.borrow(env)?;
+
+            // All the remaining locations should be valid, as they are part of the inline asm
+            if inst.location.is_none() {
+                return Ok(false);
+            }
+
+            if matches!(
+                inst.jump_type,
+                JumpType::INTO_FUNCTION | JumpType::OUTOF_FUNCTION
+            ) {
+                return Ok(false);
+            }
+        }
+
+        let last_step = match trace.steps.last() {
+            Some(Either4::A(step)) => step,
+            _ => panic!("Expected last step to be an EvmStep"),
+        };
+        let last_inst = bytecode.get_instruction_inner(last_step.pc)?;
+
+        Ok(last_inst.borrow(env)?.opcode == Opcode::REVERT)
+    }
+
+    #[napi]
+    pub fn other_execution_error_stacktrace(
+        trace: Either<CallMessageTrace, CreateMessageTrace>,
+        mut stacktrace: SolidityStackTrace,
+        env: Env,
+    ) -> napi::Result<SolidityStackTrace> {
+        let other_execution_error_frame = OtherExecutionErrorStackTraceEntry {
+            type_: StackTraceEntryTypeConst,
+            source_reference: match Self::get_last_source_reference(trace, env)? {
+                Either::A(source_reference) => Some(source_reference),
+                Either::B(_) => None,
+            },
+        };
+
+        stacktrace.push(other_execution_error_frame.into());
+        Ok(stacktrace)
+    }
+
+    pub fn other_execution_error_stacktrace_inner(
+        trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+        mut stacktrace: SolidityStackTrace,
+        env: Env,
+    ) -> napi::Result<SolidityStackTrace> {
+        let other_execution_error_frame = OtherExecutionErrorStackTraceEntry {
+            type_: StackTraceEntryTypeConst,
+            source_reference: match Self::get_last_source_reference_inner(trace, env)? {
+                Either::A(source_reference) => Some(source_reference),
+                Either::B(_) => None,
+            },
+        };
+
+        stacktrace.push(other_execution_error_frame.into());
+        Ok(stacktrace)
+    }
+
+    fn is_direct_library_call(trace: &CallMessageTrace, env: Env) -> napi::Result<bool> {
+        let contract = &trace.bytecode.as_ref().expect("JS code asserts").contract;
+        let contract = contract.borrow(env)?;
+
+        Ok(trace.depth == 0 && contract.r#type == ContractType::LIBRARY)
+    }
+
+    fn get_direct_library_call_error_stack_trace(
+        trace: &CallMessageTrace,
+        env: Env,
+    ) -> napi::Result<SolidityStackTrace> {
+        let contract = &trace.bytecode.as_ref().expect("JS code asserts").contract;
+        let contract = contract.borrow(env)?;
+
+        let func = contract.get_function_from_selector_inner(
+            trace.calldata.get(..4).unwrap_or(&trace.calldata[..]),
+        );
+
+        let func = func.map(|f| f.borrow(env)).transpose()?;
+        let source_reference = match func {
+            Some(func) => {
+                Self::get_function_start_source_reference_inner(Either::A(trace), &func, env)?
+            }
+            None => Self::get_contract_start_without_function_source_reference_inner(
+                Either::A(trace),
+                env,
+            )?,
+        };
+
+        Ok(vec![DirectLibraryCallErrorStackTraceEntry {
+            type_: StackTraceEntryTypeConst,
+            source_reference,
+        }
+        .into()])
+    }
+
+    #[napi]
+    pub fn get_function_start_source_reference(
+        trace: Either<CallMessageTrace, CreateMessageTrace>,
+        func: &ContractFunction,
+        env: Env,
+    ) -> napi::Result<SourceReference> {
+        let trace = match &trace {
+            Either::A(call) => Either::A(call),
+            Either::B(create) => Either::B(create),
+        };
+        Self::get_function_start_source_reference_inner(trace, func, env)
+    }
+
+    fn get_function_start_source_reference_inner(
+        trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+        func: &ContractFunction,
+        env: Env,
+    ) -> napi::Result<SourceReference> {
+        let bytecode = match &trace {
+            Either::A(create) => &create.bytecode,
+            Either::B(call) => &call.bytecode,
+        };
+
+        let contract = &bytecode.as_ref().expect("JS code asserts").contract;
+        let contract = contract.borrow(env)?;
+
+        let location = func.location.borrow(env)?;
+        let file = location.file.borrow(env)?;
+
+        let location = func.location.borrow(env)?;
+
+        Ok(SourceReference {
+            source_name: file.source_name.clone(),
+            source_content: file.content.clone(),
+            contract: Some(contract.name.clone()),
+
+            function: Some(func.name.clone()),
+            line: location.get_starting_line_number(env).unwrap(),
+            range: [location.offset, location.offset + location.length].to_vec(),
+        })
+    }
+
+    fn is_missing_function_and_fallback_error(
+        trace: &CallMessageTrace,
+        called_function: Option<&ContractFunction>,
+        env: Env,
+    ) -> napi::Result<bool> {
+        // This error doesn't return data
+        if trace.return_data.len() > 0 {
+            return Ok(false);
+        }
+
+        // the called function exists in the contract
+        if called_function.is_some() {
+            return Ok(false);
+        }
+
+        let bytecode = trace
+            .bytecode
+            .as_ref()
+            .expect("The TS code type-checks this to always have bytecode");
+        let contract = bytecode.contract.borrow(env)?;
+
+        // there's a receive function and no calldata
+        if trace.calldata.len() == 0 && contract.receive.is_some() {
+            return Ok(false);
+        }
+
+        Ok(contract.fallback.is_none())
+    }
+
+    pub fn empty_calldata_and_no_receive(trace: &CallMessageTrace, env: Env) -> napi::Result<bool> {
+        let bytecode = trace
+            .bytecode
+            .as_ref()
+            .expect("The TS code type-checks this to always have bytecode");
+        let contract = bytecode.contract.borrow(env)?;
+
+        let version = Version::parse(&bytecode.compiler_version).unwrap();
+        // this only makes sense when receive functions are available
+        if version < FIRST_SOLC_VERSION_RECEIVE_FUNCTION {
+            return Ok(false);
+        }
+
+        Ok(trace.calldata.is_empty() && contract.receive.is_none())
+    }
+
+    fn is_fallback_not_payable_error(
+        trace: &CallMessageTrace,
+        called_function: Option<&ContractFunction>,
+        env: Env,
+    ) -> napi::Result<bool> {
+        // This error doesn't return data
+        if !trace.return_data.is_empty() {
+            return Ok(false);
+        }
+
+        let (neg, value, _) = trace.value.get_u64();
+        if neg || value == 0 {
+            return Ok(false);
+        }
+
+        // the called function exists in the contract
+        if called_function.is_some() {
+            return Ok(false);
+        }
+
+        let bytecode = trace.bytecode.as_ref().expect("JS code asserts");
+        let contract = bytecode.contract.borrow(env)?;
+
+        match &contract.fallback {
+            None => Ok(false),
+            Some(fallback) => {
+                let fallback = fallback.borrow(env)?;
+
+                Ok(fallback.is_payable != Some(true))
+            }
+        }
+    }
+
+    #[napi(catch_unwind)]
+    pub fn get_fallback_start_source_reference(
+        trace: CallMessageTrace,
+        env: Env,
+    ) -> napi::Result<SourceReference> {
+        Self::get_fallback_start_source_reference_inner(&trace, env)
+    }
+
+    fn get_fallback_start_source_reference_inner(
+        trace: &CallMessageTrace,
+        env: Env,
+    ) -> napi::Result<SourceReference> {
+        let bytecode = trace.bytecode.as_ref().expect("JS code asserts");
+        let contract = bytecode.contract.borrow(env)?;
+
+        let func = match &contract.fallback {
+          Some(func) => func,
+          None => panic!("This shouldn't happen: trying to get fallback source reference from a contract without fallback"),
+        };
+
+        let func = func.borrow(env)?;
+        let location = func.location.borrow(env)?;
+        let file = location.file.borrow(env)?;
+
+        Ok(SourceReference {
+            source_name: file.source_name.clone(),
+            source_content: file.content.clone(),
+            contract: Some(contract.name.clone()),
+            function: Some(FALLBACK_FUNCTION_NAME.to_string()),
+            line: location.get_starting_line_number(env).unwrap(),
+            range: [location.offset, location.offset + location.length].to_vec(),
+        })
+    }
+
+    fn is_constructor_not_payable_error(
+        trace: &CreateMessageTrace,
+        env: Env,
+    ) -> napi::Result<bool> {
+        // This error doesn't return data
+        if !trace.return_data.is_empty() {
+            return Ok(false);
+        }
+
+        let bytecode = trace.bytecode.as_ref().expect("JS code asserts");
+        let contract = bytecode.contract.borrow(env)?;
+
+        // This function is only matters with contracts that have constructors defined. The ones that
+        // don't are abstract contracts, or their constructor doesn't take any argument.
+        let constructor = match &contract.constructor {
+            Some(constructor) => constructor,
+            None => return Ok(false),
+        };
+
+        let constructor = constructor.borrow(env)?;
+
+        let (neg, value, _) = trace.value.get_u64();
+        if neg || value == 0 {
+            return Ok(false);
+        }
+
+        Ok(constructor.is_payable != Some(true))
+    }
+
+    /// Returns a source reference pointing to the constructor if it exists, or to the contract otherwise.
+    #[napi]
+    pub fn get_constructor_start_source_reference(
+        trace: CreateMessageTrace,
+        env: Env,
+    ) -> napi::Result<SourceReference> {
+        Self::get_constructor_start_source_reference_inner(&trace, env)
+    }
+
+    fn get_constructor_start_source_reference_inner(
+        trace: &CreateMessageTrace,
+        env: Env,
+    ) -> napi::Result<SourceReference> {
+        let bytecode = trace.bytecode.as_ref().expect("JS code asserts");
+        let contract = bytecode.contract.borrow(env)?;
+        let contract_location = contract.location.borrow(env)?;
+
+        let line = match &contract.constructor {
+            Some(constructor) => {
+                let constructor = constructor.borrow(env)?;
+                let location = constructor.location.borrow(env)?;
+
+                location.get_starting_line_number(env)?
+            }
+            None => contract_location.get_starting_line_number(env)?,
+        };
+
+        let file = contract_location.file.borrow(env)?;
+
+        Ok(SourceReference {
+            source_name: file.source_name.clone(),
+            source_content: file.content.clone(),
+            contract: Some(contract.name.clone()),
+            function: Some(CONSTRUCTOR_FUNCTION_NAME.to_string()),
+            line,
+            range: [
+                contract_location.offset,
+                contract_location.offset + contract_location.length,
+            ]
+            .to_vec(),
+        })
+    }
+
+    fn is_constructor_invalid_arguments_error(
+        trace: &CreateMessageTrace,
+        env: Env,
+    ) -> napi::Result<bool> {
+        if trace.return_data.len() > 0 {
+            return Ok(false);
+        }
+
+        let bytecode = trace.bytecode.as_ref().expect("JS code asserts");
+        let contract = bytecode.contract.borrow(env)?;
+
+        // This function is only matters with contracts that have constructors defined. The ones that
+        // don't are abstract contracts, or their constructor doesn't take any argument.
+        let Some(constructor) = &contract.constructor else {
+            return Ok(false);
+        };
+
+        let Ok(version) = Version::parse(&bytecode.compiler_version) else {
+            return Ok(false);
+        };
+        if version < FIRST_SOLC_VERSION_CREATE_PARAMS_VALIDATION {
+            return Ok(false);
+        }
+
+        let last_step = trace.steps.last();
+        let Some(Either4::A(last_step)) = last_step else {
+            return Ok(false);
+        };
+
+        let last_inst = bytecode.get_instruction_inner(last_step.pc)?;
+        let last_inst = last_inst.borrow(env)?;
+
+        if last_inst.opcode != Opcode::REVERT || last_inst.location.is_some() {
+            return Ok(false);
+        }
+
+        let contract_location = contract.location.borrow(env)?;
+        let constructor = constructor.borrow(env)?;
+        let constructor_location = constructor.location.borrow(env)?;
+
+        let mut has_read_deployment_code_size = false;
+        for step in &trace.steps {
+            let step = match step {
+                Either4::A(step) => step,
+                _ => return Ok(false),
+            };
+
+            let inst = bytecode.get_instruction_inner(step.pc)?;
+            let inst = inst.borrow(env)?;
+            let inst_location = inst.location.as_ref().map(|x| x.borrow(env)).transpose()?;
+
+            if let Some(inst_location) = inst_location {
+                if !contract_location.equals(&inst_location, env)
+                    && !constructor_location.equals(&inst_location, env)
+                {
+                    return Ok(false);
+                }
+            }
+
+            if inst.opcode == Opcode::CODESIZE {
+                has_read_deployment_code_size = true;
+            }
+        }
+
+        Ok(has_read_deployment_code_size)
+    }
+
+    #[napi]
+    pub fn get_contract_start_without_function_source_reference(
+        trace: Either<CallMessageTrace, CreateMessageTrace>,
+        env: Env,
+    ) -> napi::Result<SourceReference> {
+        Self::get_contract_start_without_function_source_reference_inner(trace.as_ref(), env)
+    }
+
+    pub fn get_contract_start_without_function_source_reference_inner(
+        trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+        env: Env,
+    ) -> napi::Result<SourceReference> {
+        let bytecode = match &trace {
+            Either::A(create) => &create.bytecode,
+            Either::B(call) => &call.bytecode,
+        };
+
+        let contract = &bytecode.as_ref().expect("JS code asserts").contract;
+
+        let contract = contract.borrow(env)?;
+
+        let location = contract.location.borrow(env)?;
+        let file = location.file.borrow(env)?;
+
+        Ok(SourceReference {
+            source_name: file.source_name.clone(),
+            source_content: file.content.clone(),
+            contract: Some(contract.name.clone()),
+
+            function: None,
+            line: location.get_starting_line_number(env).unwrap(),
+            range: [location.offset, location.offset + location.length].to_vec(),
+        })
+    }
+
+    pub fn is_function_not_payable_error(
+        trace: &CallMessageTrace,
+        called_function: &ContractFunction,
+        env: Env,
+    ) -> napi::Result<bool> {
+        // This error doesn't return data
+        if !trace.return_data.is_empty() {
+            return Ok(false);
+        }
+
+        let (neg, value, _) = trace.value.get_u64();
+        if neg || value == 0 {
+            return Ok(false);
+        }
+
+        let bytecode = trace.bytecode.as_ref().expect("JS code asserts");
+        let contract = bytecode.contract.borrow(env)?;
+
+        // Libraries don't have a nonpayable check
+        if contract.r#type == ContractType::LIBRARY {
+            return Ok(false);
+        }
+
+        Ok(called_function.is_payable != Some(true))
+    }
+
+    #[napi]
+    pub fn get_last_source_reference(
+        trace: Either<CallMessageTrace, CreateMessageTrace>,
+        env: Env,
+    ) -> napi::Result<Either<SourceReference, Undefined>> {
+        let trace = match &trace {
+            Either::A(call) => Either::A(call),
+            Either::B(create) => Either::B(create),
+        };
+
+        Self::get_last_source_reference_inner(trace, env)
+    }
+
+    pub fn get_last_source_reference_inner(
+        trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+        env: Env,
+    ) -> napi::Result<Either<SourceReference, Undefined>> {
+        let (bytecode, steps) = match trace {
+            Either::A(create) => (&create.bytecode, &create.steps),
+            Either::B(call) => (&call.bytecode, &call.steps),
+        };
+
+        let bytecode = bytecode
+            .as_ref()
+            .expect("JS code only accepted variants that had bytecode defined");
+
+        for step in steps.iter().rev() {
+            let step = match step {
+                Either4::A(step) => step,
+                _ => continue,
+            };
+
+            let inst = bytecode.get_instruction_inner(step.pc)?;
+
+            let location = &inst.borrow(env)?.location;
+            let Some(location) = location else {
+                continue;
+            };
+            let location = location.borrow(env)?;
+
+            let source_reference =
+                source_location_to_source_reference(bytecode, Some(&*location), env)?;
+
+            if let Some(source_reference) = source_reference {
+                return Ok(Either::A(source_reference));
+            }
+        }
+
+        Ok(Either::B(()))
+    }
+
+    #[napi]
+    pub fn has_failed_inside_the_fallback_function(
+        trace: CallMessageTrace,
+        env: Env,
+    ) -> napi::Result<bool> {
+        Self::has_failed_inside_the_fallback_function_inner(&trace, env)
+    }
+
+    pub fn has_failed_inside_the_fallback_function_inner(
+        trace: &CallMessageTrace,
+        env: Env,
+    ) -> napi::Result<bool> {
+        let contract = &trace.bytecode.as_ref().expect("JS code asserts").contract;
+        let contract = contract.borrow(env)?;
+
+        match &contract.fallback {
+            Some(fallback) => {
+                let fallback = fallback.borrow(env)?;
+                Self::has_failed_inside_function(trace, &fallback, env)
+            }
+            None => Ok(false),
+        }
+    }
+
+    #[napi]
+    pub fn has_failed_inside_the_receive_function(
+        trace: CallMessageTrace,
+        env: Env,
+    ) -> napi::Result<bool> {
+        Self::has_failed_inside_the_receive_function_inner(&trace, env)
+    }
+
+    pub fn has_failed_inside_the_receive_function_inner(
+        trace: &CallMessageTrace,
+        env: Env,
+    ) -> napi::Result<bool> {
+        let contract = &trace.bytecode.as_ref().expect("JS code asserts").contract;
+        let contract = contract.borrow(env)?;
+
+        match &contract.receive {
+            Some(receive) => {
+                let receive = receive.borrow(env)?;
+                Self::has_failed_inside_function(trace, &receive, env)
+            }
+            None => Ok(false),
+        }
+    }
+
+    pub fn has_failed_inside_function(
+        trace: &CallMessageTrace,
+        func: &ContractFunction,
+        env: Env,
+    ) -> napi::Result<bool> {
+        let last_step = trace.steps.last().unwrap();
+        let last_step = match last_step {
+            Either4::A(step) => step,
+            _ => panic!("JS code asserted this is always an EvmStep"),
+        };
+
+        let last_instruction = trace
+            .bytecode
+            .as_ref()
+            .expect("The TS code type-checks this to always have bytecode")
+            .get_instruction_inner(last_step.pc)?;
+
+        let last_instruction = last_instruction.borrow(env)?;
+        let last_instruction_location = last_instruction
+            .location
+            .as_ref()
+            .map(|i| i.borrow(env))
+            .transpose()?;
+
+        Ok(match last_instruction_location {
+            Some(last_instruction_location) => {
+                last_instruction.opcode == Opcode::REVERT
+                    && func
+                        .location
+                        .borrow(env)?
+                        .contains(&last_instruction_location, env)
+            }
+            _ => false,
+        })
+    }
+
+    #[napi(catch_unwind)]
+    pub fn instruction_within_function_to_revert_stack_trace_entry(
+        trace: Either<CallMessageTrace, CreateMessageTrace>,
+        inst: &Instruction,
+        env: Env,
+    ) -> napi::Result<RevertErrorStackTraceEntry> {
+        Self::instruction_within_function_to_revert_stack_trace_entry_inner(
+            trace.as_ref(),
+            inst,
+            env,
+        )
+    }
+
+    pub fn instruction_within_function_to_revert_stack_trace_entry_inner(
+        trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+        inst: &Instruction,
+        env: Env,
+    ) -> napi::Result<RevertErrorStackTraceEntry> {
+        let bytecode = match &trace {
+            Either::A(create) => &create.bytecode,
+            Either::B(call) => &call.bytecode,
+        }
+        .as_ref()
+        .expect("JS code asserts");
+
+        let inst_location = inst.location.as_ref().map(|i| i.borrow(env)).transpose()?;
+        let inst_location = inst_location.as_deref();
+
+        let source_reference = source_location_to_source_reference(bytecode, inst_location, env)?
+            .expect("Expected source reference to be defined");
+
+        let return_data = match &trace {
+            Either::A(create) => &create.return_data,
+            Either::B(call) => &call.return_data,
+        };
+
+        Ok(RevertErrorStackTraceEntry {
+            type_: StackTraceEntryTypeConst,
+            source_reference,
+            is_invalid_opcode_error: inst.opcode == Opcode::INVALID,
+            message: ReturnData::new(return_data.clone()).into_instance(env)?,
+        })
+    }
+
+    #[napi]
+    pub fn instruction_within_function_to_unmapped_solc_0_6_3_revert_error_stack_trace_entry(
+        trace: Either<CallMessageTrace, CreateMessageTrace>,
+        inst: &Instruction,
+        env: Env,
+    ) -> napi::Result<UnmappedSolc063RevertErrorStackTraceEntry> {
+        Self::instruction_within_function_to_unmapped_solc_0_6_3_revert_error_stack_trace_entry_inner(
+        trace.as_ref(),
+        inst,
+        env
+      )
+    }
+
+    pub fn instruction_within_function_to_unmapped_solc_0_6_3_revert_error_stack_trace_entry_inner(
+        trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+        inst: &Instruction,
+        env: Env,
+    ) -> napi::Result<UnmappedSolc063RevertErrorStackTraceEntry> {
+        let bytecode = match &trace {
+            Either::A(create) => &create.bytecode,
+            Either::B(call) => &call.bytecode,
+        }
+        .as_ref()
+        .expect("JS code asserts");
+
+        let inst_location = inst.location.as_ref().map(|i| i.borrow(env)).transpose()?;
+        let inst_location = inst_location.as_deref();
+
+        let source_reference = source_location_to_source_reference(bytecode, inst_location, env)?;
+
+        Ok(UnmappedSolc063RevertErrorStackTraceEntry {
+            type_: StackTraceEntryTypeConst,
+            source_reference,
+        })
+    }
+
+    #[napi]
+    pub fn instruction_within_function_to_panic_stack_trace_entry(
+        trace: Either<CallMessageTrace, CreateMessageTrace>,
+        inst: &Instruction,
+        error_code: BigInt,
+        env: Env,
+    ) -> napi::Result<PanicErrorStackTraceEntry> {
+        Self::instruction_within_function_to_panic_stack_trace_entry_inner(
+            trace.as_ref(),
+            inst,
+            error_code,
+            env,
+        )
+    }
+
+    pub fn instruction_within_function_to_panic_stack_trace_entry_inner(
+        trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+        inst: &Instruction,
+        error_code: BigInt,
+        env: Env,
+    ) -> napi::Result<PanicErrorStackTraceEntry> {
+        let last_source_reference = Self::get_last_source_reference_inner(trace, env)?;
+
+        let bytecode = match &trace {
+            Either::A(create) => &create.bytecode,
+            Either::B(call) => &call.bytecode,
+        }
+        .as_ref()
+        .expect("JS code asserts");
+
+        let inst_location = inst.location.as_ref().map(|i| i.borrow(env)).transpose()?;
+        let inst_location = inst_location.as_deref();
+
+        let source_reference = source_location_to_source_reference(bytecode, inst_location, env)?;
+
+        let source_reference = source_reference.or(last_source_reference.into_option());
+
+        Ok(PanicErrorStackTraceEntry {
+            type_: StackTraceEntryTypeConst,
+            source_reference,
+            error_code,
+        })
+    }
+
+    #[napi(catch_unwind)]
+    pub fn instruction_within_function_to_custom_error_stack_trace_entry(
+        trace: Either<CallMessageTrace, CreateMessageTrace>,
+        inst: &Instruction,
+        message: String,
+        env: Env,
+    ) -> napi::Result<CustomErrorStackTraceEntry> {
+        Self::instruction_within_function_to_custom_error_stack_trace_entry_inner(
+            trace.as_ref(),
+            inst,
+            message,
+            env,
+        )
+    }
+
+    pub fn instruction_within_function_to_custom_error_stack_trace_entry_inner(
+        trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+        inst: &Instruction,
+        message: String,
+        env: Env,
+    ) -> napi::Result<CustomErrorStackTraceEntry> {
+        let last_source_reference = Self::get_last_source_reference_inner(trace, env)?;
+        let last_source_reference = match last_source_reference {
+            Either::A(source_reference) => source_reference,
+            Either::B(_) => panic!("Expected source reference to be defined"),
+        };
+
+        let bytecode = match &trace {
+            Either::A(create) => &create.bytecode,
+            Either::B(call) => &call.bytecode,
+        }
+        .as_ref()
+        .expect("JS code asserts");
+
+        let inst_location = inst.location.as_ref().map(|i| i.borrow(env)).transpose()?;
+        let inst_location = inst_location.as_deref();
+
+        let source_reference = source_location_to_source_reference(bytecode, inst_location, env)?;
+
+        let source_reference = source_reference.unwrap_or(last_source_reference);
+
+        Ok(CustomErrorStackTraceEntry {
+            type_: StackTraceEntryTypeConst,
+            source_reference,
+            message,
+        })
+    }
+
+    #[napi]
+    pub fn solidity_0_6_3_maybe_unmapped_revert(
+        trace: Either<CallMessageTrace, CreateMessageTrace>,
+        env: Env,
+    ) -> napi::Result<bool> {
+        Self::solidity_0_6_3_maybe_unmapped_revert_inner(trace.as_ref(), env)
+    }
+
+    pub fn solidity_0_6_3_maybe_unmapped_revert_inner(
+        trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+        env: Env,
+    ) -> napi::Result<bool> {
+        let (bytecode, steps) = match &trace {
+            Either::A(create) => (&create.bytecode, &create.steps),
+            Either::B(call) => (&call.bytecode, &call.steps),
+        };
+
+        let bytecode = bytecode
+            .as_ref()
+            .expect("JS code only accepted variants that had bytecode defined");
+
+        if steps.is_empty() {
+            return Ok(false);
+        }
+
+        let last_step = steps.last();
+        let last_step = match last_step {
+            Some(Either4::A(step)) => step,
+            _ => return Ok(false),
+        };
+
+        let last_instruction = bytecode.get_instruction_inner(last_step.pc)?;
+
+        let Ok(version) = Version::parse(&bytecode.compiler_version) else {
+            return Ok(false);
+        };
+        let req = VersionReq::parse(&format!("^{FIRST_SOLC_VERSION_WITH_UNMAPPED_REVERTS}"))
+            .expect("valid semver");
+
+        Ok(req.matches(&version) && last_instruction.borrow(env)?.opcode == Opcode::REVERT)
+    }
+
+    // Solidity 0.6.3 unmapped reverts special handling
+    // For more info: https://github.com/ethereum/solidity/issues/9006
+    #[napi]
+    pub fn solidity_0_6_3_get_frame_for_unmapped_revert_before_function(
+        trace: CallMessageTrace,
+        env: Env,
+    ) -> napi::Result<Either<UnmappedSolc063RevertErrorStackTraceEntry, Undefined>> {
+        Self::solidity_0_6_3_get_frame_for_unmapped_revert_before_function_inner(&trace, env)
+    }
+
+    // Solidity 0.6.3 unmapped reverts special handling
+    // For more info: https://github.com/ethereum/solidity/issues/9006
+    pub fn solidity_0_6_3_get_frame_for_unmapped_revert_before_function_inner(
+        trace: &CallMessageTrace,
+        env: Env,
+    ) -> napi::Result<Either<UnmappedSolc063RevertErrorStackTraceEntry, Undefined>> {
+        let bytecode = trace.bytecode.as_ref().expect("JS code asserts");
+        let contract = bytecode.contract.borrow(env)?;
+
+        let revert_frame =
+            Self::solidity_0_6_3_get_frame_for_unmapped_revert_within_function_inner(
+                Either::A(trace),
+                env,
+            )?;
+
+        let revert_frame = match revert_frame.into_option() {
+            None
+            | Some(UnmappedSolc063RevertErrorStackTraceEntry {
+                source_reference: None,
+                ..
+            }) => {
+                if contract.receive.is_none() || trace.calldata.len() > 0 {
+                    // Failed within the fallback
+                    if let Some(fallback) = &contract.fallback {
+                        let fallback = fallback.borrow(env)?;
+                        let location = fallback.location.borrow(env)?;
+                        let file = location.file.borrow(env)?;
+
+                        let revert_frame = UnmappedSolc063RevertErrorStackTraceEntry {
+                            type_: StackTraceEntryTypeConst,
+                            source_reference: Some(SourceReference {
+                                contract: Some(contract.name.clone()),
+                                function: Some(FALLBACK_FUNCTION_NAME.to_string()),
+                                source_name: file.source_name.clone(),
+                                source_content: file.content.clone(),
+                                line: location.get_starting_line_number(env).unwrap(),
+                                range: [location.offset, location.offset + location.length]
+                                    .to_vec(),
+                            }),
+                        };
+
+                        Some(Self::solidity_0_6_3_correct_line_number(revert_frame))
+                    } else {
+                        None
+                    }
+                } else {
+                    let receive = contract
+                        .receive
+                        .as_ref()
+                        .expect("None always hits branch above");
+
+                    let receive = receive.borrow(env)?;
+                    let location = receive.location.borrow(env)?;
+                    let file = location.file.borrow(env)?;
+
+                    let revert_frame = UnmappedSolc063RevertErrorStackTraceEntry {
+                        type_: StackTraceEntryTypeConst,
+                        source_reference: Some(SourceReference {
+                            contract: Some(contract.name.clone()),
+                            function: Some(RECEIVE_FUNCTION_NAME.to_string()),
+                            source_name: file.source_name.clone(),
+                            source_content: file.content.clone(),
+                            line: location.get_starting_line_number(env).unwrap(),
+                            range: [location.offset, location.offset + location.length].to_vec(),
+                        }),
+                    };
+
+                    Some(Self::solidity_0_6_3_correct_line_number(revert_frame))
+                }
+            }
+            Some(revert_frame) => Some(revert_frame),
+        };
+
+        Ok(revert_frame.into_either())
+    }
+
+    #[napi]
+    pub fn solidity_0_6_3_get_frame_for_unmapped_revert_within_function(
+        trace: Either<CallMessageTrace, CreateMessageTrace>,
+        env: Env,
+    ) -> napi::Result<Either<UnmappedSolc063RevertErrorStackTraceEntry, Undefined>> {
+        Self::solidity_0_6_3_get_frame_for_unmapped_revert_within_function_inner(
+            trace.as_ref(),
+            env,
+        )
+    }
+
+    pub fn solidity_0_6_3_get_frame_for_unmapped_revert_within_function_inner(
+        trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+        env: Env,
+    ) -> napi::Result<Either<UnmappedSolc063RevertErrorStackTraceEntry, Undefined>> {
+        let (bytecode, steps) = match &trace {
+            Either::A(create) => (&create.bytecode, &create.steps),
+            Either::B(call) => (&call.bytecode, &call.steps),
+        };
+
+        let bytecode = bytecode
+            .as_ref()
+            .expect("JS code only accepted variants that had bytecode defined");
+
+        let contract = bytecode.contract.borrow(env)?;
+
+        // If we are within a function there's a last valid location. It may
+        // be the entire contract.
+        let prev_inst = Self::get_last_instruction_with_valid_location(trace, env)?;
+        let prev_inst = prev_inst.into_option().map(|x| x.borrow(env)).transpose()?;
+        let last_step = match steps.last() {
+            Some(Either4::A(step)) => step,
+            _ => panic!("JS code asserts this is always an EvmStep"),
+        };
+        let next_inst_pc = last_step.pc + 1;
+        let has_next_inst = bytecode.has_instruction(next_inst_pc);
+
+        if has_next_inst {
+            let next_inst = bytecode.get_instruction_inner(next_inst_pc)?;
+            let next_inst = next_inst.borrow(env)?;
+
+            let prev_loc = prev_inst
+                .as_ref()
+                .and_then(|x| x.location.as_ref())
+                .map(|l| l.borrow(env))
+                .transpose()?;
+            let next_loc = next_inst
+                .location
+                .as_ref()
+                .map(|l| l.borrow(env))
+                .transpose()?;
+
+            let prev_func = prev_loc
+                .as_ref()
+                .map(|l| l.get_containing_function_inner(env))
+                .transpose()?
+                .and_then(IntoOption::into_option);
+
+            let next_func = next_loc
+                .as_ref()
+                .map(|l| l.get_containing_function_inner(env))
+                .transpose()?
+                .and_then(IntoOption::into_option);
+
+            // This is probably a require. This means that we have the exact
+            // line, but the stack trace may be degraded (e.g. missing our
+            // synthetic call frames when failing in a modifier) so we still
+            // add this frame as UNMAPPED_SOLC_0_6_3_REVERT_ERROR
+            match (&prev_func, &next_loc, &prev_loc) {
+                (Some(_), Some(next_loc), Some(prev_loc)) if prev_loc.equals(next_loc, env) => {
+                    return Ok(Either::A(Self::instruction_within_function_to_unmapped_solc_0_6_3_revert_error_stack_trace_entry_inner(
+                trace,
+                &next_inst,
+                env,
+              )?));
+                }
+                _ => {}
+            }
+
+            let mut revert_frame: Either<UnmappedSolc063RevertErrorStackTraceEntry, Undefined> =
+                Either::B(());
+
+            if prev_func.is_some() && prev_inst.is_some() {
+                revert_frame = Either::A(Self::instruction_within_function_to_unmapped_solc_0_6_3_revert_error_stack_trace_entry_inner(
+                trace,
+                prev_inst.as_ref().unwrap(),
+                env,
+              )?);
+            } else if next_func.is_some() {
+                revert_frame = Either::A(Self::instruction_within_function_to_unmapped_solc_0_6_3_revert_error_stack_trace_entry_inner(
+                trace,
+                &next_inst,
+                env,
+              )?);
+            }
+
+            return Ok(revert_frame
+                .into_option()
+                .map(Self::solidity_0_6_3_correct_line_number)
+                .into_either());
+        }
+
+        if matches!(trace, Either::B(CreateMessageTrace { .. })) && prev_inst.is_some() {
+            // Solidity is smart enough to stop emitting extra instructions after
+            // an unconditional revert happens in a constructor. If this is the case
+            // we just return a special error.
+
+            let mut constructor_revert_frame = Self::instruction_within_function_to_unmapped_solc_0_6_3_revert_error_stack_trace_entry_inner(
+                trace,
+                prev_inst.as_ref().unwrap(),
+                env,
+            )?;
+
+            // When the latest instruction is not within a function we need
+            // some default sourceReference to show to the user
+            if constructor_revert_frame.source_reference.is_none() {
+                let location = contract.location.borrow(env)?;
+                let file = location.file.borrow(env)?;
+
+                let mut default_source_reference = SourceReference {
+                    function: Some(CONSTRUCTOR_FUNCTION_NAME.to_string()),
+                    contract: Some(contract.name.clone()),
+                    source_name: file.source_name.clone(),
+                    source_content: file.content.clone(),
+                    line: location.get_starting_line_number(env)?,
+                    range: [location.offset, location.offset + location.length].to_vec(),
+                };
+
+                if let Some(constructor) = &contract.constructor {
+                    default_source_reference.line = constructor
+                        .borrow(env)?
+                        .location
+                        .borrow(env)?
+                        .get_starting_line_number(env)?;
+                }
+
+                constructor_revert_frame.source_reference = Some(default_source_reference);
+            } else {
+                constructor_revert_frame =
+                    Self::solidity_0_6_3_correct_line_number(constructor_revert_frame);
+            }
+
+            return Ok(Either::A(constructor_revert_frame));
+        }
+
+        if prev_inst.is_some() {
+            // We may as well just be in a function or modifier and just happen
+            // to be at the last instruction of the runtime bytecode.
+            // In this case we just return whatever the last mapped intruction
+            // points to.
+            let mut latest_instruction_revert_frame = Self::instruction_within_function_to_unmapped_solc_0_6_3_revert_error_stack_trace_entry_inner(
+                trace,
+                prev_inst.as_ref().unwrap(),
+                env,
+            )?;
+
+            if latest_instruction_revert_frame.source_reference.is_some() {
+                latest_instruction_revert_frame =
+                    Self::solidity_0_6_3_correct_line_number(latest_instruction_revert_frame);
+            }
+            return Ok(Either::A(latest_instruction_revert_frame));
+        }
+
+        Ok(Either::B(()))
+    }
+
+    #[napi]
+    pub fn solidity_0_6_3_correct_line_number(
+        mut revert_frame: UnmappedSolc063RevertErrorStackTraceEntry,
+    ) -> UnmappedSolc063RevertErrorStackTraceEntry {
+        let Some(source_reference) = &mut revert_frame.source_reference else {
+            return revert_frame;
+        };
+
+        let lines: Vec<_> = source_reference.source_content.split('\n').collect();
+
+        let current_line = lines[source_reference.line as usize - 1];
+        if current_line.contains("require") || current_line.contains("revert") {
+            return revert_frame;
+        }
+
+        let next_lines = &lines
+            .get(source_reference.line as usize..)
+            .unwrap_or_default();
+        let first_non_empty_line = next_lines.iter().position(|l| !l.trim().is_empty());
+
+        let Some(first_non_empty_line) = first_non_empty_line else {
+            return revert_frame;
+        };
+
+        let next_line = next_lines[first_non_empty_line];
+        if next_line.contains("require") || next_line.contains("revert") {
+            source_reference.line += 1 + first_non_empty_line as u32;
+        }
+
+        revert_frame
+    }
+
+    #[napi]
+    pub fn get_other_error_before_called_function_stack_trace_entry(
+        trace: CallMessageTrace,
+        env: Env,
+    ) -> napi::Result<OtherExecutionErrorStackTraceEntry> {
+        Self::get_other_error_before_called_function_stack_trace_entry_inner(&trace, env)
+    }
+
+    pub fn get_other_error_before_called_function_stack_trace_entry_inner(
+        trace: &CallMessageTrace,
+        env: Env,
+    ) -> napi::Result<OtherExecutionErrorStackTraceEntry> {
+        let source_reference = Self::get_contract_start_without_function_source_reference_inner(
+            Either::A(trace),
+            env,
+        )?;
+
+        Ok(OtherExecutionErrorStackTraceEntry {
+            type_: StackTraceEntryTypeConst,
+            source_reference: Some(source_reference),
+        })
+    }
+
+    fn is_called_non_contract_account_error(
+        trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+        env: Env,
+    ) -> napi::Result<bool> {
+        // We could change this to checking that the last valid location maps to a call, but
+        // it's way more complex as we need to get the ast node from that location.
+
+        let (bytecode, steps) = match &trace {
+            Either::A(create) => (&create.bytecode, &create.steps),
+            Either::B(call) => (&call.bytecode, &call.steps),
+        };
+
+        let bytecode = bytecode
+            .as_ref()
+            .expect("JS code only accepted variants that had bytecode defined");
+
+        let last_index = Self::get_last_instruction_with_valid_location_step_index(trace, env)?;
+
+        let last_index = match last_index.into_option() {
+            None | Some(0) => return Ok(false),
+            Some(last_index) => last_index as usize,
+        };
+
+        let last_step = match &steps[last_index] {
+            Either4::A(step) => step,
+            _ => panic!("We know this is an EVM step"),
+        };
+
+        let last_inst = bytecode.get_instruction_inner(last_step.pc)?;
+        let last_inst = last_inst.borrow(env)?;
+
+        if last_inst.opcode != Opcode::ISZERO {
+            return Ok(false);
+        }
+
+        let prev_step = match &steps[last_index - 1] {
+            Either4::A(step) => step,
+            _ => panic!("We know this is an EVM step"),
+        };
+
+        let prev_inst = bytecode.get_instruction_inner(prev_step.pc)?;
+        let prev_inst = prev_inst.borrow(env)?;
+
+        Ok(prev_inst.opcode == Opcode::EXTCODESIZE)
+    }
+
+    fn get_last_instruction_with_valid_location_step_index(
+        trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+        env: Env,
+    ) -> napi::Result<Either<u32, Undefined>> {
+        let (bytecode, steps) = match &trace {
+            Either::A(create) => (&create.bytecode, &create.steps),
+            Either::B(call) => (&call.bytecode, &call.steps),
+        };
+
+        let bytecode = bytecode
+            .as_ref()
+            .expect("JS code only accepted variants that had bytecode defined");
+
+        for (i, step) in steps.iter().enumerate().rev() {
+            let step = match step {
+                Either4::A(step) => step,
+                _ => return Ok(Either::B(())),
+            };
+
+            let inst = bytecode.get_instruction_inner(step.pc)?;
+
+            let inst = inst.borrow(env)?;
+            if inst.location.is_some() {
+                return Ok(Either::A(i as u32));
+            }
+        }
+
+        Ok(Either::B(()))
+    }
+
+    pub fn get_last_instruction_with_valid_location<'a>(
+        trace: Either<&'a CallMessageTrace, &'a CreateMessageTrace>,
+        env: Env,
+    ) -> napi::Result<Either<&'a ClassInstanceRef<Instruction>, Undefined>> {
+        let last_location_index =
+            Self::get_last_instruction_with_valid_location_step_index(trace, env)?;
+
+        let last_location_index = match last_location_index {
+            Either::A(last_location_index) => last_location_index,
+            Either::B(_) => return Ok(Either::B(())),
+        };
+
+        let (bytecode, steps) = match &trace {
+            Either::A(create) => (&create.bytecode, &create.steps),
+            Either::B(call) => (&call.bytecode, &call.steps),
+        };
+
+        let bytecode = bytecode
+            .as_ref()
+            .expect("JS code only accepted variants that had bytecode defined");
+
+        match &steps.get(last_location_index as usize) {
+            Some(Either4::A(step)) => {
+                let inst = bytecode.get_instruction_inner(step.pc)?;
+
+                Ok(Either::A(inst))
+            }
+            _ => Ok(Either::B(())),
+        }
+    }
+
+    #[napi]
+    pub fn is_panic_return_data(return_data: Uint8Array) -> bool {
+        ReturnData::new(return_data).is_panic_return_data()
+    }
 }
 
-#[napi]
-pub fn source_location_to_source_reference(
+fn source_location_to_source_reference(
     bytecode: &Bytecode,
-    location: Either<&SourceLocation, Undefined>,
+    location: Option<&SourceLocation>,
     env: Env,
-) -> napi::Result<Either<SourceReference, Undefined>> {
-    let Either::A(location) = location else {
-        return Ok(Either::B(()));
+) -> napi::Result<Option<SourceReference>> {
+    let Some(location) = location else {
+        return Ok(None);
     };
 
     let func = location.get_containing_function_inner(env)?;
 
     let Either::A(func) = func else {
-        return Ok(Either::B(()));
+        return Ok(None);
     };
 
-    let mut func = func.borrow_mut(env)?;
+    let func = func.borrow(env)?;
 
-    if func.r#type == ContractFunctionType::CONSTRUCTOR {
-        func.name = CONSTRUCTOR_FUNCTION_NAME.to_string();
-    } else if func.r#type == ContractFunctionType::FALLBACK {
-        func.name = FALLBACK_FUNCTION_NAME.to_string();
-    } else if func.r#type == ContractFunctionType::RECEIVE {
-        func.name = RECEIVE_FUNCTION_NAME.to_string();
-    }
+    let func_name = match func.r#type {
+        ContractFunctionType::CONSTRUCTOR => CONSTRUCTOR_FUNCTION_NAME.to_string(),
+        ContractFunctionType::FALLBACK => FALLBACK_FUNCTION_NAME.to_string(),
+        ContractFunctionType::RECEIVE => RECEIVE_FUNCTION_NAME.to_string(),
+        _ => func.name.clone(),
+    };
 
     let func_location = func.location.borrow(env)?;
     let func_location_file = func_location.file.borrow(env)?;
 
-    Ok(Either::A(SourceReference {
-        function: Some(func.name.clone()),
+    Ok(Some(SourceReference {
+        function: Some(func_name.clone()),
         contract: if func.r#type == ContractFunctionType::FREE_FUNCTION {
             None
         } else {
@@ -149,4 +3308,105 @@ pub fn source_location_to_source_reference(
         line: location.get_starting_line_number(env)?,
         range: [location.offset, location.offset + location.length].to_vec(),
     }))
+}
+
+#[napi(catch_unwind)]
+pub fn instruction_to_callstack_stack_trace_entry(
+    bytecode: &Bytecode,
+    inst: &Instruction,
+    env: Env,
+) -> napi::Result<Either<CallstackEntryStackTraceEntry, InternalFunctionCallStackEntry>> {
+    let contract = bytecode.contract.borrow(env)?;
+
+    // This means that a jump is made from within an internal solc function.
+    // These are normally made from yul code, so they don't map to any Solidity
+    // function
+    let inst_location = match &inst.location {
+        None => {
+            let location = contract.location.borrow(env)?;
+            let file = location.file.borrow(env)?;
+
+            return Ok(Either::B(InternalFunctionCallStackEntry {
+                type_: StackTraceEntryTypeConst,
+                pc: inst.pc,
+                source_reference: SourceReference {
+                    source_name: file.source_name.clone(),
+                    source_content: file.content.clone(),
+                    contract: Some(contract.name.clone()),
+                    function: None,
+                    line: location.get_starting_line_number(env)?,
+                    range: [location.offset, location.offset + location.length].to_vec(),
+                },
+            }));
+        }
+        Some(inst_location) => inst_location.borrow(env)?,
+    };
+
+    let func = inst_location.get_containing_function_inner(env)?;
+
+    if let Some(func) = func.into_option() {
+        let func = func.borrow(env)?;
+
+        let source_reference =
+            source_location_to_source_reference(bytecode, Some(&*inst_location), env)?
+                .expect("Expected source reference to be defined");
+
+        return Ok(Either::A(CallstackEntryStackTraceEntry {
+            type_: StackTraceEntryTypeConst,
+            source_reference,
+            function_type: func.r#type,
+        }));
+    };
+
+    let file = inst_location.file.borrow(env)?;
+
+    Ok(Either::A(CallstackEntryStackTraceEntry {
+        type_: StackTraceEntryTypeConst,
+        source_reference: SourceReference {
+            function: None,
+            contract: Some(contract.name.clone()),
+            source_name: file.source_name.clone(),
+            source_content: file.content.clone(),
+            line: inst_location.get_starting_line_number(env)?,
+            range: [
+                inst_location.offset,
+                inst_location.offset + inst_location.length,
+            ]
+            .to_vec(),
+        },
+        function_type: ContractFunctionType::FUNCTION,
+    }))
+}
+
+pub fn format_dyn_sol_value(val: &DynSolValue) -> String {
+    match val {
+        // print nested values as [value1, value2, ...]
+        DynSolValue::Array(items)
+        | DynSolValue::Tuple(items)
+        | DynSolValue::FixedArray(items)
+        | DynSolValue::CustomStruct { tuple: items, .. } => {
+            let mut result = String::from("[");
+            for (i, val) in items.iter().enumerate() {
+                if i > 0 {
+                    result.push_str(", ");
+                }
+                result.push_str(&format_dyn_sol_value(val));
+            }
+
+            result.push(']');
+            result
+        }
+        // surround string values with quotes
+        DynSolValue::String(s) => format!("\"{s}\""),
+
+        DynSolValue::Address(address) => format!("\"0x{address}\""),
+        DynSolValue::Bytes(bytes) => format!("\"0x{}\"", hex::encode(bytes)),
+        DynSolValue::FixedBytes(word, size) => {
+            format!("\"0x{}\"", hex::encode(&word.0.as_slice()[..*size]))
+        }
+        DynSolValue::Bool(b) => b.to_string(),
+        DynSolValue::Function(_) => "<function>".to_string(),
+        DynSolValue::Int(int, _bits) => int.to_string(),
+        DynSolValue::Uint(uint, _bits) => uint.to_string(),
+    }
 }

--- a/crates/edr_napi/src/trace/error_inferrer.rs
+++ b/crates/edr_napi/src/trace/error_inferrer.rs
@@ -73,32 +73,6 @@ pub enum Heuristic {
     Miss(SolidityStackTrace),
 }
 
-trait IntoEither<T> {
-    fn into_either(self) -> Either<T, Undefined>;
-}
-
-impl<T> IntoEither<T> for Option<T> {
-    fn into_either(self) -> Either<T, Undefined> {
-        match self {
-            Some(a) => Either::A(a),
-            None => Either::B(()),
-        }
-    }
-}
-
-trait IntoOption<T> {
-    fn into_option(self) -> Option<T>;
-}
-
-impl<T> IntoOption<T> for Either<T, Undefined> {
-    fn into_option(self) -> Option<T> {
-        match self {
-            Either::A(a) => Some(a),
-            Either::B(_) => None,
-        }
-    }
-}
-
 const FIRST_SOLC_VERSION_CREATE_PARAMS_VALIDATION: Version = Version::new(0, 5, 9);
 const FIRST_SOLC_VERSION_RECEIVE_FUNCTION: Version = Version::new(0, 6, 0);
 const FIRST_SOLC_VERSION_WITH_UNMAPPED_REVERTS: &str = "0.6.3";

--- a/crates/edr_napi/src/trace/error_inferrer.rs
+++ b/crates/edr_napi/src/trace/error_inferrer.rs
@@ -238,7 +238,7 @@ impl ErrorInferrer {
         stacktrace: SolidityStackTrace,
     ) -> napi::Result<SolidityStackTrace> {
         // To work around the borrow checker, we'll collect the indices of the frames we
-        // want to keep We can't clone the frames, because some of them contain
+        // want to keep. We can't clone the frames, because some of them contain
         // non-Clone `ClassInstance`s`
         let retained_indices: HashSet<_> = stacktrace
             .iter()

--- a/crates/edr_napi/src/trace/error_inferrer.rs
+++ b/crates/edr_napi/src/trace/error_inferrer.rs
@@ -482,7 +482,6 @@ impl ErrorInferrer {
                 break;
             }
         }
-        drop(contract);
 
         let mut stacktrace = stacktrace;
         stacktrace.push(
@@ -882,7 +881,7 @@ impl ErrorInferrer {
         if let Some(called_function) = called_function {
             let called_function = called_function.borrow(env)?;
 
-            let abi = called_function.to_alloy().map_err(|e| {
+            let abi = alloy_json_abi::Function::try_from(&*called_function).map_err(|e| {
                 napi::Error::from_reason(format!("Error converting to alloy ABI: {e}"))
             })?;
 

--- a/crates/edr_napi/src/trace/error_inferrer.rs
+++ b/crates/edr_napi/src/trace/error_inferrer.rs
@@ -1,0 +1,152 @@
+use std::collections::HashSet;
+
+use napi::{
+    bindgen_prelude::{Either24, Undefined},
+    Either, Env,
+};
+use napi_derive::napi;
+
+use crate::trace::{
+    model::ContractFunctionType,
+    solidity_stack_trace::{
+        ReturndataSizeErrorStackTraceEntry, CONSTRUCTOR_FUNCTION_NAME, FALLBACK_FUNCTION_NAME,
+        RECEIVE_FUNCTION_NAME,
+    },
+};
+
+use super::{
+    model::{Bytecode, SourceLocation},
+    solidity_stack_trace::{
+        CallstackEntryStackTraceEntry, SolidityStackTrace, SolidityStackTraceEntryExt,
+        SourceReference,
+    },
+};
+
+#[napi]
+pub struct ErrorInferrer;
+
+#[napi]
+impl ErrorInferrer {
+    #[napi]
+    pub fn filter_redundant_frames(
+        stacktrace: SolidityStackTrace,
+    ) -> napi::Result<SolidityStackTrace> {
+        // To work around the borrow checker, we'll collect the indices of the frames we want to keep
+        // We can't clone the frames, because some of them contain non-Clone `ClassInstance`s`
+        let retained_indices: HashSet<_> = stacktrace
+            .iter()
+            .enumerate()
+            .filter(|(idx, frame)| {
+                let next_frame = stacktrace.get(idx + 1);
+                let next_next_frame = stacktrace.get(idx + 2);
+
+                let Some(next_frame) = next_frame else {
+                    return true;
+                };
+
+                // we can only filter frames if we know their sourceReference
+                // and the one from the next frame
+                let (Some(frame_source), Some(next_frame_source)) =
+                    (frame.source_reference(), next_frame.source_reference())
+                else {
+                    return true;
+                };
+
+                // look TWO frames ahead to determine if this is a specific occurrence of
+                // a redundant CALLSTACK_ENTRY frame observed when using Solidity 0.8.5:
+                match (&frame, next_next_frame) {
+                    (
+                        Either24::A(CallstackEntryStackTraceEntry {
+                            source_reference, ..
+                        }),
+                        Some(Either24::N(ReturndataSizeErrorStackTraceEntry {
+                            // TODO: JS also checked that it's not undefined but it seems it never is?
+                            // looking at the types
+                            source_reference: next_next_source_reference,
+                            ..
+                        })),
+                    ) if source_reference.range == next_next_source_reference.range
+                        && source_reference.line == next_next_source_reference.line =>
+                    {
+                        return false;
+                    }
+                    _ => {}
+                }
+
+                if frame_source.function.as_deref() == Some("constructor")
+                    && next_frame_source.function.as_deref() != Some("constructor")
+                {
+                    return true;
+                }
+
+                // this is probably a recursive call
+                if *idx > 0
+                    && frame.type_() == next_frame.type_()
+                    && frame_source.range == next_frame_source.range
+                    && frame_source.line == next_frame_source.line
+                {
+                    return true;
+                }
+
+                if frame_source.range[0] <= next_frame_source.range[0]
+                    && frame_source.range[1] >= next_frame_source.range[1]
+                {
+                    return false;
+                }
+
+                true
+            })
+            .map(|(idx, _)| idx)
+            .collect();
+
+        Ok(stacktrace
+            .into_iter()
+            .enumerate()
+            .filter(|(idx, _)| retained_indices.contains(idx))
+            .map(|(_, frame)| frame)
+            .collect())
+    }
+}
+
+#[napi]
+pub fn source_location_to_source_reference(
+    bytecode: &Bytecode,
+    location: Either<&SourceLocation, Undefined>,
+    env: Env,
+) -> napi::Result<Either<SourceReference, Undefined>> {
+    let Either::A(location) = location else {
+        return Ok(Either::B(()));
+    };
+
+    let func = location.get_containing_function_inner(env)?;
+
+    let Either::A(func) = func else {
+        return Ok(Either::B(()));
+    };
+
+    let mut func = func.borrow_mut(env)?;
+
+    if func.r#type == ContractFunctionType::CONSTRUCTOR {
+        func.name = CONSTRUCTOR_FUNCTION_NAME.to_string();
+    } else if func.r#type == ContractFunctionType::FALLBACK {
+        func.name = FALLBACK_FUNCTION_NAME.to_string();
+    } else if func.r#type == ContractFunctionType::RECEIVE {
+        func.name = RECEIVE_FUNCTION_NAME.to_string();
+    }
+
+    let func_location = func.location.borrow(env)?;
+    let func_location_file = func_location.file.borrow(env)?;
+
+    Ok(Either::A(SourceReference {
+        function: Some(func.name.clone()),
+        contract: if func.r#type == ContractFunctionType::FREE_FUNCTION {
+            None
+        } else {
+            Some(bytecode.contract.borrow(env)?.name.clone())
+        },
+        source_name: func_location_file.source_name.clone(),
+        source_content: func_location_file.content.clone(),
+        line: location.get_starting_line_number(env)?,
+        range: [location.offset, location.offset + location.length].to_vec(),
+    }))
+}

--- a/crates/edr_napi/src/trace/error_inferrer.rs
+++ b/crates/edr_napi/src/trace/error_inferrer.rs
@@ -1153,7 +1153,6 @@ impl ErrorInferrer {
 
                     inferred_stacktrace.push(frame.into());
                 } else {
-                    let message = ReturnData::new(return_data.clone()).into_instance(env)?;
                     let is_invalid_opcode_error = last_instruction.opcode == Opcode::INVALID;
 
                     match &trace {
@@ -1181,7 +1180,7 @@ impl ErrorInferrer {
                                     &function,
                                     env,
                                 )?,
-                                message,
+                                return_data: return_data.clone(),
                                 is_invalid_opcode_error,
                             };
 
@@ -1193,7 +1192,7 @@ impl ErrorInferrer {
                                 type_: StackTraceEntryTypeConst,
                                 source_reference:
                                     Self::get_constructor_start_source_reference_inner(trace, env)?,
-                                message,
+                                return_data: return_data.clone(),
                                 is_invalid_opcode_error,
                             };
 
@@ -1216,7 +1215,7 @@ impl ErrorInferrer {
                     trace.as_ref(),
                     env,
                 )?,
-                message: ReturnData::new(return_data.clone()).into_instance(env)?,
+                return_data: return_data.clone(),
                 is_invalid_opcode_error: last_instruction.opcode == Opcode::INVALID,
             };
 
@@ -1318,7 +1317,6 @@ impl ErrorInferrer {
 
                     inferred_stacktrace.push(frame.into());
                 } else {
-                    let message = ReturnData::new(return_data.clone()).into_instance(env)?;
                     let is_invalid_opcode_error = last_instruction.opcode == Opcode::INVALID;
 
                     match &trace {
@@ -1344,7 +1342,7 @@ impl ErrorInferrer {
                                 source_reference: Self::get_function_start_source_reference_inner(
                                     trace, &function, env,
                                 )?,
-                                message,
+                                return_data: return_data.clone(),
                                 is_invalid_opcode_error,
                             };
 
@@ -1356,7 +1354,7 @@ impl ErrorInferrer {
                                 type_: StackTraceEntryTypeConst,
                                 source_reference:
                                     Self::get_constructor_start_source_reference_inner(trace, env)?,
-                                message,
+                                return_data: return_data.clone(),
                                 is_invalid_opcode_error,
                             };
 
@@ -1378,7 +1376,7 @@ impl ErrorInferrer {
                 source_reference: Self::get_contract_start_without_function_source_reference_inner(
                     trace, env,
                 )?,
-                message: ReturnData::new(return_data.clone()).into_instance(env)?,
+                return_data: return_data.clone(),
                 is_invalid_opcode_error: last_instruction.opcode == Opcode::INVALID,
             };
 
@@ -1464,7 +1462,7 @@ impl ErrorInferrer {
                         &failing_function,
                         env,
                     )?,
-                    message: ReturnData::new(trace.return_data.clone()).into_instance(env)?,
+                    return_data: trace.return_data.clone(),
                     is_invalid_opcode_error: last_instruction.opcode == Opcode::INVALID,
                 };
 
@@ -1595,7 +1593,7 @@ impl ErrorInferrer {
                         &failing_function,
                         env,
                     )?,
-                    message: ReturnData::new(trace.return_data.clone()).into_instance(env)?,
+                    return_data: trace.return_data.clone(),
                     is_invalid_opcode_error: last_instruction.opcode == Opcode::INVALID,
                 };
 
@@ -2675,7 +2673,7 @@ impl ErrorInferrer {
             type_: StackTraceEntryTypeConst,
             source_reference,
             is_invalid_opcode_error: inst.opcode == Opcode::INVALID,
-            message: ReturnData::new(return_data.clone()).into_instance(env)?,
+            return_data: return_data.clone(),
         })
     }
 

--- a/crates/edr_napi/src/trace/error_inferrer.rs
+++ b/crates/edr_napi/src/trace/error_inferrer.rs
@@ -41,7 +41,7 @@ use super::{
     },
 };
 
-trait AsEitherRef {
+pub(crate) trait AsEitherRef {
     type Left;
     type Right;
 

--- a/crates/edr_napi/src/trace/exit.rs
+++ b/crates/edr_napi/src/trace/exit.rs
@@ -11,7 +11,7 @@ pub struct Exit(pub(crate) ExitCode);
 
 #[napi]
 /// Represents the exit code of the EVM.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 #[allow(clippy::upper_case_acronyms, non_camel_case_types)] // These are exported and mapped 1:1 to existing JS enum
 pub enum ExitCode {
     /// Execution was successful.

--- a/crates/edr_napi/src/trace/exit.rs
+++ b/crates/edr_napi/src/trace/exit.rs
@@ -11,7 +11,7 @@ pub struct Exit(pub(crate) ExitCode);
 
 #[napi]
 /// Represents the exit code of the EVM.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 #[allow(clippy::upper_case_acronyms, non_camel_case_types)] // These are exported and mapped 1:1 to existing JS enum
 pub enum ExitCode {
     /// Execution was successful.

--- a/crates/edr_napi/src/trace/mapped_inlined_internal_functions_heuristics.rs
+++ b/crates/edr_napi/src/trace/mapped_inlined_internal_functions_heuristics.rs
@@ -1,5 +1,5 @@
-//!  This file includes Solidity tracing heuristics for solc starting with version
-//!  0.6.9.
+//!  This file includes Solidity tracing heuristics for solc starting with
+//! version  0.6.9.
 //!
 //!  This solc version introduced a significant change to how sourcemaps are
 //!  handled for inline yul/internal functions. These were mapped to the
@@ -12,15 +12,14 @@
 //!  run. In fact, this heuristics were first introduced because of unmapped
 //!  reverts.
 //!
-//!  Instead of synthetically completing stack traces when unmapped reverts occur,
-//!  we now start from complete stack traces and adjust them if we can provide
-//!  more meaningful errors.
+//!  Instead of synthetically completing stack traces when unmapped reverts
+//! occur,  we now start from complete stack traces and adjust them if we can
+//! provide  more meaningful errors.
 
 use napi::{
     bindgen_prelude::{Either24, Either4},
     Either, Env,
 };
-
 use semver::Version;
 
 use super::{

--- a/crates/edr_napi/src/trace/mapped_inlined_internal_functions_heuristics.rs
+++ b/crates/edr_napi/src/trace/mapped_inlined_internal_functions_heuristics.rs
@@ -53,7 +53,7 @@ pub fn stack_trace_may_require_adjustments(
 
     if let Either24::E(last_frame @ RevertErrorStackTraceEntry { .. }) = last_frame {
         return Ok(!last_frame.is_invalid_opcode_error
-            && last_frame.message.is_empty()
+            && last_frame.return_data.is_empty()
             && Version::parse(&bytecode.compiler_version)
                 .map(|version| version >= FIRST_SOLC_VERSION_WITH_MAPPED_SMALL_INTERNAL_FUNCTIONS)
                 .unwrap_or(false));

--- a/crates/edr_napi/src/trace/mapped_inlined_internal_functions_heuristics.rs
+++ b/crates/edr_napi/src/trace/mapped_inlined_internal_functions_heuristics.rs
@@ -9,12 +9,12 @@
 //!  This change is a very positive change, as errors would point to the correct
 //!  line by default. The only problem is that we used to rely very heavily on
 //!  unmapped reverts to decide when our error detection heuristics were to be
-//!  run. In fact, this heuristics were first introduced because of unmapped
+//!  run. In fact, these heuristics were first introduced because of unmapped
 //!  reverts.
 //!
 //!  Instead of synthetically completing stack traces when unmapped reverts
-//! occur,  we now start from complete stack traces and adjust them if we can
-//! provide  more meaningful errors.
+//! occur, we now start from complete stack traces and adjust them if we can
+//! provide more meaningful errors.
 
 use napi::{
     bindgen_prelude::{Either24, Either4},

--- a/crates/edr_napi/src/trace/mapped_inlined_internal_functions_heuristics.rs
+++ b/crates/edr_napi/src/trace/mapped_inlined_internal_functions_heuristics.rs
@@ -1,0 +1,196 @@
+//!  This file includes Solidity tracing heuristics for solc starting with version
+//!  0.6.9.
+//!
+//!  This solc version introduced a significant change to how sourcemaps are
+//!  handled for inline yul/internal functions. These were mapped to the
+//!  unmapped/-1 file before, which lead to many unmapped reverts. Now, they are
+//!  mapped to the part of the Solidity source that lead to their inlining.
+//!
+//!  This change is a very positive change, as errors would point to the correct
+//!  line by default. The only problem is that we used to rely very heavily on
+//!  unmapped reverts to decide when our error detection heuristics were to be
+//!  run. In fact, this heuristics were first introduced because of unmapped
+//!  reverts.
+//!
+//!  Instead of synthetically completing stack traces when unmapped reverts occur,
+//!  we now start from complete stack traces and adjust them if we can provide
+//!  more meaningful errors.
+
+use napi::{
+    bindgen_prelude::{Either24, Either4},
+    Either, Env,
+};
+use napi_derive::napi;
+
+use semver::Version;
+
+use super::{
+    error_inferrer::AsEitherRef as _,
+    message_trace::{CallMessageTrace, CreateMessageTrace, EvmStep},
+    opcodes::Opcode,
+    solidity_stack_trace::{
+        InvalidParamsErrorStackTraceEntry, NonContractAccountCalledErrorStackTraceEntry,
+        RevertErrorStackTraceEntry, SolidityStackTrace, StackTraceEntryTypeConst,
+    },
+};
+
+const FIRST_SOLC_VERSION_WITH_MAPPED_SMALL_INTERNAL_FUNCTIONS: Version = Version::new(0, 6, 9);
+
+#[napi]
+pub fn stack_trace_may_require_adjustments(
+    stacktrace: SolidityStackTrace,
+    decoded_trace: Either<CallMessageTrace, CreateMessageTrace>,
+) -> napi::Result<bool> {
+    let bytecode = match &decoded_trace {
+        Either::A(create) => &create.bytecode,
+        Either::B(call) => &call.bytecode,
+    };
+    let bytecode = bytecode.as_ref().expect("JS code asserts");
+
+    let Some(last_frame) = stacktrace.last() else {
+        return Ok(false);
+    };
+
+    if let Either24::E(last_frame @ RevertErrorStackTraceEntry { .. }) = last_frame {
+        return Ok(!last_frame.is_invalid_opcode_error
+            && last_frame.message.is_empty()
+            && Version::parse(&bytecode.compiler_version)
+                .map(|version| version >= FIRST_SOLC_VERSION_WITH_MAPPED_SMALL_INTERNAL_FUNCTIONS)
+                .unwrap_or(false));
+    }
+
+    Ok(false)
+}
+
+#[napi]
+fn adjust_stack_trace(
+    mut stacktrace: SolidityStackTrace,
+    decoded_trace: Either<CallMessageTrace, CreateMessageTrace>,
+    env: Env,
+) -> napi::Result<SolidityStackTrace> {
+    let Some(Either24::E(revert @ RevertErrorStackTraceEntry { .. })) = stacktrace.last() else {
+        unreachable!("JS code asserts that; it's only used immediately after we check with `stack_trace_may_require_adjustments` that the last frame is a revert frame");
+    };
+
+    let decoded_trace = decoded_trace.as_ref();
+
+    // Replace the last revert frame with an adjusted frame if needed
+    if is_non_contract_account_called_error(decoded_trace, env)? {
+        let last_revert_frame_source_reference = revert.source_reference.clone();
+        stacktrace.pop();
+        stacktrace.push(
+            NonContractAccountCalledErrorStackTraceEntry {
+                type_: StackTraceEntryTypeConst,
+                source_reference: last_revert_frame_source_reference,
+            }
+            .into(),
+        );
+        return Ok(stacktrace);
+    }
+
+    if is_constructor_invalid_params_error(decoded_trace, env)? {
+        let last_revert_frame_source_reference = revert.source_reference.clone();
+        stacktrace.pop();
+        stacktrace.push(
+            InvalidParamsErrorStackTraceEntry {
+                type_: StackTraceEntryTypeConst,
+                source_reference: last_revert_frame_source_reference,
+            }
+            .into(),
+        );
+        return Ok(stacktrace);
+    }
+
+    if is_call_invalid_params_error(decoded_trace, env)? {
+        let last_revert_frame_source_reference = revert.source_reference.clone();
+        stacktrace.pop();
+        stacktrace.push(
+            InvalidParamsErrorStackTraceEntry {
+                type_: StackTraceEntryTypeConst,
+                source_reference: last_revert_frame_source_reference,
+            }
+            .into(),
+        );
+
+        return Ok(stacktrace);
+    }
+
+    Ok(stacktrace)
+}
+
+fn is_non_contract_account_called_error(
+    decoded_trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+    env: Env,
+) -> napi::Result<bool> {
+    match_opcodes(
+        decoded_trace,
+        -9,
+        &[
+            Opcode::EXTCODESIZE,
+            Opcode::ISZERO,
+            Opcode::DUP1,
+            Opcode::ISZERO,
+        ],
+        env,
+    )
+}
+
+fn is_constructor_invalid_params_error(
+    decoded_trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+    env: Env,
+) -> napi::Result<bool> {
+    Ok(match_opcodes(decoded_trace, -20, &[Opcode::CODESIZE], env)?
+        && match_opcodes(decoded_trace, -15, &[Opcode::CODECOPY], env)?
+        && match_opcodes(decoded_trace, -7, &[Opcode::LT, Opcode::ISZERO], env)?)
+}
+
+fn is_call_invalid_params_error(
+    decoded_trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+    env: Env,
+) -> napi::Result<bool> {
+    Ok(
+        match_opcodes(decoded_trace, -11, &[Opcode::CALLDATASIZE], env)?
+            && match_opcodes(decoded_trace, -7, &[Opcode::LT, Opcode::ISZERO], env)?,
+    )
+}
+
+fn match_opcodes(
+    decoded_trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+    first_step_index: i32,
+    opcodes: &[Opcode],
+    env: Env,
+) -> napi::Result<bool> {
+    let (bytecode, steps) = match &decoded_trace {
+        Either::A(call) => (&call.bytecode, &call.steps),
+        Either::B(create) => (&create.bytecode, &create.steps),
+    };
+    let bytecode = bytecode.as_ref().expect("JS code asserts");
+
+    // If the index is negative, we start from the end of the trace,
+    // just like in the original JS code
+    let mut index = match first_step_index {
+        0.. => first_step_index as usize,
+        ..=-1 if first_step_index.abs() < steps.len() as i32 => {
+            (steps.len() as i32 + first_step_index) as usize
+        }
+        // Out of bounds
+        _ => return Ok(false),
+    };
+
+    for opcode in opcodes {
+        let Some(Either4::A(EvmStep { pc })) = steps.get(index) else {
+            return Ok(false);
+        };
+
+        let instruction = bytecode.get_instruction_inner(*pc)?;
+        let instruction = instruction.borrow(env)?;
+
+        if instruction.opcode != *opcode {
+            return Ok(false);
+        }
+
+        index += 1;
+    }
+
+    Ok(true)
+}

--- a/crates/edr_napi/src/trace/message_trace.rs
+++ b/crates/edr_napi/src/trace/message_trace.rs
@@ -1,12 +1,12 @@
 //! Bridging type for the existing `MessageTrace` interface in Hardhat.
 
 use napi::{
-    bindgen_prelude::{BigInt, ClassInstance, Either3, Either4, Object, Uint8Array, Undefined},
+    bindgen_prelude::{BigInt, ClassInstance, Either3, Either4, Reference, Uint8Array, Undefined},
     Either, Env,
 };
 use napi_derive::napi;
 
-use super::exit::Exit;
+use super::{exit::Exit, model::Bytecode};
 
 #[napi(object)]
 pub struct EvmStep {
@@ -41,8 +41,7 @@ pub struct CreateMessageTrace {
     // `BaseEvmMessageTrace`
     pub code: Uint8Array,
     pub steps: Vec<Either4<EvmStep, PrecompileMessageTrace, CallMessageTrace, CreateMessageTrace>>,
-    #[napi(ts_type = "Bytecode")]
-    pub bytecode: Option<Object>,
+    pub bytecode: Option<Reference<Bytecode>>,
     pub number_of_subtraces: u32,
     // `CreateMessageTrace`
     // HACK: It seems that `Either<Uint8Array, Undefined>` means exactly what we
@@ -66,8 +65,7 @@ pub struct CallMessageTrace {
     // `BaseEvmMessageTrace`
     pub code: Uint8Array,
     pub steps: Vec<Either4<EvmStep, PrecompileMessageTrace, CallMessageTrace, CreateMessageTrace>>,
-    #[napi(ts_type = "Bytecode")]
-    pub bytecode: Option<Object>,
+    pub bytecode: Option<Reference<Bytecode>>,
     pub number_of_subtraces: u32,
     // `CallMessageTrace`
     pub calldata: Uint8Array,

--- a/crates/edr_napi/src/trace/model.rs
+++ b/crates/edr_napi/src/trace/model.rs
@@ -111,19 +111,20 @@ impl SourceLocation {
     #[napi(ts_return_type = "ContractFunction | undefined")]
     pub fn get_containing_function(&self, env: Env) -> napi::Result<Either<JsObject, Undefined>> {
         match self.get_containing_function_inner(env)? {
-            Either::A(func) => func.as_object(env).map(Either::A),
-            Either::B(()) => Ok(Either::B(())),
+            Some(func) => func.as_object(env).map(Either::A),
+            None => Ok(Either::B(())),
         }
     }
 
     pub fn get_containing_function_inner(
         &self,
         env: Env,
-    ) -> napi::Result<Either<Rc<ClassInstanceRef<ContractFunction>>, Undefined>> {
-        match self.file.borrow(env)?.get_containing_function(self, env)? {
-            Some(func) => Ok(Either::A(func.clone())),
-            None => Ok(Either::B(())),
-        }
+    ) -> napi::Result<Option<Rc<ClassInstanceRef<ContractFunction>>>> {
+        Ok(self
+            .file
+            .borrow(env)?
+            .get_containing_function(self, env)?
+            .cloned())
     }
 
     #[napi]

--- a/crates/edr_napi/src/trace/opcodes.rs
+++ b/crates/edr_napi/src/trace/opcodes.rs
@@ -4,7 +4,7 @@ use napi_derive::napi;
 #[repr(u8)]
 #[allow(non_camel_case_types)] // intentionally mimicks the original case in TS
 #[allow(clippy::upper_case_acronyms)]
-#[derive(PartialEq, PartialOrd, strum::FromRepr, strum::IntoStaticStr)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, strum::FromRepr, strum::IntoStaticStr)]
 pub enum Opcode {
     // Arithmetic operations
     STOP = 0x00,

--- a/crates/edr_napi/src/trace/return_data.rs
+++ b/crates/edr_napi/src/trace/return_data.rs
@@ -36,9 +36,9 @@ impl ReturnData {
         self.value.is_empty()
     }
 
-    #[napi]
-    pub fn matches_selector(&self, selector: Uint8Array) -> bool {
-        self.selector.map_or(false, |value| value == selector[..])
+    pub fn matches_selector(&self, selector: impl AsRef<[u8]>) -> bool {
+        self.selector
+            .map_or(false, |value| value == selector.as_ref())
     }
 
     #[napi]

--- a/crates/edr_napi/src/trace/solidity_stack_trace.rs
+++ b/crates/edr_napi/src/trace/solidity_stack_trace.rs
@@ -10,7 +10,7 @@ use super::model::ContractFunctionType;
 #[repr(u8)]
 #[allow(non_camel_case_types)] // intentionally mimicks the original case in TS
 #[allow(clippy::upper_case_acronyms)]
-#[derive(PartialEq, PartialOrd, strum::FromRepr, strum::IntoStaticStr)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, strum::FromRepr, strum::IntoStaticStr)]
 pub enum StackTraceEntryType {
     CALLSTACK_ENTRY = 0,
     UNRECOGNIZED_CREATE_CALLSTACK_ENTRY,

--- a/crates/edr_napi/src/trace/solidity_stack_trace.rs
+++ b/crates/edr_napi/src/trace/solidity_stack_trace.rs
@@ -65,6 +65,7 @@ pub const PRECOMPILE_FUNCTION_NAME: &str = "<precompile>";
 pub const UNRECOGNIZED_CONTRACT_NAME: &str = "<UnrecognizedContract>";
 
 #[napi(object)]
+#[derive(Clone, PartialEq)]
 pub struct SourceReference {
     pub source_name: String,
     pub source_content: String,
@@ -83,6 +84,7 @@ pub struct SourceReference {
 /// when defining the N-API bindings.
 // NOTE: It's currently not possible to use an enum as const generic parameter,
 // so we use the underlying `u8` repr used by the enum.
+#[derive(Clone, Copy)]
 pub struct StackTraceEntryTypeConst<const ENTRY_TYPE: u8>;
 impl<const ENTRY_TYPE: u8> FromNapiValue for StackTraceEntryTypeConst<ENTRY_TYPE> {
     unsafe fn from_napi_value(
@@ -107,6 +109,16 @@ impl<const ENTRY_TYPE: u8> ToNapiValue for StackTraceEntryTypeConst<ENTRY_TYPE> 
         _val: Self,
     ) -> napi::Result<napi::sys::napi_value> {
         u8::to_napi_value(env, ENTRY_TYPE)
+    }
+}
+
+impl<const ENTRY_TYPE: u8> StackTraceEntryTypeConst<ENTRY_TYPE> {
+    #[allow(clippy::unused_self)] // less verbose than <value as ...>::as_value()
+    const fn as_value(&self) -> StackTraceEntryType {
+        match StackTraceEntryType::from_repr(ENTRY_TYPE) {
+            Some(val) => val,
+            None => panic!("Invalid StackTraceEntryType value"),
+        }
     }
 }
 
@@ -297,6 +309,7 @@ pub struct UnrecognizedCreateErrorStackTraceEntry {
         ts_type = "StackTraceEntryType.UNRECOGNIZED_CREATE_ERROR"
     )]
     pub type_: StackTraceEntryTypeConst<{ StackTraceEntryType::UNRECOGNIZED_CREATE_ERROR as u8 }>,
+    #[napi(ts_type = "ReturnData")]
     pub message: ClassInstance<ReturnData>,
     pub source_reference: Option<Undefined>,
     pub is_invalid_opcode_error: bool,
@@ -398,6 +411,72 @@ pub type SolidityStackTraceEntry = Either24<
 #[allow(dead_code)]
 // Same as above, but for the `SolidityStackTrace` type.
 pub type SolidityStackTrace = Vec<SolidityStackTraceEntry>;
+
+pub trait SolidityStackTraceEntryExt {
+    fn type_(&self) -> StackTraceEntryType;
+    fn source_reference(&self) -> Option<&SourceReference>;
+}
+
+impl SolidityStackTraceEntryExt for SolidityStackTraceEntry {
+    fn type_(&self) -> StackTraceEntryType {
+        match self {
+            Either24::A(entry) => entry.type_.as_value(),
+            Either24::B(entry) => entry.type_.as_value(),
+            Either24::C(entry) => entry.type_.as_value(),
+            Either24::D(entry) => entry.type_.as_value(),
+            Either24::E(entry) => entry.type_.as_value(),
+            Either24::F(entry) => entry.type_.as_value(),
+            Either24::G(entry) => entry.type_.as_value(),
+            Either24::H(entry) => entry.type_.as_value(),
+            Either24::I(entry) => entry.type_.as_value(),
+            Either24::J(entry) => entry.type_.as_value(),
+            Either24::K(entry) => entry.type_.as_value(),
+            Either24::L(entry) => entry.type_.as_value(),
+            Either24::M(entry) => entry.type_.as_value(),
+            Either24::N(entry) => entry.type_.as_value(),
+            Either24::O(entry) => entry.type_.as_value(),
+            Either24::P(entry) => entry.type_.as_value(),
+            Either24::Q(entry) => entry.type_.as_value(),
+            Either24::R(entry) => entry.type_.as_value(),
+            Either24::S(entry) => entry.type_.as_value(),
+            Either24::T(entry) => entry.type_.as_value(),
+            Either24::U(entry) => entry.type_.as_value(),
+            Either24::V(entry) => entry.type_.as_value(),
+            Either24::W(entry) => entry.type_.as_value(),
+            Either24::X(entry) => entry.type_.as_value(),
+        }
+    }
+
+    #[allow(clippy::unnecessary_lazy_evaluations)] // guards against potential variant reordering
+    fn source_reference(&self) -> Option<&SourceReference> {
+        match self {
+            Either24::A(entry) => Some(&entry.source_reference),
+            Either24::B(entry) => entry.source_reference.and_then(|_: ()| None),
+            Either24::C(entry) => entry.source_reference.and_then(|_: ()| None),
+            Either24::D(entry) => entry.source_reference.and_then(|_: ()| None),
+            Either24::E(entry) => Some(&entry.source_reference),
+            Either24::F(entry) => entry.source_reference.as_ref(),
+            Either24::G(entry) => Some(&entry.source_reference),
+            Either24::H(entry) => Some(&entry.source_reference),
+            Either24::I(entry) => Some(&entry.source_reference),
+            Either24::J(entry) => Some(&entry.source_reference),
+            Either24::K(entry) => Some(&entry.source_reference),
+            Either24::L(entry) => Some(&entry.source_reference),
+            Either24::M(entry) => Some(&entry.source_reference),
+            Either24::N(entry) => Some(&entry.source_reference),
+            Either24::O(entry) => Some(&entry.source_reference),
+            Either24::P(entry) => Some(&entry.source_reference),
+            Either24::Q(entry) => Some(&entry.source_reference),
+            Either24::R(entry) => entry.source_reference.and_then(|_: ()| None),
+            Either24::S(entry) => entry.source_reference.and_then(|_: ()| None),
+            Either24::T(entry) => entry.source_reference.as_ref(),
+            Either24::U(entry) => entry.source_reference.as_ref(),
+            Either24::V(entry) => entry.source_reference.as_ref(),
+            Either24::W(entry) => Some(&entry.source_reference),
+            Either24::X(entry) => entry.source_reference.as_ref(),
+        }
+    }
+}
 
 const _: () = {
     const fn assert_to_from_napi_value<T: FromNapiValue + ToNapiValue>() {}

--- a/crates/edr_napi/src/trace/solidity_stack_trace.rs
+++ b/crates/edr_napi/src/trace/solidity_stack_trace.rs
@@ -130,6 +130,12 @@ pub struct CallstackEntryStackTraceEntry {
     pub function_type: ContractFunctionType,
 }
 
+impl From<CallstackEntryStackTraceEntry> for SolidityStackTraceEntry {
+    fn from(val: CallstackEntryStackTraceEntry) -> Self {
+        Either24::A(val)
+    }
+}
+
 #[napi(object)]
 pub struct UnrecognizedCreateCallstackEntryStackTraceEntry {
     #[napi(
@@ -140,6 +146,12 @@ pub struct UnrecognizedCreateCallstackEntryStackTraceEntry {
         { StackTraceEntryType::UNRECOGNIZED_CREATE_CALLSTACK_ENTRY as u8 },
     >,
     pub source_reference: Option<Undefined>,
+}
+
+impl From<UnrecognizedCreateCallstackEntryStackTraceEntry> for SolidityStackTraceEntry {
+    fn from(val: UnrecognizedCreateCallstackEntryStackTraceEntry) -> Self {
+        Either24::B(val)
+    }
 }
 
 #[napi(object)]
@@ -155,12 +167,24 @@ pub struct UnrecognizedContractCallstackEntryStackTraceEntry {
     pub source_reference: Option<Undefined>,
 }
 
+impl From<UnrecognizedContractCallstackEntryStackTraceEntry> for SolidityStackTraceEntry {
+    fn from(val: UnrecognizedContractCallstackEntryStackTraceEntry) -> Self {
+        Either24::C(val)
+    }
+}
+
 #[napi(object)]
 pub struct PrecompileErrorStackTraceEntry {
     #[napi(js_name = "type", ts_type = "StackTraceEntryType.PRECOMPILE_ERROR")]
     pub type_: StackTraceEntryTypeConst<{ StackTraceEntryType::PRECOMPILE_ERROR as u8 }>,
     pub precompile: u32,
     pub source_reference: Option<Undefined>,
+}
+
+impl From<PrecompileErrorStackTraceEntry> for SolidityStackTraceEntry {
+    fn from(val: PrecompileErrorStackTraceEntry) -> Self {
+        Either24::D(val)
+    }
 }
 
 #[napi(object)]
@@ -172,12 +196,24 @@ pub struct RevertErrorStackTraceEntry {
     pub is_invalid_opcode_error: bool,
 }
 
+impl From<RevertErrorStackTraceEntry> for SolidityStackTraceEntry {
+    fn from(val: RevertErrorStackTraceEntry) -> Self {
+        Either24::E(val)
+    }
+}
+
 #[napi(object)]
 pub struct PanicErrorStackTraceEntry {
     #[napi(js_name = "type", ts_type = "StackTraceEntryType.PANIC_ERROR")]
     pub type_: StackTraceEntryTypeConst<{ StackTraceEntryType::PANIC_ERROR as u8 }>,
     pub error_code: BigInt,
     pub source_reference: Option<SourceReference>,
+}
+
+impl From<PanicErrorStackTraceEntry> for SolidityStackTraceEntry {
+    fn from(val: PanicErrorStackTraceEntry) -> Self {
+        Either24::F(val)
+    }
 }
 
 #[napi(object)]
@@ -189,15 +225,10 @@ pub struct CustomErrorStackTraceEntry {
     pub source_reference: SourceReference,
 }
 
-#[napi(object)]
-pub struct UnmappedSolc063RevertErrorStackTraceEntry {
-    #[napi(
-        js_name = "type",
-        ts_type = "StackTraceEntryType.UNMAPPED_SOLC_0_6_3_REVERT_ERROR"
-    )]
-    pub type_:
-        StackTraceEntryTypeConst<{ StackTraceEntryType::UNMAPPED_SOLC_0_6_3_REVERT_ERROR as u8 }>,
-    pub source_reference: Option<SourceReference>,
+impl From<CustomErrorStackTraceEntry> for SolidityStackTraceEntry {
+    fn from(val: CustomErrorStackTraceEntry) -> Self {
+        Either24::G(val)
+    }
 }
 
 #[napi(object)]
@@ -211,11 +242,23 @@ pub struct FunctionNotPayableErrorStackTraceEntry {
     pub source_reference: SourceReference,
 }
 
+impl From<FunctionNotPayableErrorStackTraceEntry> for SolidityStackTraceEntry {
+    fn from(val: FunctionNotPayableErrorStackTraceEntry) -> Self {
+        Either24::H(val)
+    }
+}
+
 #[napi(object)]
 pub struct InvalidParamsErrorStackTraceEntry {
     #[napi(js_name = "type", ts_type = "StackTraceEntryType.INVALID_PARAMS_ERROR")]
     pub type_: StackTraceEntryTypeConst<{ StackTraceEntryType::INVALID_PARAMS_ERROR as u8 }>,
     pub source_reference: SourceReference,
+}
+
+impl From<InvalidParamsErrorStackTraceEntry> for SolidityStackTraceEntry {
+    fn from(val: InvalidParamsErrorStackTraceEntry) -> Self {
+        Either24::I(val)
+    }
 }
 
 #[napi(object)]
@@ -227,6 +270,12 @@ pub struct FallbackNotPayableErrorStackTraceEntry {
     pub type_: StackTraceEntryTypeConst<{ StackTraceEntryType::FALLBACK_NOT_PAYABLE_ERROR as u8 }>,
     pub value: BigInt,
     pub source_reference: SourceReference,
+}
+
+impl From<FallbackNotPayableErrorStackTraceEntry> for SolidityStackTraceEntry {
+    fn from(val: FallbackNotPayableErrorStackTraceEntry) -> Self {
+        Either24::J(val)
+    }
 }
 
 #[napi(object)]
@@ -242,6 +291,12 @@ pub struct FallbackNotPayableAndNoReceiveErrorStackTraceEntry {
     pub source_reference: SourceReference,
 }
 
+impl From<FallbackNotPayableAndNoReceiveErrorStackTraceEntry> for SolidityStackTraceEntry {
+    fn from(val: FallbackNotPayableAndNoReceiveErrorStackTraceEntry) -> Self {
+        Either24::K(val)
+    }
+}
+
 #[napi(object)]
 pub struct UnrecognizedFunctionWithoutFallbackErrorStackTraceEntry {
     #[napi(
@@ -252,6 +307,12 @@ pub struct UnrecognizedFunctionWithoutFallbackErrorStackTraceEntry {
         { StackTraceEntryType::UNRECOGNIZED_FUNCTION_WITHOUT_FALLBACK_ERROR as u8 },
     >,
     pub source_reference: SourceReference,
+}
+
+impl From<UnrecognizedFunctionWithoutFallbackErrorStackTraceEntry> for SolidityStackTraceEntry {
+    fn from(val: UnrecognizedFunctionWithoutFallbackErrorStackTraceEntry) -> Self {
+        Either24::L(val)
+    }
 }
 
 #[napi(object)]
@@ -265,6 +326,12 @@ pub struct MissingFallbackOrReceiveErrorStackTraceEntry {
     pub source_reference: SourceReference,
 }
 
+impl From<MissingFallbackOrReceiveErrorStackTraceEntry> for SolidityStackTraceEntry {
+    fn from(val: MissingFallbackOrReceiveErrorStackTraceEntry) -> Self {
+        Either24::M(val)
+    }
+}
+
 #[napi(object)]
 pub struct ReturndataSizeErrorStackTraceEntry {
     #[napi(
@@ -273,6 +340,12 @@ pub struct ReturndataSizeErrorStackTraceEntry {
     )]
     pub type_: StackTraceEntryTypeConst<{ StackTraceEntryType::RETURNDATA_SIZE_ERROR as u8 }>,
     pub source_reference: SourceReference,
+}
+
+impl From<ReturndataSizeErrorStackTraceEntry> for SolidityStackTraceEntry {
+    fn from(val: ReturndataSizeErrorStackTraceEntry) -> Self {
+        Either24::N(val)
+    }
 }
 
 #[napi(object)]
@@ -286,12 +359,25 @@ pub struct NonContractAccountCalledErrorStackTraceEntry {
     pub source_reference: SourceReference,
 }
 
+impl From<NonContractAccountCalledErrorStackTraceEntry> for SolidityStackTraceEntry {
+    fn from(val: NonContractAccountCalledErrorStackTraceEntry) -> Self {
+        Either24::O(val)
+    }
+}
+
 #[napi(object)]
 pub struct CallFailedErrorStackTraceEntry {
     #[napi(js_name = "type", ts_type = "StackTraceEntryType.CALL_FAILED_ERROR")]
     pub type_: StackTraceEntryTypeConst<{ StackTraceEntryType::CALL_FAILED_ERROR as u8 }>,
     pub source_reference: SourceReference,
 }
+
+impl From<CallFailedErrorStackTraceEntry> for SolidityStackTraceEntry {
+    fn from(val: CallFailedErrorStackTraceEntry) -> Self {
+        Either24::P(val)
+    }
+}
+
 #[napi(object)]
 pub struct DirectLibraryCallErrorStackTraceEntry {
     #[napi(
@@ -302,6 +388,12 @@ pub struct DirectLibraryCallErrorStackTraceEntry {
     pub source_reference: SourceReference,
 }
 
+impl From<DirectLibraryCallErrorStackTraceEntry> for SolidityStackTraceEntry {
+    fn from(val: DirectLibraryCallErrorStackTraceEntry) -> Self {
+        Either24::Q(val)
+    }
+}
+
 #[napi(object)]
 pub struct UnrecognizedCreateErrorStackTraceEntry {
     #[napi(
@@ -309,10 +401,15 @@ pub struct UnrecognizedCreateErrorStackTraceEntry {
         ts_type = "StackTraceEntryType.UNRECOGNIZED_CREATE_ERROR"
     )]
     pub type_: StackTraceEntryTypeConst<{ StackTraceEntryType::UNRECOGNIZED_CREATE_ERROR as u8 }>,
-    #[napi(ts_type = "ReturnData")]
     pub message: ClassInstance<ReturnData>,
     pub source_reference: Option<Undefined>,
     pub is_invalid_opcode_error: bool,
+}
+
+impl From<UnrecognizedCreateErrorStackTraceEntry> for SolidityStackTraceEntry {
+    fn from(val: UnrecognizedCreateErrorStackTraceEntry) -> Self {
+        Either24::R(val)
+    }
 }
 
 #[napi(object)]
@@ -328,6 +425,12 @@ pub struct UnrecognizedContractErrorStackTraceEntry {
     pub is_invalid_opcode_error: bool,
 }
 
+impl From<UnrecognizedContractErrorStackTraceEntry> for SolidityStackTraceEntry {
+    fn from(val: UnrecognizedContractErrorStackTraceEntry) -> Self {
+        Either24::S(val)
+    }
+}
+
 #[napi(object)]
 pub struct OtherExecutionErrorStackTraceEntry {
     #[napi(
@@ -338,6 +441,29 @@ pub struct OtherExecutionErrorStackTraceEntry {
     pub source_reference: Option<SourceReference>,
 }
 
+impl From<OtherExecutionErrorStackTraceEntry> for SolidityStackTraceEntry {
+    fn from(val: OtherExecutionErrorStackTraceEntry) -> Self {
+        Either24::T(val)
+    }
+}
+
+#[napi(object)]
+pub struct UnmappedSolc063RevertErrorStackTraceEntry {
+    #[napi(
+        js_name = "type",
+        ts_type = "StackTraceEntryType.UNMAPPED_SOLC_0_6_3_REVERT_ERROR"
+    )]
+    pub type_:
+        StackTraceEntryTypeConst<{ StackTraceEntryType::UNMAPPED_SOLC_0_6_3_REVERT_ERROR as u8 }>,
+    pub source_reference: Option<SourceReference>,
+}
+
+impl From<UnmappedSolc063RevertErrorStackTraceEntry> for SolidityStackTraceEntry {
+    fn from(val: UnmappedSolc063RevertErrorStackTraceEntry) -> Self {
+        Either24::U(val)
+    }
+}
+
 #[napi(object)]
 pub struct ContractTooLargeErrorStackTraceEntry {
     #[napi(
@@ -346,6 +472,12 @@ pub struct ContractTooLargeErrorStackTraceEntry {
     )]
     pub type_: StackTraceEntryTypeConst<{ StackTraceEntryType::CONTRACT_TOO_LARGE_ERROR as u8 }>,
     pub source_reference: Option<SourceReference>,
+}
+
+impl From<ContractTooLargeErrorStackTraceEntry> for SolidityStackTraceEntry {
+    fn from(val: ContractTooLargeErrorStackTraceEntry) -> Self {
+        Either24::V(val)
+    }
 }
 
 #[napi(object)]
@@ -360,6 +492,12 @@ pub struct InternalFunctionCallStackEntry {
     pub source_reference: SourceReference,
 }
 
+impl From<InternalFunctionCallStackEntry> for SolidityStackTraceEntry {
+    fn from(val: InternalFunctionCallStackEntry) -> Self {
+        Either24::W(val)
+    }
+}
+
 #[napi(object)]
 pub struct ContractCallRunOutOfGasError {
     #[napi(
@@ -369,6 +507,12 @@ pub struct ContractCallRunOutOfGasError {
     pub type_:
         StackTraceEntryTypeConst<{ StackTraceEntryType::CONTRACT_CALL_RUN_OUT_OF_GAS_ERROR as u8 }>,
     pub source_reference: Option<SourceReference>,
+}
+
+impl From<ContractCallRunOutOfGasError> for SolidityStackTraceEntry {
+    fn from(val: ContractCallRunOutOfGasError) -> Self {
+        Either24::X(val)
+    }
 }
 
 #[allow(dead_code)]

--- a/crates/edr_napi/src/trace/solidity_stack_trace.rs
+++ b/crates/edr_napi/src/trace/solidity_stack_trace.rs
@@ -1,12 +1,10 @@
 //! Naive rewrite of `hardhat-network/stack-traces/solidity-stack-traces.ts`
 //! from Hardhat.
 
-use napi::bindgen_prelude::{
-    BigInt, ClassInstance, Either24, FromNapiValue, ToNapiValue, Uint8Array, Undefined,
-};
+use napi::bindgen_prelude::{BigInt, Either24, FromNapiValue, ToNapiValue, Uint8Array, Undefined};
 use napi_derive::napi;
 
-use super::{model::ContractFunctionType, return_data::ReturnData};
+use super::model::ContractFunctionType;
 
 #[napi]
 #[repr(u8)]
@@ -191,7 +189,7 @@ impl From<PrecompileErrorStackTraceEntry> for SolidityStackTraceEntry {
 pub struct RevertErrorStackTraceEntry {
     #[napi(js_name = "type", ts_type = "StackTraceEntryType.REVERT_ERROR")]
     pub type_: StackTraceEntryTypeConst<{ StackTraceEntryType::REVERT_ERROR as u8 }>,
-    pub message: ClassInstance<ReturnData>,
+    pub return_data: Uint8Array,
     pub source_reference: SourceReference,
     pub is_invalid_opcode_error: bool,
 }
@@ -401,7 +399,7 @@ pub struct UnrecognizedCreateErrorStackTraceEntry {
         ts_type = "StackTraceEntryType.UNRECOGNIZED_CREATE_ERROR"
     )]
     pub type_: StackTraceEntryTypeConst<{ StackTraceEntryType::UNRECOGNIZED_CREATE_ERROR as u8 }>,
-    pub message: ClassInstance<ReturnData>,
+    pub return_data: Uint8Array,
     pub source_reference: Option<Undefined>,
     pub is_invalid_opcode_error: bool,
 }
@@ -420,7 +418,7 @@ pub struct UnrecognizedContractErrorStackTraceEntry {
     )]
     pub type_: StackTraceEntryTypeConst<{ StackTraceEntryType::UNRECOGNIZED_CONTRACT_ERROR as u8 }>,
     pub address: Uint8Array,
-    pub message: ClassInstance<ReturnData>,
+    pub return_data: Uint8Array,
     pub source_reference: Option<Undefined>,
     pub is_invalid_opcode_error: bool,
 }

--- a/crates/edr_napi/src/trace/solidity_stack_trace.rs
+++ b/crates/edr_napi/src/trace/solidity_stack_trace.rs
@@ -121,6 +121,7 @@ impl<const ENTRY_TYPE: u8> StackTraceEntryTypeConst<ENTRY_TYPE> {
 }
 
 #[napi(object)]
+#[derive(Clone)]
 pub struct CallstackEntryStackTraceEntry {
     #[napi(js_name = "type", ts_type = "StackTraceEntryType.CALLSTACK_ENTRY")]
     pub type_: StackTraceEntryTypeConst<{ StackTraceEntryType::CALLSTACK_ENTRY as u8 }>,
@@ -135,6 +136,7 @@ impl From<CallstackEntryStackTraceEntry> for SolidityStackTraceEntry {
 }
 
 #[napi(object)]
+#[derive(Clone)]
 pub struct UnrecognizedCreateCallstackEntryStackTraceEntry {
     #[napi(
         js_name = "type",
@@ -153,6 +155,7 @@ impl From<UnrecognizedCreateCallstackEntryStackTraceEntry> for SolidityStackTrac
 }
 
 #[napi(object)]
+#[derive(Clone)]
 pub struct UnrecognizedContractCallstackEntryStackTraceEntry {
     #[napi(
         js_name = "type",
@@ -172,6 +175,7 @@ impl From<UnrecognizedContractCallstackEntryStackTraceEntry> for SolidityStackTr
 }
 
 #[napi(object)]
+#[derive(Clone)]
 pub struct PrecompileErrorStackTraceEntry {
     #[napi(js_name = "type", ts_type = "StackTraceEntryType.PRECOMPILE_ERROR")]
     pub type_: StackTraceEntryTypeConst<{ StackTraceEntryType::PRECOMPILE_ERROR as u8 }>,
@@ -186,6 +190,7 @@ impl From<PrecompileErrorStackTraceEntry> for SolidityStackTraceEntry {
 }
 
 #[napi(object)]
+#[derive(Clone)]
 pub struct RevertErrorStackTraceEntry {
     #[napi(js_name = "type", ts_type = "StackTraceEntryType.REVERT_ERROR")]
     pub type_: StackTraceEntryTypeConst<{ StackTraceEntryType::REVERT_ERROR as u8 }>,
@@ -201,6 +206,7 @@ impl From<RevertErrorStackTraceEntry> for SolidityStackTraceEntry {
 }
 
 #[napi(object)]
+#[derive(Clone)]
 pub struct PanicErrorStackTraceEntry {
     #[napi(js_name = "type", ts_type = "StackTraceEntryType.PANIC_ERROR")]
     pub type_: StackTraceEntryTypeConst<{ StackTraceEntryType::PANIC_ERROR as u8 }>,
@@ -215,6 +221,7 @@ impl From<PanicErrorStackTraceEntry> for SolidityStackTraceEntry {
 }
 
 #[napi(object)]
+#[derive(Clone)]
 pub struct CustomErrorStackTraceEntry {
     #[napi(js_name = "type", ts_type = "StackTraceEntryType.CUSTOM_ERROR")]
     pub type_: StackTraceEntryTypeConst<{ StackTraceEntryType::CUSTOM_ERROR as u8 }>,
@@ -230,6 +237,7 @@ impl From<CustomErrorStackTraceEntry> for SolidityStackTraceEntry {
 }
 
 #[napi(object)]
+#[derive(Clone)]
 pub struct FunctionNotPayableErrorStackTraceEntry {
     #[napi(
         js_name = "type",
@@ -247,6 +255,7 @@ impl From<FunctionNotPayableErrorStackTraceEntry> for SolidityStackTraceEntry {
 }
 
 #[napi(object)]
+#[derive(Clone)]
 pub struct InvalidParamsErrorStackTraceEntry {
     #[napi(js_name = "type", ts_type = "StackTraceEntryType.INVALID_PARAMS_ERROR")]
     pub type_: StackTraceEntryTypeConst<{ StackTraceEntryType::INVALID_PARAMS_ERROR as u8 }>,
@@ -260,6 +269,7 @@ impl From<InvalidParamsErrorStackTraceEntry> for SolidityStackTraceEntry {
 }
 
 #[napi(object)]
+#[derive(Clone)]
 pub struct FallbackNotPayableErrorStackTraceEntry {
     #[napi(
         js_name = "type",
@@ -277,6 +287,7 @@ impl From<FallbackNotPayableErrorStackTraceEntry> for SolidityStackTraceEntry {
 }
 
 #[napi(object)]
+#[derive(Clone)]
 pub struct FallbackNotPayableAndNoReceiveErrorStackTraceEntry {
     #[napi(
         js_name = "type",
@@ -296,6 +307,7 @@ impl From<FallbackNotPayableAndNoReceiveErrorStackTraceEntry> for SolidityStackT
 }
 
 #[napi(object)]
+#[derive(Clone)]
 pub struct UnrecognizedFunctionWithoutFallbackErrorStackTraceEntry {
     #[napi(
         js_name = "type",
@@ -314,6 +326,7 @@ impl From<UnrecognizedFunctionWithoutFallbackErrorStackTraceEntry> for SolidityS
 }
 
 #[napi(object)]
+#[derive(Clone)]
 pub struct MissingFallbackOrReceiveErrorStackTraceEntry {
     #[napi(
         js_name = "type",
@@ -331,6 +344,7 @@ impl From<MissingFallbackOrReceiveErrorStackTraceEntry> for SolidityStackTraceEn
 }
 
 #[napi(object)]
+#[derive(Clone)]
 pub struct ReturndataSizeErrorStackTraceEntry {
     #[napi(
         js_name = "type",
@@ -347,6 +361,7 @@ impl From<ReturndataSizeErrorStackTraceEntry> for SolidityStackTraceEntry {
 }
 
 #[napi(object)]
+#[derive(Clone)]
 pub struct NonContractAccountCalledErrorStackTraceEntry {
     #[napi(
         js_name = "type",
@@ -364,6 +379,7 @@ impl From<NonContractAccountCalledErrorStackTraceEntry> for SolidityStackTraceEn
 }
 
 #[napi(object)]
+#[derive(Clone)]
 pub struct CallFailedErrorStackTraceEntry {
     #[napi(js_name = "type", ts_type = "StackTraceEntryType.CALL_FAILED_ERROR")]
     pub type_: StackTraceEntryTypeConst<{ StackTraceEntryType::CALL_FAILED_ERROR as u8 }>,
@@ -377,6 +393,7 @@ impl From<CallFailedErrorStackTraceEntry> for SolidityStackTraceEntry {
 }
 
 #[napi(object)]
+#[derive(Clone)]
 pub struct DirectLibraryCallErrorStackTraceEntry {
     #[napi(
         js_name = "type",
@@ -393,6 +410,7 @@ impl From<DirectLibraryCallErrorStackTraceEntry> for SolidityStackTraceEntry {
 }
 
 #[napi(object)]
+#[derive(Clone)]
 pub struct UnrecognizedCreateErrorStackTraceEntry {
     #[napi(
         js_name = "type",
@@ -411,6 +429,7 @@ impl From<UnrecognizedCreateErrorStackTraceEntry> for SolidityStackTraceEntry {
 }
 
 #[napi(object)]
+#[derive(Clone)]
 pub struct UnrecognizedContractErrorStackTraceEntry {
     #[napi(
         js_name = "type",
@@ -430,6 +449,7 @@ impl From<UnrecognizedContractErrorStackTraceEntry> for SolidityStackTraceEntry 
 }
 
 #[napi(object)]
+#[derive(Clone)]
 pub struct OtherExecutionErrorStackTraceEntry {
     #[napi(
         js_name = "type",
@@ -446,6 +466,7 @@ impl From<OtherExecutionErrorStackTraceEntry> for SolidityStackTraceEntry {
 }
 
 #[napi(object)]
+#[derive(Clone)]
 pub struct UnmappedSolc063RevertErrorStackTraceEntry {
     #[napi(
         js_name = "type",
@@ -463,6 +484,7 @@ impl From<UnmappedSolc063RevertErrorStackTraceEntry> for SolidityStackTraceEntry
 }
 
 #[napi(object)]
+#[derive(Clone)]
 pub struct ContractTooLargeErrorStackTraceEntry {
     #[napi(
         js_name = "type",
@@ -479,6 +501,7 @@ impl From<ContractTooLargeErrorStackTraceEntry> for SolidityStackTraceEntry {
 }
 
 #[napi(object)]
+#[derive(Clone)]
 pub struct InternalFunctionCallStackEntry {
     #[napi(
         js_name = "type",
@@ -497,6 +520,7 @@ impl From<InternalFunctionCallStackEntry> for SolidityStackTraceEntry {
 }
 
 #[napi(object)]
+#[derive(Clone)]
 pub struct ContractCallRunOutOfGasError {
     #[napi(
         js_name = "type",

--- a/crates/edr_napi/src/trace/solidity_tracer.rs
+++ b/crates/edr_napi/src/trace/solidity_tracer.rs
@@ -1,0 +1,40 @@
+use napi::{
+    bindgen_prelude::{Either4, Undefined},
+    Either,
+};
+use napi_derive::napi;
+
+use super::message_trace::{CallMessageTrace, CreateMessageTrace, EvmStep, PrecompileMessageTrace};
+
+#[napi(constructor)]
+pub struct SolidityTracer;
+
+#[napi]
+impl SolidityTracer {
+    #[allow(clippy::unused_self)] // we allow this for convenience for now
+    #[napi]
+    pub fn _get_last_subtrace(
+        &self,
+        trace: Either<CallMessageTrace, CreateMessageTrace>,
+    ) -> Either4<PrecompileMessageTrace, CallMessageTrace, CreateMessageTrace, Undefined> {
+        let (number_of_subtraces, steps) = match trace {
+            Either::A(create) => (create.number_of_subtraces, create.steps),
+            Either::B(call) => (call.number_of_subtraces, call.steps),
+        };
+
+        if number_of_subtraces == 0 {
+            return Either4::D(());
+        }
+
+        steps
+            .into_iter()
+            .rev()
+            .find_map(|step| match step {
+                Either4::A(EvmStep { .. }) => None,
+                Either4::B(precompile) => Some(Either4::A(precompile)),
+                Either4::C(call) => Some(Either4::B(call)),
+                Either4::D(create) => Some(Either4::C(create)),
+            })
+            .unwrap_or(Either4::D(()))
+    }
+}

--- a/crates/edr_napi/src/trace/solidity_tracer.rs
+++ b/crates/edr_napi/src/trace/solidity_tracer.rs
@@ -123,7 +123,7 @@ impl SolidityTracer {
         trace: &CreateMessageTrace,
         env: Env,
     ) -> napi::Result<SolidityStackTrace> {
-        let inferred_error = ErrorInferrer.infer_before_tracing_create_message_inner(trace, env)?;
+        let inferred_error = ErrorInferrer::infer_before_tracing_create_message(trace, env)?;
 
         if let Some(inferred_error) = inferred_error {
             return Ok(inferred_error);
@@ -137,7 +137,7 @@ impl SolidityTracer {
         trace: &CallMessageTrace,
         env: Env,
     ) -> napi::Result<SolidityStackTrace> {
-        let inferred_error = ErrorInferrer.infer_before_tracing_call_message_inner(trace, env)?;
+        let inferred_error = ErrorInferrer::infer_before_tracing_call_message(trace, env)?;
 
         if let Some(inferred_error) = inferred_error {
             return Ok(inferred_error);
@@ -328,7 +328,7 @@ impl SolidityTracer {
             .collect::<Result<Vec<_>, _>>()?;
         let function_jumpdests = function_jumpdests.iter().map(|x| &**x).collect::<Vec<_>>();
 
-        let stacktrace_with_inferred_error = ErrorInferrer.infer_after_tracing_inner(
+        let stacktrace_with_inferred_error = ErrorInferrer::infer_after_tracing(
             trace,
             stacktrace,
             &function_jumpdests,
@@ -337,6 +337,6 @@ impl SolidityTracer {
             env,
         )?;
 
-        ErrorInferrer.filter_redundant_frames(stacktrace_with_inferred_error)
+        ErrorInferrer::filter_redundant_frames(stacktrace_with_inferred_error)
     }
 }

--- a/crates/edr_napi/src/trace/solidity_tracer.rs
+++ b/crates/edr_napi/src/trace/solidity_tracer.rs
@@ -31,7 +31,7 @@ use crate::{
 };
 
 #[napi(constructor)]
-pub struct SolidityTracer();
+pub struct SolidityTracer;
 
 #[allow(clippy::unused_self)] // we allow this for convenience for now
 #[napi]

--- a/crates/edr_napi/src/trace/solidity_tracer.rs
+++ b/crates/edr_napi/src/trace/solidity_tracer.rs
@@ -1,40 +1,342 @@
 use napi::{
-    bindgen_prelude::{Either4, Undefined},
-    Either,
+    bindgen_prelude::{Either3, Either4},
+    Either, Env,
 };
 use napi_derive::napi;
 
-use super::message_trace::{CallMessageTrace, CreateMessageTrace, EvmStep, PrecompileMessageTrace};
+use crate::{
+    trace::{
+        exit::ExitCode,
+        solidity_stack_trace::{
+            ContractTooLargeErrorStackTraceEntry, SolidityStackTraceEntry,
+            StackTraceEntryTypeConst, UnrecognizedContractCallstackEntryStackTraceEntry,
+            UnrecognizedContractErrorStackTraceEntry,
+            UnrecognizedCreateCallstackEntryStackTraceEntry,
+            UnrecognizedCreateErrorStackTraceEntry,
+        },
+    },
+    utils::ClassInstanceRef,
+};
+
+use super::{
+    error_inferrer::{
+        instruction_to_callstack_stack_trace_entry, ErrorInferrer, SubmessageDataRef,
+    },
+    mapped_inlined_internal_functions_heuristics::{
+        adjust_stack_trace, stack_trace_may_require_adjustments,
+    },
+    message_trace::{CallMessageTrace, CreateMessageTrace, EvmStep, PrecompileMessageTrace},
+    model::{Instruction, JumpType},
+    opcodes::Opcode,
+    solidity_stack_trace::{PrecompileErrorStackTraceEntry, SolidityStackTrace},
+};
 
 #[napi(constructor)]
-pub struct SolidityTracer;
+pub struct SolidityTracer();
 
+#[allow(clippy::unused_self)] // we allow this for convenience for now
 #[napi]
 impl SolidityTracer {
-    #[allow(clippy::unused_self)] // we allow this for convenience for now
     #[napi]
-    pub fn _get_last_subtrace(
+    pub fn get_stack_trace(
         &self,
-        trace: Either<CallMessageTrace, CreateMessageTrace>,
-    ) -> Either4<PrecompileMessageTrace, CallMessageTrace, CreateMessageTrace, Undefined> {
+        trace: Either3<PrecompileMessageTrace, CallMessageTrace, CreateMessageTrace>,
+        env: Env,
+    ) -> napi::Result<SolidityStackTrace> {
+        let trace = match &trace {
+            Either3::A(precompile) => Either3::A(precompile),
+            Either3::B(call) => Either3::B(call),
+            Either3::C(create) => Either3::C(create),
+        };
+
+        self.get_stack_trace_inner(trace, env)
+    }
+
+    pub fn get_stack_trace_inner(
+        &self,
+        trace: Either3<&PrecompileMessageTrace, &CallMessageTrace, &CreateMessageTrace>,
+        env: Env,
+    ) -> napi::Result<SolidityStackTrace> {
+        let exit = match &trace {
+            Either3::A(precompile) => &precompile.exit,
+            Either3::B(call) => &call.exit,
+            Either3::C(create) => &create.exit,
+        };
+
+        if !exit.is_error() {
+            return Ok(vec![]);
+        }
+
+        match trace {
+            Either3::A(precompile) => Ok(self.get_precompile_message_stack_trace(precompile)?),
+            Either3::B(call) if call.bytecode.is_some() => {
+                Ok(self.get_call_message_stack_trace(call, env)?)
+            }
+            Either3::C(create) if create.bytecode.is_some() => {
+                Ok(self.get_create_message_stack_trace(create, env)?)
+            }
+            // No bytecode is present
+            Either3::B(call) => {
+                Ok(self.get_unrecognized_message_stack_trace(Either::A(call), env)?)
+            }
+            Either3::C(create) => {
+                Ok(self.get_unrecognized_message_stack_trace(Either::B(create), env)?)
+            }
+        }
+    }
+
+    fn get_last_subtrace<'a>(
+        &self,
+        trace: Either<&'a CallMessageTrace, &'a CreateMessageTrace>,
+    ) -> Option<Either3<&'a PrecompileMessageTrace, &'a CallMessageTrace, &'a CreateMessageTrace>>
+    {
         let (number_of_subtraces, steps) = match trace {
-            Either::A(create) => (create.number_of_subtraces, create.steps),
-            Either::B(call) => (call.number_of_subtraces, call.steps),
+            Either::A(create) => (create.number_of_subtraces, &create.steps),
+            Either::B(call) => (call.number_of_subtraces, &call.steps),
         };
 
         if number_of_subtraces == 0 {
-            return Either4::D(());
+            return None;
         }
 
-        steps
+        steps.iter().rev().find_map(|step| match step {
+            Either4::A(EvmStep { .. }) => None,
+            Either4::B(precompile) => Some(Either3::A(precompile)),
+            Either4::C(call) => Some(Either3::B(call)),
+            Either4::D(create) => Some(Either3::C(create)),
+        })
+    }
+
+    fn get_precompile_message_stack_trace(
+        &self,
+        trace: &PrecompileMessageTrace,
+    ) -> napi::Result<SolidityStackTrace> {
+        Ok(vec![PrecompileErrorStackTraceEntry {
+            type_: StackTraceEntryTypeConst,
+            precompile: trace.precompile,
+            source_reference: None,
+        }
+        .into()])
+    }
+
+    fn get_create_message_stack_trace(
+        &self,
+        trace: &CreateMessageTrace,
+        env: Env,
+    ) -> napi::Result<SolidityStackTrace> {
+        let inferred_error = ErrorInferrer.infer_before_tracing_create_message_inner(trace, env)?;
+
+        if let Some(inferred_error) = inferred_error {
+            return Ok(inferred_error);
+        }
+
+        self.trace_evm_execution(Either::B(trace), env)
+    }
+
+    fn get_call_message_stack_trace(
+        &self,
+        trace: &CallMessageTrace,
+        env: Env,
+    ) -> napi::Result<SolidityStackTrace> {
+        let inferred_error = ErrorInferrer.infer_before_tracing_call_message_inner(trace, env)?;
+
+        if let Some(inferred_error) = inferred_error {
+            return Ok(inferred_error);
+        }
+
+        self.trace_evm_execution(Either::A(trace), env)
+    }
+
+    fn get_unrecognized_message_stack_trace(
+        &self,
+        trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+        env: Env,
+    ) -> napi::Result<SolidityStackTrace> {
+        let (trace_exit_kind, trace_return_data) = match &trace {
+            Either::A(call) => (call.exit.kind(), &call.return_data),
+            Either::B(create) => (create.exit.kind(), &create.return_data),
+        };
+
+        let subtrace = self.get_last_subtrace(trace);
+
+        if let Some(subtrace) = subtrace {
+            let (is_error, return_data) = match subtrace {
+                Either3::A(precompile) => {
+                    (precompile.exit.is_error(), precompile.return_data.clone())
+                }
+                Either3::B(call) => (call.exit.is_error(), call.return_data.clone()),
+                Either3::C(create) => (create.exit.is_error(), create.return_data.clone()),
+            };
+
+            // This is not a very exact heuristic, but most of the time it will be right, as solidity
+            // reverts if a call fails, and most contracts are in solidity
+            if is_error && trace_return_data.as_ref() == return_data.as_ref() {
+                let unrecognized_entry: SolidityStackTraceEntry = match trace {
+                    Either::A(CallMessageTrace { address, .. }) => {
+                        UnrecognizedContractCallstackEntryStackTraceEntry {
+                            type_: StackTraceEntryTypeConst,
+                            address: address.clone(),
+                            source_reference: None,
+                        }
+                        .into()
+                    }
+                    Either::B(CreateMessageTrace { .. }) => {
+                        UnrecognizedCreateCallstackEntryStackTraceEntry {
+                            type_: StackTraceEntryTypeConst,
+                            source_reference: None,
+                        }
+                        .into()
+                    }
+                };
+
+                let mut stacktrace = vec![unrecognized_entry];
+                stacktrace.extend(self.get_stack_trace_inner(subtrace, env)?);
+
+                return Ok(stacktrace);
+            }
+        }
+
+        if trace_exit_kind == ExitCode::CODESIZE_EXCEEDS_MAXIMUM {
+            return Ok(vec![ContractTooLargeErrorStackTraceEntry {
+                type_: StackTraceEntryTypeConst,
+                source_reference: None,
+            }
+            .into()]);
+        }
+
+        let is_invalid_opcode_error = trace_exit_kind == ExitCode::INVALID_OPCODE;
+
+        match trace {
+            Either::A(trace @ CallMessageTrace { .. }) => {
+                Ok(vec![UnrecognizedContractErrorStackTraceEntry {
+                    type_: StackTraceEntryTypeConst,
+                    address: trace.address.clone(),
+                    return_data: trace.return_data.clone(),
+                    is_invalid_opcode_error,
+                    source_reference: None,
+                }
+                .into()])
+            }
+            Either::B(trace @ CreateMessageTrace { .. }) => {
+                Ok(vec![UnrecognizedCreateErrorStackTraceEntry {
+                    type_: StackTraceEntryTypeConst,
+                    return_data: trace.return_data.clone(),
+                    is_invalid_opcode_error,
+                    source_reference: None,
+                }
+                .into()])
+            }
+        }
+    }
+
+    fn trace_evm_execution(
+        &self,
+        trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+        env: Env,
+    ) -> napi::Result<SolidityStackTrace> {
+        let stack_trace = self.raw_trace_evm_execution(trace, env)?;
+
+        if stack_trace_may_require_adjustments(&stack_trace, trace) {
+            return adjust_stack_trace(stack_trace, trace, env);
+        }
+
+        Ok(stack_trace)
+    }
+
+    fn raw_trace_evm_execution(
+        &self,
+        trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+        env: Env,
+    ) -> napi::Result<SolidityStackTrace> {
+        let (bytecode, steps, number_of_subtraces) = match &trace {
+            Either::A(call) => (&call.bytecode, &call.steps, call.number_of_subtraces),
+            Either::B(create) => (&create.bytecode, &create.steps, create.number_of_subtraces),
+        };
+        let bytecode = bytecode.as_ref().expect("JS code asserts");
+
+        let mut stacktrace: SolidityStackTrace = vec![];
+
+        let mut subtraces_seen = 0;
+
+        // There was a jump into a function according to the sourcemaps
+        let mut jumped_into_function = false;
+
+        let mut function_jumpdests: Vec<&ClassInstanceRef<Instruction>> = vec![];
+
+        let mut last_submessage_data: Option<SubmessageDataRef<'_>> = None;
+
+        let mut iter = steps.iter().enumerate().peekable();
+        while let Some((step_index, step)) = iter.next() {
+            if let Either4::A(EvmStep { pc }) = step {
+                let inst = bytecode.get_instruction_inner(*pc)?;
+                let inst = inst.borrow(env)?;
+
+                if inst.jump_type == JumpType::INTO_FUNCTION && iter.peek().is_some() {
+                    let (_, next_step) = iter.peek().unwrap();
+                    let Either4::A(next_evm_step) = next_step else {
+                        unreachable!("JS code asserted that");
+                    };
+                    let next_inst = bytecode.get_instruction_inner(next_evm_step.pc)?;
+                    let next_inst_borrowed = next_inst.borrow(env)?;
+
+                    if next_inst_borrowed.opcode == Opcode::JUMPDEST {
+                        let frame =
+                            instruction_to_callstack_stack_trace_entry(bytecode, &inst, env)?;
+                        stacktrace.push(match frame {
+                            Either::A(frame) => frame.into(),
+                            Either::B(frame) => frame.into(),
+                        });
+                        if next_inst_borrowed.location.is_some() {
+                            jumped_into_function = true;
+                        }
+                        function_jumpdests.push(next_inst);
+                    }
+                } else if inst.jump_type == JumpType::OUTOF_FUNCTION {
+                    stacktrace.pop();
+                    function_jumpdests.pop();
+                }
+            } else {
+                let message_trace = match step {
+                    Either4::A(_) => unreachable!("branch is taken above"),
+                    Either4::B(precompile) => Either3::A(precompile),
+                    Either4::C(call) => Either3::B(call),
+                    Either4::D(create) => Either3::C(create),
+                };
+
+                subtraces_seen += 1;
+
+                // If there are more subtraces, this one didn't terminate the execution
+                if subtraces_seen < number_of_subtraces {
+                    continue;
+                }
+
+                let submessage_trace = self.get_stack_trace_inner(message_trace, env)?;
+
+                last_submessage_data = Some(SubmessageDataRef {
+                    message_trace,
+                    step_index: step_index as u32,
+                    stacktrace: submessage_trace,
+                });
+            }
+        }
+
+        // Borrow the classes at the same time to keep it alive for the duration
+        // of the call below
+        let function_jumpdests = function_jumpdests
             .into_iter()
-            .rev()
-            .find_map(|step| match step {
-                Either4::A(EvmStep { .. }) => None,
-                Either4::B(precompile) => Some(Either4::A(precompile)),
-                Either4::C(call) => Some(Either4::B(call)),
-                Either4::D(create) => Some(Either4::C(create)),
-            })
-            .unwrap_or(Either4::D(()))
+            .map(|x| x.borrow(env))
+            .collect::<Result<Vec<_>, _>>()?;
+        let function_jumpdests = function_jumpdests.iter().map(|x| &**x).collect::<Vec<_>>();
+
+        let stacktrace_with_inferred_error = ErrorInferrer.infer_after_tracing_inner(
+            trace,
+            stacktrace,
+            &function_jumpdests,
+            jumped_into_function,
+            last_submessage_data,
+            env,
+        )?;
+
+        ErrorInferrer.filter_redundant_frames(stacktrace_with_inferred_error)
     }
 }

--- a/crates/edr_napi/src/trace/vm_trace_decoder.rs
+++ b/crates/edr_napi/src/trace/vm_trace_decoder.rs
@@ -1,6 +1,8 @@
 use edr_solidity::artifacts::BuildInfo;
 use napi::{
-    bindgen_prelude::{ClassInstance, Either3, Either4, Uint8Array, Undefined},
+    bindgen_prelude::{
+        ClassInstance, Either3, Either4, FromNapiValue, Reference, Uint8Array, Undefined,
+    },
     Either, Env,
 };
 use napi_derive::napi;
@@ -91,7 +93,16 @@ impl VmTraceDecoder {
                     })
                     .collect::<napi::Result<_>>()?;
 
-                call.bytecode = bytecode.map(|b| b.as_object(env)).transpose()?;
+                let bytecode = bytecode.map(|b| b.as_object(env)).transpose()?;
+                let bytecode: Option<Reference<Bytecode>> = bytecode
+                    .map(|b| unsafe {
+                        use napi::NapiRaw;
+
+                        FromNapiValue::from_napi_value(env.raw(), b.raw())
+                    })
+                    .transpose()?;
+
+                call.bytecode = bytecode;
                 call.steps = steps;
 
                 Ok(Either3::B(call))
@@ -123,7 +134,16 @@ impl VmTraceDecoder {
                     })
                     .collect::<napi::Result<_>>()?;
 
-                create.bytecode = bytecode.map(|b| b.as_object(env)).transpose()?;
+                let bytecode = bytecode.map(|b| b.as_object(env)).transpose()?;
+                let bytecode: Option<Reference<Bytecode>> = bytecode
+                    .map(|b| unsafe {
+                        use napi::NapiRaw;
+
+                        FromNapiValue::from_napi_value(env.raw(), b.raw())
+                    })
+                    .transpose()?;
+
+                create.bytecode = bytecode;
                 create.steps = steps;
 
                 Ok(Either3::C(create))

--- a/crates/edr_napi/src/trace/vm_trace_decoder.rs
+++ b/crates/edr_napi/src/trace/vm_trace_decoder.rs
@@ -1,8 +1,6 @@
 use edr_solidity::artifacts::BuildInfo;
 use napi::{
-    bindgen_prelude::{
-        ClassInstance, Either3, Either4, FromNapiValue, Reference, Uint8Array, Undefined,
-    },
+    bindgen_prelude::{ClassInstance, Either3, Either4, Uint8Array, Undefined},
     Either, Env,
 };
 use napi_derive::napi;
@@ -93,12 +91,12 @@ impl VmTraceDecoder {
                     })
                     .collect::<napi::Result<_>>()?;
 
-                let bytecode = bytecode.map(|b| b.as_object(env)).transpose()?;
-                let bytecode: Option<Reference<Bytecode>> = bytecode
-                    .map(|b| unsafe {
-                        use napi::NapiRaw;
-
-                        FromNapiValue::from_napi_value(env.raw(), b.raw())
+                let bytecode = bytecode
+                    .map(|b| {
+                        // SAFETY: the call is safe but the use may not be.
+                        // We only ever immutably access the bytecode, so it's safe,
+                        // see the comment in `as_unsafe_napi_reference` for more.
+                        unsafe { b.as_unsafe_napi_reference(env) }
                     })
                     .transpose()?;
 
@@ -134,15 +132,14 @@ impl VmTraceDecoder {
                     })
                     .collect::<napi::Result<_>>()?;
 
-                let bytecode = bytecode.map(|b| b.as_object(env)).transpose()?;
-                let bytecode: Option<Reference<Bytecode>> = bytecode
-                    .map(|b| unsafe {
-                        use napi::NapiRaw;
-
-                        FromNapiValue::from_napi_value(env.raw(), b.raw())
+                let bytecode = bytecode
+                    .map(|b| {
+                        // SAFETY: the call is safe but the use may not be.
+                        // We only ever immutably access the bytecode, so it's safe,
+                        // see the comment in `as_unsafe_napi_reference` for more.
+                        unsafe { b.as_unsafe_napi_reference(env) }
                     })
                     .transpose()?;
-
                 create.bytecode = bytecode;
                 create.steps = steps;
 

--- a/crates/edr_napi/src/utils.rs
+++ b/crates/edr_napi/src/utils.rs
@@ -170,7 +170,7 @@ impl<T> ClassInstanceRef<T> {
     /// wrappers.
     ///
     /// This seems more trouble than it's worth and would basically reimplement
-    /// the `Reference` type with but with guarded access (probably should be
+    /// the `Reference` type but with guarded access (probably should be
     /// done upstream in `napi-rs` instead) and we only need the JS interface
     /// for the duration of the Solidity stack trace port[^3].
     ///

--- a/hardhat-tests/test/internal/hardhat-network/stack-traces/test.ts
+++ b/hardhat-tests/test/internal/hardhat-network/stack-traces/test.ts
@@ -329,22 +329,15 @@ function compareStackTraces(
       `Stack trace of tx ${txIndex} entry ${i} type is incorrect: expected ${expectedErrorType}, got ${actualErrorType}`
     );
 
-    const actualMessage = (actual as any).message as
-      | ReturnData
-      | string
-      | undefined;
-
-    // actual.message is a ReturnData in revert errors, but a string
-    // in custom errors
-    let decodedMessage = "";
-    if (typeof actualMessage === "string") {
-      decodedMessage = actualMessage;
-    } else if (
-      actualMessage instanceof ReturnData &&
-      actualMessage.isErrorReturnData()
-    ) {
-      decodedMessage = actualMessage.decodeError();
-    }
+    // actual.message is a ReturnData in revert errors but in custom errors
+    // we need to decode it
+    const decodedMessage =
+      "message" in actual
+        ? actual.message
+        : "returnData" in actual &&
+          new ReturnData(actual.returnData).isErrorReturnData()
+        ? new ReturnData(actual.returnData).decodeError()
+        : "";
 
     if (expected.message !== undefined) {
       assert.equal(

--- a/patches/gen-hardhat-patches.sh
+++ b/patches/gen-hardhat-patches.sh
@@ -34,6 +34,19 @@ COMMITS=(
   dc28ac9fcfa1f7096677f800226bad5f801fe89a
   # refactor: Port return-data.ts
   b65376b10590219711309df2aabc9f02e62a9b50
+  # Start porting SolidityTracer
+  fc7f3ab32e51fed39a41c943923368ade43a9fba
+  # Start porting ErrorInferrer
+  ab8e8cedfe399f687d19e32344b0f316f21c125f
+  # Port 99% of the ErrorInferrer
+  c9ec023d08e25ff11b899f721dcc845daa428a38
+  # Prune StackTraceEntry.message to make it clonable
+  243b2a76be55f9ac90bc0522f4c4100b60b0d192
+  # Port mapped-inlined-internal-functions-heuristics.ts
+  cc0ff8069444a8c98b014bc72191e5b0ec8fbac3
+  # Finish porting ErrorInferrer and SolidityTracer
+  cb1e10ff142964e0afaecf4753bc82398810195f
+
 )
 
 for commit in "${COMMITS[@]}"; do

--- a/patches/hardhat@2.22.6.patch
+++ b/patches/hardhat@2.22.6.patch
@@ -977,7 +977,7 @@ index 967ed191a2c3239b887083f0afe66c002a218713..42078f494e72169d6e769239a02159db
 +{"version":3,"file":"debug.d.ts","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/debug.ts"],"names":[],"mappings":"AAIA,OAAO,EACL,gBAAgB,EAChB,kBAAkB,EAIlB,YAAY,EACZ,sBAAsB,EACvB,MAAM,iBAAiB,CAAC;AAGzB,OAAO,EACL,kBAAkB,EAGnB,MAAM,wBAAwB,CAAC;AAIhC,wBAAgB,iBAAiB,CAAC,KAAK,EAAE,YAAY,EAAE,KAAK,SAAI,QAY/D;AAED,wBAAgB,gBAAgB,CAAC,KAAK,EAAE,kBAAkB,EAAE,KAAK,EAAE,MAAM,QAgCxE;AAED,wBAAgB,oBAAoB,CAClC,KAAK,EAAE,sBAAsB,EAC7B,KAAK,EAAE,MAAM,QAcd;AAED,wBAAgB,cAAc,CAAC,KAAK,EAAE,gBAAgB,EAAE,KAAK,EAAE,MAAM,QAyBpE;AA4ED,wBAAgB,eAAe,CAAC,KAAK,EAAE,kBAAkB,QA8BxD"}
 \ No newline at end of file
 diff --git a/internal/hardhat-network/stack-traces/debug.js b/internal/hardhat-network/stack-traces/debug.js
-index d0ee28a6c8f2eb4137e9dd9858b0c806896659b0..f87a4d77c559056b7547679406b87d24107cd4cb 100644
+index d0ee28a6c8f2eb4137e9dd9858b0c806896659b0..e70e8fa80e1cc9b3e775d42bf6947d2189988a81 100644
 --- a/internal/hardhat-network/stack-traces/debug.js
 +++ b/internal/hardhat-network/stack-traces/debug.js
 @@ -6,10 +6,10 @@ Object.defineProperty(exports, "__esModule", { value: true });
@@ -1014,16 +1014,17 @@ index d0ee28a6c8f2eb4137e9dd9858b0c806896659b0..f87a4d77c559056b7547679406b87d24
                  }
              }
              else {
-@@ -128,7 +128,7 @@ function flattenSourceReference(sourceReference) {
+@@ -128,15 +128,15 @@ function flattenSourceReference(sourceReference) {
      };
  }
  function printStackTrace(trace) {
 -    const withDecodedMessages = trace.map((entry) => entry.type === solidity_stack_trace_1.StackTraceEntryType.REVERT_ERROR
+-        ? { ...entry, message: entry.message.decodeError() }
 +    const withDecodedMessages = trace.map((entry) => entry.type === 4 /* StackTraceEntryType.REVERT_ERROR */
-         ? { ...entry, message: entry.message.decodeError() }
++        ? { ...entry, message: new edr_1.ReturnData(entry.returnData).decodeError() }
          : entry);
      const withHexAddress = withDecodedMessages.map((entry) => "address" in entry
-@@ -136,7 +136,7 @@ function printStackTrace(trace) {
+         ? { ...entry, address: (0, ethereumjs_util_1.bytesToHex)(entry.address) }
          : entry);
      const withTextualType = withHexAddress.map((entry) => ({
          ...entry,
@@ -1033,608 +1034,1296 @@ index d0ee28a6c8f2eb4137e9dd9858b0c806896659b0..f87a4d77c559056b7547679406b87d24
      const withFlattenedSourceReferences = withTextualType.map((entry) => ({
          ...entry,
 diff --git a/internal/hardhat-network/stack-traces/debug.js.map b/internal/hardhat-network/stack-traces/debug.js.map
-index 5687ea1ba89513386b08df144e97e53d5b21af89..3849d0288018c96614a54a9ac2e5dff68b763b06 100644
+index 5687ea1ba89513386b08df144e97e53d5b21af89..3fca97b54b9e95b503d7697d734e280573f90f7c 100644
 --- a/internal/hardhat-network/stack-traces/debug.js.map
 +++ b/internal/hardhat-network/stack-traces/debug.js.map
 @@ -1 +1 @@
 -{"version":3,"file":"debug.js","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/debug.ts"],"names":[],"mappings":";;;;;;AAAA,sEAA6E;AAC7E,kDAA0B;AAE1B,mDAQyB;AACzB,mCAAmC;AACnC,uCAAmD;AACnD,iEAIgC;AAEhC,MAAM,YAAY,GAAG,CAAC,CAAC;AAEvB,SAAgB,iBAAiB,CAAC,KAAmB,EAAE,KAAK,GAAG,CAAC;IAC9D,OAAO,CAAC,GAAG,CAAC,EAAE,CAAC,CAAC;IAEhB,IAAI,IAAA,6BAAa,EAAC,KAAK,CAAC,EAAE;QACxB,gBAAgB,CAAC,KAAK,EAAE,KAAK,CAAC,CAAC;KAChC;SAAM,IAAI,IAAA,iCAAiB,EAAC,KAAK,CAAC,EAAE;QACnC,oBAAoB,CAAC,KAAK,EAAE,KAAK,CAAC,CAAC;KACpC;SAAM;QACL,cAAc,CAAC,KAAK,EAAE,KAAK,CAAC,CAAC;KAC9B;IAED,OAAO,CAAC,GAAG,CAAC,EAAE,CAAC,CAAC;AAClB,CAAC;AAZD,8CAYC;AAED,SAAgB,gBAAgB,CAAC,KAAyB,EAAE,KAAa;IACvE,MAAM,MAAM,GAAG,EAAE,CAAC,QAAQ,CAAC,KAAK,GAAG,YAAY,CAAC,CAAC;IACjD,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,cAAc,CAAC,CAAC;IAErC,IAAI,KAAK,CAAC,QAAQ,KAAK,SAAS,EAAE;QAChC,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,wBAAwB,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI,CAAC,UAAU,IAAI,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI,EAAE,CACpH,CAAC;QAEF,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,UAAU,IAAA,4BAAW,EAAC,KAAK,CAAC,IAAI,CAAC,EAAE,CAAC,CAAC;KAC3D;SAAM;QACL,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,kCAAkC,IAAA,4BAAW,EAAC,KAAK,CAAC,IAAI,CAAC,EAAE,CACrE,CAAC;KACH;IAED,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,WAAW,KAAK,CAAC,KAAK,CAAC,QAAQ,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC;IAE5D,IAAI,KAAK,CAAC,gBAAgB,KAAK,SAAS,EAAE;QACxC,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,sBAAsB,IAAA,4BAAW,EAAC,KAAK,CAAC,gBAAgB,CAAC,EAAE,CACrE,CAAC;KACH;IAED,IAAI,KAAK,CAAC,IAAI,CAAC,OAAO,EAAE,EAAE;QACxB,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,WAAW,KAAK,CAAC,IAAI,CAAC,SAAS,EAAE,EAAE,CAAC,CAAC;QAE1D,sFAAsF;QACtF,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,gBAAgB,IAAA,4BAAW,EAAC,KAAK,CAAC,UAAU,CAAC,EAAE,CAAC,CAAC;KACvE;IAED,UAAU,CAAC,KAAK,EAAE,KAAK,CAAC,CAAC;AAC3B,CAAC;AAhCD,4CAgCC;AAED,SAAgB,oBAAoB,CAClC,KAA6B,EAC7B,KAAa;IAEb,MAAM,MAAM,GAAG,EAAE,CAAC,QAAQ,CAAC,KAAK,GAAG,YAAY,CAAC,CAAC;IACjD,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,kBAAkB,CAAC,CAAC;IAEzC,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,uBAAuB,KAAK,CAAC,UAAU,EAAE,CAAC,CAAC;IAChE,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,WAAW,KAAK,CAAC,KAAK,CAAC,QAAQ,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC;IAC5D,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,cAAc,IAAA,4BAAW,EAAC,KAAK,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC;IAElE,IAAI,KAAK,CAAC,IAAI,CAAC,OAAO,EAAE,EAAE;QACxB,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,WAAW,KAAK,CAAC,IAAI,CAAC,SAAS,EAAE,EAAE,CAAC,CAAC;KAC3D;IAED,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,gBAAgB,IAAA,4BAAW,EAAC,KAAK,CAAC,UAAU,CAAC,EAAE,CAAC,CAAC;AACxE,CAAC;AAhBD,oDAgBC;AAED,SAAgB,cAAc,CAAC,KAAuB,EAAE,KAAa;IACnE,MAAM,MAAM,GAAG,EAAE,CAAC,QAAQ,CAAC,KAAK,GAAG,YAAY,CAAC,CAAC;IACjD,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,YAAY,CAAC,CAAC;IAEnC,IAAI,KAAK,CAAC,QAAQ,KAAK,SAAS,EAAE;QAChC,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,sBAAsB,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI,CAAC,UAAU,IAAI,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI,EAAE,CAClH,CAAC;KACH;SAAM;QACL,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,gCAAgC,IAAA,4BAAW,EAAC,KAAK,CAAC,IAAI,CAAC,EAAE,CACnE,CAAC;QACF,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,cAAc,IAAA,4BAAW,EAAC,KAAK,CAAC,OAAO,CAAC,EAAE,CAAC,CAAC;KAClE;IAED,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,WAAW,KAAK,CAAC,KAAK,CAAC,QAAQ,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC;IAC5D,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,cAAc,IAAA,4BAAW,EAAC,KAAK,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC;IAElE,IAAI,KAAK,CAAC,IAAI,CAAC,OAAO,EAAE,EAAE;QACxB,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,WAAW,KAAK,CAAC,IAAI,CAAC,SAAS,EAAE,EAAE,CAAC,CAAC;KAC3D;IAED,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,gBAAgB,IAAA,4BAAW,EAAC,KAAK,CAAC,UAAU,CAAC,EAAE,CAAC,CAAC;IAEtE,UAAU,CAAC,KAAK,EAAE,KAAK,CAAC,CAAC;AAC3B,CAAC;AAzBD,wCAyBC;AAED,SAAS,UAAU,CACjB,KAA4C,EAC5C,KAAa;IAEb,MAAM,MAAM,GAAG,EAAE,CAAC,QAAQ,CAAC,KAAK,GAAG,YAAY,CAAC,CAAC;IAEjD,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,SAAS,CAAC,CAAC;IAChC,OAAO,CAAC,GAAG,CAAC,EAAE,CAAC,CAAC;IAEhB,KAAK,MAAM,IAAI,IAAI,KAAK,CAAC,KAAK,EAAE;QAC9B,IAAI,IAAA,yBAAS,EAAC,IAAI,CAAC,EAAE;YACnB,MAAM,EAAE,GAAG,IAAI,CAAC,EAAE,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC,QAAQ,CAAC,CAAC,EAAE,GAAG,CAAC,CAAC,QAAQ,CAAC,CAAC,CAAC,CAAC;YAE7D,IAAI,KAAK,CAAC,QAAQ,KAAK,SAAS,EAAE;gBAChC,MAAM,IAAI,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,IAAI,CAAC,EAAE,CAAC,CAAC;gBAEpD,IAAI,QAAQ,GAAW,EAAE,CAAC;gBAE1B,IAAI,IAAI,CAAC,QAAQ,KAAK,SAAS,EAAE;oBAC/B,QAAQ,IAAI,IAAI,CAAC,QAAQ,CAAC,IAAI,CAAC,UAAU,CAAC;oBAE1C,MAAM,IAAI,GAAG,IAAI,CAAC,QAAQ,CAAC,qBAAqB,EAAE,CAAC;oBACnD,IAAI,IAAI,KAAK,SAAS,EAAE;wBACtB,QAAQ,IAAI,IACV,IAAI,CAAC,QAAQ,EAAE,IAAI,IAAI,IAAI,CAAC,QAAQ,CAAC,IAAI,CAAC,UAC5C,IAAI,IAAI,CAAC,IAAI,EAAE,CAAC;qBACjB;oBAED,QAAQ,IAAI,SAAS,IAAI,CAAC,QAAQ,CAAC,MAAM,IAAI,IAAI,CAAC,QAAQ,CAAC,MAAM,EAAE,CAAC;iBACrE;gBAED,IAAI,IAAA,gBAAM,EAAC,IAAI,CAAC,MAAM,CAAC,EAAE;oBACvB,MAAM,IAAI,GACR,IAAI,CAAC,QAAQ,KAAK,gBAAQ,CAAC,QAAQ;wBACjC,CAAC,CAAC,eAAK,CAAC,IAAI,CAAC,IAAI,gBAAQ,CAAC,IAAI,CAAC,QAAQ,CAAC,GAAG,CAAC;wBAC5C,CAAC,CAAC,EAAE,CAAC;oBAET,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,KAAK,EAAE,MAAM,gBAAM,CAAC,IAAI,CAAC,MAAM,CAAC,IAAI,IAAI,EAAE,CAAC,MAAM,CAAC,EAAE,CAAC,EAC9D,QAAQ,CACT,CAAC;iBACH;qBAAM,IAAI,IAAA,gBAAM,EAAC,IAAI,CAAC,MAAM,CAAC,EAAE;oBAC9B,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,KAAK,EAAE,MAAM,gBAAM,CAAC,IAAI,CAAC,MAAM,CAAC,IAAI,IAAA,4BAAW,EACtD,IAAI,CAAC,QAAS,CACf,EAAE,CAAC,MAAM,CAAC,EAAE,CAAC,EACd,QAAQ,CACT,CAAC;iBACH;qBAAM;oBACL,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,KAAK,EAAE,MAAM,gBAAM,CAAC,IAAI,CAAC,MAAM,CAAC,EAAE,CAAC,MAAM,CAAC,EAAE,CAAC,EACtD,QAAQ,CACT,CAAC;iBACH;aACF;iBAAM;gBACL,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,KAAK,EAAE,EAAE,CAAC,CAAC;aACjC;SACF;aAAM;YACL,iBAAiB,CAAC,IAAI,EAAE,KAAK,GAAG,CAAC,CAAC,CAAC;SACpC;KACF;AACH,CAAC;AAED,SAAS,sBAAsB,CAAC,eAAiC;IAC/D,IAAI,eAAe,KAAK,SAAS,EAAE;QACjC,OAAO,SAAS,CAAC;KAClB;IAED,OAAO;QACL,GAAG,eAAe;QAClB,IAAI,EAAE,eAAe,CAAC,UAAU;KACjC,CAAC;AACJ,CAAC;AAED,SAAgB,eAAe,CAAC,KAAyB;IACvD,MAAM,mBAAmB,GAAG,KAAK,CAAC,GAAG,CAAC,CAAC,KAAK,EAAE,EAAE,CAC9C,KAAK,CAAC,IAAI,KAAK,0CAAmB,CAAC,YAAY;QAC7C,CAAC,CAAC,EAAE,GAAG,KAAK,EAAE,OAAO,EAAE,KAAK,CAAC,OAAO,CAAC,WAAW,EAAE,EAAE;QACpD,CAAC,CAAC,KAAK,CACV,CAAC;IAEF,MAAM,cAAc,GAAG,mBAAmB,CAAC,GAAG,CAAC,CAAC,KAAK,EAAE,EAAE,CACvD,SAAS,IAAI,KAAK;QAChB,CAAC,CAAC,EAAE,GAAG,KAAK,EAAE,OAAO,EAAE,IAAA,4BAAW,EAAC,KAAK,CAAC,OAAO,CAAC,EAAE;QACnD,CAAC,CAAC,KAAK,CACV,CAAC;IAEF,MAAM,eAAe,GAAG,cAAc,CAAC,GAAG,CAAC,CAAC,KAAK,EAAE,EAAE,CAAC,CAAC;QACrD,GAAG,KAAK;QACR,IAAI,EAAE,0CAAmB,CAAC,KAAK,CAAC,IAAI,CAAC;KACtC,CAAC,CAAC,CAAC;IAEJ,MAAM,6BAA6B,GAAG,eAAe,CAAC,GAAG,CAAC,CAAC,KAAK,EAAE,EAAE,CAAC,CAAC;QACpE,GAAG,KAAK;QACR,eAAe,EAAE,sBAAsB,CAAC,KAAK,CAAC,eAAe,CAAC;KAC/D,CAAC,CAAC,CAAC;IAEJ,OAAO,CAAC,GAAG,CACT,IAAI,CAAC,SAAS,CACZ,6BAA6B,EAC7B,CAAC,GAAG,EAAE,KAAK,EAAE,EAAE,CAAC,CAAC,OAAO,KAAK,KAAK,QAAQ,CAAC,CAAC,CAAC,KAAK,CAAC,QAAQ,EAAE,CAAC,CAAC,CAAC,KAAK,CAAC,EACtE,CAAC,CACF,CACF,CAAC;AACJ,CAAC;AA9BD,0CA8BC"}
 \ No newline at end of file
-+{"version":3,"file":"debug.js","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/debug.ts"],"names":[],"mappings":";;;;;;AAAA,sEAA6E;AAC7E,kDAA0B;AAE1B,8CAAmE;AACnE,mDAQyB;AACzB,mCAAqD;AACrD,uCAA2D;AAO3D,MAAM,YAAY,GAAG,CAAC,CAAC;AAEvB,SAAgB,iBAAiB,CAAC,KAAmB,EAAE,KAAK,GAAG,CAAC;IAC9D,OAAO,CAAC,GAAG,CAAC,EAAE,CAAC,CAAC;IAEhB,IAAI,IAAA,6BAAa,EAAC,KAAK,CAAC,EAAE;QACxB,gBAAgB,CAAC,KAAK,EAAE,KAAK,CAAC,CAAC;KAChC;SAAM,IAAI,IAAA,iCAAiB,EAAC,KAAK,CAAC,EAAE;QACnC,oBAAoB,CAAC,KAAK,EAAE,KAAK,CAAC,CAAC;KACpC;SAAM;QACL,cAAc,CAAC,KAAK,EAAE,KAAK,CAAC,CAAC;KAC9B;IAED,OAAO,CAAC,GAAG,CAAC,EAAE,CAAC,CAAC;AAClB,CAAC;AAZD,8CAYC;AAED,SAAgB,gBAAgB,CAAC,KAAyB,EAAE,KAAa;IACvE,MAAM,MAAM,GAAG,EAAE,CAAC,QAAQ,CAAC,KAAK,GAAG,YAAY,CAAC,CAAC;IACjD,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,cAAc,CAAC,CAAC;IAErC,IAAI,KAAK,CAAC,QAAQ,KAAK,SAAS,EAAE;QAChC,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,wBAAwB,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI,CAAC,UAAU,IAAI,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI,EAAE,CACpH,CAAC;QAEF,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,UAAU,IAAA,4BAAW,EAAC,KAAK,CAAC,IAAI,CAAC,EAAE,CAAC,CAAC;KAC3D;SAAM;QACL,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,kCAAkC,IAAA,4BAAW,EAAC,KAAK,CAAC,IAAI,CAAC,EAAE,CACrE,CAAC;KACH;IAED,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,WAAW,KAAK,CAAC,KAAK,CAAC,QAAQ,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC;IAE5D,IAAI,KAAK,CAAC,gBAAgB,KAAK,SAAS,EAAE;QACxC,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,sBAAsB,IAAA,4BAAW,EAAC,KAAK,CAAC,gBAAgB,CAAC,EAAE,CACrE,CAAC;KACH;IAED,IAAI,KAAK,CAAC,IAAI,CAAC,OAAO,EAAE,EAAE;QACxB,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,WAAW,KAAK,CAAC,IAAI,CAAC,SAAS,EAAE,EAAE,CAAC,CAAC;QAE1D,sFAAsF;QACtF,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,gBAAgB,IAAA,4BAAW,EAAC,KAAK,CAAC,UAAU,CAAC,EAAE,CAAC,CAAC;KACvE;IAED,UAAU,CAAC,KAAK,EAAE,KAAK,CAAC,CAAC;AAC3B,CAAC;AAhCD,4CAgCC;AAED,SAAgB,oBAAoB,CAClC,KAA6B,EAC7B,KAAa;IAEb,MAAM,MAAM,GAAG,EAAE,CAAC,QAAQ,CAAC,KAAK,GAAG,YAAY,CAAC,CAAC;IACjD,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,kBAAkB,CAAC,CAAC;IAEzC,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,uBAAuB,KAAK,CAAC,UAAU,EAAE,CAAC,CAAC;IAChE,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,WAAW,KAAK,CAAC,KAAK,CAAC,QAAQ,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC;IAC5D,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,cAAc,IAAA,4BAAW,EAAC,KAAK,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC;IAElE,IAAI,KAAK,CAAC,IAAI,CAAC,OAAO,EAAE,EAAE;QACxB,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,WAAW,KAAK,CAAC,IAAI,CAAC,SAAS,EAAE,EAAE,CAAC,CAAC;KAC3D;IAED,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,gBAAgB,IAAA,4BAAW,EAAC,KAAK,CAAC,UAAU,CAAC,EAAE,CAAC,CAAC;AACxE,CAAC;AAhBD,oDAgBC;AAED,SAAgB,cAAc,CAAC,KAAuB,EAAE,KAAa;IACnE,MAAM,MAAM,GAAG,EAAE,CAAC,QAAQ,CAAC,KAAK,GAAG,YAAY,CAAC,CAAC;IACjD,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,YAAY,CAAC,CAAC;IAEnC,IAAI,KAAK,CAAC,QAAQ,KAAK,SAAS,EAAE;QAChC,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,sBAAsB,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI,CAAC,UAAU,IAAI,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI,EAAE,CAClH,CAAC;KACH;SAAM;QACL,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,gCAAgC,IAAA,4BAAW,EAAC,KAAK,CAAC,IAAI,CAAC,EAAE,CACnE,CAAC;QACF,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,cAAc,IAAA,4BAAW,EAAC,KAAK,CAAC,OAAO,CAAC,EAAE,CAAC,CAAC;KAClE;IAED,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,WAAW,KAAK,CAAC,KAAK,CAAC,QAAQ,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC;IAC5D,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,cAAc,IAAA,4BAAW,EAAC,KAAK,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC;IAElE,IAAI,KAAK,CAAC,IAAI,CAAC,OAAO,EAAE,EAAE;QACxB,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,WAAW,KAAK,CAAC,IAAI,CAAC,SAAS,EAAE,EAAE,CAAC,CAAC;KAC3D;IAED,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,gBAAgB,IAAA,4BAAW,EAAC,KAAK,CAAC,UAAU,CAAC,EAAE,CAAC,CAAC;IAEtE,UAAU,CAAC,KAAK,EAAE,KAAK,CAAC,CAAC;AAC3B,CAAC;AAzBD,wCAyBC;AAED,SAAS,UAAU,CACjB,KAA4C,EAC5C,KAAa;IAEb,MAAM,MAAM,GAAG,EAAE,CAAC,QAAQ,CAAC,KAAK,GAAG,YAAY,CAAC,CAAC;IAEjD,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,SAAS,CAAC,CAAC;IAChC,OAAO,CAAC,GAAG,CAAC,EAAE,CAAC,CAAC;IAEhB,KAAK,MAAM,IAAI,IAAI,KAAK,CAAC,KAAK,EAAE;QAC9B,IAAI,IAAA,yBAAS,EAAC,IAAI,CAAC,EAAE;YACnB,MAAM,EAAE,GAAG,IAAI,CAAC,EAAE,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC,QAAQ,CAAC,CAAC,EAAE,GAAG,CAAC,CAAC,QAAQ,CAAC,CAAC,CAAC,CAAC;YAE7D,IAAI,KAAK,CAAC,QAAQ,KAAK,SAAS,EAAE;gBAChC,MAAM,IAAI,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,IAAI,CAAC,EAAE,CAAC,CAAC;gBAEpD,IAAI,QAAQ,GAAW,EAAE,CAAC;gBAE1B,IAAI,IAAI,CAAC,QAAQ,KAAK,SAAS,EAAE;oBAC/B,QAAQ,IAAI,IAAI,CAAC,QAAQ,CAAC,IAAI,CAAC,UAAU,CAAC;oBAE1C,MAAM,IAAI,GAAG,IAAI,CAAC,QAAQ,CAAC,qBAAqB,EAAE,CAAC;oBACnD,IAAI,IAAI,KAAK,SAAS,EAAE;wBACtB,QAAQ,IAAI,IACV,IAAI,CAAC,QAAQ,EAAE,IAAI,IAAI,IAAI,CAAC,QAAQ,CAAC,IAAI,CAAC,UAC5C,IAAI,IAAI,CAAC,IAAI,EAAE,CAAC;qBACjB;oBAED,QAAQ,IAAI,SAAS,IAAI,CAAC,QAAQ,CAAC,MAAM,IAAI,IAAI,CAAC,QAAQ,CAAC,MAAM,EAAE,CAAC;iBACrE;gBAED,IAAI,IAAA,gBAAM,EAAC,IAAI,CAAC,MAAM,CAAC,EAAE;oBACvB,MAAM,IAAI,GACR,IAAI,CAAC,QAAQ,8BAAsB;wBACjC,CAAC,CAAC,eAAK,CAAC,IAAI,CAAC,IAAI,IAAA,wBAAgB,EAAC,IAAI,CAAC,QAAQ,CAAC,GAAG,CAAC;wBACpD,CAAC,CAAC,EAAE,CAAC;oBAET,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,KAAK,EAAE,MAAM,IAAA,wBAAc,EAAC,IAAI,CAAC,MAAM,CAAC,IAAI,IAAI,EAAE,CAAC,MAAM,CAAC,EAAE,CAAC,EACtE,QAAQ,CACT,CAAC;iBACH;qBAAM,IAAI,IAAA,gBAAM,EAAC,IAAI,CAAC,MAAM,CAAC,EAAE;oBAC9B,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,KAAK,EAAE,MAAM,IAAA,wBAAc,EAAC,IAAI,CAAC,MAAM,CAAC,IAAI,IAAA,4BAAW,EAC9D,IAAI,CAAC,QAAS,CACf,EAAE,CAAC,MAAM,CAAC,EAAE,CAAC,EACd,QAAQ,CACT,CAAC;iBACH;qBAAM;oBACL,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,KAAK,EAAE,MAAM,IAAA,wBAAc,EAAC,IAAI,CAAC,MAAM,CAAC,EAAE,CAAC,MAAM,CAAC,EAAE,CAAC,EAC9D,QAAQ,CACT,CAAC;iBACH;aACF;iBAAM;gBACL,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,KAAK,EAAE,EAAE,CAAC,CAAC;aACjC;SACF;aAAM;YACL,iBAAiB,CAAC,IAAI,EAAE,KAAK,GAAG,CAAC,CAAC,CAAC;SACpC;KACF;AACH,CAAC;AAED,SAAS,sBAAsB,CAAC,eAAiC;IAC/D,IAAI,eAAe,KAAK,SAAS,EAAE;QACjC,OAAO,SAAS,CAAC;KAClB;IAED,OAAO;QACL,GAAG,eAAe;QAClB,IAAI,EAAE,eAAe,CAAC,UAAU;KACjC,CAAC;AACJ,CAAC;AAED,SAAgB,eAAe,CAAC,KAAyB;IACvD,MAAM,mBAAmB,GAAG,KAAK,CAAC,GAAG,CAAC,CAAC,KAAK,EAAE,EAAE,CAC9C,KAAK,CAAC,IAAI,6CAAqC;QAC7C,CAAC,CAAC,EAAE,GAAG,KAAK,EAAE,OAAO,EAAE,KAAK,CAAC,OAAO,CAAC,WAAW,EAAE,EAAE;QACpD,CAAC,CAAC,KAAK,CACV,CAAC;IAEF,MAAM,cAAc,GAAG,mBAAmB,CAAC,GAAG,CAAC,CAAC,KAAK,EAAE,EAAE,CACvD,SAAS,IAAI,KAAK;QAChB,CAAC,CAAC,EAAE,GAAG,KAAK,EAAE,OAAO,EAAE,IAAA,4BAAW,EAAC,KAAK,CAAC,OAAO,CAAC,EAAE;QACnD,CAAC,CAAC,KAAK,CACV,CAAC;IAEF,MAAM,eAAe,GAAG,cAAc,CAAC,GAAG,CAAC,CAAC,KAAK,EAAE,EAAE,CAAC,CAAC;QACrD,GAAG,KAAK;QACR,IAAI,EAAE,IAAA,iCAA2B,EAAC,KAAK,CAAC,IAAI,CAAC;KAC9C,CAAC,CAAC,CAAC;IAEJ,MAAM,6BAA6B,GAAG,eAAe,CAAC,GAAG,CAAC,CAAC,KAAK,EAAE,EAAE,CAAC,CAAC;QACpE,GAAG,KAAK;QACR,eAAe,EAAE,sBAAsB,CAAC,KAAK,CAAC,eAAe,CAAC;KAC/D,CAAC,CAAC,CAAC;IAEJ,OAAO,CAAC,GAAG,CACT,IAAI,CAAC,SAAS,CACZ,6BAA6B,EAC7B,CAAC,GAAG,EAAE,KAAK,EAAE,EAAE,CAAC,CAAC,OAAO,KAAK,KAAK,QAAQ,CAAC,CAAC,CAAC,KAAK,CAAC,QAAQ,EAAE,CAAC,CAAC,CAAC,KAAK,CAAC,EACtE,CAAC,CACF,CACF,CAAC;AACJ,CAAC;AA9BD,0CA8BC"}
++{"version":3,"file":"debug.js","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/debug.ts"],"names":[],"mappings":";;;;;;AAAA,sEAA6E;AAC7E,kDAA0B;AAE1B,8CAA+E;AAC/E,mDAQyB;AACzB,mCAAqD;AACrD,uCAA2D;AAO3D,MAAM,YAAY,GAAG,CAAC,CAAC;AAEvB,SAAgB,iBAAiB,CAAC,KAAmB,EAAE,KAAK,GAAG,CAAC;IAC9D,OAAO,CAAC,GAAG,CAAC,EAAE,CAAC,CAAC;IAEhB,IAAI,IAAA,6BAAa,EAAC,KAAK,CAAC,EAAE;QACxB,gBAAgB,CAAC,KAAK,EAAE,KAAK,CAAC,CAAC;KAChC;SAAM,IAAI,IAAA,iCAAiB,EAAC,KAAK,CAAC,EAAE;QACnC,oBAAoB,CAAC,KAAK,EAAE,KAAK,CAAC,CAAC;KACpC;SAAM;QACL,cAAc,CAAC,KAAK,EAAE,KAAK,CAAC,CAAC;KAC9B;IAED,OAAO,CAAC,GAAG,CAAC,EAAE,CAAC,CAAC;AAClB,CAAC;AAZD,8CAYC;AAED,SAAgB,gBAAgB,CAAC,KAAyB,EAAE,KAAa;IACvE,MAAM,MAAM,GAAG,EAAE,CAAC,QAAQ,CAAC,KAAK,GAAG,YAAY,CAAC,CAAC;IACjD,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,cAAc,CAAC,CAAC;IAErC,IAAI,KAAK,CAAC,QAAQ,KAAK,SAAS,EAAE;QAChC,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,wBAAwB,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI,CAAC,UAAU,IAAI,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI,EAAE,CACpH,CAAC;QAEF,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,UAAU,IAAA,4BAAW,EAAC,KAAK,CAAC,IAAI,CAAC,EAAE,CAAC,CAAC;KAC3D;SAAM;QACL,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,kCAAkC,IAAA,4BAAW,EAAC,KAAK,CAAC,IAAI,CAAC,EAAE,CACrE,CAAC;KACH;IAED,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,WAAW,KAAK,CAAC,KAAK,CAAC,QAAQ,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC;IAE5D,IAAI,KAAK,CAAC,gBAAgB,KAAK,SAAS,EAAE;QACxC,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,sBAAsB,IAAA,4BAAW,EAAC,KAAK,CAAC,gBAAgB,CAAC,EAAE,CACrE,CAAC;KACH;IAED,IAAI,KAAK,CAAC,IAAI,CAAC,OAAO,EAAE,EAAE;QACxB,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,WAAW,KAAK,CAAC,IAAI,CAAC,SAAS,EAAE,EAAE,CAAC,CAAC;QAE1D,sFAAsF;QACtF,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,gBAAgB,IAAA,4BAAW,EAAC,KAAK,CAAC,UAAU,CAAC,EAAE,CAAC,CAAC;KACvE;IAED,UAAU,CAAC,KAAK,EAAE,KAAK,CAAC,CAAC;AAC3B,CAAC;AAhCD,4CAgCC;AAED,SAAgB,oBAAoB,CAClC,KAA6B,EAC7B,KAAa;IAEb,MAAM,MAAM,GAAG,EAAE,CAAC,QAAQ,CAAC,KAAK,GAAG,YAAY,CAAC,CAAC;IACjD,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,kBAAkB,CAAC,CAAC;IAEzC,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,uBAAuB,KAAK,CAAC,UAAU,EAAE,CAAC,CAAC;IAChE,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,WAAW,KAAK,CAAC,KAAK,CAAC,QAAQ,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC;IAC5D,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,cAAc,IAAA,4BAAW,EAAC,KAAK,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC;IAElE,IAAI,KAAK,CAAC,IAAI,CAAC,OAAO,EAAE,EAAE;QACxB,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,WAAW,KAAK,CAAC,IAAI,CAAC,SAAS,EAAE,EAAE,CAAC,CAAC;KAC3D;IAED,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,gBAAgB,IAAA,4BAAW,EAAC,KAAK,CAAC,UAAU,CAAC,EAAE,CAAC,CAAC;AACxE,CAAC;AAhBD,oDAgBC;AAED,SAAgB,cAAc,CAAC,KAAuB,EAAE,KAAa;IACnE,MAAM,MAAM,GAAG,EAAE,CAAC,QAAQ,CAAC,KAAK,GAAG,YAAY,CAAC,CAAC;IACjD,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,YAAY,CAAC,CAAC;IAEnC,IAAI,KAAK,CAAC,QAAQ,KAAK,SAAS,EAAE;QAChC,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,sBAAsB,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI,CAAC,UAAU,IAAI,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI,EAAE,CAClH,CAAC;KACH;SAAM;QACL,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,gCAAgC,IAAA,4BAAW,EAAC,KAAK,CAAC,IAAI,CAAC,EAAE,CACnE,CAAC;QACF,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,cAAc,IAAA,4BAAW,EAAC,KAAK,CAAC,OAAO,CAAC,EAAE,CAAC,CAAC;KAClE;IAED,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,WAAW,KAAK,CAAC,KAAK,CAAC,QAAQ,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC;IAC5D,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,cAAc,IAAA,4BAAW,EAAC,KAAK,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC;IAElE,IAAI,KAAK,CAAC,IAAI,CAAC,OAAO,EAAE,EAAE;QACxB,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,WAAW,KAAK,CAAC,IAAI,CAAC,SAAS,EAAE,EAAE,CAAC,CAAC;KAC3D;IAED,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,gBAAgB,IAAA,4BAAW,EAAC,KAAK,CAAC,UAAU,CAAC,EAAE,CAAC,CAAC;IAEtE,UAAU,CAAC,KAAK,EAAE,KAAK,CAAC,CAAC;AAC3B,CAAC;AAzBD,wCAyBC;AAED,SAAS,UAAU,CACjB,KAA4C,EAC5C,KAAa;IAEb,MAAM,MAAM,GAAG,EAAE,CAAC,QAAQ,CAAC,KAAK,GAAG,YAAY,CAAC,CAAC;IAEjD,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,SAAS,CAAC,CAAC;IAChC,OAAO,CAAC,GAAG,CAAC,EAAE,CAAC,CAAC;IAEhB,KAAK,MAAM,IAAI,IAAI,KAAK,CAAC,KAAK,EAAE;QAC9B,IAAI,IAAA,yBAAS,EAAC,IAAI,CAAC,EAAE;YACnB,MAAM,EAAE,GAAG,IAAI,CAAC,EAAE,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC,QAAQ,CAAC,CAAC,EAAE,GAAG,CAAC,CAAC,QAAQ,CAAC,CAAC,CAAC,CAAC;YAE7D,IAAI,KAAK,CAAC,QAAQ,KAAK,SAAS,EAAE;gBAChC,MAAM,IAAI,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,IAAI,CAAC,EAAE,CAAC,CAAC;gBAEpD,IAAI,QAAQ,GAAW,EAAE,CAAC;gBAE1B,IAAI,IAAI,CAAC,QAAQ,KAAK,SAAS,EAAE;oBAC/B,QAAQ,IAAI,IAAI,CAAC,QAAQ,CAAC,IAAI,CAAC,UAAU,CAAC;oBAE1C,MAAM,IAAI,GAAG,IAAI,CAAC,QAAQ,CAAC,qBAAqB,EAAE,CAAC;oBACnD,IAAI,IAAI,KAAK,SAAS,EAAE;wBACtB,QAAQ,IAAI,IACV,IAAI,CAAC,QAAQ,EAAE,IAAI,IAAI,IAAI,CAAC,QAAQ,CAAC,IAAI,CAAC,UAC5C,IAAI,IAAI,CAAC,IAAI,EAAE,CAAC;qBACjB;oBAED,QAAQ,IAAI,SAAS,IAAI,CAAC,QAAQ,CAAC,MAAM,IAAI,IAAI,CAAC,QAAQ,CAAC,MAAM,EAAE,CAAC;iBACrE;gBAED,IAAI,IAAA,gBAAM,EAAC,IAAI,CAAC,MAAM,CAAC,EAAE;oBACvB,MAAM,IAAI,GACR,IAAI,CAAC,QAAQ,8BAAsB;wBACjC,CAAC,CAAC,eAAK,CAAC,IAAI,CAAC,IAAI,IAAA,wBAAgB,EAAC,IAAI,CAAC,QAAQ,CAAC,GAAG,CAAC;wBACpD,CAAC,CAAC,EAAE,CAAC;oBAET,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,KAAK,EAAE,MAAM,IAAA,wBAAc,EAAC,IAAI,CAAC,MAAM,CAAC,IAAI,IAAI,EAAE,CAAC,MAAM,CAAC,EAAE,CAAC,EACtE,QAAQ,CACT,CAAC;iBACH;qBAAM,IAAI,IAAA,gBAAM,EAAC,IAAI,CAAC,MAAM,CAAC,EAAE;oBAC9B,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,KAAK,EAAE,MAAM,IAAA,wBAAc,EAAC,IAAI,CAAC,MAAM,CAAC,IAAI,IAAA,4BAAW,EAC9D,IAAI,CAAC,QAAS,CACf,EAAE,CAAC,MAAM,CAAC,EAAE,CAAC,EACd,QAAQ,CACT,CAAC;iBACH;qBAAM;oBACL,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,KAAK,EAAE,MAAM,IAAA,wBAAc,EAAC,IAAI,CAAC,MAAM,CAAC,EAAE,CAAC,MAAM,CAAC,EAAE,CAAC,EAC9D,QAAQ,CACT,CAAC;iBACH;aACF;iBAAM;gBACL,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,KAAK,EAAE,EAAE,CAAC,CAAC;aACjC;SACF;aAAM;YACL,iBAAiB,CAAC,IAAI,EAAE,KAAK,GAAG,CAAC,CAAC,CAAC;SACpC;KACF;AACH,CAAC;AAED,SAAS,sBAAsB,CAAC,eAAiC;IAC/D,IAAI,eAAe,KAAK,SAAS,EAAE;QACjC,OAAO,SAAS,CAAC;KAClB;IAED,OAAO;QACL,GAAG,eAAe;QAClB,IAAI,EAAE,eAAe,CAAC,UAAU;KACjC,CAAC;AACJ,CAAC;AAED,SAAgB,eAAe,CAAC,KAAyB;IACvD,MAAM,mBAAmB,GAAG,KAAK,CAAC,GAAG,CAAC,CAAC,KAAK,EAAE,EAAE,CAC9C,KAAK,CAAC,IAAI,6CAAqC;QAC7C,CAAC,CAAC,EAAE,GAAG,KAAK,EAAE,OAAO,EAAE,IAAI,gBAAU,CAAC,KAAK,CAAC,UAAU,CAAC,CAAC,WAAW,EAAE,EAAE;QACvE,CAAC,CAAC,KAAK,CACV,CAAC;IAEF,MAAM,cAAc,GAAG,mBAAmB,CAAC,GAAG,CAAC,CAAC,KAAK,EAAE,EAAE,CACvD,SAAS,IAAI,KAAK;QAChB,CAAC,CAAC,EAAE,GAAG,KAAK,EAAE,OAAO,EAAE,IAAA,4BAAW,EAAC,KAAK,CAAC,OAAO,CAAC,EAAE;QACnD,CAAC,CAAC,KAAK,CACV,CAAC;IAEF,MAAM,eAAe,GAAG,cAAc,CAAC,GAAG,CAAC,CAAC,KAAK,EAAE,EAAE,CAAC,CAAC;QACrD,GAAG,KAAK;QACR,IAAI,EAAE,IAAA,iCAA2B,EAAC,KAAK,CAAC,IAAI,CAAC;KAC9C,CAAC,CAAC,CAAC;IAEJ,MAAM,6BAA6B,GAAG,eAAe,CAAC,GAAG,CAAC,CAAC,KAAK,EAAE,EAAE,CAAC,CAAC;QACpE,GAAG,KAAK;QACR,eAAe,EAAE,sBAAsB,CAAC,KAAK,CAAC,eAAe,CAAC;KAC/D,CAAC,CAAC,CAAC;IAEJ,OAAO,CAAC,GAAG,CACT,IAAI,CAAC,SAAS,CACZ,6BAA6B,EAC7B,CAAC,GAAG,EAAE,KAAK,EAAE,EAAE,CAAC,CAAC,OAAO,KAAK,KAAK,QAAQ,CAAC,CAAC,CAAC,KAAK,CAAC,QAAQ,EAAE,CAAC,CAAC,CAAC,KAAK,CAAC,EACtE,CAAC,CACF,CACF,CAAC;AACJ,CAAC;AA9BD,0CA8BC"}
+\ No newline at end of file
+diff --git a/internal/hardhat-network/stack-traces/error-inferrer.d.ts b/internal/hardhat-network/stack-traces/error-inferrer.d.ts
+index b764cdf20700f14f1c40913e05d431beb26456f4..05d16bc67123b73a160dadefac0ab3d8231c3ead 100644
+--- a/internal/hardhat-network/stack-traces/error-inferrer.d.ts
++++ b/internal/hardhat-network/stack-traces/error-inferrer.d.ts
+@@ -1,85 +1 @@
+-import { DecodedCallMessageTrace, DecodedCreateMessageTrace, DecodedEvmMessageTrace, MessageTrace } from "./message-trace";
+-import { Bytecode, Instruction } from "./model";
+-import { CallstackEntryStackTraceEntry, InternalFunctionCallStackEntry, SolidityStackTrace } from "./solidity-stack-trace";
+-export interface SubmessageData {
+-    messageTrace: MessageTrace;
+-    stacktrace: SolidityStackTrace;
+-    stepIndex: number;
+-}
+-export declare class ErrorInferrer {
+-    inferBeforeTracingCallMessage(trace: DecodedCallMessageTrace): SolidityStackTrace | undefined;
+-    inferBeforeTracingCreateMessage(trace: DecodedCreateMessageTrace): SolidityStackTrace | undefined;
+-    inferAfterTracing(trace: DecodedEvmMessageTrace, stacktrace: SolidityStackTrace, functionJumpdests: Instruction[], jumpedIntoFunction: boolean, lastSubmessageData: SubmessageData | undefined): SolidityStackTrace;
+-    filterRedundantFrames(stacktrace: SolidityStackTrace): SolidityStackTrace;
+-    /**
+-     * Check if the last submessage can be used to generate the stack trace.
+-     */
+-    private _checkLastSubmessage;
+-    /**
+-     * Check if the last call/create that was done failed.
+-     */
+-    private _checkFailedLastCall;
+-    /**
+-     * Check if the execution stopped with a revert or an invalid opcode.
+-     */
+-    private _checkRevertOrInvalidOpcode;
+-    /**
+-     * Check if the trace reverted with a panic error.
+-     */
+-    private _checkPanic;
+-    private _checkCustomErrors;
+-    /**
+-     * Check last instruction to try to infer the error.
+-     */
+-    private _checkLastInstruction;
+-    private _checkNonContractCalled;
+-    private _checkSolidity063UnmappedRevert;
+-    private _checkContractTooLarge;
+-    private _otherExecutionErrorStacktrace;
+-    private _fixInitialModifier;
+-    private _isDirectLibraryCall;
+-    private _getDirectLibraryCallErrorStackTrace;
+-    private _isFunctionNotPayableError;
+-    private _getFunctionStartSourceReference;
+-    private _isMissingFunctionAndFallbackError;
+-    private _emptyCalldataAndNoReceive;
+-    private _getContractStartWithoutFunctionSourceReference;
+-    private _isFallbackNotPayableError;
+-    private _getFallbackStartSourceReference;
+-    private _isConstructorNotPayableError;
+-    /**
+-     * Returns a source reference pointing to the constructor if it exists, or to the contract
+-     * otherwise.
+-     */
+-    private _getConstructorStartSourceReference;
+-    private _isConstructorInvalidArgumentsError;
+-    private _getEntryBeforeInitialModifierCallstackEntry;
+-    private _getLastSourceReference;
+-    private _hasFailedInsideTheFallbackFunction;
+-    private _hasFailedInsideTheReceiveFunction;
+-    private _hasFailedInsideFunction;
+-    private _instructionWithinFunctionToRevertStackTraceEntry;
+-    private _instructionWithinFunctionToUnmappedSolc063RevertErrorStackTraceEntry;
+-    private _instructionWithinFunctionToPanicStackTraceEntry;
+-    private _instructionWithinFunctionToCustomErrorStackTraceEntry;
+-    private _solidity063MaybeUnmappedRevert;
+-    private _solidity063GetFrameForUnmappedRevertBeforeFunction;
+-    private _getOtherErrorBeforeCalledFunctionStackTraceEntry;
+-    private _isCalledNonContractAccountError;
+-    private _solidity063GetFrameForUnmappedRevertWithinFunction;
+-    private _isContractTooLargeError;
+-    private _solidity063CorrectLineNumber;
+-    private _getLastInstructionWithValidLocationStepIndex;
+-    private _getLastInstructionWithValidLocation;
+-    private _callInstructionToCallFailedToExecuteStackTraceEntry;
+-    private _getEntryBeforeFailureInModifier;
+-    private _failsRightAfterCall;
+-    private _isCallFailedError;
+-    private _isLastLocation;
+-    private _isSubtraceErrorPropagated;
+-    private _isProxyErrorPropagated;
+-    private _isContractCallRunOutOfGasError;
+-    private _isPanicReturnData;
+-}
+-export declare function instructionToCallstackStackTraceEntry(bytecode: Bytecode, inst: Instruction): CallstackEntryStackTraceEntry | InternalFunctionCallStackEntry;
+ //# sourceMappingURL=error-inferrer.d.ts.map
 \ No newline at end of file
 diff --git a/internal/hardhat-network/stack-traces/error-inferrer.d.ts.map b/internal/hardhat-network/stack-traces/error-inferrer.d.ts.map
-index 3caaa807d4af2ca61beb1ecb3008f1f071736a10..4ebf97785f77dbc0dcbe3e7000886f2cd9f80c4b 100644
+index 3caaa807d4af2ca61beb1ecb3008f1f071736a10..96c2020330da3c21b1c08292e3c9cbaeb1ed17c3 100644
 --- a/internal/hardhat-network/stack-traces/error-inferrer.d.ts.map
 +++ b/internal/hardhat-network/stack-traces/error-inferrer.d.ts.map
 @@ -1 +1 @@
 -{"version":3,"file":"error-inferrer.d.ts","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/error-inferrer.ts"],"names":[],"mappings":"AAUA,OAAO,EACL,uBAAuB,EACvB,yBAAyB,EACzB,sBAAsB,EAOtB,YAAY,EACb,MAAM,iBAAiB,CAAC;AACzB,OAAO,EACL,QAAQ,EAIR,WAAW,EAGZ,MAAM,SAAS,CAAC;AAEjB,OAAO,EAEL,6BAA6B,EAI7B,8BAA8B,EAK9B,kBAAkB,EAKnB,MAAM,wBAAwB,CAAC;AAMhC,MAAM,WAAW,cAAc;IAC7B,YAAY,EAAE,YAAY,CAAC;IAC3B,UAAU,EAAE,kBAAkB,CAAC;IAC/B,SAAS,EAAE,MAAM,CAAC;CACnB;AAID,qBAAa,aAAa;IACjB,6BAA6B,CAClC,KAAK,EAAE,uBAAuB,GAC7B,kBAAkB,GAAG,SAAS;IAkE1B,+BAA+B,CACpC,KAAK,EAAE,yBAAyB,GAC/B,kBAAkB,GAAG,SAAS;IAqB1B,iBAAiB,CACtB,KAAK,EAAE,sBAAsB,EAC7B,UAAU,EAAE,kBAAkB,EAC9B,iBAAiB,EAAE,WAAW,EAAE,EAChC,kBAAkB,EAAE,OAAO,EAC3B,kBAAkB,EAAE,cAAc,GAAG,SAAS,GAC7C,kBAAkB;IAiBd,qBAAqB,CAC1B,UAAU,EAAE,kBAAkB,GAC7B,kBAAkB;IAqErB;;OAEG;IACH,OAAO,CAAC,oBAAoB;IAwE5B;;OAEG;IACH,OAAO,CAAC,oBAAoB;IAgC5B;;OAEG;IACH,OAAO,CAAC,2BAA2B;IA2HnC;;OAEG;IACH,OAAO,CAAC,WAAW;IAyCnB,OAAO,CAAC,kBAAkB;IA2C1B;;OAEG;IACH,OAAO,CAAC,qBAAqB;IAmG7B,OAAO,CAAC,uBAAuB;IAsB/B,OAAO,CAAC,+BAA+B;IAcvC,OAAO,CAAC,sBAAsB;IAa9B,OAAO,CAAC,8BAA8B;IActC,OAAO,CAAC,mBAAmB;IAmB3B,OAAO,CAAC,oBAAoB;IAM5B,OAAO,CAAC,oCAAoC;IAyB5C,OAAO,CAAC,0BAA0B;IAqBlC,OAAO,CAAC,gCAAgC;IAiBxC,OAAO,CAAC,kCAAkC;IAyB1C,OAAO,CAAC,0BAA0B;IAiBlC,OAAO,CAAC,+CAA+C;IAavD,OAAO,CAAC,0BAA0B;IA0BlC,OAAO,CAAC,gCAAgC;IAwBxC,OAAO,CAAC,6BAA6B;IAsBrC;;;OAGG;IACH,OAAO,CAAC,mCAAmC;IAwB3C,OAAO,CAAC,mCAAmC;IA+D3C,OAAO,CAAC,4CAA4C;IAmCpD,OAAO,CAAC,uBAAuB;IA4B/B,OAAO,CAAC,mCAAmC;IAY3C,OAAO,CAAC,kCAAkC;IAY1C,OAAO,CAAC,wBAAwB;IAchC,OAAO,CAAC,iDAAiD;IAqBzD,OAAO,CAAC,qEAAqE;IAe7E,OAAO,CAAC,gDAAgD;IAexD,OAAO,CAAC,sDAAsD;IAqB9D,OAAO,CAAC,+BAA+B;IAsBvC,OAAO,CAAC,mDAAmD;IAoD3D,OAAO,CAAC,iDAAiD;IAUzD,OAAO,CAAC,gCAAgC;IAsBxC,OAAO,CAAC,mDAAmD;IAgH3D,OAAO,CAAC,wBAAwB;IAIhC,OAAO,CAAC,6BAA6B;IA6BrC,OAAO,CAAC,6CAA6C;IAoBrD,OAAO,CAAC,oCAAoC;IAqB5C,OAAO,CAAC,oDAAoD;IAoB5D,OAAO,CAAC,gCAAgC;IA4BxC,OAAO,CAAC,oBAAoB;IA8B5B,OAAO,CAAC,kBAAkB;IAgB1B,OAAO,CAAC,eAAe;IA0BvB,OAAO,CAAC,0BAA0B;IA0BlC,OAAO,CAAC,uBAAuB;IAmE/B,OAAO,CAAC,+BAA+B;IAoBvC,OAAO,CAAC,kBAAkB;CAG3B;AAED,wBAAgB,qCAAqC,CACnD,QAAQ,EAAE,QAAQ,EAClB,IAAI,EAAE,WAAW,GAChB,6BAA6B,GAAG,8BAA8B,CA2DhE"}
 \ No newline at end of file
-+{"version":3,"file":"error-inferrer.d.ts","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/error-inferrer.ts"],"names":[],"mappings":"AAUA,OAAO,EACL,uBAAuB,EACvB,yBAAyB,EACzB,sBAAsB,EAOtB,YAAY,EACb,MAAM,iBAAiB,CAAC;AACzB,OAAO,EACL,QAAQ,EAIR,WAAW,EAGZ,MAAM,SAAS,CAAC;AAEjB,OAAO,EAEL,6BAA6B,EAI7B,8BAA8B,EAK9B,kBAAkB,EAKnB,MAAM,wBAAwB,CAAC;AAMhC,MAAM,WAAW,cAAc;IAC7B,YAAY,EAAE,YAAY,CAAC;IAC3B,UAAU,EAAE,kBAAkB,CAAC;IAC/B,SAAS,EAAE,MAAM,CAAC;CACnB;AAID,qBAAa,aAAa;IACjB,6BAA6B,CAClC,KAAK,EAAE,uBAAuB,GAC7B,kBAAkB,GAAG,SAAS;IAkE1B,+BAA+B,CACpC,KAAK,EAAE,yBAAyB,GAC/B,kBAAkB,GAAG,SAAS;IAqB1B,iBAAiB,CACtB,KAAK,EAAE,sBAAsB,EAC7B,UAAU,EAAE,kBAAkB,EAC9B,iBAAiB,EAAE,WAAW,EAAE,EAChC,kBAAkB,EAAE,OAAO,EAC3B,kBAAkB,EAAE,cAAc,GAAG,SAAS,GAC7C,kBAAkB;IAiBd,qBAAqB,CAC1B,UAAU,EAAE,kBAAkB,GAC7B,kBAAkB;IAqErB;;OAEG;IACH,OAAO,CAAC,oBAAoB;IAwE5B;;OAEG;IACH,OAAO,CAAC,oBAAoB;IAgC5B;;OAEG;IACH,OAAO,CAAC,2BAA2B;IA2HnC;;OAEG;IACH,OAAO,CAAC,WAAW;IAyCnB,OAAO,CAAC,kBAAkB;IA2C1B;;OAEG;IACH,OAAO,CAAC,qBAAqB;IAuG7B,OAAO,CAAC,uBAAuB;IAsB/B,OAAO,CAAC,+BAA+B;IAcvC,OAAO,CAAC,sBAAsB;IAa9B,OAAO,CAAC,8BAA8B;IActC,OAAO,CAAC,mBAAmB;IAmB3B,OAAO,CAAC,oBAAoB;IAM5B,OAAO,CAAC,oCAAoC;IAyB5C,OAAO,CAAC,0BAA0B;IAqBlC,OAAO,CAAC,gCAAgC;IAiBxC,OAAO,CAAC,kCAAkC;IAyB1C,OAAO,CAAC,0BAA0B;IAiBlC,OAAO,CAAC,+CAA+C;IAavD,OAAO,CAAC,0BAA0B;IA0BlC,OAAO,CAAC,gCAAgC;IAwBxC,OAAO,CAAC,6BAA6B;IAsBrC;;;OAGG;IACH,OAAO,CAAC,mCAAmC;IAwB3C,OAAO,CAAC,mCAAmC;IA+D3C,OAAO,CAAC,4CAA4C;IAmCpD,OAAO,CAAC,uBAAuB;IA4B/B,OAAO,CAAC,mCAAmC;IAY3C,OAAO,CAAC,kCAAkC;IAY1C,OAAO,CAAC,wBAAwB;IAchC,OAAO,CAAC,iDAAiD;IAqBzD,OAAO,CAAC,qEAAqE;IAe7E,OAAO,CAAC,gDAAgD;IAexD,OAAO,CAAC,sDAAsD;IAqB9D,OAAO,CAAC,+BAA+B;IAsBvC,OAAO,CAAC,mDAAmD;IAoD3D,OAAO,CAAC,iDAAiD;IAUzD,OAAO,CAAC,gCAAgC;IAsBxC,OAAO,CAAC,mDAAmD;IAgH3D,OAAO,CAAC,wBAAwB;IAIhC,OAAO,CAAC,6BAA6B;IA6BrC,OAAO,CAAC,6CAA6C;IAoBrD,OAAO,CAAC,oCAAoC;IAqB5C,OAAO,CAAC,oDAAoD;IAoB5D,OAAO,CAAC,gCAAgC;IA4BxC,OAAO,CAAC,oBAAoB;IA8B5B,OAAO,CAAC,kBAAkB;IAgB1B,OAAO,CAAC,eAAe;IA0BvB,OAAO,CAAC,0BAA0B;IA0BlC,OAAO,CAAC,uBAAuB;IAmE/B,OAAO,CAAC,+BAA+B;IAoBvC,OAAO,CAAC,kBAAkB;CAG3B;AAED,wBAAgB,qCAAqC,CACnD,QAAQ,EAAE,QAAQ,EAClB,IAAI,EAAE,WAAW,GAChB,6BAA6B,GAAG,8BAA8B,CA2DhE"}
++{"version":3,"file":"error-inferrer.d.ts","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/error-inferrer.ts"],"names":[],"mappings":""}
 \ No newline at end of file
 diff --git a/internal/hardhat-network/stack-traces/error-inferrer.js b/internal/hardhat-network/stack-traces/error-inferrer.js
-index 01d194cc72fe5a33ea86ad45ad28c8d7d507d426..ab7b7c2b3d35fd71b5d7fb9ed00c1e186868c977 100644
+index 01d194cc72fe5a33ea86ad45ad28c8d7d507d426..c42742d2ef564b3e883383bb8e4161ad0e31f0e6 100644
 --- a/internal/hardhat-network/stack-traces/error-inferrer.js
 +++ b/internal/hardhat-network/stack-traces/error-inferrer.js
-@@ -11,9 +11,7 @@ const semver_1 = __importDefault(require("semver"));
- const errors_1 = require("../../core/errors");
- const abi_helpers_1 = require("../../util/abi-helpers");
- const return_data_1 = require("../provider/return-data");
+@@ -1,1168 +1,2 @@
+ "use strict";
+-var __importDefault = (this && this.__importDefault) || function (mod) {
+-    return (mod && mod.__esModule) ? mod : { "default": mod };
+-};
+-Object.defineProperty(exports, "__esModule", { value: true });
+-exports.instructionToCallstackStackTraceEntry = exports.ErrorInferrer = void 0;
+-/* eslint "@typescript-eslint/no-non-null-assertion": "error" */
+-const abi_1 = require("@ethersproject/abi");
+-const ethereumjs_util_1 = require("@nomicfoundation/ethereumjs-util");
+-const semver_1 = __importDefault(require("semver"));
+-const errors_1 = require("../../core/errors");
+-const abi_helpers_1 = require("../../util/abi-helpers");
+-const return_data_1 = require("../provider/return-data");
 -const exit_1 = require("../provider/vm/exit");
- const message_trace_1 = require("./message-trace");
+-const message_trace_1 = require("./message-trace");
 -const model_1 = require("./model");
- const opcodes_1 = require("./opcodes");
- const solidity_stack_trace_1 = require("./solidity-stack-trace");
- const FIRST_SOLC_VERSION_CREATE_PARAMS_VALIDATION = "0.5.9";
-@@ -30,7 +28,7 @@ class ErrorInferrer {
-             this._isFunctionNotPayableError(trace, calledFunction)) {
-             return [
-                 {
+-const opcodes_1 = require("./opcodes");
+-const solidity_stack_trace_1 = require("./solidity-stack-trace");
+-const FIRST_SOLC_VERSION_CREATE_PARAMS_VALIDATION = "0.5.9";
+-const FIRST_SOLC_VERSION_RECEIVE_FUNCTION = "0.6.0";
+-const FIRST_SOLC_VERSION_WITH_UNMAPPED_REVERTS = "0.6.3";
+-/* eslint-disable @nomicfoundation/hardhat-internal-rules/only-hardhat-error */
+-class ErrorInferrer {
+-    inferBeforeTracingCallMessage(trace) {
+-        if (this._isDirectLibraryCall(trace)) {
+-            return this._getDirectLibraryCallErrorStackTrace(trace);
+-        }
+-        const calledFunction = trace.bytecode.contract.getFunctionFromSelector(trace.calldata.slice(0, 4));
+-        if (calledFunction !== undefined &&
+-            this._isFunctionNotPayableError(trace, calledFunction)) {
+-            return [
+-                {
 -                    type: solidity_stack_trace_1.StackTraceEntryType.FUNCTION_NOT_PAYABLE_ERROR,
-+                    type: 7 /* StackTraceEntryType.FUNCTION_NOT_PAYABLE_ERROR */,
-                     sourceReference: this._getFunctionStartSourceReference(trace, calledFunction),
-                     value: trace.value,
-                 },
-@@ -40,14 +38,14 @@ class ErrorInferrer {
-             if (this._emptyCalldataAndNoReceive(trace)) {
-                 return [
-                     {
+-                    sourceReference: this._getFunctionStartSourceReference(trace, calledFunction),
+-                    value: trace.value,
+-                },
+-            ];
+-        }
+-        if (this._isMissingFunctionAndFallbackError(trace, calledFunction)) {
+-            if (this._emptyCalldataAndNoReceive(trace)) {
+-                return [
+-                    {
 -                        type: solidity_stack_trace_1.StackTraceEntryType.MISSING_FALLBACK_OR_RECEIVE_ERROR,
-+                        type: 12 /* StackTraceEntryType.MISSING_FALLBACK_OR_RECEIVE_ERROR */,
-                         sourceReference: this._getContractStartWithoutFunctionSourceReference(trace),
-                     },
-                 ];
-             }
-             return [
-                 {
+-                        sourceReference: this._getContractStartWithoutFunctionSourceReference(trace),
+-                    },
+-                ];
+-            }
+-            return [
+-                {
 -                    type: solidity_stack_trace_1.StackTraceEntryType.UNRECOGNIZED_FUNCTION_WITHOUT_FALLBACK_ERROR,
-+                    type: 11 /* StackTraceEntryType.UNRECOGNIZED_FUNCTION_WITHOUT_FALLBACK_ERROR */,
-                     sourceReference: this._getContractStartWithoutFunctionSourceReference(trace),
-                 },
-             ];
-@@ -56,7 +54,7 @@ class ErrorInferrer {
-             if (this._emptyCalldataAndNoReceive(trace)) {
-                 return [
-                     {
+-                    sourceReference: this._getContractStartWithoutFunctionSourceReference(trace),
+-                },
+-            ];
+-        }
+-        if (this._isFallbackNotPayableError(trace, calledFunction)) {
+-            if (this._emptyCalldataAndNoReceive(trace)) {
+-                return [
+-                    {
 -                        type: solidity_stack_trace_1.StackTraceEntryType.FALLBACK_NOT_PAYABLE_AND_NO_RECEIVE_ERROR,
-+                        type: 10 /* StackTraceEntryType.FALLBACK_NOT_PAYABLE_AND_NO_RECEIVE_ERROR */,
-                         sourceReference: this._getFallbackStartSourceReference(trace),
-                         value: trace.value,
-                     },
-@@ -64,7 +62,7 @@ class ErrorInferrer {
-             }
-             return [
-                 {
+-                        sourceReference: this._getFallbackStartSourceReference(trace),
+-                        value: trace.value,
+-                    },
+-                ];
+-            }
+-            return [
+-                {
 -                    type: solidity_stack_trace_1.StackTraceEntryType.FALLBACK_NOT_PAYABLE_ERROR,
-+                    type: 9 /* StackTraceEntryType.FALLBACK_NOT_PAYABLE_ERROR */,
-                     sourceReference: this._getFallbackStartSourceReference(trace),
-                     value: trace.value,
-                 },
-@@ -75,7 +73,7 @@ class ErrorInferrer {
-         if (this._isConstructorNotPayableError(trace)) {
-             return [
-                 {
+-                    sourceReference: this._getFallbackStartSourceReference(trace),
+-                    value: trace.value,
+-                },
+-            ];
+-        }
+-    }
+-    inferBeforeTracingCreateMessage(trace) {
+-        if (this._isConstructorNotPayableError(trace)) {
+-            return [
+-                {
 -                    type: solidity_stack_trace_1.StackTraceEntryType.FUNCTION_NOT_PAYABLE_ERROR,
-+                    type: 7 /* StackTraceEntryType.FUNCTION_NOT_PAYABLE_ERROR */,
-                     sourceReference: this._getConstructorStartSourceReference(trace),
-                     value: trace.value,
-                 },
-@@ -84,7 +82,7 @@ class ErrorInferrer {
-         if (this._isConstructorInvalidArgumentsError(trace)) {
-             return [
-                 {
+-                    sourceReference: this._getConstructorStartSourceReference(trace),
+-                    value: trace.value,
+-                },
+-            ];
+-        }
+-        if (this._isConstructorInvalidArgumentsError(trace)) {
+-            return [
+-                {
 -                    type: solidity_stack_trace_1.StackTraceEntryType.INVALID_PARAMS_ERROR,
-+                    type: 8 /* StackTraceEntryType.INVALID_PARAMS_ERROR */,
-                     sourceReference: this._getConstructorStartSourceReference(trace),
-                 },
-             ];
-@@ -113,10 +111,10 @@ class ErrorInferrer {
-             }
-             // look TWO frames ahead to determine if this is a specific occurrence of
-             // a redundant CALLSTACK_ENTRY frame observed when using Solidity 0.8.5:
+-                    sourceReference: this._getConstructorStartSourceReference(trace),
+-                },
+-            ];
+-        }
+-    }
+-    inferAfterTracing(trace, stacktrace, functionJumpdests, jumpedIntoFunction, lastSubmessageData) {
+-        return (this._checkLastSubmessage(trace, stacktrace, lastSubmessageData) ??
+-            this._checkFailedLastCall(trace, stacktrace) ??
+-            this._checkLastInstruction(trace, stacktrace, functionJumpdests, jumpedIntoFunction) ??
+-            this._checkNonContractCalled(trace, stacktrace) ??
+-            this._checkSolidity063UnmappedRevert(trace, stacktrace) ??
+-            this._checkContractTooLarge(trace) ??
+-            this._otherExecutionErrorStacktrace(trace, stacktrace));
+-    }
+-    filterRedundantFrames(stacktrace) {
+-        return stacktrace.filter((frame, i) => {
+-            if (i + 1 === stacktrace.length) {
+-                return true;
+-            }
+-            const nextFrame = stacktrace[i + 1];
+-            // we can only filter frames if we know their sourceReference
+-            // and the one from the next frame
+-            if (frame.sourceReference === undefined ||
+-                nextFrame.sourceReference === undefined) {
+-                return true;
+-            }
+-            // look TWO frames ahead to determine if this is a specific occurrence of
+-            // a redundant CALLSTACK_ENTRY frame observed when using Solidity 0.8.5:
 -            if (frame.type === solidity_stack_trace_1.StackTraceEntryType.CALLSTACK_ENTRY &&
-+            if (frame.type === 0 /* StackTraceEntryType.CALLSTACK_ENTRY */ &&
-                 i + 2 < stacktrace.length &&
-                 stacktrace[i + 2].sourceReference !== undefined &&
+-                i + 2 < stacktrace.length &&
+-                stacktrace[i + 2].sourceReference !== undefined &&
 -                stacktrace[i + 2].type === solidity_stack_trace_1.StackTraceEntryType.RETURNDATA_SIZE_ERROR) {
-+                stacktrace[i + 2].type === 13 /* StackTraceEntryType.RETURNDATA_SIZE_ERROR */) {
-                 // ! below for tsc. we confirmed existence in the enclosing conditional.
-                 const thatSrcRef = stacktrace[i + 2].sourceReference;
-                 if (thatSrcRef !== undefined &&
-@@ -173,7 +171,7 @@ class ErrorInferrer {
-                     const lastFrame = inferredStacktrace.pop();
-                     (0, errors_1.assertHardhatInvariant)(lastFrame !== undefined, "Expected inferred stack trace to have at least one frame");
-                     inferredStacktrace.push({
+-                // ! below for tsc. we confirmed existence in the enclosing conditional.
+-                const thatSrcRef = stacktrace[i + 2].sourceReference;
+-                if (thatSrcRef !== undefined &&
+-                    frame.sourceReference.range[0] === thatSrcRef.range[0] &&
+-                    frame.sourceReference.range[1] === thatSrcRef.range[1] &&
+-                    frame.sourceReference.line === thatSrcRef.line) {
+-                    return false;
+-                }
+-            }
+-            // constructors contain the whole contract, so we ignore them
+-            if (frame.sourceReference.function === "constructor" &&
+-                nextFrame.sourceReference.function !== "constructor") {
+-                return true;
+-            }
+-            // this is probably a recursive call
+-            if (i > 0 &&
+-                frame.type === nextFrame.type &&
+-                frame.sourceReference.range[0] === nextFrame.sourceReference.range[0] &&
+-                frame.sourceReference.range[1] === nextFrame.sourceReference.range[1] &&
+-                frame.sourceReference.line === nextFrame.sourceReference.line) {
+-                return true;
+-            }
+-            if (frame.sourceReference.range[0] <= nextFrame.sourceReference.range[0] &&
+-                frame.sourceReference.range[1] >= nextFrame.sourceReference.range[1]) {
+-                return false;
+-            }
+-            return true;
+-        });
+-    }
+-    // Heuristics
+-    /**
+-     * Check if the last submessage can be used to generate the stack trace.
+-     */
+-    _checkLastSubmessage(trace, stacktrace, lastSubmessageData) {
+-        if (lastSubmessageData === undefined) {
+-            return undefined;
+-        }
+-        const inferredStacktrace = [...stacktrace];
+-        // get the instruction before the submessage and add it to the stack trace
+-        const callStep = trace.steps[lastSubmessageData.stepIndex - 1];
+-        if (!(0, message_trace_1.isEvmStep)(callStep)) {
+-            throw new Error("This should not happen: MessageTrace should be preceded by a EVM step");
+-        }
+-        const callInst = trace.bytecode.getInstruction(callStep.pc);
+-        const callStackFrame = instructionToCallstackStackTraceEntry(trace.bytecode, callInst);
+-        const lastMessageFailed = lastSubmessageData.messageTrace.exit.isError();
+-        if (lastMessageFailed) {
+-            // add the call/create that generated the message to the stack trace
+-            inferredStacktrace.push(callStackFrame);
+-            if (this._isSubtraceErrorPropagated(trace, lastSubmessageData.stepIndex) ||
+-                this._isProxyErrorPropagated(trace, lastSubmessageData.stepIndex)) {
+-                inferredStacktrace.push(...lastSubmessageData.stacktrace);
+-                if (this._isContractCallRunOutOfGasError(trace, lastSubmessageData.stepIndex)) {
+-                    const lastFrame = inferredStacktrace.pop();
+-                    (0, errors_1.assertHardhatInvariant)(lastFrame !== undefined, "Expected inferred stack trace to have at least one frame");
+-                    inferredStacktrace.push({
 -                        type: solidity_stack_trace_1.StackTraceEntryType.CONTRACT_CALL_RUN_OUT_OF_GAS_ERROR,
-+                        type: 23 /* StackTraceEntryType.CONTRACT_CALL_RUN_OUT_OF_GAS_ERROR */,
-                         sourceReference: lastFrame.sourceReference,
-                     });
-                 }
-@@ -184,7 +182,7 @@ class ErrorInferrer {
-             const isReturnDataSizeError = this._failsRightAfterCall(trace, lastSubmessageData.stepIndex);
-             if (isReturnDataSizeError) {
-                 inferredStacktrace.push({
+-                        sourceReference: lastFrame.sourceReference,
+-                    });
+-                }
+-                return this._fixInitialModifier(trace, inferredStacktrace);
+-            }
+-        }
+-        else {
+-            const isReturnDataSizeError = this._failsRightAfterCall(trace, lastSubmessageData.stepIndex);
+-            if (isReturnDataSizeError) {
+-                inferredStacktrace.push({
 -                    type: solidity_stack_trace_1.StackTraceEntryType.RETURNDATA_SIZE_ERROR,
-+                    type: 13 /* StackTraceEntryType.RETURNDATA_SIZE_ERROR */,
-                     sourceReference: callStackFrame.sourceReference,
-                 });
-                 return this._fixInitialModifier(trace, inferredStacktrace);
-@@ -218,8 +216,8 @@ class ErrorInferrer {
-      * Check if the execution stopped with a revert or an invalid opcode.
-      */
-     _checkRevertOrInvalidOpcode(trace, stacktrace, lastInstruction, functionJumpdests, jumpedIntoFunction) {
+-                    sourceReference: callStackFrame.sourceReference,
+-                });
+-                return this._fixInitialModifier(trace, inferredStacktrace);
+-            }
+-        }
+-    }
+-    /**
+-     * Check if the last call/create that was done failed.
+-     */
+-    _checkFailedLastCall(trace, stacktrace) {
+-        for (let stepIndex = trace.steps.length - 2; stepIndex >= 0; stepIndex--) {
+-            const step = trace.steps[stepIndex];
+-            const nextStep = trace.steps[stepIndex + 1];
+-            if (!(0, message_trace_1.isEvmStep)(step)) {
+-                return;
+-            }
+-            const inst = trace.bytecode.getInstruction(step.pc);
+-            const isCallOrCreate = (0, opcodes_1.isCall)(inst.opcode) || (0, opcodes_1.isCreate)(inst.opcode);
+-            if (isCallOrCreate && (0, message_trace_1.isEvmStep)(nextStep)) {
+-                if (this._isCallFailedError(trace, stepIndex, inst)) {
+-                    const inferredStacktrace = [
+-                        ...stacktrace,
+-                        this._callInstructionToCallFailedToExecuteStackTraceEntry(trace.bytecode, inst),
+-                    ];
+-                    return this._fixInitialModifier(trace, inferredStacktrace);
+-                }
+-            }
+-        }
+-    }
+-    /**
+-     * Check if the execution stopped with a revert or an invalid opcode.
+-     */
+-    _checkRevertOrInvalidOpcode(trace, stacktrace, lastInstruction, functionJumpdests, jumpedIntoFunction) {
 -        if (lastInstruction.opcode !== opcodes_1.Opcode.REVERT &&
 -            lastInstruction.opcode !== opcodes_1.Opcode.INVALID) {
-+        if (lastInstruction.opcode !== 253 /* Opcode.REVERT */ &&
-+            lastInstruction.opcode !== 254 /* Opcode.INVALID */) {
-             return;
-         }
-         const inferredStacktrace = [...stacktrace];
-@@ -234,7 +232,7 @@ class ErrorInferrer {
-             const failingFunction = lastInstruction.location.getContainingFunction();
-             // If the failure is in a modifier we add an entry with the function/constructor
-             if (failingFunction !== undefined &&
+-            return;
+-        }
+-        const inferredStacktrace = [...stacktrace];
+-        if (lastInstruction.location !== undefined &&
+-            (!(0, message_trace_1.isDecodedCallTrace)(trace) || jumpedIntoFunction)) {
+-            // There should always be a function here, but that's not the case with optimizations.
+-            //
+-            // If this is a create trace, we already checked args and nonpayable failures before
+-            // calling this function.
+-            //
+-            // If it's a call trace, we already jumped into a function. But optimizations can happen.
+-            const failingFunction = lastInstruction.location.getContainingFunction();
+-            // If the failure is in a modifier we add an entry with the function/constructor
+-            if (failingFunction !== undefined &&
 -                failingFunction.type === model_1.ContractFunctionType.MODIFIER) {
-+                failingFunction.type === 5 /* ContractFunctionType.MODIFIER */) {
-                 inferredStacktrace.push(this._getEntryBeforeFailureInModifier(trace, functionJumpdests));
-             }
-         }
-@@ -262,19 +260,19 @@ class ErrorInferrer {
-                     return;
-                 }
-                 inferredStacktrace.push({
+-                inferredStacktrace.push(this._getEntryBeforeFailureInModifier(trace, functionJumpdests));
+-            }
+-        }
+-        const panicStacktrace = this._checkPanic(trace, inferredStacktrace, lastInstruction);
+-        if (panicStacktrace !== undefined) {
+-            return panicStacktrace;
+-        }
+-        const customErrorStacktrace = this._checkCustomErrors(trace, inferredStacktrace, lastInstruction);
+-        if (customErrorStacktrace !== undefined) {
+-            return customErrorStacktrace;
+-        }
+-        if (lastInstruction.location !== undefined &&
+-            (!(0, message_trace_1.isDecodedCallTrace)(trace) || jumpedIntoFunction)) {
+-            const failingFunction = lastInstruction.location.getContainingFunction();
+-            if (failingFunction !== undefined) {
+-                inferredStacktrace.push(this._instructionWithinFunctionToRevertStackTraceEntry(trace, lastInstruction));
+-            }
+-            else if ((0, message_trace_1.isDecodedCallTrace)(trace)) {
+-                // This is here because of the optimizations
+-                const functionSelector = trace.bytecode.contract.getFunctionFromSelector(trace.calldata.slice(0, 4));
+-                // in general this shouldn't happen, but it does when viaIR is enabled,
+-                // "optimizerSteps": "u" is used, and the called function is fallback or
+-                // receive
+-                if (functionSelector === undefined) {
+-                    return;
+-                }
+-                inferredStacktrace.push({
 -                    type: solidity_stack_trace_1.StackTraceEntryType.REVERT_ERROR,
-+                    type: 4 /* StackTraceEntryType.REVERT_ERROR */,
-                     sourceReference: this._getFunctionStartSourceReference(trace, functionSelector),
-                     message: new return_data_1.ReturnData(trace.returnData),
+-                    sourceReference: this._getFunctionStartSourceReference(trace, functionSelector),
+-                    message: new return_data_1.ReturnData(trace.returnData),
 -                    isInvalidOpcodeError: lastInstruction.opcode === opcodes_1.Opcode.INVALID,
-+                    isInvalidOpcodeError: lastInstruction.opcode === 254 /* Opcode.INVALID */,
-                 });
-             }
-             else {
-                 // This is here because of the optimizations
-                 inferredStacktrace.push({
+-                });
+-            }
+-            else {
+-                // This is here because of the optimizations
+-                inferredStacktrace.push({
 -                    type: solidity_stack_trace_1.StackTraceEntryType.REVERT_ERROR,
-+                    type: 4 /* StackTraceEntryType.REVERT_ERROR */,
-                     sourceReference: this._getConstructorStartSourceReference(trace),
-                     message: new return_data_1.ReturnData(trace.returnData),
+-                    sourceReference: this._getConstructorStartSourceReference(trace),
+-                    message: new return_data_1.ReturnData(trace.returnData),
 -                    isInvalidOpcodeError: lastInstruction.opcode === opcodes_1.Opcode.INVALID,
-+                    isInvalidOpcodeError: lastInstruction.opcode === 254 /* Opcode.INVALID */,
-                 });
-             }
-             return this._fixInitialModifier(trace, inferredStacktrace);
-@@ -283,11 +281,11 @@ class ErrorInferrer {
-         // we add the frame anyway, sith the best sourceReference we can get
-         if (lastInstruction.location === undefined && trace.returnData.length > 0) {
-             const revertFrame = {
+-                });
+-            }
+-            return this._fixInitialModifier(trace, inferredStacktrace);
+-        }
+-        // If the revert instruction is not mapped but there is return data,
+-        // we add the frame anyway, sith the best sourceReference we can get
+-        if (lastInstruction.location === undefined && trace.returnData.length > 0) {
+-            const revertFrame = {
 -                type: solidity_stack_trace_1.StackTraceEntryType.REVERT_ERROR,
-+                type: 4 /* StackTraceEntryType.REVERT_ERROR */,
-                 sourceReference: this._getLastSourceReference(trace) ??
-                     this._getContractStartWithoutFunctionSourceReference(trace),
-                 message: new return_data_1.ReturnData(trace.returnData),
+-                sourceReference: this._getLastSourceReference(trace) ??
+-                    this._getContractStartWithoutFunctionSourceReference(trace),
+-                message: new return_data_1.ReturnData(trace.returnData),
 -                isInvalidOpcodeError: lastInstruction.opcode === opcodes_1.Opcode.INVALID,
-+                isInvalidOpcodeError: lastInstruction.opcode === 254 /* Opcode.INVALID */,
-             };
-             inferredStacktrace.push(revertFrame);
-             return this._fixInitialModifier(trace, inferredStacktrace);
-@@ -304,7 +302,7 @@ class ErrorInferrer {
-         // jumped there to return the panic. If that's the case, we remove that
-         // frame.
-         const lastFrame = stacktrace[stacktrace.length - 1];
+-            };
+-            inferredStacktrace.push(revertFrame);
+-            return this._fixInitialModifier(trace, inferredStacktrace);
+-        }
+-    }
+-    /**
+-     * Check if the trace reverted with a panic error.
+-     */
+-    _checkPanic(trace, stacktrace, lastInstruction) {
+-        if (!this._isPanicReturnData(trace.returnData)) {
+-            return;
+-        }
+-        // If the last frame is an internal function, it means that the trace
+-        // jumped there to return the panic. If that's the case, we remove that
+-        // frame.
+-        const lastFrame = stacktrace[stacktrace.length - 1];
 -        if (lastFrame?.type === solidity_stack_trace_1.StackTraceEntryType.INTERNAL_FUNCTION_CALLSTACK_ENTRY) {
-+        if (lastFrame?.type === 22 /* StackTraceEntryType.INTERNAL_FUNCTION_CALLSTACK_ENTRY */) {
-             stacktrace.splice(-1);
-         }
-         const panicReturnData = new return_data_1.ReturnData(trace.returnData);
-@@ -371,21 +369,24 @@ class ErrorInferrer {
-                 if (failingFunction !== undefined) {
-                     return [
-                         {
+-            stacktrace.splice(-1);
+-        }
+-        const panicReturnData = new return_data_1.ReturnData(trace.returnData);
+-        const errorCode = panicReturnData.decodePanic();
+-        // if the error comes from a call to a zero-initialized function,
+-        // we remove the last frame, which represents the call, to avoid
+-        // having duplicated frames
+-        if (errorCode === 0x51n) {
+-            stacktrace.splice(-1);
+-        }
+-        const inferredStacktrace = [...stacktrace];
+-        inferredStacktrace.push(this._instructionWithinFunctionToPanicStackTraceEntry(trace, lastInstruction, errorCode));
+-        return this._fixInitialModifier(trace, inferredStacktrace);
+-    }
+-    _checkCustomErrors(trace, stacktrace, lastInstruction) {
+-        const returnData = new return_data_1.ReturnData(trace.returnData);
+-        if (returnData.isEmpty() || returnData.isErrorReturnData()) {
+-            // if there is no return data, or if it's a Error(string),
+-            // then it can't be a custom error
+-            return;
+-        }
+-        const rawReturnData = Buffer.from(returnData.value).toString("hex");
+-        let errorMessage = `reverted with an unrecognized custom error (return data: 0x${rawReturnData})`;
+-        for (const customError of trace.bytecode.contract.customErrors) {
+-            if (returnData.matchesSelector(customError.selector)) {
+-                // if the return data matches a custom error in the called contract,
+-                // we format the message using the returnData and the custom error instance
+-                const decodedValues = abi_1.defaultAbiCoder.decode(customError.paramTypes, returnData.value.slice(4));
+-                const params = abi_helpers_1.AbiHelpers.formatValues([...decodedValues]);
+-                errorMessage = `reverted with custom error '${customError.name}(${params})'`;
+-                break;
+-            }
+-        }
+-        const inferredStacktrace = [...stacktrace];
+-        inferredStacktrace.push(this._instructionWithinFunctionToCustomErrorStackTraceEntry(trace, lastInstruction, errorMessage));
+-        return this._fixInitialModifier(trace, inferredStacktrace);
+-    }
+-    /**
+-     * Check last instruction to try to infer the error.
+-     */
+-    _checkLastInstruction(trace, stacktrace, functionJumpdests, jumpedIntoFunction) {
+-        if (trace.steps.length === 0) {
+-            return;
+-        }
+-        const lastStep = trace.steps[trace.steps.length - 1];
+-        if (!(0, message_trace_1.isEvmStep)(lastStep)) {
+-            throw new Error("This should not happen: MessageTrace ends with a subtrace");
+-        }
+-        const lastInstruction = trace.bytecode.getInstruction(lastStep.pc);
+-        const revertOrInvalidStacktrace = this._checkRevertOrInvalidOpcode(trace, stacktrace, lastInstruction, functionJumpdests, jumpedIntoFunction);
+-        if (revertOrInvalidStacktrace !== undefined) {
+-            return revertOrInvalidStacktrace;
+-        }
+-        if ((0, message_trace_1.isDecodedCallTrace)(trace) && !jumpedIntoFunction) {
+-            if (this._hasFailedInsideTheFallbackFunction(trace) ||
+-                this._hasFailedInsideTheReceiveFunction(trace)) {
+-                return [
+-                    this._instructionWithinFunctionToRevertStackTraceEntry(trace, lastInstruction),
+-                ];
+-            }
+-            // Sometimes we do fail inside of a function but there's no jump into
+-            if (lastInstruction.location !== undefined) {
+-                const failingFunction = lastInstruction.location.getContainingFunction();
+-                if (failingFunction !== undefined) {
+-                    return [
+-                        {
 -                            type: solidity_stack_trace_1.StackTraceEntryType.REVERT_ERROR,
-+                            type: 4 /* StackTraceEntryType.REVERT_ERROR */,
-                             sourceReference: this._getFunctionStartSourceReference(trace, failingFunction),
-                             message: new return_data_1.ReturnData(trace.returnData),
+-                            sourceReference: this._getFunctionStartSourceReference(trace, failingFunction),
+-                            message: new return_data_1.ReturnData(trace.returnData),
 -                            isInvalidOpcodeError: lastInstruction.opcode === opcodes_1.Opcode.INVALID,
-+                            isInvalidOpcodeError: lastInstruction.opcode === 254 /* Opcode.INVALID */,
-                         },
-                     ];
-                 }
-             }
-             const calledFunction = trace.bytecode.contract.getFunctionFromSelector(trace.calldata.slice(0, 4));
-             if (calledFunction !== undefined) {
+-                        },
+-                    ];
+-                }
+-            }
+-            const calledFunction = trace.bytecode.contract.getFunctionFromSelector(trace.calldata.slice(0, 4));
+-            if (calledFunction !== undefined) {
 -                const isValidCalldata = calledFunction.isValidCalldata(trace.calldata.slice(4));
-+                const isValidCalldata = 
-+                // if we don't know the param types, we just assume that the call is valid
-+                calledFunction.paramTypes === undefined ||
-+                    abi_helpers_1.AbiHelpers.isValidCalldata(calledFunction.paramTypes, trace.calldata.slice(4));
-                 if (!isValidCalldata) {
-                     return [
-                         {
+-                if (!isValidCalldata) {
+-                    return [
+-                        {
 -                            type: solidity_stack_trace_1.StackTraceEntryType.INVALID_PARAMS_ERROR,
-+                            type: 8 /* StackTraceEntryType.INVALID_PARAMS_ERROR */,
-                             sourceReference: this._getFunctionStartSourceReference(trace, calledFunction),
-                         },
-                     ];
-@@ -406,7 +407,7 @@ class ErrorInferrer {
-             // We are sure this is not undefined because there was at least a call instruction
-             (0, errors_1.assertHardhatInvariant)(sourceReference !== undefined, "Expected source reference to be defined");
-             const nonContractCalledFrame = {
+-                            sourceReference: this._getFunctionStartSourceReference(trace, calledFunction),
+-                        },
+-                    ];
+-                }
+-            }
+-            if (this._solidity063MaybeUnmappedRevert(trace)) {
+-                const revertFrame = this._solidity063GetFrameForUnmappedRevertBeforeFunction(trace);
+-                if (revertFrame !== undefined) {
+-                    return [revertFrame];
+-                }
+-            }
+-            return [this._getOtherErrorBeforeCalledFunctionStackTraceEntry(trace)];
+-        }
+-    }
+-    _checkNonContractCalled(trace, stacktrace) {
+-        if (this._isCalledNonContractAccountError(trace)) {
+-            const sourceReference = this._getLastSourceReference(trace);
+-            // We are sure this is not undefined because there was at least a call instruction
+-            (0, errors_1.assertHardhatInvariant)(sourceReference !== undefined, "Expected source reference to be defined");
+-            const nonContractCalledFrame = {
 -                type: solidity_stack_trace_1.StackTraceEntryType.NONCONTRACT_ACCOUNT_CALLED_ERROR,
-+                type: 14 /* StackTraceEntryType.NONCONTRACT_ACCOUNT_CALLED_ERROR */,
-                 sourceReference,
-             };
-             return [...stacktrace, nonContractCalledFrame];
-@@ -424,7 +425,7 @@ class ErrorInferrer {
-         if ((0, message_trace_1.isCreateTrace)(trace) && this._isContractTooLargeError(trace)) {
-             return [
-                 {
+-                sourceReference,
+-            };
+-            return [...stacktrace, nonContractCalledFrame];
+-        }
+-    }
+-    _checkSolidity063UnmappedRevert(trace, stacktrace) {
+-        if (this._solidity063MaybeUnmappedRevert(trace)) {
+-            const revertFrame = this._solidity063GetFrameForUnmappedRevertWithinFunction(trace);
+-            if (revertFrame !== undefined) {
+-                return [...stacktrace, revertFrame];
+-            }
+-        }
+-    }
+-    _checkContractTooLarge(trace) {
+-        if ((0, message_trace_1.isCreateTrace)(trace) && this._isContractTooLargeError(trace)) {
+-            return [
+-                {
 -                    type: solidity_stack_trace_1.StackTraceEntryType.CONTRACT_TOO_LARGE_ERROR,
-+                    type: 21 /* StackTraceEntryType.CONTRACT_TOO_LARGE_ERROR */,
-                     sourceReference: this._getConstructorStartSourceReference(trace),
-                 },
-             ];
-@@ -432,7 +433,7 @@ class ErrorInferrer {
-     }
-     _otherExecutionErrorStacktrace(trace, stacktrace) {
-         const otherExecutionErrorFrame = {
+-                    sourceReference: this._getConstructorStartSourceReference(trace),
+-                },
+-            ];
+-        }
+-    }
+-    _otherExecutionErrorStacktrace(trace, stacktrace) {
+-        const otherExecutionErrorFrame = {
 -            type: solidity_stack_trace_1.StackTraceEntryType.OTHER_EXECUTION_ERROR,
-+            type: 19 /* StackTraceEntryType.OTHER_EXECUTION_ERROR */,
-             sourceReference: this._getLastSourceReference(trace),
-         };
-         return [...stacktrace, otherExecutionErrorFrame];
-@@ -441,8 +442,8 @@ class ErrorInferrer {
-     _fixInitialModifier(trace, stacktrace) {
-         const firstEntry = stacktrace[0];
-         if (firstEntry !== undefined &&
+-            sourceReference: this._getLastSourceReference(trace),
+-        };
+-        return [...stacktrace, otherExecutionErrorFrame];
+-    }
+-    // Helpers
+-    _fixInitialModifier(trace, stacktrace) {
+-        const firstEntry = stacktrace[0];
+-        if (firstEntry !== undefined &&
 -            firstEntry.type === solidity_stack_trace_1.StackTraceEntryType.CALLSTACK_ENTRY &&
 -            firstEntry.functionType === model_1.ContractFunctionType.MODIFIER) {
-+            firstEntry.type === 0 /* StackTraceEntryType.CALLSTACK_ENTRY */ &&
-+            firstEntry.functionType === 5 /* ContractFunctionType.MODIFIER */) {
-             return [
-                 this._getEntryBeforeInitialModifierCallstackEntry(trace),
-                 ...stacktrace,
-@@ -451,21 +452,21 @@ class ErrorInferrer {
-         return stacktrace;
-     }
-     _isDirectLibraryCall(trace) {
+-            return [
+-                this._getEntryBeforeInitialModifierCallstackEntry(trace),
+-                ...stacktrace,
+-            ];
+-        }
+-        return stacktrace;
+-    }
+-    _isDirectLibraryCall(trace) {
 -        return (trace.depth === 0 && trace.bytecode.contract.type === model_1.ContractType.LIBRARY);
-+        return (trace.depth === 0 && trace.bytecode.contract.type === 1 /* ContractType.LIBRARY */);
-     }
-     _getDirectLibraryCallErrorStackTrace(trace) {
-         const func = trace.bytecode.contract.getFunctionFromSelector(trace.calldata.slice(0, 4));
-         if (func !== undefined) {
-             return [
-                 {
+-    }
+-    _getDirectLibraryCallErrorStackTrace(trace) {
+-        const func = trace.bytecode.contract.getFunctionFromSelector(trace.calldata.slice(0, 4));
+-        if (func !== undefined) {
+-            return [
+-                {
 -                    type: solidity_stack_trace_1.StackTraceEntryType.DIRECT_LIBRARY_CALL_ERROR,
-+                    type: 16 /* StackTraceEntryType.DIRECT_LIBRARY_CALL_ERROR */,
-                     sourceReference: this._getFunctionStartSourceReference(trace, func),
-                 },
-             ];
-         }
-         return [
-             {
+-                    sourceReference: this._getFunctionStartSourceReference(trace, func),
+-                },
+-            ];
+-        }
+-        return [
+-            {
 -                type: solidity_stack_trace_1.StackTraceEntryType.DIRECT_LIBRARY_CALL_ERROR,
-+                type: 16 /* StackTraceEntryType.DIRECT_LIBRARY_CALL_ERROR */,
-                 sourceReference: this._getContractStartWithoutFunctionSourceReference(trace),
-             },
-         ];
-@@ -479,7 +480,7 @@ class ErrorInferrer {
-             return false;
-         }
-         // Libraries don't have a nonpayable check
+-                sourceReference: this._getContractStartWithoutFunctionSourceReference(trace),
+-            },
+-        ];
+-    }
+-    _isFunctionNotPayableError(trace, calledFunction) {
+-        // This error doesn't return data
+-        if (trace.returnData.length > 0) {
+-            return false;
+-        }
+-        if (trace.value <= 0n) {
+-            return false;
+-        }
+-        // Libraries don't have a nonpayable check
 -        if (trace.bytecode.contract.type === model_1.ContractType.LIBRARY) {
-+        if (trace.bytecode.contract.type === 1 /* ContractType.LIBRARY */) {
-             return false;
-         }
-         return calledFunction.isPayable === undefined || !calledFunction.isPayable;
-@@ -621,7 +622,7 @@ class ErrorInferrer {
-             return false;
-         }
-         const lastInst = trace.bytecode.getInstruction(lastStep.pc);
+-            return false;
+-        }
+-        return calledFunction.isPayable === undefined || !calledFunction.isPayable;
+-    }
+-    _getFunctionStartSourceReference(trace, func) {
+-        return {
+-            sourceName: func.location.file.sourceName,
+-            sourceContent: func.location.file.content,
+-            contract: trace.bytecode.contract.name,
+-            function: func.name,
+-            line: func.location.getStartingLineNumber(),
+-            range: [
+-                func.location.offset,
+-                func.location.offset + func.location.length,
+-            ],
+-        };
+-    }
+-    _isMissingFunctionAndFallbackError(trace, calledFunction) {
+-        // This error doesn't return data
+-        if (trace.returnData.length > 0) {
+-            return false;
+-        }
+-        // the called function exists in the contract
+-        if (calledFunction !== undefined) {
+-            return false;
+-        }
+-        // there's a receive function and no calldata
+-        if (trace.calldata.length === 0 &&
+-            trace.bytecode.contract.receive !== undefined) {
+-            return false;
+-        }
+-        return trace.bytecode.contract.fallback === undefined;
+-    }
+-    _emptyCalldataAndNoReceive(trace) {
+-        // this only makes sense when receive functions are available
+-        if (semver_1.default.lt(trace.bytecode.compilerVersion, FIRST_SOLC_VERSION_RECEIVE_FUNCTION)) {
+-            return false;
+-        }
+-        return (trace.calldata.length === 0 &&
+-            trace.bytecode.contract.receive === undefined);
+-    }
+-    _getContractStartWithoutFunctionSourceReference(trace) {
+-        const location = trace.bytecode.contract.location;
+-        return {
+-            sourceName: location.file.sourceName,
+-            sourceContent: location.file.content,
+-            contract: trace.bytecode.contract.name,
+-            line: location.getStartingLineNumber(),
+-            range: [location.offset, location.offset + location.length],
+-        };
+-    }
+-    _isFallbackNotPayableError(trace, calledFunction) {
+-        if (calledFunction !== undefined) {
+-            return false;
+-        }
+-        // This error doesn't return data
+-        if (trace.returnData.length > 0) {
+-            return false;
+-        }
+-        if (trace.value <= 0n) {
+-            return false;
+-        }
+-        if (trace.bytecode.contract.fallback === undefined) {
+-            return false;
+-        }
+-        const isPayable = trace.bytecode.contract.fallback.isPayable;
+-        return isPayable === undefined || !isPayable;
+-    }
+-    _getFallbackStartSourceReference(trace) {
+-        const func = trace.bytecode.contract.fallback;
+-        if (func === undefined) {
+-            throw new Error("This shouldn't happen: trying to get fallback source reference from a contract without fallback");
+-        }
+-        return {
+-            sourceName: func.location.file.sourceName,
+-            sourceContent: func.location.file.content,
+-            contract: trace.bytecode.contract.name,
+-            function: solidity_stack_trace_1.FALLBACK_FUNCTION_NAME,
+-            line: func.location.getStartingLineNumber(),
+-            range: [
+-                func.location.offset,
+-                func.location.offset + func.location.length,
+-            ],
+-        };
+-    }
+-    _isConstructorNotPayableError(trace) {
+-        // This error doesn't return data
+-        if (trace.returnData.length > 0) {
+-            return false;
+-        }
+-        const constructor = trace.bytecode.contract.constructorFunction;
+-        // This function is only matters with contracts that have constructors defined. The ones that
+-        // don't are abstract contracts, or their constructor doesn't take any argument.
+-        if (constructor === undefined) {
+-            return false;
+-        }
+-        return (trace.value > 0n &&
+-            (constructor.isPayable === undefined || !constructor.isPayable));
+-    }
+-    /**
+-     * Returns a source reference pointing to the constructor if it exists, or to the contract
+-     * otherwise.
+-     */
+-    _getConstructorStartSourceReference(trace) {
+-        const contract = trace.bytecode.contract;
+-        const constructor = contract.constructorFunction;
+-        const line = constructor !== undefined
+-            ? constructor.location.getStartingLineNumber()
+-            : contract.location.getStartingLineNumber();
+-        return {
+-            sourceName: contract.location.file.sourceName,
+-            sourceContent: contract.location.file.content,
+-            contract: contract.name,
+-            function: solidity_stack_trace_1.CONSTRUCTOR_FUNCTION_NAME,
+-            line,
+-            range: [
+-                contract.location.offset,
+-                contract.location.offset + contract.location.length,
+-            ],
+-        };
+-    }
+-    _isConstructorInvalidArgumentsError(trace) {
+-        // This error doesn't return data
+-        if (trace.returnData.length > 0) {
+-            return false;
+-        }
+-        const contract = trace.bytecode.contract;
+-        const constructor = contract.constructorFunction;
+-        // This function is only matters with contracts that have constructors defined. The ones that
+-        // don't are abstract contracts, or their constructor doesn't take any argument.
+-        if (constructor === undefined) {
+-            return false;
+-        }
+-        if (semver_1.default.lt(trace.bytecode.compilerVersion, FIRST_SOLC_VERSION_CREATE_PARAMS_VALIDATION)) {
+-            return false;
+-        }
+-        const lastStep = trace.steps[trace.steps.length - 1];
+-        if (!(0, message_trace_1.isEvmStep)(lastStep)) {
+-            return false;
+-        }
+-        const lastInst = trace.bytecode.getInstruction(lastStep.pc);
 -        if (lastInst.opcode !== opcodes_1.Opcode.REVERT || lastInst.location !== undefined) {
-+        if (lastInst.opcode !== 253 /* Opcode.REVERT */ || lastInst.location !== undefined) {
-             return false;
-         }
-         let hasReadDeploymentCodeSize = false;
-@@ -637,7 +638,7 @@ class ErrorInferrer {
-                 !constructor.location.equals(inst.location)) {
-                 return false;
-             }
+-            return false;
+-        }
+-        let hasReadDeploymentCodeSize = false;
+-        // eslint-disable-next-line @typescript-eslint/prefer-for-of
+-        for (let stepIndex = 0; stepIndex < trace.steps.length; stepIndex++) {
+-            const step = trace.steps[stepIndex];
+-            if (!(0, message_trace_1.isEvmStep)(step)) {
+-                return false;
+-            }
+-            const inst = trace.bytecode.getInstruction(step.pc);
+-            if (inst.location !== undefined &&
+-                !contract.location.equals(inst.location) &&
+-                !constructor.location.equals(inst.location)) {
+-                return false;
+-            }
 -            if (inst.opcode === opcodes_1.Opcode.CODESIZE && (0, message_trace_1.isCreateTrace)(trace)) {
-+            if (inst.opcode === 56 /* Opcode.CODESIZE */ && (0, message_trace_1.isCreateTrace)(trace)) {
-                 hasReadDeploymentCodeSize = true;
-             }
-         }
-@@ -646,25 +647,25 @@ class ErrorInferrer {
-     _getEntryBeforeInitialModifierCallstackEntry(trace) {
-         if ((0, message_trace_1.isDecodedCreateTrace)(trace)) {
-             return {
+-                hasReadDeploymentCodeSize = true;
+-            }
+-        }
+-        return hasReadDeploymentCodeSize;
+-    }
+-    _getEntryBeforeInitialModifierCallstackEntry(trace) {
+-        if ((0, message_trace_1.isDecodedCreateTrace)(trace)) {
+-            return {
 -                type: solidity_stack_trace_1.StackTraceEntryType.CALLSTACK_ENTRY,
-+                type: 0 /* StackTraceEntryType.CALLSTACK_ENTRY */,
-                 sourceReference: this._getConstructorStartSourceReference(trace),
+-                sourceReference: this._getConstructorStartSourceReference(trace),
 -                functionType: model_1.ContractFunctionType.CONSTRUCTOR,
-+                functionType: 0 /* ContractFunctionType.CONSTRUCTOR */,
-             };
-         }
-         const calledFunction = trace.bytecode.contract.getFunctionFromSelector(trace.calldata.slice(0, 4));
-         if (calledFunction !== undefined) {
-             return {
+-            };
+-        }
+-        const calledFunction = trace.bytecode.contract.getFunctionFromSelector(trace.calldata.slice(0, 4));
+-        if (calledFunction !== undefined) {
+-            return {
 -                type: solidity_stack_trace_1.StackTraceEntryType.CALLSTACK_ENTRY,
-+                type: 0 /* StackTraceEntryType.CALLSTACK_ENTRY */,
-                 sourceReference: this._getFunctionStartSourceReference(trace, calledFunction),
+-                sourceReference: this._getFunctionStartSourceReference(trace, calledFunction),
 -                functionType: model_1.ContractFunctionType.FUNCTION,
-+                functionType: 1 /* ContractFunctionType.FUNCTION */,
-             };
-         }
-         // If it failed or made a call from within a modifier, and the selector doesn't match
-         // any function, it must have a fallback.
-         return {
+-            };
+-        }
+-        // If it failed or made a call from within a modifier, and the selector doesn't match
+-        // any function, it must have a fallback.
+-        return {
 -            type: solidity_stack_trace_1.StackTraceEntryType.CALLSTACK_ENTRY,
-+            type: 0 /* StackTraceEntryType.CALLSTACK_ENTRY */,
-             sourceReference: this._getFallbackStartSourceReference(trace),
+-            sourceReference: this._getFallbackStartSourceReference(trace),
 -            functionType: model_1.ContractFunctionType.FALLBACK,
-+            functionType: 2 /* ContractFunctionType.FALLBACK */,
-         };
-     }
-     _getLastSourceReference(trace) {
-@@ -702,30 +703,30 @@ class ErrorInferrer {
-         const lastStep = trace.steps[trace.steps.length - 1];
-         const lastInstruction = trace.bytecode.getInstruction(lastStep.pc);
-         return (lastInstruction.location !== undefined &&
+-        };
+-    }
+-    _getLastSourceReference(trace) {
+-        for (let i = trace.steps.length - 1; i >= 0; i--) {
+-            const step = trace.steps[i];
+-            if (!(0, message_trace_1.isEvmStep)(step)) {
+-                continue;
+-            }
+-            const inst = trace.bytecode.getInstruction(step.pc);
+-            if (inst.location === undefined) {
+-                continue;
+-            }
+-            const sourceReference = sourceLocationToSourceReference(trace.bytecode, inst.location);
+-            if (sourceReference !== undefined) {
+-                return sourceReference;
+-            }
+-        }
+-        return undefined;
+-    }
+-    _hasFailedInsideTheFallbackFunction(trace) {
+-        const contract = trace.bytecode.contract;
+-        if (contract.fallback === undefined) {
+-            return false;
+-        }
+-        return this._hasFailedInsideFunction(trace, contract.fallback);
+-    }
+-    _hasFailedInsideTheReceiveFunction(trace) {
+-        const contract = trace.bytecode.contract;
+-        if (contract.receive === undefined) {
+-            return false;
+-        }
+-        return this._hasFailedInsideFunction(trace, contract.receive);
+-    }
+-    _hasFailedInsideFunction(trace, func) {
+-        const lastStep = trace.steps[trace.steps.length - 1];
+-        const lastInstruction = trace.bytecode.getInstruction(lastStep.pc);
+-        return (lastInstruction.location !== undefined &&
 -            lastInstruction.opcode === opcodes_1.Opcode.REVERT &&
-+            lastInstruction.opcode === 253 /* Opcode.REVERT */ &&
-             func.location.contains(lastInstruction.location));
-     }
-     _instructionWithinFunctionToRevertStackTraceEntry(trace, inst) {
-         const sourceReference = sourceLocationToSourceReference(trace.bytecode, inst.location);
-         (0, errors_1.assertHardhatInvariant)(sourceReference !== undefined, "Expected source reference to be defined");
-         return {
+-            func.location.contains(lastInstruction.location));
+-    }
+-    _instructionWithinFunctionToRevertStackTraceEntry(trace, inst) {
+-        const sourceReference = sourceLocationToSourceReference(trace.bytecode, inst.location);
+-        (0, errors_1.assertHardhatInvariant)(sourceReference !== undefined, "Expected source reference to be defined");
+-        return {
 -            type: solidity_stack_trace_1.StackTraceEntryType.REVERT_ERROR,
-+            type: 4 /* StackTraceEntryType.REVERT_ERROR */,
-             sourceReference,
-             message: new return_data_1.ReturnData(trace.returnData),
+-            sourceReference,
+-            message: new return_data_1.ReturnData(trace.returnData),
 -            isInvalidOpcodeError: inst.opcode === opcodes_1.Opcode.INVALID,
-+            isInvalidOpcodeError: inst.opcode === 254 /* Opcode.INVALID */,
-         };
-     }
-     _instructionWithinFunctionToUnmappedSolc063RevertErrorStackTraceEntry(trace, inst) {
-         const sourceReference = sourceLocationToSourceReference(trace.bytecode, inst.location);
-         return {
+-        };
+-    }
+-    _instructionWithinFunctionToUnmappedSolc063RevertErrorStackTraceEntry(trace, inst) {
+-        const sourceReference = sourceLocationToSourceReference(trace.bytecode, inst.location);
+-        return {
 -            type: solidity_stack_trace_1.StackTraceEntryType.UNMAPPED_SOLC_0_6_3_REVERT_ERROR,
-+            type: 20 /* StackTraceEntryType.UNMAPPED_SOLC_0_6_3_REVERT_ERROR */,
-             sourceReference,
-         };
-     }
-     _instructionWithinFunctionToPanicStackTraceEntry(trace, inst, errorCode) {
-         const lastSourceReference = this._getLastSourceReference(trace);
-         return {
+-            sourceReference,
+-        };
+-    }
+-    _instructionWithinFunctionToPanicStackTraceEntry(trace, inst, errorCode) {
+-        const lastSourceReference = this._getLastSourceReference(trace);
+-        return {
 -            type: solidity_stack_trace_1.StackTraceEntryType.PANIC_ERROR,
-+            type: 5 /* StackTraceEntryType.PANIC_ERROR */,
-             sourceReference: sourceLocationToSourceReference(trace.bytecode, inst.location) ??
-                 lastSourceReference,
-             errorCode,
-@@ -735,7 +736,7 @@ class ErrorInferrer {
-         const lastSourceReference = this._getLastSourceReference(trace);
-         (0, errors_1.assertHardhatInvariant)(lastSourceReference !== undefined, "Expected last source reference to be defined");
-         return {
+-            sourceReference: sourceLocationToSourceReference(trace.bytecode, inst.location) ??
+-                lastSourceReference,
+-            errorCode,
+-        };
+-    }
+-    _instructionWithinFunctionToCustomErrorStackTraceEntry(trace, inst, message) {
+-        const lastSourceReference = this._getLastSourceReference(trace);
+-        (0, errors_1.assertHardhatInvariant)(lastSourceReference !== undefined, "Expected last source reference to be defined");
+-        return {
 -            type: solidity_stack_trace_1.StackTraceEntryType.CUSTOM_ERROR,
-+            type: 6 /* StackTraceEntryType.CUSTOM_ERROR */,
-             sourceReference: sourceLocationToSourceReference(trace.bytecode, inst.location) ??
-                 lastSourceReference,
-             message,
-@@ -750,7 +751,7 @@ class ErrorInferrer {
-             return false;
-         }
-         const lastInst = trace.bytecode.getInstruction(lastStep.pc);
+-            sourceReference: sourceLocationToSourceReference(trace.bytecode, inst.location) ??
+-                lastSourceReference,
+-            message,
+-        };
+-    }
+-    _solidity063MaybeUnmappedRevert(trace) {
+-        if (trace.steps.length === 0) {
+-            return false;
+-        }
+-        const lastStep = trace.steps[trace.steps.length - 1];
+-        if (!(0, message_trace_1.isEvmStep)(lastStep)) {
+-            return false;
+-        }
+-        const lastInst = trace.bytecode.getInstruction(lastStep.pc);
 -        return (semver_1.default.satisfies(trace.bytecode.compilerVersion, `^${FIRST_SOLC_VERSION_WITH_UNMAPPED_REVERTS}`) && lastInst.opcode === opcodes_1.Opcode.REVERT);
-+        return (semver_1.default.satisfies(trace.bytecode.compilerVersion, `^${FIRST_SOLC_VERSION_WITH_UNMAPPED_REVERTS}`) && lastInst.opcode === 253 /* Opcode.REVERT */);
-     }
-     // Solidity 0.6.3 unmapped reverts special handling
-     // For more info: https://github.com/ethereum/solidity/issues/9006
-@@ -764,7 +765,7 @@ class ErrorInferrer {
-                     // Failed within the fallback
-                     const location = trace.bytecode.contract.fallback.location;
-                     revertFrame = {
+-    }
+-    // Solidity 0.6.3 unmapped reverts special handling
+-    // For more info: https://github.com/ethereum/solidity/issues/9006
+-    _solidity063GetFrameForUnmappedRevertBeforeFunction(trace) {
+-        let revertFrame = this._solidity063GetFrameForUnmappedRevertWithinFunction(trace);
+-        if (revertFrame === undefined ||
+-            revertFrame.sourceReference === undefined) {
+-            if (trace.bytecode.contract.receive === undefined ||
+-                trace.calldata.length > 0) {
+-                if (trace.bytecode.contract.fallback !== undefined) {
+-                    // Failed within the fallback
+-                    const location = trace.bytecode.contract.fallback.location;
+-                    revertFrame = {
 -                        type: solidity_stack_trace_1.StackTraceEntryType.UNMAPPED_SOLC_0_6_3_REVERT_ERROR,
-+                        type: 20 /* StackTraceEntryType.UNMAPPED_SOLC_0_6_3_REVERT_ERROR */,
-                         sourceReference: {
-                             contract: trace.bytecode.contract.name,
-                             function: solidity_stack_trace_1.FALLBACK_FUNCTION_NAME,
-@@ -781,7 +782,7 @@ class ErrorInferrer {
-                 // Failed within the receive function
-                 const location = trace.bytecode.contract.receive.location;
-                 revertFrame = {
+-                        sourceReference: {
+-                            contract: trace.bytecode.contract.name,
+-                            function: solidity_stack_trace_1.FALLBACK_FUNCTION_NAME,
+-                            sourceName: location.file.sourceName,
+-                            sourceContent: location.file.content,
+-                            line: location.getStartingLineNumber(),
+-                            range: [location.offset, location.offset + location.length],
+-                        },
+-                    };
+-                    this._solidity063CorrectLineNumber(revertFrame);
+-                }
+-            }
+-            else {
+-                // Failed within the receive function
+-                const location = trace.bytecode.contract.receive.location;
+-                revertFrame = {
 -                    type: solidity_stack_trace_1.StackTraceEntryType.UNMAPPED_SOLC_0_6_3_REVERT_ERROR,
-+                    type: 20 /* StackTraceEntryType.UNMAPPED_SOLC_0_6_3_REVERT_ERROR */,
-                     sourceReference: {
-                         contract: trace.bytecode.contract.name,
-                         function: solidity_stack_trace_1.RECEIVE_FUNCTION_NAME,
-@@ -798,7 +799,7 @@ class ErrorInferrer {
-     }
-     _getOtherErrorBeforeCalledFunctionStackTraceEntry(trace) {
-         return {
+-                    sourceReference: {
+-                        contract: trace.bytecode.contract.name,
+-                        function: solidity_stack_trace_1.RECEIVE_FUNCTION_NAME,
+-                        sourceName: location.file.sourceName,
+-                        sourceContent: location.file.content,
+-                        line: location.getStartingLineNumber(),
+-                        range: [location.offset, location.offset + location.length],
+-                    },
+-                };
+-                this._solidity063CorrectLineNumber(revertFrame);
+-            }
+-        }
+-        return revertFrame;
+-    }
+-    _getOtherErrorBeforeCalledFunctionStackTraceEntry(trace) {
+-        return {
 -            type: solidity_stack_trace_1.StackTraceEntryType.OTHER_EXECUTION_ERROR,
-+            type: 19 /* StackTraceEntryType.OTHER_EXECUTION_ERROR */,
-             sourceReference: this._getContractStartWithoutFunctionSourceReference(trace),
-         };
-     }
-@@ -811,12 +812,12 @@ class ErrorInferrer {
-         }
-         const lastStep = trace.steps[lastIndex]; // We know this is an EVM step
-         const lastInst = trace.bytecode.getInstruction(lastStep.pc);
+-            sourceReference: this._getContractStartWithoutFunctionSourceReference(trace),
+-        };
+-    }
+-    _isCalledNonContractAccountError(trace) {
+-        // We could change this to checking that the last valid location maps to a call, but
+-        // it's way more complex as we need to get the ast node from that location.
+-        const lastIndex = this._getLastInstructionWithValidLocationStepIndex(trace);
+-        if (lastIndex === undefined || lastIndex === 0) {
+-            return false;
+-        }
+-        const lastStep = trace.steps[lastIndex]; // We know this is an EVM step
+-        const lastInst = trace.bytecode.getInstruction(lastStep.pc);
 -        if (lastInst.opcode !== opcodes_1.Opcode.ISZERO) {
-+        if (lastInst.opcode !== 21 /* Opcode.ISZERO */) {
-             return false;
-         }
-         const prevStep = trace.steps[lastIndex - 1]; // We know this is an EVM step
-         const prevInst = trace.bytecode.getInstruction(prevStep.pc);
+-            return false;
+-        }
+-        const prevStep = trace.steps[lastIndex - 1]; // We know this is an EVM step
+-        const prevInst = trace.bytecode.getInstruction(prevStep.pc);
 -        return prevInst.opcode === opcodes_1.Opcode.EXTCODESIZE;
-+        return prevInst.opcode === 59 /* Opcode.EXTCODESIZE */;
-     }
-     _solidity063GetFrameForUnmappedRevertWithinFunction(trace) {
-         // If we are within a function there's a last valid location. It may
-@@ -898,7 +899,7 @@ class ErrorInferrer {
-         }
-     }
-     _isContractTooLargeError(trace) {
+-    }
+-    _solidity063GetFrameForUnmappedRevertWithinFunction(trace) {
+-        // If we are within a function there's a last valid location. It may
+-        // be the entire contract.
+-        const prevInst = this._getLastInstructionWithValidLocation(trace);
+-        const lastStep = trace.steps[trace.steps.length - 1];
+-        const nextInstPc = lastStep.pc + 1;
+-        const hasNextInst = trace.bytecode.hasInstruction(nextInstPc);
+-        if (hasNextInst) {
+-            const nextInst = trace.bytecode.getInstruction(nextInstPc);
+-            const prevLoc = prevInst?.location;
+-            const nextLoc = nextInst.location;
+-            const prevFunc = prevLoc?.getContainingFunction();
+-            const nextFunc = nextLoc?.getContainingFunction();
+-            // This is probably a require. This means that we have the exact
+-            // line, but the stack trace may be degraded (e.g. missing our
+-            // synthetic call frames when failing in a modifier) so we still
+-            // add this frame as UNMAPPED_SOLC_0_6_3_REVERT_ERROR
+-            if (prevFunc !== undefined &&
+-                nextLoc !== undefined &&
+-                prevLoc !== undefined &&
+-                prevLoc.equals(nextLoc)) {
+-                return this._instructionWithinFunctionToUnmappedSolc063RevertErrorStackTraceEntry(trace, nextInst);
+-            }
+-            let revertFrame;
+-            // If the previous and next location don't match, we try to use the
+-            // previous one if it's inside a function, otherwise we use the next one
+-            if (prevFunc !== undefined && prevInst !== undefined) {
+-                revertFrame =
+-                    this._instructionWithinFunctionToUnmappedSolc063RevertErrorStackTraceEntry(trace, prevInst);
+-            }
+-            else if (nextFunc !== undefined) {
+-                revertFrame =
+-                    this._instructionWithinFunctionToUnmappedSolc063RevertErrorStackTraceEntry(trace, nextInst);
+-            }
+-            if (revertFrame !== undefined) {
+-                this._solidity063CorrectLineNumber(revertFrame);
+-            }
+-            return revertFrame;
+-        }
+-        if ((0, message_trace_1.isCreateTrace)(trace) && prevInst !== undefined) {
+-            // Solidity is smart enough to stop emitting extra instructions after
+-            // an unconditional revert happens in a constructor. If this is the case
+-            // we just return a special error.
+-            const constructorRevertFrame = this._instructionWithinFunctionToUnmappedSolc063RevertErrorStackTraceEntry(trace, prevInst);
+-            // When the latest instruction is not within a function we need
+-            // some default sourceReference to show to the user
+-            if (constructorRevertFrame.sourceReference === undefined) {
+-                const location = trace.bytecode.contract.location;
+-                const defaultSourceReference = {
+-                    function: solidity_stack_trace_1.CONSTRUCTOR_FUNCTION_NAME,
+-                    contract: trace.bytecode.contract.name,
+-                    sourceName: location.file.sourceName,
+-                    sourceContent: location.file.content,
+-                    line: location.getStartingLineNumber(),
+-                    range: [location.offset, location.offset + location.length],
+-                };
+-                if (trace.bytecode.contract.constructorFunction !== undefined) {
+-                    defaultSourceReference.line =
+-                        trace.bytecode.contract.constructorFunction.location.getStartingLineNumber();
+-                }
+-                constructorRevertFrame.sourceReference = defaultSourceReference;
+-            }
+-            else {
+-                this._solidity063CorrectLineNumber(constructorRevertFrame);
+-            }
+-            return constructorRevertFrame;
+-        }
+-        if (prevInst !== undefined) {
+-            // We may as well just be in a function or modifier and just happen
+-            // to be at the last instruction of the runtime bytecode.
+-            // In this case we just return whatever the last mapped intruction
+-            // points to.
+-            const latestInstructionRevertFrame = this._instructionWithinFunctionToUnmappedSolc063RevertErrorStackTraceEntry(trace, prevInst);
+-            if (latestInstructionRevertFrame.sourceReference !== undefined) {
+-                this._solidity063CorrectLineNumber(latestInstructionRevertFrame);
+-            }
+-            return latestInstructionRevertFrame;
+-        }
+-    }
+-    _isContractTooLargeError(trace) {
 -        return trace.exit.kind === exit_1.ExitCode.CODESIZE_EXCEEDS_MAXIMUM;
-+        return trace.exit.kind === 6 /* ExitCode.CODESIZE_EXCEEDS_MAXIMUM */;
-     }
-     _solidity063CorrectLineNumber(revertFrame) {
-         if (revertFrame.sourceReference === undefined) {
-@@ -949,7 +950,7 @@ class ErrorInferrer {
-         (0, errors_1.assertHardhatInvariant)(sourceReference !== undefined, "Expected source reference to be defined");
-         // Calls only happen within functions
-         return {
+-    }
+-    _solidity063CorrectLineNumber(revertFrame) {
+-        if (revertFrame.sourceReference === undefined) {
+-            return;
+-        }
+-        const lines = revertFrame.sourceReference.sourceContent.split("\n");
+-        const currentLine = lines[revertFrame.sourceReference.line - 1];
+-        if (currentLine.includes("require") || currentLine.includes("revert")) {
+-            return;
+-        }
+-        const nextLines = lines.slice(revertFrame.sourceReference.line);
+-        const firstNonEmptyLine = nextLines.findIndex((l) => l.trim() !== "");
+-        if (firstNonEmptyLine === -1) {
+-            return;
+-        }
+-        const nextLine = nextLines[firstNonEmptyLine];
+-        if (nextLine.includes("require") || nextLine.includes("revert")) {
+-            revertFrame.sourceReference.line += 1 + firstNonEmptyLine;
+-        }
+-    }
+-    _getLastInstructionWithValidLocationStepIndex(trace) {
+-        for (let i = trace.steps.length - 1; i >= 0; i--) {
+-            const step = trace.steps[i];
+-            if (!(0, message_trace_1.isEvmStep)(step)) {
+-                return undefined;
+-            }
+-            const inst = trace.bytecode.getInstruction(step.pc);
+-            if (inst.location !== undefined) {
+-                return i;
+-            }
+-        }
+-        return undefined;
+-    }
+-    _getLastInstructionWithValidLocation(trace) {
+-        const lastLocationIndex = this._getLastInstructionWithValidLocationStepIndex(trace);
+-        if (lastLocationIndex === undefined) {
+-            return undefined;
+-        }
+-        const lastLocationStep = trace.steps[lastLocationIndex];
+-        if ((0, message_trace_1.isEvmStep)(lastLocationStep)) {
+-            const lastInstructionWithLocation = trace.bytecode.getInstruction(lastLocationStep.pc);
+-            return lastInstructionWithLocation;
+-        }
+-        return undefined;
+-    }
+-    _callInstructionToCallFailedToExecuteStackTraceEntry(bytecode, callInst) {
+-        const sourceReference = sourceLocationToSourceReference(bytecode, callInst.location);
+-        (0, errors_1.assertHardhatInvariant)(sourceReference !== undefined, "Expected source reference to be defined");
+-        // Calls only happen within functions
+-        return {
 -            type: solidity_stack_trace_1.StackTraceEntryType.CALL_FAILED_ERROR,
-+            type: 15 /* StackTraceEntryType.CALL_FAILED_ERROR */,
-             sourceReference,
-         };
-     }
-@@ -965,9 +966,9 @@ class ErrorInferrer {
-         }
-         // If there's no jump dest, we point to the constructor.
-         return {
+-            sourceReference,
+-        };
+-    }
+-    _getEntryBeforeFailureInModifier(trace, functionJumpdests) {
+-        // If there's a jumpdest, this modifier belongs to the last function that it represents
+-        if (functionJumpdests.length > 0) {
+-            return instructionToCallstackStackTraceEntry(trace.bytecode, functionJumpdests[functionJumpdests.length - 1]);
+-        }
+-        // This function is only called after we jumped into the initial function in call traces, so
+-        // there should always be at least a function jumpdest.
+-        if (!(0, message_trace_1.isDecodedCreateTrace)(trace)) {
+-            throw new Error("This shouldn't happen: a call trace has no functionJumpdest but has already jumped into a function");
+-        }
+-        // If there's no jump dest, we point to the constructor.
+-        return {
 -            type: solidity_stack_trace_1.StackTraceEntryType.CALLSTACK_ENTRY,
-+            type: 0 /* StackTraceEntryType.CALLSTACK_ENTRY */,
-             sourceReference: this._getConstructorStartSourceReference(trace),
+-            sourceReference: this._getConstructorStartSourceReference(trace),
 -            functionType: model_1.ContractFunctionType.CONSTRUCTOR,
-+            functionType: 0 /* ContractFunctionType.CONSTRUCTOR */,
-         };
-     }
-     _failsRightAfterCall(trace, callSubtraceStepIndex) {
-@@ -976,7 +977,7 @@ class ErrorInferrer {
-             return false;
-         }
-         const lastInst = trace.bytecode.getInstruction(lastStep.pc);
+-        };
+-    }
+-    _failsRightAfterCall(trace, callSubtraceStepIndex) {
+-        const lastStep = trace.steps[trace.steps.length - 1];
+-        if (!(0, message_trace_1.isEvmStep)(lastStep)) {
+-            return false;
+-        }
+-        const lastInst = trace.bytecode.getInstruction(lastStep.pc);
 -        if (lastInst.opcode !== opcodes_1.Opcode.REVERT) {
-+        if (lastInst.opcode !== 253 /* Opcode.REVERT */) {
-             return false;
-         }
-         const callOpcodeStep = trace.steps[callSubtraceStepIndex - 1];
-@@ -1012,8 +1013,8 @@ class ErrorInferrer {
-         if (!(0, ethereumjs_util_1.equalsBytes)(trace.returnData, call.returnData)) {
-             return false;
-         }
+-            return false;
+-        }
+-        const callOpcodeStep = trace.steps[callSubtraceStepIndex - 1];
+-        const callInst = trace.bytecode.getInstruction(callOpcodeStep.pc);
+-        // Calls are always made from within functions
+-        (0, errors_1.assertHardhatInvariant)(callInst.location !== undefined, "Expected call instruction location to be defined");
+-        return this._isLastLocation(trace, callSubtraceStepIndex + 1, callInst.location);
+-    }
+-    _isCallFailedError(trace, instIndex, callInstruction) {
+-        const callLocation = callInstruction.location;
+-        // Calls are always made from within functions
+-        (0, errors_1.assertHardhatInvariant)(callLocation !== undefined, "Expected call location to be defined");
+-        return this._isLastLocation(trace, instIndex, callLocation);
+-    }
+-    _isLastLocation(trace, fromStep, location) {
+-        for (let i = fromStep; i < trace.steps.length; i++) {
+-            const step = trace.steps[i];
+-            if (!(0, message_trace_1.isEvmStep)(step)) {
+-                return false;
+-            }
+-            const stepInst = trace.bytecode.getInstruction(step.pc);
+-            if (stepInst.location === undefined) {
+-                continue;
+-            }
+-            if (!location.equals(stepInst.location)) {
+-                return false;
+-            }
+-        }
+-        return true;
+-    }
+-    _isSubtraceErrorPropagated(trace, callSubtraceStepIndex) {
+-        const call = trace.steps[callSubtraceStepIndex];
+-        if (!(0, ethereumjs_util_1.equalsBytes)(trace.returnData, call.returnData)) {
+-            return false;
+-        }
 -        if (trace.exit.kind === exit_1.ExitCode.OUT_OF_GAS &&
 -            call.exit.kind === exit_1.ExitCode.OUT_OF_GAS) {
-+        if (trace.exit.kind === 2 /* ExitCode.OUT_OF_GAS */ &&
-+            call.exit.kind === 2 /* ExitCode.OUT_OF_GAS */) {
-             return true;
-         }
-         // If the return data is not empty, and it's still the same, we assume it
-@@ -1032,7 +1033,7 @@ class ErrorInferrer {
-             return false;
-         }
-         const callInst = trace.bytecode.getInstruction(callStep.pc);
+-            return true;
+-        }
+-        // If the return data is not empty, and it's still the same, we assume it
+-        // is being propagated
+-        if (trace.returnData.length > 0) {
+-            return true;
+-        }
+-        return this._failsRightAfterCall(trace, callSubtraceStepIndex);
+-    }
+-    _isProxyErrorPropagated(trace, callSubtraceStepIndex) {
+-        if (!(0, message_trace_1.isDecodedCallTrace)(trace)) {
+-            return false;
+-        }
+-        const callStep = trace.steps[callSubtraceStepIndex - 1];
+-        if (!(0, message_trace_1.isEvmStep)(callStep)) {
+-            return false;
+-        }
+-        const callInst = trace.bytecode.getInstruction(callStep.pc);
 -        if (callInst.opcode !== opcodes_1.Opcode.DELEGATECALL) {
-+        if (callInst.opcode !== 244 /* Opcode.DELEGATECALL */) {
-             return false;
-         }
-         const subtrace = trace.steps[callSubtraceStepIndex];
-@@ -1046,7 +1047,7 @@ class ErrorInferrer {
-         if (subtrace.bytecode === undefined) {
-             return false;
-         }
+-            return false;
+-        }
+-        const subtrace = trace.steps[callSubtraceStepIndex];
+-        if ((0, message_trace_1.isEvmStep)(subtrace)) {
+-            return false;
+-        }
+-        if ((0, message_trace_1.isPrecompileTrace)(subtrace)) {
+-            return false;
+-        }
+-        // If we can't recognize the implementation we'd better don't consider it as such
+-        if (subtrace.bytecode === undefined) {
+-            return false;
+-        }
 -        if (subtrace.bytecode.contract.type === model_1.ContractType.LIBRARY) {
-+        if (subtrace.bytecode.contract.type === 1 /* ContractType.LIBRARY */) {
-             return false;
-         }
-         if (!(0, ethereumjs_util_1.equalsBytes)(trace.returnData, subtrace.returnData)) {
-@@ -1062,24 +1063,24 @@ class ErrorInferrer {
-             if (inst.location === undefined) {
-                 return false;
-             }
+-            return false;
+-        }
+-        if (!(0, ethereumjs_util_1.equalsBytes)(trace.returnData, subtrace.returnData)) {
+-            return false;
+-        }
+-        for (let i = callSubtraceStepIndex + 1; i < trace.steps.length; i++) {
+-            const step = trace.steps[i];
+-            if (!(0, message_trace_1.isEvmStep)(step)) {
+-                return false;
+-            }
+-            const inst = trace.bytecode.getInstruction(step.pc);
+-            // All the remaining locations should be valid, as they are part of the inline asm
+-            if (inst.location === undefined) {
+-                return false;
+-            }
 -            if (inst.jumpType === model_1.JumpType.INTO_FUNCTION ||
 -                inst.jumpType === model_1.JumpType.OUTOF_FUNCTION) {
-+            if (inst.jumpType === 1 /* JumpType.INTO_FUNCTION */ ||
-+                inst.jumpType === 2 /* JumpType.OUTOF_FUNCTION */) {
-                 return false;
-             }
-         }
-         const lastStep = trace.steps[trace.steps.length - 1];
-         const lastInst = trace.bytecode.getInstruction(lastStep.pc);
+-                return false;
+-            }
+-        }
+-        const lastStep = trace.steps[trace.steps.length - 1];
+-        const lastInst = trace.bytecode.getInstruction(lastStep.pc);
 -        return lastInst.opcode === opcodes_1.Opcode.REVERT;
-+        return lastInst.opcode === 253 /* Opcode.REVERT */;
-     }
-     _isContractCallRunOutOfGasError(trace, callStepIndex) {
-         if (trace.returnData.length > 0) {
-             return false;
-         }
+-    }
+-    _isContractCallRunOutOfGasError(trace, callStepIndex) {
+-        if (trace.returnData.length > 0) {
+-            return false;
+-        }
 -        if (trace.exit.kind !== exit_1.ExitCode.REVERT) {
-+        if (trace.exit.kind !== 1 /* ExitCode.REVERT */) {
-             return false;
-         }
-         const call = trace.steps[callStepIndex];
+-            return false;
+-        }
+-        const call = trace.steps[callStepIndex];
 -        if (call.exit.kind !== exit_1.ExitCode.OUT_OF_GAS) {
-+        if (call.exit.kind !== 2 /* ExitCode.OUT_OF_GAS */) {
-             return false;
-         }
-         return this._failsRightAfterCall(trace, callStepIndex);
-@@ -1096,7 +1097,7 @@ function instructionToCallstackStackTraceEntry(bytecode, inst) {
-     if (inst.location === undefined) {
-         const location = bytecode.contract.location;
-         return {
+-            return false;
+-        }
+-        return this._failsRightAfterCall(trace, callStepIndex);
+-    }
+-    _isPanicReturnData(returnData) {
+-        return new return_data_1.ReturnData(returnData).isPanicReturnData();
+-    }
+-}
+-exports.ErrorInferrer = ErrorInferrer;
+-function instructionToCallstackStackTraceEntry(bytecode, inst) {
+-    // This means that a jump is made from within an internal solc function.
+-    // These are normally made from yul code, so they don't map to any Solidity
+-    // function
+-    if (inst.location === undefined) {
+-        const location = bytecode.contract.location;
+-        return {
 -            type: solidity_stack_trace_1.StackTraceEntryType.INTERNAL_FUNCTION_CALLSTACK_ENTRY,
-+            type: 22 /* StackTraceEntryType.INTERNAL_FUNCTION_CALLSTACK_ENTRY */,
-             pc: inst.pc,
-             sourceReference: {
-                 sourceName: bytecode.contract.location.file.sourceName,
-@@ -1113,14 +1114,14 @@ function instructionToCallstackStackTraceEntry(bytecode, inst) {
-         const sourceReference = sourceLocationToSourceReference(bytecode, inst.location);
-         (0, errors_1.assertHardhatInvariant)(sourceReference !== undefined, "Expected source reference to be defined");
-         return {
+-            pc: inst.pc,
+-            sourceReference: {
+-                sourceName: bytecode.contract.location.file.sourceName,
+-                sourceContent: bytecode.contract.location.file.content,
+-                contract: bytecode.contract.name,
+-                function: undefined,
+-                line: bytecode.contract.location.getStartingLineNumber(),
+-                range: [location.offset, location.offset + location.length],
+-            },
+-        };
+-    }
+-    const func = inst.location?.getContainingFunction();
+-    if (func !== undefined) {
+-        const sourceReference = sourceLocationToSourceReference(bytecode, inst.location);
+-        (0, errors_1.assertHardhatInvariant)(sourceReference !== undefined, "Expected source reference to be defined");
+-        return {
 -            type: solidity_stack_trace_1.StackTraceEntryType.CALLSTACK_ENTRY,
-+            type: 0 /* StackTraceEntryType.CALLSTACK_ENTRY */,
-             sourceReference,
-             functionType: func.type,
-         };
-     }
-     (0, errors_1.assertHardhatInvariant)(inst.location !== undefined, "Expected instruction location to be defined");
-     return {
+-            sourceReference,
+-            functionType: func.type,
+-        };
+-    }
+-    (0, errors_1.assertHardhatInvariant)(inst.location !== undefined, "Expected instruction location to be defined");
+-    return {
 -        type: solidity_stack_trace_1.StackTraceEntryType.CALLSTACK_ENTRY,
-+        type: 0 /* StackTraceEntryType.CALLSTACK_ENTRY */,
-         sourceReference: {
-             function: undefined,
-             contract: bytecode.contract.name,
-@@ -1132,7 +1133,7 @@ function instructionToCallstackStackTraceEntry(bytecode, inst) {
-                 inst.location.offset + inst.location.length,
-             ],
-         },
+-        sourceReference: {
+-            function: undefined,
+-            contract: bytecode.contract.name,
+-            sourceName: inst.location.file.sourceName,
+-            sourceContent: inst.location.file.content,
+-            line: inst.location.getStartingLineNumber(),
+-            range: [
+-                inst.location.offset,
+-                inst.location.offset + inst.location.length,
+-            ],
+-        },
 -        functionType: model_1.ContractFunctionType.FUNCTION,
-+        functionType: 1 /* ContractFunctionType.FUNCTION */,
-     };
- }
- exports.instructionToCallstackStackTraceEntry = instructionToCallstackStackTraceEntry;
-@@ -1145,18 +1146,18 @@ function sourceLocationToSourceReference(bytecode, location) {
-         return undefined;
-     }
-     let funcName = func.name;
+-    };
+-}
+-exports.instructionToCallstackStackTraceEntry = instructionToCallstackStackTraceEntry;
+-function sourceLocationToSourceReference(bytecode, location) {
+-    if (location === undefined) {
+-        return undefined;
+-    }
+-    const func = location.getContainingFunction();
+-    if (func === undefined) {
+-        return undefined;
+-    }
+-    let funcName = func.name;
 -    if (func.type === model_1.ContractFunctionType.CONSTRUCTOR) {
-+    if (func.type === 0 /* ContractFunctionType.CONSTRUCTOR */) {
-         funcName = solidity_stack_trace_1.CONSTRUCTOR_FUNCTION_NAME;
-     }
+-        funcName = solidity_stack_trace_1.CONSTRUCTOR_FUNCTION_NAME;
+-    }
 -    else if (func.type === model_1.ContractFunctionType.FALLBACK) {
-+    else if (func.type === 2 /* ContractFunctionType.FALLBACK */) {
-         funcName = solidity_stack_trace_1.FALLBACK_FUNCTION_NAME;
-     }
+-        funcName = solidity_stack_trace_1.FALLBACK_FUNCTION_NAME;
+-    }
 -    else if (func.type === model_1.ContractFunctionType.RECEIVE) {
-+    else if (func.type === 3 /* ContractFunctionType.RECEIVE */) {
-         funcName = solidity_stack_trace_1.RECEIVE_FUNCTION_NAME;
-     }
-     return {
-         function: funcName,
+-        funcName = solidity_stack_trace_1.RECEIVE_FUNCTION_NAME;
+-    }
+-    return {
+-        function: funcName,
 -        contract: func.type === model_1.ContractFunctionType.FREE_FUNCTION
-+        contract: func.type === 6 /* ContractFunctionType.FREE_FUNCTION */
-             ? undefined
-             : bytecode.contract.name,
-         sourceName: func.location.file.sourceName,
+-            ? undefined
+-            : bytecode.contract.name,
+-        sourceName: func.location.file.sourceName,
+-        sourceContent: func.location.file.content,
+-        line: location.getStartingLineNumber(),
+-        range: [location.offset, location.offset + location.length],
+-    };
+-}
+ //# sourceMappingURL=error-inferrer.js.map
+\ No newline at end of file
 diff --git a/internal/hardhat-network/stack-traces/error-inferrer.js.map b/internal/hardhat-network/stack-traces/error-inferrer.js.map
-index eeba5c914068055d7cd9d7db13a741a02c44a378..a3d1e6b0d475bdb16a51e8bf4558cf7a43ba2c86 100644
+index eeba5c914068055d7cd9d7db13a741a02c44a378..e632162c4728cbeaa7a195dd167ab9f0a80d94ea 100644
 --- a/internal/hardhat-network/stack-traces/error-inferrer.js.map
 +++ b/internal/hardhat-network/stack-traces/error-inferrer.js.map
 @@ -1 +1 @@
 -{"version":3,"file":"error-inferrer.js","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/error-inferrer.ts"],"names":[],"mappings":";;;;;;AAAA,gEAAgE;AAChE,4CAA4D;AAC5D,sEAA+D;AAC/D,oDAA4B;AAE5B,8CAA2D;AAC3D,wDAAoD;AACpD,yDAAqD;AACrD,8CAA+C;AAE/C,mDAWyB;AACzB,mCAQiB;AACjB,uCAAqD;AACrD,iEAgBgC;AAEhC,MAAM,2CAA2C,GAAG,OAAO,CAAC;AAC5D,MAAM,mCAAmC,GAAG,OAAO,CAAC;AACpD,MAAM,wCAAwC,GAAG,OAAO,CAAC;AAQzD,+EAA+E;AAE/E,MAAa,aAAa;IACjB,6BAA6B,CAClC,KAA8B;QAE9B,IAAI,IAAI,CAAC,oBAAoB,CAAC,KAAK,CAAC,EAAE;YACpC,OAAO,IAAI,CAAC,oCAAoC,CAAC,KAAK,CAAC,CAAC;SACzD;QAED,MAAM,cAAc,GAAG,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,uBAAuB,CACpE,KAAK,CAAC,QAAQ,CAAC,KAAK,CAAC,CAAC,EAAE,CAAC,CAAC,CAC3B,CAAC;QAEF,IACE,cAAc,KAAK,SAAS;YAC5B,IAAI,CAAC,0BAA0B,CAAC,KAAK,EAAE,cAAc,CAAC,EACtD;YACA,OAAO;gBACL;oBACE,IAAI,EAAE,0CAAmB,CAAC,0BAA0B;oBACpD,eAAe,EAAE,IAAI,CAAC,gCAAgC,CACpD,KAAK,EACL,cAAc,CACf;oBACD,KAAK,EAAE,KAAK,CAAC,KAAK;iBACnB;aACF,CAAC;SACH;QAED,IAAI,IAAI,CAAC,kCAAkC,CAAC,KAAK,EAAE,cAAc,CAAC,EAAE;YAClE,IAAI,IAAI,CAAC,0BAA0B,CAAC,KAAK,CAAC,EAAE;gBAC1C,OAAO;oBACL;wBACE,IAAI,EAAE,0CAAmB,CAAC,iCAAiC;wBAC3D,eAAe,EACb,IAAI,CAAC,+CAA+C,CAAC,KAAK,CAAC;qBAC9D;iBACF,CAAC;aACH;YAED,OAAO;gBACL;oBACE,IAAI,EAAE,0CAAmB,CAAC,4CAA4C;oBACtE,eAAe,EACb,IAAI,CAAC,+CAA+C,CAAC,KAAK,CAAC;iBAC9D;aACF,CAAC;SACH;QAED,IAAI,IAAI,CAAC,0BAA0B,CAAC,KAAK,EAAE,cAAc,CAAC,EAAE;YAC1D,IAAI,IAAI,CAAC,0BAA0B,CAAC,KAAK,CAAC,EAAE;gBAC1C,OAAO;oBACL;wBACE,IAAI,EAAE,0CAAmB,CAAC,yCAAyC;wBACnE,eAAe,EAAE,IAAI,CAAC,gCAAgC,CAAC,KAAK,CAAC;wBAC7D,KAAK,EAAE,KAAK,CAAC,KAAK;qBACnB;iBACF,CAAC;aACH;YAED,OAAO;gBACL;oBACE,IAAI,EAAE,0CAAmB,CAAC,0BAA0B;oBACpD,eAAe,EAAE,IAAI,CAAC,gCAAgC,CAAC,KAAK,CAAC;oBAC7D,KAAK,EAAE,KAAK,CAAC,KAAK;iBACnB;aACF,CAAC;SACH;IACH,CAAC;IAEM,+BAA+B,CACpC,KAAgC;QAEhC,IAAI,IAAI,CAAC,6BAA6B,CAAC,KAAK,CAAC,EAAE;YAC7C,OAAO;gBACL;oBACE,IAAI,EAAE,0CAAmB,CAAC,0BAA0B;oBACpD,eAAe,EAAE,IAAI,CAAC,mCAAmC,CAAC,KAAK,CAAC;oBAChE,KAAK,EAAE,KAAK,CAAC,KAAK;iBACnB;aACF,CAAC;SACH;QAED,IAAI,IAAI,CAAC,mCAAmC,CAAC,KAAK,CAAC,EAAE;YACnD,OAAO;gBACL;oBACE,IAAI,EAAE,0CAAmB,CAAC,oBAAoB;oBAC9C,eAAe,EAAE,IAAI,CAAC,mCAAmC,CAAC,KAAK,CAAC;iBACjE;aACF,CAAC;SACH;IACH,CAAC;IAEM,iBAAiB,CACtB,KAA6B,EAC7B,UAA8B,EAC9B,iBAAgC,EAChC,kBAA2B,EAC3B,kBAA8C;QAE9C,OAAO,CACL,IAAI,CAAC,oBAAoB,CAAC,KAAK,EAAE,UAAU,EAAE,kBAAkB,CAAC;YAChE,IAAI,CAAC,oBAAoB,CAAC,KAAK,EAAE,UAAU,CAAC;YAC5C,IAAI,CAAC,qBAAqB,CACxB,KAAK,EACL,UAAU,EACV,iBAAiB,EACjB,kBAAkB,CACnB;YACD,IAAI,CAAC,uBAAuB,CAAC,KAAK,EAAE,UAAU,CAAC;YAC/C,IAAI,CAAC,+BAA+B,CAAC,KAAK,EAAE,UAAU,CAAC;YACvD,IAAI,CAAC,sBAAsB,CAAC,KAAK,CAAC;YAClC,IAAI,CAAC,8BAA8B,CAAC,KAAK,EAAE,UAAU,CAAC,CACvD,CAAC;IACJ,CAAC;IAEM,qBAAqB,CAC1B,UAA8B;QAE9B,OAAO,UAAU,CAAC,MAAM,CAAC,CAAC,KAAK,EAAE,CAAC,EAAE,EAAE;YACpC,IAAI,CAAC,GAAG,CAAC,KAAK,UAAU,CAAC,MAAM,EAAE;gBAC/B,OAAO,IAAI,CAAC;aACb;YAED,MAAM,SAAS,GAAG,UAAU,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC;YAEpC,6DAA6D;YAC7D,kCAAkC;YAClC,IACE,KAAK,CAAC,eAAe,KAAK,SAAS;gBACnC,SAAS,CAAC,eAAe,KAAK,SAAS,EACvC;gBACA,OAAO,IAAI,CAAC;aACb;YAED,yEAAyE;YACzE,wEAAwE;YACxE,IACE,KAAK,CAAC,IAAI,KAAK,0CAAmB,CAAC,eAAe;gBAClD,CAAC,GAAG,CAAC,GAAG,UAAU,CAAC,MAAM;gBACzB,UAAU,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,eAAe,KAAK,SAAS;gBAC/C,UAAU,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,IAAI,KAAK,0CAAmB,CAAC,qBAAqB,EACpE;gBACA,wEAAwE;gBACxE,MAAM,UAAU,GAAG,UAAU,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,eAAe,CAAC;gBACrD,IACE,UAAU,KAAK,SAAS;oBACxB,KAAK,CAAC,eAAe,CAAC,KAAK,CAAC,CAAC,CAAC,KAAK,UAAU,CAAC,KAAK,CAAC,CAAC,CAAC;oBACtD,KAAK,CAAC,eAAe,CAAC,KAAK,CAAC,CAAC,CAAC,KAAK,UAAU,CAAC,KAAK,CAAC,CAAC,CAAC;oBACtD,KAAK,CAAC,eAAe,CAAC,IAAI,KAAK,UAAU,CAAC,IAAI,EAC9C;oBACA,OAAO,KAAK,CAAC;iBACd;aACF;YAED,6DAA6D;YAC7D,IACE,KAAK,CAAC,eAAe,CAAC,QAAQ,KAAK,aAAa;gBAChD,SAAS,CAAC,eAAe,CAAC,QAAQ,KAAK,aAAa,EACpD;gBACA,OAAO,IAAI,CAAC;aACb;YAED,oCAAoC;YACpC,IACE,CAAC,GAAG,CAAC;gBACL,KAAK,CAAC,IAAI,KAAK,SAAS,CAAC,IAAI;gBAC7B,KAAK,CAAC,eAAe,CAAC,KAAK,CAAC,CAAC,CAAC,KAAK,SAAS,CAAC,eAAe,CAAC,KAAK,CAAC,CAAC,CAAC;gBACrE,KAAK,CAAC,eAAe,CAAC,KAAK,CAAC,CAAC,CAAC,KAAK,SAAS,CAAC,eAAe,CAAC,KAAK,CAAC,CAAC,CAAC;gBACrE,KAAK,CAAC,eAAe,CAAC,IAAI,KAAK,SAAS,CAAC,eAAe,CAAC,IAAI,EAC7D;gBACA,OAAO,IAAI,CAAC;aACb;YAED,IACE,KAAK,CAAC,eAAe,CAAC,KAAK,CAAC,CAAC,CAAC,IAAI,SAAS,CAAC,eAAe,CAAC,KAAK,CAAC,CAAC,CAAC;gBACpE,KAAK,CAAC,eAAe,CAAC,KAAK,CAAC,CAAC,CAAC,IAAI,SAAS,CAAC,eAAe,CAAC,KAAK,CAAC,CAAC,CAAC,EACpE;gBACA,OAAO,KAAK,CAAC;aACd;YAED,OAAO,IAAI,CAAC;QACd,CAAC,CAAC,CAAC;IACL,CAAC;IAED,aAAa;IAEb;;OAEG;IACK,oBAAoB,CAC1B,KAA6B,EAC7B,UAA8B,EAC9B,kBAA8C;QAE9C,IAAI,kBAAkB,KAAK,SAAS,EAAE;YACpC,OAAO,SAAS,CAAC;SAClB;QAED,MAAM,kBAAkB,GAAG,CAAC,GAAG,UAAU,CAAC,CAAC;QAE3C,0EAA0E;QAC1E,MAAM,QAAQ,GAAG,KAAK,CAAC,KAAK,CAAC,kBAAkB,CAAC,SAAS,GAAG,CAAC,CAAC,CAAC;QAE/D,IAAI,CAAC,IAAA,yBAAS,EAAC,QAAQ,CAAC,EAAE;YACxB,MAAM,IAAI,KAAK,CACb,uEAAuE,CACxE,CAAC;SACH;QAED,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC;QAC5D,MAAM,cAAc,GAAG,qCAAqC,CAC1D,KAAK,CAAC,QAAQ,EACd,QAAQ,CACT,CAAC;QAEF,MAAM,iBAAiB,GAAG,kBAAkB,CAAC,YAAY,CAAC,IAAI,CAAC,OAAO,EAAE,CAAC;QACzE,IAAI,iBAAiB,EAAE;YACrB,oEAAoE;YACpE,kBAAkB,CAAC,IAAI,CAAC,cAAc,CAAC,CAAC;YAExC,IACE,IAAI,CAAC,0BAA0B,CAAC,KAAK,EAAE,kBAAkB,CAAC,SAAS,CAAC;gBACpE,IAAI,CAAC,uBAAuB,CAAC,KAAK,EAAE,kBAAkB,CAAC,SAAS,CAAC,EACjE;gBACA,kBAAkB,CAAC,IAAI,CAAC,GAAG,kBAAkB,CAAC,UAAU,CAAC,CAAC;gBAE1D,IACE,IAAI,CAAC,+BAA+B,CAClC,KAAK,EACL,kBAAkB,CAAC,SAAS,CAC7B,EACD;oBACA,MAAM,SAAS,GAAG,kBAAkB,CAAC,GAAG,EAAE,CAAC;oBAC3C,IAAA,+BAAsB,EACpB,SAAS,KAAK,SAAS,EACvB,0DAA0D,CAC3D,CAAC;oBACF,kBAAkB,CAAC,IAAI,CAAC;wBACtB,IAAI,EAAE,0CAAmB,CAAC,kCAAkC;wBAC5D,eAAe,EAAE,SAAS,CAAC,eAAe;qBAC3C,CAAC,CAAC;iBACJ;gBAED,OAAO,IAAI,CAAC,mBAAmB,CAAC,KAAK,EAAE,kBAAkB,CAAC,CAAC;aAC5D;SACF;aAAM;YACL,MAAM,qBAAqB,GAAG,IAAI,CAAC,oBAAoB,CACrD,KAAK,EACL,kBAAkB,CAAC,SAAS,CAC7B,CAAC;YACF,IAAI,qBAAqB,EAAE;gBACzB,kBAAkB,CAAC,IAAI,CAAC;oBACtB,IAAI,EAAE,0CAAmB,CAAC,qBAAqB;oBAC/C,eAAe,EAAE,cAAc,CAAC,eAAe;iBAChD,CAAC,CAAC;gBAEH,OAAO,IAAI,CAAC,mBAAmB,CAAC,KAAK,EAAE,kBAAkB,CAAC,CAAC;aAC5D;SACF;IACH,CAAC;IAED;;OAEG;IACK,oBAAoB,CAC1B,KAA6B,EAC7B,UAA8B;QAE9B,KAAK,IAAI,SAAS,GAAG,KAAK,CAAC,KAAK,CAAC,MAAM,GAAG,CAAC,EAAE,SAAS,IAAI,CAAC,EAAE,SAAS,EAAE,EAAE;YACxE,MAAM,IAAI,GAAG,KAAK,CAAC,KAAK,CAAC,SAAS,CAAC,CAAC;YACpC,MAAM,QAAQ,GAAG,KAAK,CAAC,KAAK,CAAC,SAAS,GAAG,CAAC,CAAC,CAAC;YAE5C,IAAI,CAAC,IAAA,yBAAS,EAAC,IAAI,CAAC,EAAE;gBACpB,OAAO;aACR;YAED,MAAM,IAAI,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,IAAI,CAAC,EAAE,CAAC,CAAC;YAEpD,MAAM,cAAc,GAAG,IAAA,gBAAM,EAAC,IAAI,CAAC,MAAM,CAAC,IAAI,IAAA,kBAAQ,EAAC,IAAI,CAAC,MAAM,CAAC,CAAC;YAEpE,IAAI,cAAc,IAAI,IAAA,yBAAS,EAAC,QAAQ,CAAC,EAAE;gBACzC,IAAI,IAAI,CAAC,kBAAkB,CAAC,KAAK,EAAE,SAAS,EAAE,IAAI,CAAC,EAAE;oBACnD,MAAM,kBAAkB,GAAG;wBACzB,GAAG,UAAU;wBACb,IAAI,CAAC,oDAAoD,CACvD,KAAK,CAAC,QAAQ,EACd,IAAI,CACL;qBACF,CAAC;oBAEF,OAAO,IAAI,CAAC,mBAAmB,CAAC,KAAK,EAAE,kBAAkB,CAAC,CAAC;iBAC5D;aACF;SACF;IACH,CAAC;IAED;;OAEG;IACK,2BAA2B,CACjC,KAA6B,EAC7B,UAA8B,EAC9B,eAA4B,EAC5B,iBAAgC,EAChC,kBAA2B;QAE3B,IACE,eAAe,CAAC,MAAM,KAAK,gBAAM,CAAC,MAAM;YACxC,eAAe,CAAC,MAAM,KAAK,gBAAM,CAAC,OAAO,EACzC;YACA,OAAO;SACR;QAED,MAAM,kBAAkB,GAAG,CAAC,GAAG,UAAU,CAAC,CAAC;QAE3C,IACE,eAAe,CAAC,QAAQ,KAAK,SAAS;YACtC,CAAC,CAAC,IAAA,kCAAkB,EAAC,KAAK,CAAC,IAAI,kBAAkB,CAAC,EAClD;YACA,sFAAsF;YACtF,EAAE;YACF,oFAAoF;YACpF,yBAAyB;YACzB,EAAE;YACF,yFAAyF;YACzF,MAAM,eAAe,GAAG,eAAe,CAAC,QAAQ,CAAC,qBAAqB,EAAE,CAAC;YAEzE,gFAAgF;YAChF,IACE,eAAe,KAAK,SAAS;gBAC7B,eAAe,CAAC,IAAI,KAAK,4BAAoB,CAAC,QAAQ,EACtD;gBACA,kBAAkB,CAAC,IAAI,CACrB,IAAI,CAAC,gCAAgC,CAAC,KAAK,EAAE,iBAAiB,CAAC,CAChE,CAAC;aACH;SACF;QAED,MAAM,eAAe,GAAG,IAAI,CAAC,WAAW,CACtC,KAAK,EACL,kBAAkB,EAClB,eAAe,CAChB,CAAC;QACF,IAAI,eAAe,KAAK,SAAS,EAAE;YACjC,OAAO,eAAe,CAAC;SACxB;QAED,MAAM,qBAAqB,GAAG,IAAI,CAAC,kBAAkB,CACnD,KAAK,EACL,kBAAkB,EAClB,eAAe,CAChB,CAAC;QACF,IAAI,qBAAqB,KAAK,SAAS,EAAE;YACvC,OAAO,qBAAqB,CAAC;SAC9B;QAED,IACE,eAAe,CAAC,QAAQ,KAAK,SAAS;YACtC,CAAC,CAAC,IAAA,kCAAkB,EAAC,KAAK,CAAC,IAAI,kBAAkB,CAAC,EAClD;YACA,MAAM,eAAe,GAAG,eAAe,CAAC,QAAQ,CAAC,qBAAqB,EAAE,CAAC;YAEzE,IAAI,eAAe,KAAK,SAAS,EAAE;gBACjC,kBAAkB,CAAC,IAAI,CACrB,IAAI,CAAC,iDAAiD,CACpD,KAAK,EACL,eAAe,CAChB,CACF,CAAC;aACH;iBAAM,IAAI,IAAA,kCAAkB,EAAC,KAAK,CAAC,EAAE;gBACpC,4CAA4C;gBAC5C,MAAM,gBAAgB,GACpB,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,uBAAuB,CAC7C,KAAK,CAAC,QAAQ,CAAC,KAAK,CAAC,CAAC,EAAE,CAAC,CAAC,CAC3B,CAAC;gBAEJ,uEAAuE;gBACvE,wEAAwE;gBACxE,UAAU;gBACV,IAAI,gBAAgB,KAAK,SAAS,EAAE;oBAClC,OAAO;iBACR;gBAED,kBAAkB,CAAC,IAAI,CAAC;oBACtB,IAAI,EAAE,0CAAmB,CAAC,YAAY;oBACtC,eAAe,EAAE,IAAI,CAAC,gCAAgC,CACpD,KAAK,EACL,gBAAgB,CACjB;oBACD,OAAO,EAAE,IAAI,wBAAU,CAAC,KAAK,CAAC,UAAU,CAAC;oBACzC,oBAAoB,EAAE,eAAe,CAAC,MAAM,KAAK,gBAAM,CAAC,OAAO;iBAChE,CAAC,CAAC;aACJ;iBAAM;gBACL,4CAA4C;gBAC5C,kBAAkB,CAAC,IAAI,CAAC;oBACtB,IAAI,EAAE,0CAAmB,CAAC,YAAY;oBACtC,eAAe,EAAE,IAAI,CAAC,mCAAmC,CAAC,KAAK,CAAC;oBAChE,OAAO,EAAE,IAAI,wBAAU,CAAC,KAAK,CAAC,UAAU,CAAC;oBACzC,oBAAoB,EAAE,eAAe,CAAC,MAAM,KAAK,gBAAM,CAAC,OAAO;iBAChE,CAAC,CAAC;aACJ;YAED,OAAO,IAAI,CAAC,mBAAmB,CAAC,KAAK,EAAE,kBAAkB,CAAC,CAAC;SAC5D;QAED,oEAAoE;QACpE,oEAAoE;QACpE,IAAI,eAAe,CAAC,QAAQ,KAAK,SAAS,IAAI,KAAK,CAAC,UAAU,CAAC,MAAM,GAAG,CAAC,EAAE;YACzE,MAAM,WAAW,GAA+B;gBAC9C,IAAI,EAAE,0CAAmB,CAAC,YAAY;gBACtC,eAAe,EACb,IAAI,CAAC,uBAAuB,CAAC,KAAK,CAAC;oBACnC,IAAI,CAAC,+CAA+C,CAAC,KAAK,CAAC;gBAC7D,OAAO,EAAE,IAAI,wBAAU,CAAC,KAAK,CAAC,UAAU,CAAC;gBACzC,oBAAoB,EAAE,eAAe,CAAC,MAAM,KAAK,gBAAM,CAAC,OAAO;aAChE,CAAC;YACF,kBAAkB,CAAC,IAAI,CAAC,WAAW,CAAC,CAAC;YAErC,OAAO,IAAI,CAAC,mBAAmB,CAAC,KAAK,EAAE,kBAAkB,CAAC,CAAC;SAC5D;IACH,CAAC;IAED;;OAEG;IACK,WAAW,CACjB,KAA6B,EAC7B,UAA8B,EAC9B,eAA4B;QAE5B,IAAI,CAAC,IAAI,CAAC,kBAAkB,CAAC,KAAK,CAAC,UAAU,CAAC,EAAE;YAC9C,OAAO;SACR;QAED,qEAAqE;QACrE,uEAAuE;QACvE,SAAS;QACT,MAAM,SAAS,GAAG,UAAU,CAAC,UAAU,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC;QACpD,IACE,SAAS,EAAE,IAAI,KAAK,0CAAmB,CAAC,iCAAiC,EACzE;YACA,UAAU,CAAC,MAAM,CAAC,CAAC,CAAC,CAAC,CAAC;SACvB;QAED,MAAM,eAAe,GAAG,IAAI,wBAAU,CAAC,KAAK,CAAC,UAAU,CAAC,CAAC;QACzD,MAAM,SAAS,GAAG,eAAe,CAAC,WAAW,EAAE,CAAC;QAEhD,iEAAiE;QACjE,gEAAgE;QAChE,2BAA2B;QAC3B,IAAI,SAAS,KAAK,KAAK,EAAE;YACvB,UAAU,CAAC,MAAM,CAAC,CAAC,CAAC,CAAC,CAAC;SACvB;QAED,MAAM,kBAAkB,GAAG,CAAC,GAAG,UAAU,CAAC,CAAC;QAC3C,kBAAkB,CAAC,IAAI,CACrB,IAAI,CAAC,gDAAgD,CACnD,KAAK,EACL,eAAe,EACf,SAAS,CACV,CACF,CAAC;QAEF,OAAO,IAAI,CAAC,mBAAmB,CAAC,KAAK,EAAE,kBAAkB,CAAC,CAAC;IAC7D,CAAC;IAEO,kBAAkB,CACxB,KAA6B,EAC7B,UAA8B,EAC9B,eAA4B;QAE5B,MAAM,UAAU,GAAG,IAAI,wBAAU,CAAC,KAAK,CAAC,UAAU,CAAC,CAAC;QAEpD,IAAI,UAAU,CAAC,OAAO,EAAE,IAAI,UAAU,CAAC,iBAAiB,EAAE,EAAE;YAC1D,0DAA0D;YAC1D,kCAAkC;YAClC,OAAO;SACR;QAED,MAAM,aAAa,GAAG,MAAM,CAAC,IAAI,CAAC,UAAU,CAAC,KAAK,CAAC,CAAC,QAAQ,CAAC,KAAK,CAAC,CAAC;QACpE,IAAI,YAAY,GAAG,8DAA8D,aAAa,GAAG,CAAC;QAElG,KAAK,MAAM,WAAW,IAAI,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,YAAY,EAAE;YAC9D,IAAI,UAAU,CAAC,eAAe,CAAC,WAAW,CAAC,QAAQ,CAAC,EAAE;gBACpD,oEAAoE;gBACpE,2EAA2E;gBAC3E,MAAM,aAAa,GAAG,qBAAG,CAAC,MAAM,CAC9B,WAAW,CAAC,UAAU,EACtB,UAAU,CAAC,KAAK,CAAC,KAAK,CAAC,CAAC,CAAC,CAC1B,CAAC;gBAEF,MAAM,MAAM,GAAG,wBAAU,CAAC,YAAY,CAAC,CAAC,GAAG,aAAa,CAAC,CAAC,CAAC;gBAC3D,YAAY,GAAG,+BAA+B,WAAW,CAAC,IAAI,IAAI,MAAM,IAAI,CAAC;gBAC7E,MAAM;aACP;SACF;QAED,MAAM,kBAAkB,GAAG,CAAC,GAAG,UAAU,CAAC,CAAC;QAC3C,kBAAkB,CAAC,IAAI,CACrB,IAAI,CAAC,sDAAsD,CACzD,KAAK,EACL,eAAe,EACf,YAAY,CACb,CACF,CAAC;QAEF,OAAO,IAAI,CAAC,mBAAmB,CAAC,KAAK,EAAE,kBAAkB,CAAC,CAAC;IAC7D,CAAC;IAED;;OAEG;IACK,qBAAqB,CAC3B,KAA6B,EAC7B,UAA8B,EAC9B,iBAAgC,EAChC,kBAA2B;QAE3B,IAAI,KAAK,CAAC,KAAK,CAAC,MAAM,KAAK,CAAC,EAAE;YAC5B,OAAO;SACR;QAED,MAAM,QAAQ,GAAG,KAAK,CAAC,KAAK,CAAC,KAAK,CAAC,KAAK,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC;QAErD,IAAI,CAAC,IAAA,yBAAS,EAAC,QAAQ,CAAC,EAAE;YACxB,MAAM,IAAI,KAAK,CACb,2DAA2D,CAC5D,CAAC;SACH;QAED,MAAM,eAAe,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC;QAEnE,MAAM,yBAAyB,GAAG,IAAI,CAAC,2BAA2B,CAChE,KAAK,EACL,UAAU,EACV,eAAe,EACf,iBAAiB,EACjB,kBAAkB,CACnB,CAAC;QAEF,IAAI,yBAAyB,KAAK,SAAS,EAAE;YAC3C,OAAO,yBAAyB,CAAC;SAClC;QAED,IAAI,IAAA,kCAAkB,EAAC,KAAK,CAAC,IAAI,CAAC,kBAAkB,EAAE;YACpD,IACE,IAAI,CAAC,mCAAmC,CAAC,KAAK,CAAC;gBAC/C,IAAI,CAAC,kCAAkC,CAAC,KAAK,CAAC,EAC9C;gBACA,OAAO;oBACL,IAAI,CAAC,iDAAiD,CACpD,KAAK,EACL,eAAe,CAChB;iBACF,CAAC;aACH;YAED,qEAAqE;YACrE,IAAI,eAAe,CAAC,QAAQ,KAAK,SAAS,EAAE;gBAC1C,MAAM,eAAe,GACnB,eAAe,CAAC,QAAQ,CAAC,qBAAqB,EAAE,CAAC;gBACnD,IAAI,eAAe,KAAK,SAAS,EAAE;oBACjC,OAAO;wBACL;4BACE,IAAI,EAAE,0CAAmB,CAAC,YAAY;4BACtC,eAAe,EAAE,IAAI,CAAC,gCAAgC,CACpD,KAAK,EACL,eAAe,CAChB;4BACD,OAAO,EAAE,IAAI,wBAAU,CAAC,KAAK,CAAC,UAAU,CAAC;4BACzC,oBAAoB,EAAE,eAAe,CAAC,MAAM,KAAK,gBAAM,CAAC,OAAO;yBAChE;qBACF,CAAC;iBACH;aACF;YAED,MAAM,cAAc,GAAG,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,uBAAuB,CACpE,KAAK,CAAC,QAAQ,CAAC,KAAK,CAAC,CAAC,EAAE,CAAC,CAAC,CAC3B,CAAC;YAEF,IAAI,cAAc,KAAK,SAAS,EAAE;gBAChC,MAAM,eAAe,GAAG,cAAc,CAAC,eAAe,CACpD,KAAK,CAAC,QAAQ,CAAC,KAAK,CAAC,CAAC,CAAC,CACxB,CAAC;gBAEF,IAAI,CAAC,eAAe,EAAE;oBACpB,OAAO;wBACL;4BACE,IAAI,EAAE,0CAAmB,CAAC,oBAAoB;4BAC9C,eAAe,EAAE,IAAI,CAAC,gCAAgC,CACpD,KAAK,EACL,cAAc,CACf;yBACF;qBACF,CAAC;iBACH;aACF;YAED,IAAI,IAAI,CAAC,+BAA+B,CAAC,KAAK,CAAC,EAAE;gBAC/C,MAAM,WAAW,GACf,IAAI,CAAC,mDAAmD,CAAC,KAAK,CAAC,CAAC;gBAElE,IAAI,WAAW,KAAK,SAAS,EAAE;oBAC7B,OAAO,CAAC,WAAW,CAAC,CAAC;iBACtB;aACF;YAED,OAAO,CAAC,IAAI,CAAC,iDAAiD,CAAC,KAAK,CAAC,CAAC,CAAC;SACxE;IACH,CAAC;IAEO,uBAAuB,CAC7B,KAA6B,EAC7B,UAA8B;QAE9B,IAAI,IAAI,CAAC,gCAAgC,CAAC,KAAK,CAAC,EAAE;YAChD,MAAM,eAAe,GAAG,IAAI,CAAC,uBAAuB,CAAC,KAAK,CAAC,CAAC;YAE5D,kFAAkF;YAClF,IAAA,+BAAsB,EACpB,eAAe,KAAK,SAAS,EAC7B,yCAAyC,CAC1C,CAAC;YAEF,MAAM,sBAAsB,GAA4B;gBACtD,IAAI,EAAE,0CAAmB,CAAC,gCAAgC;gBAC1D,eAAe;aAChB,CAAC;YAEF,OAAO,CAAC,GAAG,UAAU,EAAE,sBAAsB,CAAC,CAAC;SAChD;IACH,CAAC;IAEO,+BAA+B,CACrC,KAA6B,EAC7B,UAA8B;QAE9B,IAAI,IAAI,CAAC,+BAA+B,CAAC,KAAK,CAAC,EAAE;YAC/C,MAAM,WAAW,GACf,IAAI,CAAC,mDAAmD,CAAC,KAAK,CAAC,CAAC;YAElE,IAAI,WAAW,KAAK,SAAS,EAAE;gBAC7B,OAAO,CAAC,GAAG,UAAU,EAAE,WAAW,CAAC,CAAC;aACrC;SACF;IACH,CAAC;IAEO,sBAAsB,CAC5B,KAA6B;QAE7B,IAAI,IAAA,6BAAa,EAAC,KAAK,CAAC,IAAI,IAAI,CAAC,wBAAwB,CAAC,KAAK,CAAC,EAAE;YAChE,OAAO;gBACL;oBACE,IAAI,EAAE,0CAAmB,CAAC,wBAAwB;oBAClD,eAAe,EAAE,IAAI,CAAC,mCAAmC,CAAC,KAAK,CAAC;iBACjE;aACF,CAAC;SACH;IACH,CAAC;IAEO,8BAA8B,CACpC,KAA6B,EAC7B,UAA8B;QAE9B,MAAM,wBAAwB,GAA4B;YACxD,IAAI,EAAE,0CAAmB,CAAC,qBAAqB;YAC/C,eAAe,EAAE,IAAI,CAAC,uBAAuB,CAAC,KAAK,CAAC;SACrD,CAAC;QAEF,OAAO,CAAC,GAAG,UAAU,EAAE,wBAAwB,CAAC,CAAC;IACnD,CAAC;IAED,UAAU;IAEF,mBAAmB,CACzB,KAA6B,EAC7B,UAA8B;QAE9B,MAAM,UAAU,GAAG,UAAU,CAAC,CAAC,CAAC,CAAC;QACjC,IACE,UAAU,KAAK,SAAS;YACxB,UAAU,CAAC,IAAI,KAAK,0CAAmB,CAAC,eAAe;YACvD,UAAU,CAAC,YAAY,KAAK,4BAAoB,CAAC,QAAQ,EACzD;YACA,OAAO;gBACL,IAAI,CAAC,4CAA4C,CAAC,KAAK,CAAC;gBACxD,GAAG,UAAU;aACd,CAAC;SACH;QAED,OAAO,UAAU,CAAC;IACpB,CAAC;IAEO,oBAAoB,CAAC,KAA8B;QACzD,OAAO,CACL,KAAK,CAAC,KAAK,KAAK,CAAC,IAAI,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI,KAAK,oBAAY,CAAC,OAAO,CAC3E,CAAC;IACJ,CAAC;IAEO,oCAAoC,CAC1C,KAA8B;QAE9B,MAAM,IAAI,GAAG,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,uBAAuB,CAC1D,KAAK,CAAC,QAAQ,CAAC,KAAK,CAAC,CAAC,EAAE,CAAC,CAAC,CAC3B,CAAC;QAEF,IAAI,IAAI,KAAK,SAAS,EAAE;YACtB,OAAO;gBACL;oBACE,IAAI,EAAE,0CAAmB,CAAC,yBAAyB;oBACnD,eAAe,EAAE,IAAI,CAAC,gCAAgC,CAAC,KAAK,EAAE,IAAI,CAAC;iBACpE;aACF,CAAC;SACH;QAED,OAAO;YACL;gBACE,IAAI,EAAE,0CAAmB,CAAC,yBAAyB;gBACnD,eAAe,EACb,IAAI,CAAC,+CAA+C,CAAC,KAAK,CAAC;aAC9D;SACF,CAAC;IACJ,CAAC;IAEO,0BAA0B,CAChC,KAA8B,EAC9B,cAAgC;QAEhC,iCAAiC;QACjC,IAAI,KAAK,CAAC,UAAU,CAAC,MAAM,GAAG,CAAC,EAAE;YAC/B,OAAO,KAAK,CAAC;SACd;QAED,IAAI,KAAK,CAAC,KAAK,IAAI,EAAE,EAAE;YACrB,OAAO,KAAK,CAAC;SACd;QAED,0CAA0C;QAC1C,IAAI,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI,KAAK,oBAAY,CAAC,OAAO,EAAE;YACzD,OAAO,KAAK,CAAC;SACd;QAED,OAAO,cAAc,CAAC,SAAS,KAAK,SAAS,IAAI,CAAC,cAAc,CAAC,SAAS,CAAC;IAC7E,CAAC;IAEO,gCAAgC,CACtC,KAA6B,EAC7B,IAAsB;QAEtB,OAAO;YACL,UAAU,EAAE,IAAI,CAAC,QAAQ,CAAC,IAAI,CAAC,UAAU;YACzC,aAAa,EAAE,IAAI,CAAC,QAAQ,CAAC,IAAI,CAAC,OAAO;YACzC,QAAQ,EAAE,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI;YACtC,QAAQ,EAAE,IAAI,CAAC,IAAI;YACnB,IAAI,EAAE,IAAI,CAAC,QAAQ,CAAC,qBAAqB,EAAE;YAC3C,KAAK,EAAE;gBACL,IAAI,CAAC,QAAQ,CAAC,MAAM;gBACpB,IAAI,CAAC,QAAQ,CAAC,MAAM,GAAG,IAAI,CAAC,QAAQ,CAAC,MAAM;aAC5C;SACF,CAAC;IACJ,CAAC;IAEO,kCAAkC,CACxC,KAA8B,EAC9B,cAA4C;QAE5C,iCAAiC;QACjC,IAAI,KAAK,CAAC,UAAU,CAAC,MAAM,GAAG,CAAC,EAAE;YAC/B,OAAO,KAAK,CAAC;SACd;QAED,6CAA6C;QAC7C,IAAI,cAAc,KAAK,SAAS,EAAE;YAChC,OAAO,KAAK,CAAC;SACd;QAED,6CAA6C;QAC7C,IACE,KAAK,CAAC,QAAQ,CAAC,MAAM,KAAK,CAAC;YAC3B,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,OAAO,KAAK,SAAS,EAC7C;YACA,OAAO,KAAK,CAAC;SACd;QAED,OAAO,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,QAAQ,KAAK,SAAS,CAAC;IACxD,CAAC;IAEO,0BAA0B,CAAC,KAA8B;QAC/D,6DAA6D;QAC7D,IACE,gBAAM,CAAC,EAAE,CACP,KAAK,CAAC,QAAQ,CAAC,eAAe,EAC9B,mCAAmC,CACpC,EACD;YACA,OAAO,KAAK,CAAC;SACd;QAED,OAAO,CACL,KAAK,CAAC,QAAQ,CAAC,MAAM,KAAK,CAAC;YAC3B,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,OAAO,KAAK,SAAS,CAC9C,CAAC;IACJ,CAAC;IAEO,+CAA+C,CACrD,KAA6B;QAE7B,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,QAAQ,CAAC;QAClD,OAAO;YACL,UAAU,EAAE,QAAQ,CAAC,IAAI,CAAC,UAAU;YACpC,aAAa,EAAE,QAAQ,CAAC,IAAI,CAAC,OAAO;YACpC,QAAQ,EAAE,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI;YACtC,IAAI,EAAE,QAAQ,CAAC,qBAAqB,EAAE;YACtC,KAAK,EAAE,CAAC,QAAQ,CAAC,MAAM,EAAE,QAAQ,CAAC,MAAM,GAAG,QAAQ,CAAC,MAAM,CAAC;SAC5D,CAAC;IACJ,CAAC;IAEO,0BAA0B,CAChC,KAA8B,EAC9B,cAA4C;QAE5C,IAAI,cAAc,KAAK,SAAS,EAAE;YAChC,OAAO,KAAK,CAAC;SACd;QAED,iCAAiC;QACjC,IAAI,KAAK,CAAC,UAAU,CAAC,MAAM,GAAG,CAAC,EAAE;YAC/B,OAAO,KAAK,CAAC;SACd;QAED,IAAI,KAAK,CAAC,KAAK,IAAI,EAAE,EAAE;YACrB,OAAO,KAAK,CAAC;SACd;QAED,IAAI,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,QAAQ,KAAK,SAAS,EAAE;YAClD,OAAO,KAAK,CAAC;SACd;QAED,MAAM,SAAS,GAAG,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,QAAQ,CAAC,SAAS,CAAC;QAE7D,OAAO,SAAS,KAAK,SAAS,IAAI,CAAC,SAAS,CAAC;IAC/C,CAAC;IAEO,gCAAgC,CACtC,KAA8B;QAE9B,MAAM,IAAI,GAAG,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,QAAQ,CAAC;QAE9C,IAAI,IAAI,KAAK,SAAS,EAAE;YACtB,MAAM,IAAI,KAAK,CACb,iGAAiG,CAClG,CAAC;SACH;QAED,OAAO;YACL,UAAU,EAAE,IAAI,CAAC,QAAQ,CAAC,IAAI,CAAC,UAAU;YACzC,aAAa,EAAE,IAAI,CAAC,QAAQ,CAAC,IAAI,CAAC,OAAO;YACzC,QAAQ,EAAE,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI;YACtC,QAAQ,EAAE,6CAAsB;YAChC,IAAI,EAAE,IAAI,CAAC,QAAQ,CAAC,qBAAqB,EAAE;YAC3C,KAAK,EAAE;gBACL,IAAI,CAAC,QAAQ,CAAC,MAAM;gBACpB,IAAI,CAAC,QAAQ,CAAC,MAAM,GAAG,IAAI,CAAC,QAAQ,CAAC,MAAM;aAC5C;SACF,CAAC;IACJ,CAAC;IAEO,6BAA6B,CACnC,KAAgC;QAEhC,iCAAiC;QACjC,IAAI,KAAK,CAAC,UAAU,CAAC,MAAM,GAAG,CAAC,EAAE;YAC/B,OAAO,KAAK,CAAC;SACd;QAED,MAAM,WAAW,GAAG,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,mBAAmB,CAAC;QAEhE,6FAA6F;QAC7F,gFAAgF;QAChF,IAAI,WAAW,KAAK,SAAS,EAAE;YAC7B,OAAO,KAAK,CAAC;SACd;QAED,OAAO,CACL,KAAK,CAAC,KAAK,GAAG,EAAE;YAChB,CAAC,WAAW,CAAC,SAAS,KAAK,SAAS,IAAI,CAAC,WAAW,CAAC,SAAS,CAAC,CAChE,CAAC;IACJ,CAAC;IAED;;;OAGG;IACK,mCAAmC,CACzC,KAAgC;QAEhC,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC;QACzC,MAAM,WAAW,GAAG,QAAQ,CAAC,mBAAmB,CAAC;QAEjD,MAAM,IAAI,GACR,WAAW,KAAK,SAAS;YACvB,CAAC,CAAC,WAAW,CAAC,QAAQ,CAAC,qBAAqB,EAAE;YAC9C,CAAC,CAAC,QAAQ,CAAC,QAAQ,CAAC,qBAAqB,EAAE,CAAC;QAEhD,OAAO;YACL,UAAU,EAAE,QAAQ,CAAC,QAAQ,CAAC,IAAI,CAAC,UAAU;YAC7C,aAAa,EAAE,QAAQ,CAAC,QAAQ,CAAC,IAAI,CAAC,OAAO;YAC7C,QAAQ,EAAE,QAAQ,CAAC,IAAI;YACvB,QAAQ,EAAE,gDAAyB;YACnC,IAAI;YACJ,KAAK,EAAE;gBACL,QAAQ,CAAC,QAAQ,CAAC,MAAM;gBACxB,QAAQ,CAAC,QAAQ,CAAC,MAAM,GAAG,QAAQ,CAAC,QAAQ,CAAC,MAAM;aACpD;SACF,CAAC;IACJ,CAAC;IAEO,mCAAmC,CACzC,KAAgC;QAEhC,iCAAiC;QACjC,IAAI,KAAK,CAAC,UAAU,CAAC,MAAM,GAAG,CAAC,EAAE;YAC/B,OAAO,KAAK,CAAC;SACd;QAED,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC;QACzC,MAAM,WAAW,GAAG,QAAQ,CAAC,mBAAmB,CAAC;QAEjD,6FAA6F;QAC7F,gFAAgF;QAChF,IAAI,WAAW,KAAK,SAAS,EAAE;YAC7B,OAAO,KAAK,CAAC;SACd;QAED,IACE,gBAAM,CAAC,EAAE,CACP,KAAK,CAAC,QAAQ,CAAC,eAAe,EAC9B,2CAA2C,CAC5C,EACD;YACA,OAAO,KAAK,CAAC;SACd;QAED,MAAM,QAAQ,GAAG,KAAK,CAAC,KAAK,CAAC,KAAK,CAAC,KAAK,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC;QACrD,IAAI,CAAC,IAAA,yBAAS,EAAC,QAAQ,CAAC,EAAE;YACxB,OAAO,KAAK,CAAC;SACd;QAED,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC;QAC5D,IAAI,QAAQ,CAAC,MAAM,KAAK,gBAAM,CAAC,MAAM,IAAI,QAAQ,CAAC,QAAQ,KAAK,SAAS,EAAE;YACxE,OAAO,KAAK,CAAC;SACd;QAED,IAAI,yBAAyB,GAAG,KAAK,CAAC;QAEtC,4DAA4D;QAC5D,KAAK,IAAI,SAAS,GAAG,CAAC,EAAE,SAAS,GAAG,KAAK,CAAC,KAAK,CAAC,MAAM,EAAE,SAAS,EAAE,EAAE;YACnE,MAAM,IAAI,GAAG,KAAK,CAAC,KAAK,CAAC,SAAS,CAAC,CAAC;YACpC,IAAI,CAAC,IAAA,yBAAS,EAAC,IAAI,CAAC,EAAE;gBACpB,OAAO,KAAK,CAAC;aACd;YAED,MAAM,IAAI,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,IAAI,CAAC,EAAE,CAAC,CAAC;YAEpD,IACE,IAAI,CAAC,QAAQ,KAAK,SAAS;gBAC3B,CAAC,QAAQ,CAAC,QAAQ,CAAC,MAAM,CAAC,IAAI,CAAC,QAAQ,CAAC;gBACxC,CAAC,WAAW,CAAC,QAAQ,CAAC,MAAM,CAAC,IAAI,CAAC,QAAQ,CAAC,EAC3C;gBACA,OAAO,KAAK,CAAC;aACd;YAED,IAAI,IAAI,CAAC,MAAM,KAAK,gBAAM,CAAC,QAAQ,IAAI,IAAA,6BAAa,EAAC,KAAK,CAAC,EAAE;gBAC3D,yBAAyB,GAAG,IAAI,CAAC;aAClC;SACF;QAED,OAAO,yBAAyB,CAAC;IACnC,CAAC;IAEO,4CAA4C,CAClD,KAA6B;QAE7B,IAAI,IAAA,oCAAoB,EAAC,KAAK,CAAC,EAAE;YAC/B,OAAO;gBACL,IAAI,EAAE,0CAAmB,CAAC,eAAe;gBACzC,eAAe,EAAE,IAAI,CAAC,mCAAmC,CAAC,KAAK,CAAC;gBAChE,YAAY,EAAE,4BAAoB,CAAC,WAAW;aAC/C,CAAC;SACH;QAED,MAAM,cAAc,GAAG,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,uBAAuB,CACpE,KAAK,CAAC,QAAQ,CAAC,KAAK,CAAC,CAAC,EAAE,CAAC,CAAC,CAC3B,CAAC;QAEF,IAAI,cAAc,KAAK,SAAS,EAAE;YAChC,OAAO;gBACL,IAAI,EAAE,0CAAmB,CAAC,eAAe;gBACzC,eAAe,EAAE,IAAI,CAAC,gCAAgC,CACpD,KAAK,EACL,cAAc,CACf;gBACD,YAAY,EAAE,4BAAoB,CAAC,QAAQ;aAC5C,CAAC;SACH;QAED,qFAAqF;QACrF,yCAAyC;QACzC,OAAO;YACL,IAAI,EAAE,0CAAmB,CAAC,eAAe;YACzC,eAAe,EAAE,IAAI,CAAC,gCAAgC,CAAC,KAAK,CAAC;YAC7D,YAAY,EAAE,4BAAoB,CAAC,QAAQ;SAC5C,CAAC;IACJ,CAAC;IAEO,uBAAuB,CAC7B,KAA6B;QAE7B,KAAK,IAAI,CAAC,GAAG,KAAK,CAAC,KAAK,CAAC,MAAM,GAAG,CAAC,EAAE,CAAC,IAAI,CAAC,EAAE,CAAC,EAAE,EAAE;YAChD,MAAM,IAAI,GAAG,KAAK,CAAC,KAAK,CAAC,CAAC,CAAC,CAAC;YAC5B,IAAI,CAAC,IAAA,yBAAS,EAAC,IAAI,CAAC,EAAE;gBACpB,SAAS;aACV;YAED,MAAM,IAAI,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,IAAI,CAAC,EAAE,CAAC,CAAC;YAEpD,IAAI,IAAI,CAAC,QAAQ,KAAK,SAAS,EAAE;gBAC/B,SAAS;aACV;YAED,MAAM,eAAe,GAAG,+BAA+B,CACrD,KAAK,CAAC,QAAQ,EACd,IAAI,CAAC,QAAQ,CACd,CAAC;YAEF,IAAI,eAAe,KAAK,SAAS,EAAE;gBACjC,OAAO,eAAe,CAAC;aACxB;SACF;QAED,OAAO,SAAS,CAAC;IACnB,CAAC;IAEO,mCAAmC,CACzC,KAA8B;QAE9B,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC;QAEzC,IAAI,QAAQ,CAAC,QAAQ,KAAK,SAAS,EAAE;YACnC,OAAO,KAAK,CAAC;SACd;QAED,OAAO,IAAI,CAAC,wBAAwB,CAAC,KAAK,EAAE,QAAQ,CAAC,QAAQ,CAAC,CAAC;IACjE,CAAC;IAEO,kCAAkC,CACxC,KAA8B;QAE9B,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC;QAEzC,IAAI,QAAQ,CAAC,OAAO,KAAK,SAAS,EAAE;YAClC,OAAO,KAAK,CAAC;SACd;QAED,OAAO,IAAI,CAAC,wBAAwB,CAAC,KAAK,EAAE,QAAQ,CAAC,OAAO,CAAC,CAAC;IAChE,CAAC;IAEO,wBAAwB,CAC9B,KAA8B,EAC9B,IAAsB;QAEtB,MAAM,QAAQ,GAAG,KAAK,CAAC,KAAK,CAAC,KAAK,CAAC,KAAK,CAAC,MAAM,GAAG,CAAC,CAAY,CAAC;QAChE,MAAM,eAAe,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC;QAEnE,OAAO,CACL,eAAe,CAAC,QAAQ,KAAK,SAAS;YACtC,eAAe,CAAC,MAAM,KAAK,gBAAM,CAAC,MAAM;YACxC,IAAI,CAAC,QAAQ,CAAC,QAAQ,CAAC,eAAe,CAAC,QAAQ,CAAC,CACjD,CAAC;IACJ,CAAC;IAEO,iDAAiD,CACvD,KAA6B,EAC7B,IAAiB;QAEjB,MAAM,eAAe,GAAG,+BAA+B,CACrD,KAAK,CAAC,QAAQ,EACd,IAAI,CAAC,QAAQ,CACd,CAAC;QACF,IAAA,+BAAsB,EACpB,eAAe,KAAK,SAAS,EAC7B,yCAAyC,CAC1C,CAAC;QAEF,OAAO;YACL,IAAI,EAAE,0CAAmB,CAAC,YAAY;YACtC,eAAe;YACf,OAAO,EAAE,IAAI,wBAAU,CAAC,KAAK,CAAC,UAAU,CAAC;YACzC,oBAAoB,EAAE,IAAI,CAAC,MAAM,KAAK,gBAAM,CAAC,OAAO;SACrD,CAAC;IACJ,CAAC;IAEO,qEAAqE,CAC3E,KAA6B,EAC7B,IAAiB;QAEjB,MAAM,eAAe,GAAG,+BAA+B,CACrD,KAAK,CAAC,QAAQ,EACd,IAAI,CAAC,QAAQ,CACd,CAAC;QAEF,OAAO;YACL,IAAI,EAAE,0CAAmB,CAAC,gCAAgC;YAC1D,eAAe;SAChB,CAAC;IACJ,CAAC;IAEO,gDAAgD,CACtD,KAA6B,EAC7B,IAAiB,EACjB,SAAiB;QAEjB,MAAM,mBAAmB,GAAG,IAAI,CAAC,uBAAuB,CAAC,KAAK,CAAC,CAAC;QAChE,OAAO;YACL,IAAI,EAAE,0CAAmB,CAAC,WAAW;YACrC,eAAe,EACb,+BAA+B,CAAC,KAAK,CAAC,QAAQ,EAAE,IAAI,CAAC,QAAQ,CAAC;gBAC9D,mBAAmB;YACrB,SAAS;SACV,CAAC;IACJ,CAAC;IAEO,sDAAsD,CAC5D,KAA6B,EAC7B,IAAiB,EACjB,OAAe;QAEf,MAAM,mBAAmB,GAAG,IAAI,CAAC,uBAAuB,CAAC,KAAK,CAAC,CAAC;QAEhE,IAAA,+BAAsB,EACpB,mBAAmB,KAAK,SAAS,EACjC,8CAA8C,CAC/C,CAAC;QAEF,OAAO;YACL,IAAI,EAAE,0CAAmB,CAAC,YAAY;YACtC,eAAe,EACb,+BAA+B,CAAC,KAAK,CAAC,QAAQ,EAAE,IAAI,CAAC,QAAQ,CAAC;gBAC9D,mBAAmB;YACrB,OAAO;SACR,CAAC;IACJ,CAAC;IAEO,+BAA+B,CAAC,KAA6B;QACnE,IAAI,KAAK,CAAC,KAAK,CAAC,MAAM,KAAK,CAAC,EAAE;YAC5B,OAAO,KAAK,CAAC;SACd;QAED,MAAM,QAAQ,GAAG,KAAK,CAAC,KAAK,CAAC,KAAK,CAAC,KAAK,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC;QACrD,IAAI,CAAC,IAAA,yBAAS,EAAC,QAAQ,CAAC,EAAE;YACxB,OAAO,KAAK,CAAC;SACd;QAED,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC;QAE5D,OAAO,CACL,gBAAM,CAAC,SAAS,CACd,KAAK,CAAC,QAAQ,CAAC,eAAe,EAC9B,IAAI,wCAAwC,EAAE,CAC/C,IAAI,QAAQ,CAAC,MAAM,KAAK,gBAAM,CAAC,MAAM,CACvC,CAAC;IACJ,CAAC;IAED,mDAAmD;IACnD,kEAAkE;IAC1D,mDAAmD,CACzD,KAA8B;QAE9B,IAAI,WAAW,GACb,IAAI,CAAC,mDAAmD,CAAC,KAAK,CAAC,CAAC;QAElE,IACE,WAAW,KAAK,SAAS;YACzB,WAAW,CAAC,eAAe,KAAK,SAAS,EACzC;YACA,IACE,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,OAAO,KAAK,SAAS;gBAC7C,KAAK,CAAC,QAAQ,CAAC,MAAM,GAAG,CAAC,EACzB;gBACA,IAAI,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,QAAQ,KAAK,SAAS,EAAE;oBAClD,6BAA6B;oBAC7B,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,QAAQ,CAAC,QAAQ,CAAC;oBAC3D,WAAW,GAAG;wBACZ,IAAI,EAAE,0CAAmB,CAAC,gCAAgC;wBAC1D,eAAe,EAAE;4BACf,QAAQ,EAAE,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI;4BACtC,QAAQ,EAAE,6CAAsB;4BAChC,UAAU,EAAE,QAAQ,CAAC,IAAI,CAAC,UAAU;4BACpC,aAAa,EAAE,QAAQ,CAAC,IAAI,CAAC,OAAO;4BACpC,IAAI,EAAE,QAAQ,CAAC,qBAAqB,EAAE;4BACtC,KAAK,EAAE,CAAC,QAAQ,CAAC,MAAM,EAAE,QAAQ,CAAC,MAAM,GAAG,QAAQ,CAAC,MAAM,CAAC;yBAC5D;qBACF,CAAC;oBAEF,IAAI,CAAC,6BAA6B,CAAC,WAAW,CAAC,CAAC;iBACjD;aACF;iBAAM;gBACL,qCAAqC;gBACrC,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,OAAO,CAAC,QAAQ,CAAC;gBAC1D,WAAW,GAAG;oBACZ,IAAI,EAAE,0CAAmB,CAAC,gCAAgC;oBAC1D,eAAe,EAAE;wBACf,QAAQ,EAAE,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI;wBACtC,QAAQ,EAAE,4CAAqB;wBAC/B,UAAU,EAAE,QAAQ,CAAC,IAAI,CAAC,UAAU;wBACpC,aAAa,EAAE,QAAQ,CAAC,IAAI,CAAC,OAAO;wBACpC,IAAI,EAAE,QAAQ,CAAC,qBAAqB,EAAE;wBACtC,KAAK,EAAE,CAAC,QAAQ,CAAC,MAAM,EAAE,QAAQ,CAAC,MAAM,GAAG,QAAQ,CAAC,MAAM,CAAC;qBAC5D;iBACF,CAAC;gBAEF,IAAI,CAAC,6BAA6B,CAAC,WAAW,CAAC,CAAC;aACjD;SACF;QACD,OAAO,WAAW,CAAC;IACrB,CAAC;IAEO,iDAAiD,CACvD,KAA8B;QAE9B,OAAO;YACL,IAAI,EAAE,0CAAmB,CAAC,qBAAqB;YAC/C,eAAe,EACb,IAAI,CAAC,+CAA+C,CAAC,KAAK,CAAC;SAC9D,CAAC;IACJ,CAAC;IAEO,gCAAgC,CACtC,KAA6B;QAE7B,oFAAoF;QACpF,2EAA2E;QAE3E,MAAM,SAAS,GAAG,IAAI,CAAC,6CAA6C,CAAC,KAAK,CAAC,CAAC;QAC5E,IAAI,SAAS,KAAK,SAAS,IAAI,SAAS,KAAK,CAAC,EAAE;YAC9C,OAAO,KAAK,CAAC;SACd;QAED,MAAM,QAAQ,GAAG,KAAK,CAAC,KAAK,CAAC,SAAS,CAAY,CAAC,CAAC,8BAA8B;QAClF,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC;QAC5D,IAAI,QAAQ,CAAC,MAAM,KAAK,gBAAM,CAAC,MAAM,EAAE;YACrC,OAAO,KAAK,CAAC;SACd;QAED,MAAM,QAAQ,GAAG,KAAK,CAAC,KAAK,CAAC,SAAS,GAAG,CAAC,CAAY,CAAC,CAAC,8BAA8B;QACtF,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC;QAC5D,OAAO,QAAQ,CAAC,MAAM,KAAK,gBAAM,CAAC,WAAW,CAAC;IAChD,CAAC;IAEO,mDAAmD,CACzD,KAA6B;QAE7B,oEAAoE;QACpE,0BAA0B;QAC1B,MAAM,QAAQ,GAAG,IAAI,CAAC,oCAAoC,CAAC,KAAK,CAAC,CAAC;QAClE,MAAM,QAAQ,GAAG,KAAK,CAAC,KAAK,CAAC,KAAK,CAAC,KAAK,CAAC,MAAM,GAAG,CAAC,CAAY,CAAC;QAChE,MAAM,UAAU,GAAG,QAAQ,CAAC,EAAE,GAAG,CAAC,CAAC;QACnC,MAAM,WAAW,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,UAAU,CAAC,CAAC;QAE9D,IAAI,WAAW,EAAE;YACf,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,UAAU,CAAC,CAAC;YAC3D,MAAM,OAAO,GAAG,QAAQ,EAAE,QAAQ,CAAC;YACnC,MAAM,OAAO,GAAG,QAAQ,CAAC,QAAQ,CAAC;YAClC,MAAM,QAAQ,GAAG,OAAO,EAAE,qBAAqB,EAAE,CAAC;YAClD,MAAM,QAAQ,GAAG,OAAO,EAAE,qBAAqB,EAAE,CAAC;YAElD,gEAAgE;YAChE,8DAA8D;YAC9D,gEAAgE;YAChE,qDAAqD;YACrD,IACE,QAAQ,KAAK,SAAS;gBACtB,OAAO,KAAK,SAAS;gBACrB,OAAO,KAAK,SAAS;gBACrB,OAAO,CAAC,MAAM,CAAC,OAAO,CAAC,EACvB;gBACA,OAAO,IAAI,CAAC,qEAAqE,CAC/E,KAAK,EACL,QAAQ,CACT,CAAC;aACH;YAED,IAAI,WAAkE,CAAC;YAEvE,mEAAmE;YACnE,wEAAwE;YACxE,IAAI,QAAQ,KAAK,SAAS,IAAI,QAAQ,KAAK,SAAS,EAAE;gBACpD,WAAW;oBACT,IAAI,CAAC,qEAAqE,CACxE,KAAK,EACL,QAAQ,CACT,CAAC;aACL;iBAAM,IAAI,QAAQ,KAAK,SAAS,EAAE;gBACjC,WAAW;oBACT,IAAI,CAAC,qEAAqE,CACxE,KAAK,EACL,QAAQ,CACT,CAAC;aACL;YAED,IAAI,WAAW,KAAK,SAAS,EAAE;gBAC7B,IAAI,CAAC,6BAA6B,CAAC,WAAW,CAAC,CAAC;aACjD;YAED,OAAO,WAAW,CAAC;SACpB;QAED,IAAI,IAAA,6BAAa,EAAC,KAAK,CAAC,IAAI,QAAQ,KAAK,SAAS,EAAE;YAClD,qEAAqE;YACrE,wEAAwE;YACxE,kCAAkC;YAClC,MAAM,sBAAsB,GAC1B,IAAI,CAAC,qEAAqE,CACxE,KAAK,EACL,QAAQ,CACT,CAAC;YAEJ,+DAA+D;YAC/D,mDAAmD;YACnD,IAAI,sBAAsB,CAAC,eAAe,KAAK,SAAS,EAAE;gBACxD,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,QAAQ,CAAC;gBAClD,MAAM,sBAAsB,GAAoB;oBAC9C,QAAQ,EAAE,gDAAyB;oBACnC,QAAQ,EAAE,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI;oBACtC,UAAU,EAAE,QAAQ,CAAC,IAAI,CAAC,UAAU;oBACpC,aAAa,EAAE,QAAQ,CAAC,IAAI,CAAC,OAAO;oBACpC,IAAI,EAAE,QAAQ,CAAC,qBAAqB,EAAE;oBACtC,KAAK,EAAE,CAAC,QAAQ,CAAC,MAAM,EAAE,QAAQ,CAAC,MAAM,GAAG,QAAQ,CAAC,MAAM,CAAC;iBAC5D,CAAC;gBAEF,IAAI,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,mBAAmB,KAAK,SAAS,EAAE;oBAC7D,sBAAsB,CAAC,IAAI;wBACzB,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,mBAAmB,CAAC,QAAQ,CAAC,qBAAqB,EAAE,CAAC;iBAChF;gBAED,sBAAsB,CAAC,eAAe,GAAG,sBAAsB,CAAC;aACjE;iBAAM;gBACL,IAAI,CAAC,6BAA6B,CAAC,sBAAsB,CAAC,CAAC;aAC5D;YAED,OAAO,sBAAsB,CAAC;SAC/B;QAED,IAAI,QAAQ,KAAK,SAAS,EAAE;YAC1B,mEAAmE;YACnE,yDAAyD;YACzD,kEAAkE;YAClE,aAAa;YACb,MAAM,4BAA4B,GAChC,IAAI,CAAC,qEAAqE,CACxE,KAAK,EACL,QAAQ,CACT,CAAC;YAEJ,IAAI,4BAA4B,CAAC,eAAe,KAAK,SAAS,EAAE;gBAC9D,IAAI,CAAC,6BAA6B,CAAC,4BAA4B,CAAC,CAAC;aAClE;YACD,OAAO,4BAA4B,CAAC;SACrC;IACH,CAAC;IAEO,wBAAwB,CAAC,KAAgC;QAC/D,OAAO,KAAK,CAAC,IAAI,CAAC,IAAI,KAAK,eAAQ,CAAC,wBAAwB,CAAC;IAC/D,CAAC;IAEO,6BAA6B,CACnC,WAAsD;QAEtD,IAAI,WAAW,CAAC,eAAe,KAAK,SAAS,EAAE;YAC7C,OAAO;SACR;QAED,MAAM,KAAK,GAAG,WAAW,CAAC,eAAe,CAAC,aAAa,CAAC,KAAK,CAAC,IAAI,CAAC,CAAC;QAEpE,MAAM,WAAW,GAAG,KAAK,CAAC,WAAW,CAAC,eAAe,CAAC,IAAI,GAAG,CAAC,CAAC,CAAC;QAEhE,IAAI,WAAW,CAAC,QAAQ,CAAC,SAAS,CAAC,IAAI,WAAW,CAAC,QAAQ,CAAC,QAAQ,CAAC,EAAE;YACrE,OAAO;SACR;QAED,MAAM,SAAS,GAAG,KAAK,CAAC,KAAK,CAAC,WAAW,CAAC,eAAe,CAAC,IAAI,CAAC,CAAC;QAChE,MAAM,iBAAiB,GAAG,SAAS,CAAC,SAAS,CAAC,CAAC,CAAC,EAAE,EAAE,CAAC,CAAC,CAAC,IAAI,EAAE,KAAK,EAAE,CAAC,CAAC;QAEtE,IAAI,iBAAiB,KAAK,CAAC,CAAC,EAAE;YAC5B,OAAO;SACR;QAED,MAAM,QAAQ,GAAG,SAAS,CAAC,iBAAiB,CAAC,CAAC;QAE9C,IAAI,QAAQ,CAAC,QAAQ,CAAC,SAAS,CAAC,IAAI,QAAQ,CAAC,QAAQ,CAAC,QAAQ,CAAC,EAAE;YAC/D,WAAW,CAAC,eAAe,CAAC,IAAI,IAAI,CAAC,GAAG,iBAAiB,CAAC;SAC3D;IACH,CAAC;IAEO,6CAA6C,CACnD,KAA6B;QAE7B,KAAK,IAAI,CAAC,GAAG,KAAK,CAAC,KAAK,CAAC,MAAM,GAAG,CAAC,EAAE,CAAC,IAAI,CAAC,EAAE,CAAC,EAAE,EAAE;YAChD,MAAM,IAAI,GAAG,KAAK,CAAC,KAAK,CAAC,CAAC,CAAC,CAAC;YAE5B,IAAI,CAAC,IAAA,yBAAS,EAAC,IAAI,CAAC,EAAE;gBACpB,OAAO,SAAS,CAAC;aAClB;YAED,MAAM,IAAI,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,IAAI,CAAC,EAAE,CAAC,CAAC;YAEpD,IAAI,IAAI,CAAC,QAAQ,KAAK,SAAS,EAAE;gBAC/B,OAAO,CAAC,CAAC;aACV;SACF;QAED,OAAO,SAAS,CAAC;IACnB,CAAC;IAEO,oCAAoC,CAC1C,KAA6B;QAE7B,MAAM,iBAAiB,GACrB,IAAI,CAAC,6CAA6C,CAAC,KAAK,CAAC,CAAC;QAE5D,IAAI,iBAAiB,KAAK,SAAS,EAAE;YACnC,OAAO,SAAS,CAAC;SAClB;QAED,MAAM,gBAAgB,GAAG,KAAK,CAAC,KAAK,CAAC,iBAAiB,CAAC,CAAC;QACxD,IAAI,IAAA,yBAAS,EAAC,gBAAgB,CAAC,EAAE;YAC/B,MAAM,2BAA2B,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAC/D,gBAAgB,CAAC,EAAE,CACpB,CAAC;YACF,OAAO,2BAA2B,CAAC;SACpC;QAED,OAAO,SAAS,CAAC;IACnB,CAAC;IAEO,oDAAoD,CAC1D,QAAkB,EAClB,QAAqB;QAErB,MAAM,eAAe,GAAG,+BAA+B,CACrD,QAAQ,EACR,QAAQ,CAAC,QAAQ,CAClB,CAAC;QACF,IAAA,+BAAsB,EACpB,eAAe,KAAK,SAAS,EAC7B,yCAAyC,CAC1C,CAAC;QAEF,qCAAqC;QACrC,OAAO;YACL,IAAI,EAAE,0CAAmB,CAAC,iBAAiB;YAC3C,eAAe;SAChB,CAAC;IACJ,CAAC;IAEO,gCAAgC,CACtC,KAA6B,EAC7B,iBAAgC;QAEhC,uFAAuF;QACvF,IAAI,iBAAiB,CAAC,MAAM,GAAG,CAAC,EAAE;YAChC,OAAO,qCAAqC,CAC1C,KAAK,CAAC,QAAQ,EACd,iBAAiB,CAAC,iBAAiB,CAAC,MAAM,GAAG,CAAC,CAAC,CAChD,CAAC;SACH;QAED,4FAA4F;QAC5F,uDAAuD;QACvD,IAAI,CAAC,IAAA,oCAAoB,EAAC,KAAK,CAAC,EAAE;YAChC,MAAM,IAAI,KAAK,CACb,oGAAoG,CACrG,CAAC;SACH;QAED,wDAAwD;QACxD,OAAO;YACL,IAAI,EAAE,0CAAmB,CAAC,eAAe;YACzC,eAAe,EAAE,IAAI,CAAC,mCAAmC,CAAC,KAAK,CAAC;YAChE,YAAY,EAAE,4BAAoB,CAAC,WAAW;SAC/C,CAAC;IACJ,CAAC;IAEO,oBAAoB,CAC1B,KAA6B,EAC7B,qBAA6B;QAE7B,MAAM,QAAQ,GAAG,KAAK,CAAC,KAAK,CAAC,KAAK,CAAC,KAAK,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC;QACrD,IAAI,CAAC,IAAA,yBAAS,EAAC,QAAQ,CAAC,EAAE;YACxB,OAAO,KAAK,CAAC;SACd;QAED,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC;QAC5D,IAAI,QAAQ,CAAC,MAAM,KAAK,gBAAM,CAAC,MAAM,EAAE;YACrC,OAAO,KAAK,CAAC;SACd;QAED,MAAM,cAAc,GAAG,KAAK,CAAC,KAAK,CAAC,qBAAqB,GAAG,CAAC,CAAY,CAAC;QACzE,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,cAAc,CAAC,EAAE,CAAC,CAAC;QAElE,8CAA8C;QAC9C,IAAA,+BAAsB,EACpB,QAAQ,CAAC,QAAQ,KAAK,SAAS,EAC/B,kDAAkD,CACnD,CAAC;QAEF,OAAO,IAAI,CAAC,eAAe,CACzB,KAAK,EACL,qBAAqB,GAAG,CAAC,EACzB,QAAQ,CAAC,QAAQ,CAClB,CAAC;IACJ,CAAC;IAEO,kBAAkB,CACxB,KAA6B,EAC7B,SAAiB,EACjB,eAA4B;QAE5B,MAAM,YAAY,GAAG,eAAe,CAAC,QAAQ,CAAC;QAE9C,8CAA8C;QAC9C,IAAA,+BAAsB,EACpB,YAAY,KAAK,SAAS,EAC1B,sCAAsC,CACvC,CAAC;QAEF,OAAO,IAAI,CAAC,eAAe,CAAC,KAAK,EAAE,SAAS,EAAE,YAAY,CAAC,CAAC;IAC9D,CAAC;IAEO,eAAe,CACrB,KAA6B,EAC7B,QAAgB,EAChB,QAAwB;QAExB,KAAK,IAAI,CAAC,GAAG,QAAQ,EAAE,CAAC,GAAG,KAAK,CAAC,KAAK,CAAC,MAAM,EAAE,CAAC,EAAE,EAAE;YAClD,MAAM,IAAI,GAAG,KAAK,CAAC,KAAK,CAAC,CAAC,CAAC,CAAC;YAE5B,IAAI,CAAC,IAAA,yBAAS,EAAC,IAAI,CAAC,EAAE;gBACpB,OAAO,KAAK,CAAC;aACd;YAED,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,IAAI,CAAC,EAAE,CAAC,CAAC;YAExD,IAAI,QAAQ,CAAC,QAAQ,KAAK,SAAS,EAAE;gBACnC,SAAS;aACV;YAED,IAAI,CAAC,QAAQ,CAAC,MAAM,CAAC,QAAQ,CAAC,QAAQ,CAAC,EAAE;gBACvC,OAAO,KAAK,CAAC;aACd;SACF;QAED,OAAO,IAAI,CAAC;IACd,CAAC;IAEO,0BAA0B,CAChC,KAA6B,EAC7B,qBAA6B;QAE7B,MAAM,IAAI,GAAG,KAAK,CAAC,KAAK,CAAC,qBAAqB,CAAiB,CAAC;QAEhE,IAAI,CAAC,IAAA,6BAAW,EAAC,KAAK,CAAC,UAAU,EAAE,IAAI,CAAC,UAAU,CAAC,EAAE;YACnD,OAAO,KAAK,CAAC;SACd;QAED,IACE,KAAK,CAAC,IAAI,CAAC,IAAI,KAAK,eAAQ,CAAC,UAAU;YACvC,IAAI,CAAC,IAAI,CAAC,IAAI,KAAK,eAAQ,CAAC,UAAU,EACtC;YACA,OAAO,IAAI,CAAC;SACb;QAED,yEAAyE;QACzE,sBAAsB;QACtB,IAAI,KAAK,CAAC,UAAU,CAAC,MAAM,GAAG,CAAC,EAAE;YAC/B,OAAO,IAAI,CAAC;SACb;QAED,OAAO,IAAI,CAAC,oBAAoB,CAAC,KAAK,EAAE,qBAAqB,CAAC,CAAC;IACjE,CAAC;IAEO,uBAAuB,CAC7B,KAA6B,EAC7B,qBAA6B;QAE7B,IAAI,CAAC,IAAA,kCAAkB,EAAC,KAAK,CAAC,EAAE;YAC9B,OAAO,KAAK,CAAC;SACd;QAED,MAAM,QAAQ,GAAG,KAAK,CAAC,KAAK,CAAC,qBAAqB,GAAG,CAAC,CAAC,CAAC;QACxD,IAAI,CAAC,IAAA,yBAAS,EAAC,QAAQ,CAAC,EAAE;YACxB,OAAO,KAAK,CAAC;SACd;QAED,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC;QAC5D,IAAI,QAAQ,CAAC,MAAM,KAAK,gBAAM,CAAC,YAAY,EAAE;YAC3C,OAAO,KAAK,CAAC;SACd;QAED,MAAM,QAAQ,GAAG,KAAK,CAAC,KAAK,CAAC,qBAAqB,CAAC,CAAC;QACpD,IAAI,IAAA,yBAAS,EAAC,QAAQ,CAAC,EAAE;YACvB,OAAO,KAAK,CAAC;SACd;QAED,IAAI,IAAA,iCAAiB,EAAC,QAAQ,CAAC,EAAE;YAC/B,OAAO,KAAK,CAAC;SACd;QAED,iFAAiF;QACjF,IAAI,QAAQ,CAAC,QAAQ,KAAK,SAAS,EAAE;YACnC,OAAO,KAAK,CAAC;SACd;QAED,IAAI,QAAQ,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI,KAAK,oBAAY,CAAC,OAAO,EAAE;YAC5D,OAAO,KAAK,CAAC;SACd;QAED,IAAI,CAAC,IAAA,6BAAW,EAAC,KAAK,CAAC,UAAU,EAAE,QAAQ,CAAC,UAAU,CAAC,EAAE;YACvD,OAAO,KAAK,CAAC;SACd;QAED,KAAK,IAAI,CAAC,GAAG,qBAAqB,GAAG,CAAC,EAAE,CAAC,GAAG,KAAK,CAAC,KAAK,CAAC,MAAM,EAAE,CAAC,EAAE,EAAE;YACnE,MAAM,IAAI,GAAG,KAAK,CAAC,KAAK,CAAC,CAAC,CAAC,CAAC;YAC5B,IAAI,CAAC,IAAA,yBAAS,EAAC,IAAI,CAAC,EAAE;gBACpB,OAAO,KAAK,CAAC;aACd;YAED,MAAM,IAAI,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,IAAI,CAAC,EAAE,CAAC,CAAC;YAEpD,kFAAkF;YAClF,IAAI,IAAI,CAAC,QAAQ,KAAK,SAAS,EAAE;gBAC/B,OAAO,KAAK,CAAC;aACd;YAED,IACE,IAAI,CAAC,QAAQ,KAAK,gBAAQ,CAAC,aAAa;gBACxC,IAAI,CAAC,QAAQ,KAAK,gBAAQ,CAAC,cAAc,EACzC;gBACA,OAAO,KAAK,CAAC;aACd;SACF;QAED,MAAM,QAAQ,GAAG,KAAK,CAAC,KAAK,CAAC,KAAK,CAAC,KAAK,CAAC,MAAM,GAAG,CAAC,CAAY,CAAC;QAChE,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC;QAE5D,OAAO,QAAQ,CAAC,MAAM,KAAK,gBAAM,CAAC,MAAM,CAAC;IAC3C,CAAC;IAEO,+BAA+B,CACrC,KAA6B,EAC7B,aAAqB;QAErB,IAAI,KAAK,CAAC,UAAU,CAAC,MAAM,GAAG,CAAC,EAAE;YAC/B,OAAO,KAAK,CAAC;SACd;QAED,IAAI,KAAK,CAAC,IAAI,CAAC,IAAI,KAAK,eAAQ,CAAC,MAAM,EAAE;YACvC,OAAO,KAAK,CAAC;SACd;QAED,MAAM,IAAI,GAAG,KAAK,CAAC,KAAK,CAAC,aAAa,CAAiB,CAAC;QACxD,IAAI,IAAI,CAAC,IAAI,CAAC,IAAI,KAAK,eAAQ,CAAC,UAAU,EAAE;YAC1C,OAAO,KAAK,CAAC;SACd;QAED,OAAO,IAAI,CAAC,oBAAoB,CAAC,KAAK,EAAE,aAAa,CAAC,CAAC;IACzD,CAAC;IAEO,kBAAkB,CAAC,UAAsB;QAC/C,OAAO,IAAI,wBAAU,CAAC,UAAU,CAAC,CAAC,iBAAiB,EAAE,CAAC;IACxD,CAAC;CACF;AAjpDD,sCAipDC;AAED,SAAgB,qCAAqC,CACnD,QAAkB,EAClB,IAAiB;IAEjB,wEAAwE;IACxE,2EAA2E;IAC3E,WAAW;IACX,IAAI,IAAI,CAAC,QAAQ,KAAK,SAAS,EAAE;QAC/B,MAAM,QAAQ,GAAG,QAAQ,CAAC,QAAQ,CAAC,QAAQ,CAAC;QAC5C,OAAO;YACL,IAAI,EAAE,0CAAmB,CAAC,iCAAiC;YAC3D,EAAE,EAAE,IAAI,CAAC,EAAE;YACX,eAAe,EAAE;gBACf,UAAU,EAAE,QAAQ,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI,CAAC,UAAU;gBACtD,aAAa,EAAE,QAAQ,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI,CAAC,OAAO;gBACtD,QAAQ,EAAE,QAAQ,CAAC,QAAQ,CAAC,IAAI;gBAChC,QAAQ,EAAE,SAAS;gBACnB,IAAI,EAAE,QAAQ,CAAC,QAAQ,CAAC,QAAQ,CAAC,qBAAqB,EAAE;gBACxD,KAAK,EAAE,CAAC,QAAQ,CAAC,MAAM,EAAE,QAAQ,CAAC,MAAM,GAAG,QAAQ,CAAC,MAAM,CAAC;aAC5D;SACF,CAAC;KACH;IAED,MAAM,IAAI,GAAG,IAAI,CAAC,QAAQ,EAAE,qBAAqB,EAAE,CAAC;IAEpD,IAAI,IAAI,KAAK,SAAS,EAAE;QACtB,MAAM,eAAe,GAAG,+BAA+B,CACrD,QAAQ,EACR,IAAI,CAAC,QAAQ,CACd,CAAC;QACF,IAAA,+BAAsB,EACpB,eAAe,KAAK,SAAS,EAC7B,yCAAyC,CAC1C,CAAC;QAEF,OAAO;YACL,IAAI,EAAE,0CAAmB,CAAC,eAAe;YACzC,eAAe;YACf,YAAY,EAAE,IAAI,CAAC,IAAI;SACxB,CAAC;KACH;IAED,IAAA,+BAAsB,EACpB,IAAI,CAAC,QAAQ,KAAK,SAAS,EAC3B,6CAA6C,CAC9C,CAAC;IAEF,OAAO;QACL,IAAI,EAAE,0CAAmB,CAAC,eAAe;QACzC,eAAe,EAAE;YACf,QAAQ,EAAE,SAAS;YACnB,QAAQ,EAAE,QAAQ,CAAC,QAAQ,CAAC,IAAI;YAChC,UAAU,EAAE,IAAI,CAAC,QAAQ,CAAC,IAAI,CAAC,UAAU;YACzC,aAAa,EAAE,IAAI,CAAC,QAAQ,CAAC,IAAI,CAAC,OAAO;YACzC,IAAI,EAAE,IAAI,CAAC,QAAQ,CAAC,qBAAqB,EAAE;YAC3C,KAAK,EAAE;gBACL,IAAI,CAAC,QAAQ,CAAC,MAAM;gBACpB,IAAI,CAAC,QAAQ,CAAC,MAAM,GAAG,IAAI,CAAC,QAAQ,CAAC,MAAM;aAC5C;SACF;QACD,YAAY,EAAE,4BAAoB,CAAC,QAAQ;KAC5C,CAAC;AACJ,CAAC;AA9DD,sFA8DC;AAED,SAAS,+BAA+B,CACtC,QAAkB,EAClB,QAAyB;IAEzB,IAAI,QAAQ,KAAK,SAAS,EAAE;QAC1B,OAAO,SAAS,CAAC;KAClB;IAED,MAAM,IAAI,GAAG,QAAQ,CAAC,qBAAqB,EAAE,CAAC;IAE9C,IAAI,IAAI,KAAK,SAAS,EAAE;QACtB,OAAO,SAAS,CAAC;KAClB;IAED,IAAI,QAAQ,GAAG,IAAI,CAAC,IAAI,CAAC;IAEzB,IAAI,IAAI,CAAC,IAAI,KAAK,4BAAoB,CAAC,WAAW,EAAE;QAClD,QAAQ,GAAG,gDAAyB,CAAC;KACtC;SAAM,IAAI,IAAI,CAAC,IAAI,KAAK,4BAAoB,CAAC,QAAQ,EAAE;QACtD,QAAQ,GAAG,6CAAsB,CAAC;KACnC;SAAM,IAAI,IAAI,CAAC,IAAI,KAAK,4BAAoB,CAAC,OAAO,EAAE;QACrD,QAAQ,GAAG,4CAAqB,CAAC;KAClC;IAED,OAAO;QACL,QAAQ,EAAE,QAAQ;QAClB,QAAQ,EACN,IAAI,CAAC,IAAI,KAAK,4BAAoB,CAAC,aAAa;YAC9C,CAAC,CAAC,SAAS;YACX,CAAC,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI;QAC5B,UAAU,EAAE,IAAI,CAAC,QAAQ,CAAC,IAAI,CAAC,UAAU;QACzC,aAAa,EAAE,IAAI,CAAC,QAAQ,CAAC,IAAI,CAAC,OAAO;QACzC,IAAI,EAAE,QAAQ,CAAC,qBAAqB,EAAE;QACtC,KAAK,EAAE,CAAC,QAAQ,CAAC,MAAM,EAAE,QAAQ,CAAC,MAAM,GAAG,QAAQ,CAAC,MAAM,CAAC;KAC5D,CAAC;AACJ,CAAC"}
 \ No newline at end of file
-+{"version":3,"file":"error-inferrer.js","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/error-inferrer.ts"],"names":[],"mappings":";;;;;;AAAA,gEAAgE;AAChE,4CAA4D;AAC5D,sEAA+D;AAC/D,oDAA4B;AAE5B,8CAA2D;AAC3D,wDAAoD;AACpD,yDAAqD;AAGrD,mDAWyB;AAUzB,uCAAqD;AACrD,iEAgBgC;AAEhC,MAAM,2CAA2C,GAAG,OAAO,CAAC;AAC5D,MAAM,mCAAmC,GAAG,OAAO,CAAC;AACpD,MAAM,wCAAwC,GAAG,OAAO,CAAC;AAQzD,+EAA+E;AAE/E,MAAa,aAAa;IACjB,6BAA6B,CAClC,KAA8B;QAE9B,IAAI,IAAI,CAAC,oBAAoB,CAAC,KAAK,CAAC,EAAE;YACpC,OAAO,IAAI,CAAC,oCAAoC,CAAC,KAAK,CAAC,CAAC;SACzD;QAED,MAAM,cAAc,GAAG,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,uBAAuB,CACpE,KAAK,CAAC,QAAQ,CAAC,KAAK,CAAC,CAAC,EAAE,CAAC,CAAC,CAC3B,CAAC;QAEF,IACE,cAAc,KAAK,SAAS;YAC5B,IAAI,CAAC,0BAA0B,CAAC,KAAK,EAAE,cAAc,CAAC,EACtD;YACA,OAAO;gBACL;oBACE,IAAI,wDAAgD;oBACpD,eAAe,EAAE,IAAI,CAAC,gCAAgC,CACpD,KAAK,EACL,cAAc,CACf;oBACD,KAAK,EAAE,KAAK,CAAC,KAAK;iBACnB;aACF,CAAC;SACH;QAED,IAAI,IAAI,CAAC,kCAAkC,CAAC,KAAK,EAAE,cAAc,CAAC,EAAE;YAClE,IAAI,IAAI,CAAC,0BAA0B,CAAC,KAAK,CAAC,EAAE;gBAC1C,OAAO;oBACL;wBACE,IAAI,gEAAuD;wBAC3D,eAAe,EACb,IAAI,CAAC,+CAA+C,CAAC,KAAK,CAAC;qBAC9D;iBACF,CAAC;aACH;YAED,OAAO;gBACL;oBACE,IAAI,2EAAkE;oBACtE,eAAe,EACb,IAAI,CAAC,+CAA+C,CAAC,KAAK,CAAC;iBAC9D;aACF,CAAC;SACH;QAED,IAAI,IAAI,CAAC,0BAA0B,CAAC,KAAK,EAAE,cAAc,CAAC,EAAE;YAC1D,IAAI,IAAI,CAAC,0BAA0B,CAAC,KAAK,CAAC,EAAE;gBAC1C,OAAO;oBACL;wBACE,IAAI,wEAA+D;wBACnE,eAAe,EAAE,IAAI,CAAC,gCAAgC,CAAC,KAAK,CAAC;wBAC7D,KAAK,EAAE,KAAK,CAAC,KAAK;qBACnB;iBACF,CAAC;aACH;YAED,OAAO;gBACL;oBACE,IAAI,wDAAgD;oBACpD,eAAe,EAAE,IAAI,CAAC,gCAAgC,CAAC,KAAK,CAAC;oBAC7D,KAAK,EAAE,KAAK,CAAC,KAAK;iBACnB;aACF,CAAC;SACH;IACH,CAAC;IAEM,+BAA+B,CACpC,KAAgC;QAEhC,IAAI,IAAI,CAAC,6BAA6B,CAAC,KAAK,CAAC,EAAE;YAC7C,OAAO;gBACL;oBACE,IAAI,wDAAgD;oBACpD,eAAe,EAAE,IAAI,CAAC,mCAAmC,CAAC,KAAK,CAAC;oBAChE,KAAK,EAAE,KAAK,CAAC,KAAK;iBACnB;aACF,CAAC;SACH;QAED,IAAI,IAAI,CAAC,mCAAmC,CAAC,KAAK,CAAC,EAAE;YACnD,OAAO;gBACL;oBACE,IAAI,kDAA0C;oBAC9C,eAAe,EAAE,IAAI,CAAC,mCAAmC,CAAC,KAAK,CAAC;iBACjE;aACF,CAAC;SACH;IACH,CAAC;IAEM,iBAAiB,CACtB,KAA6B,EAC7B,UAA8B,EAC9B,iBAAgC,EAChC,kBAA2B,EAC3B,kBAA8C;QAE9C,OAAO,CACL,IAAI,CAAC,oBAAoB,CAAC,KAAK,EAAE,UAAU,EAAE,kBAAkB,CAAC;YAChE,IAAI,CAAC,oBAAoB,CAAC,KAAK,EAAE,UAAU,CAAC;YAC5C,IAAI,CAAC,qBAAqB,CACxB,KAAK,EACL,UAAU,EACV,iBAAiB,EACjB,kBAAkB,CACnB;YACD,IAAI,CAAC,uBAAuB,CAAC,KAAK,EAAE,UAAU,CAAC;YAC/C,IAAI,CAAC,+BAA+B,CAAC,KAAK,EAAE,UAAU,CAAC;YACvD,IAAI,CAAC,sBAAsB,CAAC,KAAK,CAAC;YAClC,IAAI,CAAC,8BAA8B,CAAC,KAAK,EAAE,UAAU,CAAC,CACvD,CAAC;IACJ,CAAC;IAEM,qBAAqB,CAC1B,UAA8B;QAE9B,OAAO,UAAU,CAAC,MAAM,CAAC,CAAC,KAAK,EAAE,CAAC,EAAE,EAAE;YACpC,IAAI,CAAC,GAAG,CAAC,KAAK,UAAU,CAAC,MAAM,EAAE;gBAC/B,OAAO,IAAI,CAAC;aACb;YAED,MAAM,SAAS,GAAG,UAAU,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC;YAEpC,6DAA6D;YAC7D,kCAAkC;YAClC,IACE,KAAK,CAAC,eAAe,KAAK,SAAS;gBACnC,SAAS,CAAC,eAAe,KAAK,SAAS,EACvC;gBACA,OAAO,IAAI,CAAC;aACb;YAED,yEAAyE;YACzE,wEAAwE;YACxE,IACE,KAAK,CAAC,IAAI,gDAAwC;gBAClD,CAAC,GAAG,CAAC,GAAG,UAAU,CAAC,MAAM;gBACzB,UAAU,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,eAAe,KAAK,SAAS;gBAC/C,UAAU,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,IAAI,uDAA8C,EACpE;gBACA,wEAAwE;gBACxE,MAAM,UAAU,GAAG,UAAU,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,eAAe,CAAC;gBACrD,IACE,UAAU,KAAK,SAAS;oBACxB,KAAK,CAAC,eAAe,CAAC,KAAK,CAAC,CAAC,CAAC,KAAK,UAAU,CAAC,KAAK,CAAC,CAAC,CAAC;oBACtD,KAAK,CAAC,eAAe,CAAC,KAAK,CAAC,CAAC,CAAC,KAAK,UAAU,CAAC,KAAK,CAAC,CAAC,CAAC;oBACtD,KAAK,CAAC,eAAe,CAAC,IAAI,KAAK,UAAU,CAAC,IAAI,EAC9C;oBACA,OAAO,KAAK,CAAC;iBACd;aACF;YAED,6DAA6D;YAC7D,IACE,KAAK,CAAC,eAAe,CAAC,QAAQ,KAAK,aAAa;gBAChD,SAAS,CAAC,eAAe,CAAC,QAAQ,KAAK,aAAa,EACpD;gBACA,OAAO,IAAI,CAAC;aACb;YAED,oCAAoC;YACpC,IACE,CAAC,GAAG,CAAC;gBACL,KAAK,CAAC,IAAI,KAAK,SAAS,CAAC,IAAI;gBAC7B,KAAK,CAAC,eAAe,CAAC,KAAK,CAAC,CAAC,CAAC,KAAK,SAAS,CAAC,eAAe,CAAC,KAAK,CAAC,CAAC,CAAC;gBACrE,KAAK,CAAC,eAAe,CAAC,KAAK,CAAC,CAAC,CAAC,KAAK,SAAS,CAAC,eAAe,CAAC,KAAK,CAAC,CAAC,CAAC;gBACrE,KAAK,CAAC,eAAe,CAAC,IAAI,KAAK,SAAS,CAAC,eAAe,CAAC,IAAI,EAC7D;gBACA,OAAO,IAAI,CAAC;aACb;YAED,IACE,KAAK,CAAC,eAAe,CAAC,KAAK,CAAC,CAAC,CAAC,IAAI,SAAS,CAAC,eAAe,CAAC,KAAK,CAAC,CAAC,CAAC;gBACpE,KAAK,CAAC,eAAe,CAAC,KAAK,CAAC,CAAC,CAAC,IAAI,SAAS,CAAC,eAAe,CAAC,KAAK,CAAC,CAAC,CAAC,EACpE;gBACA,OAAO,KAAK,CAAC;aACd;YAED,OAAO,IAAI,CAAC;QACd,CAAC,CAAC,CAAC;IACL,CAAC;IAED,aAAa;IAEb;;OAEG;IACK,oBAAoB,CAC1B,KAA6B,EAC7B,UAA8B,EAC9B,kBAA8C;QAE9C,IAAI,kBAAkB,KAAK,SAAS,EAAE;YACpC,OAAO,SAAS,CAAC;SAClB;QAED,MAAM,kBAAkB,GAAG,CAAC,GAAG,UAAU,CAAC,CAAC;QAE3C,0EAA0E;QAC1E,MAAM,QAAQ,GAAG,KAAK,CAAC,KAAK,CAAC,kBAAkB,CAAC,SAAS,GAAG,CAAC,CAAC,CAAC;QAE/D,IAAI,CAAC,IAAA,yBAAS,EAAC,QAAQ,CAAC,EAAE;YACxB,MAAM,IAAI,KAAK,CACb,uEAAuE,CACxE,CAAC;SACH;QAED,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC;QAC5D,MAAM,cAAc,GAAG,qCAAqC,CAC1D,KAAK,CAAC,QAAQ,EACd,QAAQ,CACT,CAAC;QAEF,MAAM,iBAAiB,GAAG,kBAAkB,CAAC,YAAY,CAAC,IAAI,CAAC,OAAO,EAAE,CAAC;QACzE,IAAI,iBAAiB,EAAE;YACrB,oEAAoE;YACpE,kBAAkB,CAAC,IAAI,CAAC,cAAc,CAAC,CAAC;YAExC,IACE,IAAI,CAAC,0BAA0B,CAAC,KAAK,EAAE,kBAAkB,CAAC,SAAS,CAAC;gBACpE,IAAI,CAAC,uBAAuB,CAAC,KAAK,EAAE,kBAAkB,CAAC,SAAS,CAAC,EACjE;gBACA,kBAAkB,CAAC,IAAI,CAAC,GAAG,kBAAkB,CAAC,UAAU,CAAC,CAAC;gBAE1D,IACE,IAAI,CAAC,+BAA+B,CAClC,KAAK,EACL,kBAAkB,CAAC,SAAS,CAC7B,EACD;oBACA,MAAM,SAAS,GAAG,kBAAkB,CAAC,GAAG,EAAE,CAAC;oBAC3C,IAAA,+BAAsB,EACpB,SAAS,KAAK,SAAS,EACvB,0DAA0D,CAC3D,CAAC;oBACF,kBAAkB,CAAC,IAAI,CAAC;wBACtB,IAAI,iEAAwD;wBAC5D,eAAe,EAAE,SAAS,CAAC,eAAe;qBAC3C,CAAC,CAAC;iBACJ;gBAED,OAAO,IAAI,CAAC,mBAAmB,CAAC,KAAK,EAAE,kBAAkB,CAAC,CAAC;aAC5D;SACF;aAAM;YACL,MAAM,qBAAqB,GAAG,IAAI,CAAC,oBAAoB,CACrD,KAAK,EACL,kBAAkB,CAAC,SAAS,CAC7B,CAAC;YACF,IAAI,qBAAqB,EAAE;gBACzB,kBAAkB,CAAC,IAAI,CAAC;oBACtB,IAAI,oDAA2C;oBAC/C,eAAe,EAAE,cAAc,CAAC,eAAe;iBAChD,CAAC,CAAC;gBAEH,OAAO,IAAI,CAAC,mBAAmB,CAAC,KAAK,EAAE,kBAAkB,CAAC,CAAC;aAC5D;SACF;IACH,CAAC;IAED;;OAEG;IACK,oBAAoB,CAC1B,KAA6B,EAC7B,UAA8B;QAE9B,KAAK,IAAI,SAAS,GAAG,KAAK,CAAC,KAAK,CAAC,MAAM,GAAG,CAAC,EAAE,SAAS,IAAI,CAAC,EAAE,SAAS,EAAE,EAAE;YACxE,MAAM,IAAI,GAAG,KAAK,CAAC,KAAK,CAAC,SAAS,CAAC,CAAC;YACpC,MAAM,QAAQ,GAAG,KAAK,CAAC,KAAK,CAAC,SAAS,GAAG,CAAC,CAAC,CAAC;YAE5C,IAAI,CAAC,IAAA,yBAAS,EAAC,IAAI,CAAC,EAAE;gBACpB,OAAO;aACR;YAED,MAAM,IAAI,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,IAAI,CAAC,EAAE,CAAC,CAAC;YAEpD,MAAM,cAAc,GAAG,IAAA,gBAAM,EAAC,IAAI,CAAC,MAAM,CAAC,IAAI,IAAA,kBAAQ,EAAC,IAAI,CAAC,MAAM,CAAC,CAAC;YAEpE,IAAI,cAAc,IAAI,IAAA,yBAAS,EAAC,QAAQ,CAAC,EAAE;gBACzC,IAAI,IAAI,CAAC,kBAAkB,CAAC,KAAK,EAAE,SAAS,EAAE,IAAI,CAAC,EAAE;oBACnD,MAAM,kBAAkB,GAAG;wBACzB,GAAG,UAAU;wBACb,IAAI,CAAC,oDAAoD,CACvD,KAAK,CAAC,QAAQ,EACd,IAAI,CACL;qBACF,CAAC;oBAEF,OAAO,IAAI,CAAC,mBAAmB,CAAC,KAAK,EAAE,kBAAkB,CAAC,CAAC;iBAC5D;aACF;SACF;IACH,CAAC;IAED;;OAEG;IACK,2BAA2B,CACjC,KAA6B,EAC7B,UAA8B,EAC9B,eAA4B,EAC5B,iBAAgC,EAChC,kBAA2B;QAE3B,IACE,eAAe,CAAC,MAAM,4BAAkB;YACxC,eAAe,CAAC,MAAM,6BAAmB,EACzC;YACA,OAAO;SACR;QAED,MAAM,kBAAkB,GAAG,CAAC,GAAG,UAAU,CAAC,CAAC;QAE3C,IACE,eAAe,CAAC,QAAQ,KAAK,SAAS;YACtC,CAAC,CAAC,IAAA,kCAAkB,EAAC,KAAK,CAAC,IAAI,kBAAkB,CAAC,EAClD;YACA,sFAAsF;YACtF,EAAE;YACF,oFAAoF;YACpF,yBAAyB;YACzB,EAAE;YACF,yFAAyF;YACzF,MAAM,eAAe,GAAG,eAAe,CAAC,QAAQ,CAAC,qBAAqB,EAAE,CAAC;YAEzE,gFAAgF;YAChF,IACE,eAAe,KAAK,SAAS;gBAC7B,eAAe,CAAC,IAAI,0CAAkC,EACtD;gBACA,kBAAkB,CAAC,IAAI,CACrB,IAAI,CAAC,gCAAgC,CAAC,KAAK,EAAE,iBAAiB,CAAC,CAChE,CAAC;aACH;SACF;QAED,MAAM,eAAe,GAAG,IAAI,CAAC,WAAW,CACtC,KAAK,EACL,kBAAkB,EAClB,eAAe,CAChB,CAAC;QACF,IAAI,eAAe,KAAK,SAAS,EAAE;YACjC,OAAO,eAAe,CAAC;SACxB;QAED,MAAM,qBAAqB,GAAG,IAAI,CAAC,kBAAkB,CACnD,KAAK,EACL,kBAAkB,EAClB,eAAe,CAChB,CAAC;QACF,IAAI,qBAAqB,KAAK,SAAS,EAAE;YACvC,OAAO,qBAAqB,CAAC;SAC9B;QAED,IACE,eAAe,CAAC,QAAQ,KAAK,SAAS;YACtC,CAAC,CAAC,IAAA,kCAAkB,EAAC,KAAK,CAAC,IAAI,kBAAkB,CAAC,EAClD;YACA,MAAM,eAAe,GAAG,eAAe,CAAC,QAAQ,CAAC,qBAAqB,EAAE,CAAC;YAEzE,IAAI,eAAe,KAAK,SAAS,EAAE;gBACjC,kBAAkB,CAAC,IAAI,CACrB,IAAI,CAAC,iDAAiD,CACpD,KAAK,EACL,eAAe,CAChB,CACF,CAAC;aACH;iBAAM,IAAI,IAAA,kCAAkB,EAAC,KAAK,CAAC,EAAE;gBACpC,4CAA4C;gBAC5C,MAAM,gBAAgB,GACpB,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,uBAAuB,CAC7C,KAAK,CAAC,QAAQ,CAAC,KAAK,CAAC,CAAC,EAAE,CAAC,CAAC,CAC3B,CAAC;gBAEJ,uEAAuE;gBACvE,wEAAwE;gBACxE,UAAU;gBACV,IAAI,gBAAgB,KAAK,SAAS,EAAE;oBAClC,OAAO;iBACR;gBAED,kBAAkB,CAAC,IAAI,CAAC;oBACtB,IAAI,0CAAkC;oBACtC,eAAe,EAAE,IAAI,CAAC,gCAAgC,CACpD,KAAK,EACL,gBAAgB,CACjB;oBACD,OAAO,EAAE,IAAI,wBAAU,CAAC,KAAK,CAAC,UAAU,CAAC;oBACzC,oBAAoB,EAAE,eAAe,CAAC,MAAM,6BAAmB;iBAChE,CAAC,CAAC;aACJ;iBAAM;gBACL,4CAA4C;gBAC5C,kBAAkB,CAAC,IAAI,CAAC;oBACtB,IAAI,0CAAkC;oBACtC,eAAe,EAAE,IAAI,CAAC,mCAAmC,CAAC,KAAK,CAAC;oBAChE,OAAO,EAAE,IAAI,wBAAU,CAAC,KAAK,CAAC,UAAU,CAAC;oBACzC,oBAAoB,EAAE,eAAe,CAAC,MAAM,6BAAmB;iBAChE,CAAC,CAAC;aACJ;YAED,OAAO,IAAI,CAAC,mBAAmB,CAAC,KAAK,EAAE,kBAAkB,CAAC,CAAC;SAC5D;QAED,oEAAoE;QACpE,oEAAoE;QACpE,IAAI,eAAe,CAAC,QAAQ,KAAK,SAAS,IAAI,KAAK,CAAC,UAAU,CAAC,MAAM,GAAG,CAAC,EAAE;YACzE,MAAM,WAAW,GAA+B;gBAC9C,IAAI,0CAAkC;gBACtC,eAAe,EACb,IAAI,CAAC,uBAAuB,CAAC,KAAK,CAAC;oBACnC,IAAI,CAAC,+CAA+C,CAAC,KAAK,CAAC;gBAC7D,OAAO,EAAE,IAAI,wBAAU,CAAC,KAAK,CAAC,UAAU,CAAC;gBACzC,oBAAoB,EAAE,eAAe,CAAC,MAAM,6BAAmB;aAChE,CAAC;YACF,kBAAkB,CAAC,IAAI,CAAC,WAAW,CAAC,CAAC;YAErC,OAAO,IAAI,CAAC,mBAAmB,CAAC,KAAK,EAAE,kBAAkB,CAAC,CAAC;SAC5D;IACH,CAAC;IAED;;OAEG;IACK,WAAW,CACjB,KAA6B,EAC7B,UAA8B,EAC9B,eAA4B;QAE5B,IAAI,CAAC,IAAI,CAAC,kBAAkB,CAAC,KAAK,CAAC,UAAU,CAAC,EAAE;YAC9C,OAAO;SACR;QAED,qEAAqE;QACrE,uEAAuE;QACvE,SAAS;QACT,MAAM,SAAS,GAAG,UAAU,CAAC,UAAU,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC;QACpD,IACE,SAAS,EAAE,IAAI,mEAA0D,EACzE;YACA,UAAU,CAAC,MAAM,CAAC,CAAC,CAAC,CAAC,CAAC;SACvB;QAED,MAAM,eAAe,GAAG,IAAI,wBAAU,CAAC,KAAK,CAAC,UAAU,CAAC,CAAC;QACzD,MAAM,SAAS,GAAG,eAAe,CAAC,WAAW,EAAE,CAAC;QAEhD,iEAAiE;QACjE,gEAAgE;QAChE,2BAA2B;QAC3B,IAAI,SAAS,KAAK,KAAK,EAAE;YACvB,UAAU,CAAC,MAAM,CAAC,CAAC,CAAC,CAAC,CAAC;SACvB;QAED,MAAM,kBAAkB,GAAG,CAAC,GAAG,UAAU,CAAC,CAAC;QAC3C,kBAAkB,CAAC,IAAI,CACrB,IAAI,CAAC,gDAAgD,CACnD,KAAK,EACL,eAAe,EACf,SAAS,CACV,CACF,CAAC;QAEF,OAAO,IAAI,CAAC,mBAAmB,CAAC,KAAK,EAAE,kBAAkB,CAAC,CAAC;IAC7D,CAAC;IAEO,kBAAkB,CACxB,KAA6B,EAC7B,UAA8B,EAC9B,eAA4B;QAE5B,MAAM,UAAU,GAAG,IAAI,wBAAU,CAAC,KAAK,CAAC,UAAU,CAAC,CAAC;QAEpD,IAAI,UAAU,CAAC,OAAO,EAAE,IAAI,UAAU,CAAC,iBAAiB,EAAE,EAAE;YAC1D,0DAA0D;YAC1D,kCAAkC;YAClC,OAAO;SACR;QAED,MAAM,aAAa,GAAG,MAAM,CAAC,IAAI,CAAC,UAAU,CAAC,KAAK,CAAC,CAAC,QAAQ,CAAC,KAAK,CAAC,CAAC;QACpE,IAAI,YAAY,GAAG,8DAA8D,aAAa,GAAG,CAAC;QAElG,KAAK,MAAM,WAAW,IAAI,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,YAAY,EAAE;YAC9D,IAAI,UAAU,CAAC,eAAe,CAAC,WAAW,CAAC,QAAQ,CAAC,EAAE;gBACpD,oEAAoE;gBACpE,2EAA2E;gBAC3E,MAAM,aAAa,GAAG,qBAAG,CAAC,MAAM,CAC9B,WAAW,CAAC,UAAU,EACtB,UAAU,CAAC,KAAK,CAAC,KAAK,CAAC,CAAC,CAAC,CAC1B,CAAC;gBAEF,MAAM,MAAM,GAAG,wBAAU,CAAC,YAAY,CAAC,CAAC,GAAG,aAAa,CAAC,CAAC,CAAC;gBAC3D,YAAY,GAAG,+BAA+B,WAAW,CAAC,IAAI,IAAI,MAAM,IAAI,CAAC;gBAC7E,MAAM;aACP;SACF;QAED,MAAM,kBAAkB,GAAG,CAAC,GAAG,UAAU,CAAC,CAAC;QAC3C,kBAAkB,CAAC,IAAI,CACrB,IAAI,CAAC,sDAAsD,CACzD,KAAK,EACL,eAAe,EACf,YAAY,CACb,CACF,CAAC;QAEF,OAAO,IAAI,CAAC,mBAAmB,CAAC,KAAK,EAAE,kBAAkB,CAAC,CAAC;IAC7D,CAAC;IAED;;OAEG;IACK,qBAAqB,CAC3B,KAA6B,EAC7B,UAA8B,EAC9B,iBAAgC,EAChC,kBAA2B;QAE3B,IAAI,KAAK,CAAC,KAAK,CAAC,MAAM,KAAK,CAAC,EAAE;YAC5B,OAAO;SACR;QAED,MAAM,QAAQ,GAAG,KAAK,CAAC,KAAK,CAAC,KAAK,CAAC,KAAK,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC;QAErD,IAAI,CAAC,IAAA,yBAAS,EAAC,QAAQ,CAAC,EAAE;YACxB,MAAM,IAAI,KAAK,CACb,2DAA2D,CAC5D,CAAC;SACH;QAED,MAAM,eAAe,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC;QAEnE,MAAM,yBAAyB,GAAG,IAAI,CAAC,2BAA2B,CAChE,KAAK,EACL,UAAU,EACV,eAAe,EACf,iBAAiB,EACjB,kBAAkB,CACnB,CAAC;QAEF,IAAI,yBAAyB,KAAK,SAAS,EAAE;YAC3C,OAAO,yBAAyB,CAAC;SAClC;QAED,IAAI,IAAA,kCAAkB,EAAC,KAAK,CAAC,IAAI,CAAC,kBAAkB,EAAE;YACpD,IACE,IAAI,CAAC,mCAAmC,CAAC,KAAK,CAAC;gBAC/C,IAAI,CAAC,kCAAkC,CAAC,KAAK,CAAC,EAC9C;gBACA,OAAO;oBACL,IAAI,CAAC,iDAAiD,CACpD,KAAK,EACL,eAAe,CAChB;iBACF,CAAC;aACH;YAED,qEAAqE;YACrE,IAAI,eAAe,CAAC,QAAQ,KAAK,SAAS,EAAE;gBAC1C,MAAM,eAAe,GACnB,eAAe,CAAC,QAAQ,CAAC,qBAAqB,EAAE,CAAC;gBACnD,IAAI,eAAe,KAAK,SAAS,EAAE;oBACjC,OAAO;wBACL;4BACE,IAAI,0CAAkC;4BACtC,eAAe,EAAE,IAAI,CAAC,gCAAgC,CACpD,KAAK,EACL,eAAe,CAChB;4BACD,OAAO,EAAE,IAAI,wBAAU,CAAC,KAAK,CAAC,UAAU,CAAC;4BACzC,oBAAoB,EAAE,eAAe,CAAC,MAAM,6BAAmB;yBAChE;qBACF,CAAC;iBACH;aACF;YAED,MAAM,cAAc,GAAG,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,uBAAuB,CACpE,KAAK,CAAC,QAAQ,CAAC,KAAK,CAAC,CAAC,EAAE,CAAC,CAAC,CAC3B,CAAC;YAEF,IAAI,cAAc,KAAK,SAAS,EAAE;gBAChC,MAAM,eAAe;gBACnB,0EAA0E;gBAC1E,cAAc,CAAC,UAAU,KAAK,SAAS;oBACvC,wBAAU,CAAC,eAAe,CACxB,cAAc,CAAC,UAAU,EACzB,KAAK,CAAC,QAAQ,CAAC,KAAK,CAAC,CAAC,CAAC,CACxB,CAAC;gBAEJ,IAAI,CAAC,eAAe,EAAE;oBACpB,OAAO;wBACL;4BACE,IAAI,kDAA0C;4BAC9C,eAAe,EAAE,IAAI,CAAC,gCAAgC,CACpD,KAAK,EACL,cAAc,CACf;yBACF;qBACF,CAAC;iBACH;aACF;YAED,IAAI,IAAI,CAAC,+BAA+B,CAAC,KAAK,CAAC,EAAE;gBAC/C,MAAM,WAAW,GACf,IAAI,CAAC,mDAAmD,CAAC,KAAK,CAAC,CAAC;gBAElE,IAAI,WAAW,KAAK,SAAS,EAAE;oBAC7B,OAAO,CAAC,WAAW,CAAC,CAAC;iBACtB;aACF;YAED,OAAO,CAAC,IAAI,CAAC,iDAAiD,CAAC,KAAK,CAAC,CAAC,CAAC;SACxE;IACH,CAAC;IAEO,uBAAuB,CAC7B,KAA6B,EAC7B,UAA8B;QAE9B,IAAI,IAAI,CAAC,gCAAgC,CAAC,KAAK,CAAC,EAAE;YAChD,MAAM,eAAe,GAAG,IAAI,CAAC,uBAAuB,CAAC,KAAK,CAAC,CAAC;YAE5D,kFAAkF;YAClF,IAAA,+BAAsB,EACpB,eAAe,KAAK,SAAS,EAC7B,yCAAyC,CAC1C,CAAC;YAEF,MAAM,sBAAsB,GAA4B;gBACtD,IAAI,+DAAsD;gBAC1D,eAAe;aAChB,CAAC;YAEF,OAAO,CAAC,GAAG,UAAU,EAAE,sBAAsB,CAAC,CAAC;SAChD;IACH,CAAC;IAEO,+BAA+B,CACrC,KAA6B,EAC7B,UAA8B;QAE9B,IAAI,IAAI,CAAC,+BAA+B,CAAC,KAAK,CAAC,EAAE;YAC/C,MAAM,WAAW,GACf,IAAI,CAAC,mDAAmD,CAAC,KAAK,CAAC,CAAC;YAElE,IAAI,WAAW,KAAK,SAAS,EAAE;gBAC7B,OAAO,CAAC,GAAG,UAAU,EAAE,WAAW,CAAC,CAAC;aACrC;SACF;IACH,CAAC;IAEO,sBAAsB,CAC5B,KAA6B;QAE7B,IAAI,IAAA,6BAAa,EAAC,KAAK,CAAC,IAAI,IAAI,CAAC,wBAAwB,CAAC,KAAK,CAAC,EAAE;YAChE,OAAO;gBACL;oBACE,IAAI,uDAA8C;oBAClD,eAAe,EAAE,IAAI,CAAC,mCAAmC,CAAC,KAAK,CAAC;iBACjE;aACF,CAAC;SACH;IACH,CAAC;IAEO,8BAA8B,CACpC,KAA6B,EAC7B,UAA8B;QAE9B,MAAM,wBAAwB,GAA4B;YACxD,IAAI,oDAA2C;YAC/C,eAAe,EAAE,IAAI,CAAC,uBAAuB,CAAC,KAAK,CAAC;SACrD,CAAC;QAEF,OAAO,CAAC,GAAG,UAAU,EAAE,wBAAwB,CAAC,CAAC;IACnD,CAAC;IAED,UAAU;IAEF,mBAAmB,CACzB,KAA6B,EAC7B,UAA8B;QAE9B,MAAM,UAAU,GAAG,UAAU,CAAC,CAAC,CAAC,CAAC;QACjC,IACE,UAAU,KAAK,SAAS;YACxB,UAAU,CAAC,IAAI,gDAAwC;YACvD,UAAU,CAAC,YAAY,0CAAkC,EACzD;YACA,OAAO;gBACL,IAAI,CAAC,4CAA4C,CAAC,KAAK,CAAC;gBACxD,GAAG,UAAU;aACd,CAAC;SACH;QAED,OAAO,UAAU,CAAC;IACpB,CAAC;IAEO,oBAAoB,CAAC,KAA8B;QACzD,OAAO,CACL,KAAK,CAAC,KAAK,KAAK,CAAC,IAAI,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI,iCAAyB,CAC3E,CAAC;IACJ,CAAC;IAEO,oCAAoC,CAC1C,KAA8B;QAE9B,MAAM,IAAI,GAAG,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,uBAAuB,CAC1D,KAAK,CAAC,QAAQ,CAAC,KAAK,CAAC,CAAC,EAAE,CAAC,CAAC,CAC3B,CAAC;QAEF,IAAI,IAAI,KAAK,SAAS,EAAE;YACtB,OAAO;gBACL;oBACE,IAAI,wDAA+C;oBACnD,eAAe,EAAE,IAAI,CAAC,gCAAgC,CAAC,KAAK,EAAE,IAAI,CAAC;iBACpE;aACF,CAAC;SACH;QAED,OAAO;YACL;gBACE,IAAI,wDAA+C;gBACnD,eAAe,EACb,IAAI,CAAC,+CAA+C,CAAC,KAAK,CAAC;aAC9D;SACF,CAAC;IACJ,CAAC;IAEO,0BAA0B,CAChC,KAA8B,EAC9B,cAAgC;QAEhC,iCAAiC;QACjC,IAAI,KAAK,CAAC,UAAU,CAAC,MAAM,GAAG,CAAC,EAAE;YAC/B,OAAO,KAAK,CAAC;SACd;QAED,IAAI,KAAK,CAAC,KAAK,IAAI,EAAE,EAAE;YACrB,OAAO,KAAK,CAAC;SACd;QAED,0CAA0C;QAC1C,IAAI,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI,iCAAyB,EAAE;YACzD,OAAO,KAAK,CAAC;SACd;QAED,OAAO,cAAc,CAAC,SAAS,KAAK,SAAS,IAAI,CAAC,cAAc,CAAC,SAAS,CAAC;IAC7E,CAAC;IAEO,gCAAgC,CACtC,KAA6B,EAC7B,IAAsB;QAEtB,OAAO;YACL,UAAU,EAAE,IAAI,CAAC,QAAQ,CAAC,IAAI,CAAC,UAAU;YACzC,aAAa,EAAE,IAAI,CAAC,QAAQ,CAAC,IAAI,CAAC,OAAO;YACzC,QAAQ,EAAE,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI;YACtC,QAAQ,EAAE,IAAI,CAAC,IAAI;YACnB,IAAI,EAAE,IAAI,CAAC,QAAQ,CAAC,qBAAqB,EAAE;YAC3C,KAAK,EAAE;gBACL,IAAI,CAAC,QAAQ,CAAC,MAAM;gBACpB,IAAI,CAAC,QAAQ,CAAC,MAAM,GAAG,IAAI,CAAC,QAAQ,CAAC,MAAM;aAC5C;SACF,CAAC;IACJ,CAAC;IAEO,kCAAkC,CACxC,KAA8B,EAC9B,cAA4C;QAE5C,iCAAiC;QACjC,IAAI,KAAK,CAAC,UAAU,CAAC,MAAM,GAAG,CAAC,EAAE;YAC/B,OAAO,KAAK,CAAC;SACd;QAED,6CAA6C;QAC7C,IAAI,cAAc,KAAK,SAAS,EAAE;YAChC,OAAO,KAAK,CAAC;SACd;QAED,6CAA6C;QAC7C,IACE,KAAK,CAAC,QAAQ,CAAC,MAAM,KAAK,CAAC;YAC3B,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,OAAO,KAAK,SAAS,EAC7C;YACA,OAAO,KAAK,CAAC;SACd;QAED,OAAO,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,QAAQ,KAAK,SAAS,CAAC;IACxD,CAAC;IAEO,0BAA0B,CAAC,KAA8B;QAC/D,6DAA6D;QAC7D,IACE,gBAAM,CAAC,EAAE,CACP,KAAK,CAAC,QAAQ,CAAC,eAAe,EAC9B,mCAAmC,CACpC,EACD;YACA,OAAO,KAAK,CAAC;SACd;QAED,OAAO,CACL,KAAK,CAAC,QAAQ,CAAC,MAAM,KAAK,CAAC;YAC3B,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,OAAO,KAAK,SAAS,CAC9C,CAAC;IACJ,CAAC;IAEO,+CAA+C,CACrD,KAA6B;QAE7B,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,QAAQ,CAAC;QAClD,OAAO;YACL,UAAU,EAAE,QAAQ,CAAC,IAAI,CAAC,UAAU;YACpC,aAAa,EAAE,QAAQ,CAAC,IAAI,CAAC,OAAO;YACpC,QAAQ,EAAE,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI;YACtC,IAAI,EAAE,QAAQ,CAAC,qBAAqB,EAAE;YACtC,KAAK,EAAE,CAAC,QAAQ,CAAC,MAAM,EAAE,QAAQ,CAAC,MAAM,GAAG,QAAQ,CAAC,MAAM,CAAC;SAC5D,CAAC;IACJ,CAAC;IAEO,0BAA0B,CAChC,KAA8B,EAC9B,cAA4C;QAE5C,IAAI,cAAc,KAAK,SAAS,EAAE;YAChC,OAAO,KAAK,CAAC;SACd;QAED,iCAAiC;QACjC,IAAI,KAAK,CAAC,UAAU,CAAC,MAAM,GAAG,CAAC,EAAE;YAC/B,OAAO,KAAK,CAAC;SACd;QAED,IAAI,KAAK,CAAC,KAAK,IAAI,EAAE,EAAE;YACrB,OAAO,KAAK,CAAC;SACd;QAED,IAAI,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,QAAQ,KAAK,SAAS,EAAE;YAClD,OAAO,KAAK,CAAC;SACd;QAED,MAAM,SAAS,GAAG,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,QAAQ,CAAC,SAAS,CAAC;QAE7D,OAAO,SAAS,KAAK,SAAS,IAAI,CAAC,SAAS,CAAC;IAC/C,CAAC;IAEO,gCAAgC,CACtC,KAA8B;QAE9B,MAAM,IAAI,GAAG,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,QAAQ,CAAC;QAE9C,IAAI,IAAI,KAAK,SAAS,EAAE;YACtB,MAAM,IAAI,KAAK,CACb,iGAAiG,CAClG,CAAC;SACH;QAED,OAAO;YACL,UAAU,EAAE,IAAI,CAAC,QAAQ,CAAC,IAAI,CAAC,UAAU;YACzC,aAAa,EAAE,IAAI,CAAC,QAAQ,CAAC,IAAI,CAAC,OAAO;YACzC,QAAQ,EAAE,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI;YACtC,QAAQ,EAAE,6CAAsB;YAChC,IAAI,EAAE,IAAI,CAAC,QAAQ,CAAC,qBAAqB,EAAE;YAC3C,KAAK,EAAE;gBACL,IAAI,CAAC,QAAQ,CAAC,MAAM;gBACpB,IAAI,CAAC,QAAQ,CAAC,MAAM,GAAG,IAAI,CAAC,QAAQ,CAAC,MAAM;aAC5C;SACF,CAAC;IACJ,CAAC;IAEO,6BAA6B,CACnC,KAAgC;QAEhC,iCAAiC;QACjC,IAAI,KAAK,CAAC,UAAU,CAAC,MAAM,GAAG,CAAC,EAAE;YAC/B,OAAO,KAAK,CAAC;SACd;QAED,MAAM,WAAW,GAAG,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,mBAAmB,CAAC;QAEhE,6FAA6F;QAC7F,gFAAgF;QAChF,IAAI,WAAW,KAAK,SAAS,EAAE;YAC7B,OAAO,KAAK,CAAC;SACd;QAED,OAAO,CACL,KAAK,CAAC,KAAK,GAAG,EAAE;YAChB,CAAC,WAAW,CAAC,SAAS,KAAK,SAAS,IAAI,CAAC,WAAW,CAAC,SAAS,CAAC,CAChE,CAAC;IACJ,CAAC;IAED;;;OAGG;IACK,mCAAmC,CACzC,KAAgC;QAEhC,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC;QACzC,MAAM,WAAW,GAAG,QAAQ,CAAC,mBAAmB,CAAC;QAEjD,MAAM,IAAI,GACR,WAAW,KAAK,SAAS;YACvB,CAAC,CAAC,WAAW,CAAC,QAAQ,CAAC,qBAAqB,EAAE;YAC9C,CAAC,CAAC,QAAQ,CAAC,QAAQ,CAAC,qBAAqB,EAAE,CAAC;QAEhD,OAAO;YACL,UAAU,EAAE,QAAQ,CAAC,QAAQ,CAAC,IAAI,CAAC,UAAU;YAC7C,aAAa,EAAE,QAAQ,CAAC,QAAQ,CAAC,IAAI,CAAC,OAAO;YAC7C,QAAQ,EAAE,QAAQ,CAAC,IAAI;YACvB,QAAQ,EAAE,gDAAyB;YACnC,IAAI;YACJ,KAAK,EAAE;gBACL,QAAQ,CAAC,QAAQ,CAAC,MAAM;gBACxB,QAAQ,CAAC,QAAQ,CAAC,MAAM,GAAG,QAAQ,CAAC,QAAQ,CAAC,MAAM;aACpD;SACF,CAAC;IACJ,CAAC;IAEO,mCAAmC,CACzC,KAAgC;QAEhC,iCAAiC;QACjC,IAAI,KAAK,CAAC,UAAU,CAAC,MAAM,GAAG,CAAC,EAAE;YAC/B,OAAO,KAAK,CAAC;SACd;QAED,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC;QACzC,MAAM,WAAW,GAAG,QAAQ,CAAC,mBAAmB,CAAC;QAEjD,6FAA6F;QAC7F,gFAAgF;QAChF,IAAI,WAAW,KAAK,SAAS,EAAE;YAC7B,OAAO,KAAK,CAAC;SACd;QAED,IACE,gBAAM,CAAC,EAAE,CACP,KAAK,CAAC,QAAQ,CAAC,eAAe,EAC9B,2CAA2C,CAC5C,EACD;YACA,OAAO,KAAK,CAAC;SACd;QAED,MAAM,QAAQ,GAAG,KAAK,CAAC,KAAK,CAAC,KAAK,CAAC,KAAK,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC;QACrD,IAAI,CAAC,IAAA,yBAAS,EAAC,QAAQ,CAAC,EAAE;YACxB,OAAO,KAAK,CAAC;SACd;QAED,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC;QAC5D,IAAI,QAAQ,CAAC,MAAM,4BAAkB,IAAI,QAAQ,CAAC,QAAQ,KAAK,SAAS,EAAE;YACxE,OAAO,KAAK,CAAC;SACd;QAED,IAAI,yBAAyB,GAAG,KAAK,CAAC;QAEtC,4DAA4D;QAC5D,KAAK,IAAI,SAAS,GAAG,CAAC,EAAE,SAAS,GAAG,KAAK,CAAC,KAAK,CAAC,MAAM,EAAE,SAAS,EAAE,EAAE;YACnE,MAAM,IAAI,GAAG,KAAK,CAAC,KAAK,CAAC,SAAS,CAAC,CAAC;YACpC,IAAI,CAAC,IAAA,yBAAS,EAAC,IAAI,CAAC,EAAE;gBACpB,OAAO,KAAK,CAAC;aACd;YAED,MAAM,IAAI,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,IAAI,CAAC,EAAE,CAAC,CAAC;YAEpD,IACE,IAAI,CAAC,QAAQ,KAAK,SAAS;gBAC3B,CAAC,QAAQ,CAAC,QAAQ,CAAC,MAAM,CAAC,IAAI,CAAC,QAAQ,CAAC;gBACxC,CAAC,WAAW,CAAC,QAAQ,CAAC,MAAM,CAAC,IAAI,CAAC,QAAQ,CAAC,EAC3C;gBACA,OAAO,KAAK,CAAC;aACd;YAED,IAAI,IAAI,CAAC,MAAM,6BAAoB,IAAI,IAAA,6BAAa,EAAC,KAAK,CAAC,EAAE;gBAC3D,yBAAyB,GAAG,IAAI,CAAC;aAClC;SACF;QAED,OAAO,yBAAyB,CAAC;IACnC,CAAC;IAEO,4CAA4C,CAClD,KAA6B;QAE7B,IAAI,IAAA,oCAAoB,EAAC,KAAK,CAAC,EAAE;YAC/B,OAAO;gBACL,IAAI,6CAAqC;gBACzC,eAAe,EAAE,IAAI,CAAC,mCAAmC,CAAC,KAAK,CAAC;gBAChE,YAAY,0CAAkC;aAC/C,CAAC;SACH;QAED,MAAM,cAAc,GAAG,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,uBAAuB,CACpE,KAAK,CAAC,QAAQ,CAAC,KAAK,CAAC,CAAC,EAAE,CAAC,CAAC,CAC3B,CAAC;QAEF,IAAI,cAAc,KAAK,SAAS,EAAE;YAChC,OAAO;gBACL,IAAI,6CAAqC;gBACzC,eAAe,EAAE,IAAI,CAAC,gCAAgC,CACpD,KAAK,EACL,cAAc,CACf;gBACD,YAAY,uCAA+B;aAC5C,CAAC;SACH;QAED,qFAAqF;QACrF,yCAAyC;QACzC,OAAO;YACL,IAAI,6CAAqC;YACzC,eAAe,EAAE,IAAI,CAAC,gCAAgC,CAAC,KAAK,CAAC;YAC7D,YAAY,uCAA+B;SAC5C,CAAC;IACJ,CAAC;IAEO,uBAAuB,CAC7B,KAA6B;QAE7B,KAAK,IAAI,CAAC,GAAG,KAAK,CAAC,KAAK,CAAC,MAAM,GAAG,CAAC,EAAE,CAAC,IAAI,CAAC,EAAE,CAAC,EAAE,EAAE;YAChD,MAAM,IAAI,GAAG,KAAK,CAAC,KAAK,CAAC,CAAC,CAAC,CAAC;YAC5B,IAAI,CAAC,IAAA,yBAAS,EAAC,IAAI,CAAC,EAAE;gBACpB,SAAS;aACV;YAED,MAAM,IAAI,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,IAAI,CAAC,EAAE,CAAC,CAAC;YAEpD,IAAI,IAAI,CAAC,QAAQ,KAAK,SAAS,EAAE;gBAC/B,SAAS;aACV;YAED,MAAM,eAAe,GAAG,+BAA+B,CACrD,KAAK,CAAC,QAAQ,EACd,IAAI,CAAC,QAAQ,CACd,CAAC;YAEF,IAAI,eAAe,KAAK,SAAS,EAAE;gBACjC,OAAO,eAAe,CAAC;aACxB;SACF;QAED,OAAO,SAAS,CAAC;IACnB,CAAC;IAEO,mCAAmC,CACzC,KAA8B;QAE9B,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC;QAEzC,IAAI,QAAQ,CAAC,QAAQ,KAAK,SAAS,EAAE;YACnC,OAAO,KAAK,CAAC;SACd;QAED,OAAO,IAAI,CAAC,wBAAwB,CAAC,KAAK,EAAE,QAAQ,CAAC,QAAQ,CAAC,CAAC;IACjE,CAAC;IAEO,kCAAkC,CACxC,KAA8B;QAE9B,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC;QAEzC,IAAI,QAAQ,CAAC,OAAO,KAAK,SAAS,EAAE;YAClC,OAAO,KAAK,CAAC;SACd;QAED,OAAO,IAAI,CAAC,wBAAwB,CAAC,KAAK,EAAE,QAAQ,CAAC,OAAO,CAAC,CAAC;IAChE,CAAC;IAEO,wBAAwB,CAC9B,KAA8B,EAC9B,IAAsB;QAEtB,MAAM,QAAQ,GAAG,KAAK,CAAC,KAAK,CAAC,KAAK,CAAC,KAAK,CAAC,MAAM,GAAG,CAAC,CAAY,CAAC;QAChE,MAAM,eAAe,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC;QAEnE,OAAO,CACL,eAAe,CAAC,QAAQ,KAAK,SAAS;YACtC,eAAe,CAAC,MAAM,4BAAkB;YACxC,IAAI,CAAC,QAAQ,CAAC,QAAQ,CAAC,eAAe,CAAC,QAAQ,CAAC,CACjD,CAAC;IACJ,CAAC;IAEO,iDAAiD,CACvD,KAA6B,EAC7B,IAAiB;QAEjB,MAAM,eAAe,GAAG,+BAA+B,CACrD,KAAK,CAAC,QAAQ,EACd,IAAI,CAAC,QAAQ,CACd,CAAC;QACF,IAAA,+BAAsB,EACpB,eAAe,KAAK,SAAS,EAC7B,yCAAyC,CAC1C,CAAC;QAEF,OAAO;YACL,IAAI,0CAAkC;YACtC,eAAe;YACf,OAAO,EAAE,IAAI,wBAAU,CAAC,KAAK,CAAC,UAAU,CAAC;YACzC,oBAAoB,EAAE,IAAI,CAAC,MAAM,6BAAmB;SACrD,CAAC;IACJ,CAAC;IAEO,qEAAqE,CAC3E,KAA6B,EAC7B,IAAiB;QAEjB,MAAM,eAAe,GAAG,+BAA+B,CACrD,KAAK,CAAC,QAAQ,EACd,IAAI,CAAC,QAAQ,CACd,CAAC;QAEF,OAAO;YACL,IAAI,+DAAsD;YAC1D,eAAe;SAChB,CAAC;IACJ,CAAC;IAEO,gDAAgD,CACtD,KAA6B,EAC7B,IAAiB,EACjB,SAAiB;QAEjB,MAAM,mBAAmB,GAAG,IAAI,CAAC,uBAAuB,CAAC,KAAK,CAAC,CAAC;QAChE,OAAO;YACL,IAAI,yCAAiC;YACrC,eAAe,EACb,+BAA+B,CAAC,KAAK,CAAC,QAAQ,EAAE,IAAI,CAAC,QAAQ,CAAC;gBAC9D,mBAAmB;YACrB,SAAS;SACV,CAAC;IACJ,CAAC;IAEO,sDAAsD,CAC5D,KAA6B,EAC7B,IAAiB,EACjB,OAAe;QAEf,MAAM,mBAAmB,GAAG,IAAI,CAAC,uBAAuB,CAAC,KAAK,CAAC,CAAC;QAEhE,IAAA,+BAAsB,EACpB,mBAAmB,KAAK,SAAS,EACjC,8CAA8C,CAC/C,CAAC;QAEF,OAAO;YACL,IAAI,0CAAkC;YACtC,eAAe,EACb,+BAA+B,CAAC,KAAK,CAAC,QAAQ,EAAE,IAAI,CAAC,QAAQ,CAAC;gBAC9D,mBAAmB;YACrB,OAAO;SACR,CAAC;IACJ,CAAC;IAEO,+BAA+B,CAAC,KAA6B;QACnE,IAAI,KAAK,CAAC,KAAK,CAAC,MAAM,KAAK,CAAC,EAAE;YAC5B,OAAO,KAAK,CAAC;SACd;QAED,MAAM,QAAQ,GAAG,KAAK,CAAC,KAAK,CAAC,KAAK,CAAC,KAAK,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC;QACrD,IAAI,CAAC,IAAA,yBAAS,EAAC,QAAQ,CAAC,EAAE;YACxB,OAAO,KAAK,CAAC;SACd;QAED,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC;QAE5D,OAAO,CACL,gBAAM,CAAC,SAAS,CACd,KAAK,CAAC,QAAQ,CAAC,eAAe,EAC9B,IAAI,wCAAwC,EAAE,CAC/C,IAAI,QAAQ,CAAC,MAAM,4BAAkB,CACvC,CAAC;IACJ,CAAC;IAED,mDAAmD;IACnD,kEAAkE;IAC1D,mDAAmD,CACzD,KAA8B;QAE9B,IAAI,WAAW,GACb,IAAI,CAAC,mDAAmD,CAAC,KAAK,CAAC,CAAC;QAElE,IACE,WAAW,KAAK,SAAS;YACzB,WAAW,CAAC,eAAe,KAAK,SAAS,EACzC;YACA,IACE,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,OAAO,KAAK,SAAS;gBAC7C,KAAK,CAAC,QAAQ,CAAC,MAAM,GAAG,CAAC,EACzB;gBACA,IAAI,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,QAAQ,KAAK,SAAS,EAAE;oBAClD,6BAA6B;oBAC7B,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,QAAQ,CAAC,QAAQ,CAAC;oBAC3D,WAAW,GAAG;wBACZ,IAAI,+DAAsD;wBAC1D,eAAe,EAAE;4BACf,QAAQ,EAAE,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI;4BACtC,QAAQ,EAAE,6CAAsB;4BAChC,UAAU,EAAE,QAAQ,CAAC,IAAI,CAAC,UAAU;4BACpC,aAAa,EAAE,QAAQ,CAAC,IAAI,CAAC,OAAO;4BACpC,IAAI,EAAE,QAAQ,CAAC,qBAAqB,EAAE;4BACtC,KAAK,EAAE,CAAC,QAAQ,CAAC,MAAM,EAAE,QAAQ,CAAC,MAAM,GAAG,QAAQ,CAAC,MAAM,CAAC;yBAC5D;qBACF,CAAC;oBAEF,IAAI,CAAC,6BAA6B,CAAC,WAAW,CAAC,CAAC;iBACjD;aACF;iBAAM;gBACL,qCAAqC;gBACrC,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,OAAO,CAAC,QAAQ,CAAC;gBAC1D,WAAW,GAAG;oBACZ,IAAI,+DAAsD;oBAC1D,eAAe,EAAE;wBACf,QAAQ,EAAE,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI;wBACtC,QAAQ,EAAE,4CAAqB;wBAC/B,UAAU,EAAE,QAAQ,CAAC,IAAI,CAAC,UAAU;wBACpC,aAAa,EAAE,QAAQ,CAAC,IAAI,CAAC,OAAO;wBACpC,IAAI,EAAE,QAAQ,CAAC,qBAAqB,EAAE;wBACtC,KAAK,EAAE,CAAC,QAAQ,CAAC,MAAM,EAAE,QAAQ,CAAC,MAAM,GAAG,QAAQ,CAAC,MAAM,CAAC;qBAC5D;iBACF,CAAC;gBAEF,IAAI,CAAC,6BAA6B,CAAC,WAAW,CAAC,CAAC;aACjD;SACF;QACD,OAAO,WAAW,CAAC;IACrB,CAAC;IAEO,iDAAiD,CACvD,KAA8B;QAE9B,OAAO;YACL,IAAI,oDAA2C;YAC/C,eAAe,EACb,IAAI,CAAC,+CAA+C,CAAC,KAAK,CAAC;SAC9D,CAAC;IACJ,CAAC;IAEO,gCAAgC,CACtC,KAA6B;QAE7B,oFAAoF;QACpF,2EAA2E;QAE3E,MAAM,SAAS,GAAG,IAAI,CAAC,6CAA6C,CAAC,KAAK,CAAC,CAAC;QAC5E,IAAI,SAAS,KAAK,SAAS,IAAI,SAAS,KAAK,CAAC,EAAE;YAC9C,OAAO,KAAK,CAAC;SACd;QAED,MAAM,QAAQ,GAAG,KAAK,CAAC,KAAK,CAAC,SAAS,CAAY,CAAC,CAAC,8BAA8B;QAClF,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC;QAC5D,IAAI,QAAQ,CAAC,MAAM,2BAAkB,EAAE;YACrC,OAAO,KAAK,CAAC;SACd;QAED,MAAM,QAAQ,GAAG,KAAK,CAAC,KAAK,CAAC,SAAS,GAAG,CAAC,CAAY,CAAC,CAAC,8BAA8B;QACtF,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC;QAC5D,OAAO,QAAQ,CAAC,MAAM,gCAAuB,CAAC;IAChD,CAAC;IAEO,mDAAmD,CACzD,KAA6B;QAE7B,oEAAoE;QACpE,0BAA0B;QAC1B,MAAM,QAAQ,GAAG,IAAI,CAAC,oCAAoC,CAAC,KAAK,CAAC,CAAC;QAClE,MAAM,QAAQ,GAAG,KAAK,CAAC,KAAK,CAAC,KAAK,CAAC,KAAK,CAAC,MAAM,GAAG,CAAC,CAAY,CAAC;QAChE,MAAM,UAAU,GAAG,QAAQ,CAAC,EAAE,GAAG,CAAC,CAAC;QACnC,MAAM,WAAW,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,UAAU,CAAC,CAAC;QAE9D,IAAI,WAAW,EAAE;YACf,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,UAAU,CAAC,CAAC;YAC3D,MAAM,OAAO,GAAG,QAAQ,EAAE,QAAQ,CAAC;YACnC,MAAM,OAAO,GAAG,QAAQ,CAAC,QAAQ,CAAC;YAClC,MAAM,QAAQ,GAAG,OAAO,EAAE,qBAAqB,EAAE,CAAC;YAClD,MAAM,QAAQ,GAAG,OAAO,EAAE,qBAAqB,EAAE,CAAC;YAElD,gEAAgE;YAChE,8DAA8D;YAC9D,gEAAgE;YAChE,qDAAqD;YACrD,IACE,QAAQ,KAAK,SAAS;gBACtB,OAAO,KAAK,SAAS;gBACrB,OAAO,KAAK,SAAS;gBACrB,OAAO,CAAC,MAAM,CAAC,OAAO,CAAC,EACvB;gBACA,OAAO,IAAI,CAAC,qEAAqE,CAC/E,KAAK,EACL,QAAQ,CACT,CAAC;aACH;YAED,IAAI,WAAkE,CAAC;YAEvE,mEAAmE;YACnE,wEAAwE;YACxE,IAAI,QAAQ,KAAK,SAAS,IAAI,QAAQ,KAAK,SAAS,EAAE;gBACpD,WAAW;oBACT,IAAI,CAAC,qEAAqE,CACxE,KAAK,EACL,QAAQ,CACT,CAAC;aACL;iBAAM,IAAI,QAAQ,KAAK,SAAS,EAAE;gBACjC,WAAW;oBACT,IAAI,CAAC,qEAAqE,CACxE,KAAK,EACL,QAAQ,CACT,CAAC;aACL;YAED,IAAI,WAAW,KAAK,SAAS,EAAE;gBAC7B,IAAI,CAAC,6BAA6B,CAAC,WAAW,CAAC,CAAC;aACjD;YAED,OAAO,WAAW,CAAC;SACpB;QAED,IAAI,IAAA,6BAAa,EAAC,KAAK,CAAC,IAAI,QAAQ,KAAK,SAAS,EAAE;YAClD,qEAAqE;YACrE,wEAAwE;YACxE,kCAAkC;YAClC,MAAM,sBAAsB,GAC1B,IAAI,CAAC,qEAAqE,CACxE,KAAK,EACL,QAAQ,CACT,CAAC;YAEJ,+DAA+D;YAC/D,mDAAmD;YACnD,IAAI,sBAAsB,CAAC,eAAe,KAAK,SAAS,EAAE;gBACxD,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,QAAQ,CAAC;gBAClD,MAAM,sBAAsB,GAAoB;oBAC9C,QAAQ,EAAE,gDAAyB;oBACnC,QAAQ,EAAE,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI;oBACtC,UAAU,EAAE,QAAQ,CAAC,IAAI,CAAC,UAAU;oBACpC,aAAa,EAAE,QAAQ,CAAC,IAAI,CAAC,OAAO;oBACpC,IAAI,EAAE,QAAQ,CAAC,qBAAqB,EAAE;oBACtC,KAAK,EAAE,CAAC,QAAQ,CAAC,MAAM,EAAE,QAAQ,CAAC,MAAM,GAAG,QAAQ,CAAC,MAAM,CAAC;iBAC5D,CAAC;gBAEF,IAAI,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,mBAAmB,KAAK,SAAS,EAAE;oBAC7D,sBAAsB,CAAC,IAAI;wBACzB,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,mBAAmB,CAAC,QAAQ,CAAC,qBAAqB,EAAE,CAAC;iBAChF;gBAED,sBAAsB,CAAC,eAAe,GAAG,sBAAsB,CAAC;aACjE;iBAAM;gBACL,IAAI,CAAC,6BAA6B,CAAC,sBAAsB,CAAC,CAAC;aAC5D;YAED,OAAO,sBAAsB,CAAC;SAC/B;QAED,IAAI,QAAQ,KAAK,SAAS,EAAE;YAC1B,mEAAmE;YACnE,yDAAyD;YACzD,kEAAkE;YAClE,aAAa;YACb,MAAM,4BAA4B,GAChC,IAAI,CAAC,qEAAqE,CACxE,KAAK,EACL,QAAQ,CACT,CAAC;YAEJ,IAAI,4BAA4B,CAAC,eAAe,KAAK,SAAS,EAAE;gBAC9D,IAAI,CAAC,6BAA6B,CAAC,4BAA4B,CAAC,CAAC;aAClE;YACD,OAAO,4BAA4B,CAAC;SACrC;IACH,CAAC;IAEO,wBAAwB,CAAC,KAAgC;QAC/D,OAAO,KAAK,CAAC,IAAI,CAAC,IAAI,8CAAsC,CAAC;IAC/D,CAAC;IAEO,6BAA6B,CACnC,WAAsD;QAEtD,IAAI,WAAW,CAAC,eAAe,KAAK,SAAS,EAAE;YAC7C,OAAO;SACR;QAED,MAAM,KAAK,GAAG,WAAW,CAAC,eAAe,CAAC,aAAa,CAAC,KAAK,CAAC,IAAI,CAAC,CAAC;QAEpE,MAAM,WAAW,GAAG,KAAK,CAAC,WAAW,CAAC,eAAe,CAAC,IAAI,GAAG,CAAC,CAAC,CAAC;QAEhE,IAAI,WAAW,CAAC,QAAQ,CAAC,SAAS,CAAC,IAAI,WAAW,CAAC,QAAQ,CAAC,QAAQ,CAAC,EAAE;YACrE,OAAO;SACR;QAED,MAAM,SAAS,GAAG,KAAK,CAAC,KAAK,CAAC,WAAW,CAAC,eAAe,CAAC,IAAI,CAAC,CAAC;QAChE,MAAM,iBAAiB,GAAG,SAAS,CAAC,SAAS,CAAC,CAAC,CAAC,EAAE,EAAE,CAAC,CAAC,CAAC,IAAI,EAAE,KAAK,EAAE,CAAC,CAAC;QAEtE,IAAI,iBAAiB,KAAK,CAAC,CAAC,EAAE;YAC5B,OAAO;SACR;QAED,MAAM,QAAQ,GAAG,SAAS,CAAC,iBAAiB,CAAC,CAAC;QAE9C,IAAI,QAAQ,CAAC,QAAQ,CAAC,SAAS,CAAC,IAAI,QAAQ,CAAC,QAAQ,CAAC,QAAQ,CAAC,EAAE;YAC/D,WAAW,CAAC,eAAe,CAAC,IAAI,IAAI,CAAC,GAAG,iBAAiB,CAAC;SAC3D;IACH,CAAC;IAEO,6CAA6C,CACnD,KAA6B;QAE7B,KAAK,IAAI,CAAC,GAAG,KAAK,CAAC,KAAK,CAAC,MAAM,GAAG,CAAC,EAAE,CAAC,IAAI,CAAC,EAAE,CAAC,EAAE,EAAE;YAChD,MAAM,IAAI,GAAG,KAAK,CAAC,KAAK,CAAC,CAAC,CAAC,CAAC;YAE5B,IAAI,CAAC,IAAA,yBAAS,EAAC,IAAI,CAAC,EAAE;gBACpB,OAAO,SAAS,CAAC;aAClB;YAED,MAAM,IAAI,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,IAAI,CAAC,EAAE,CAAC,CAAC;YAEpD,IAAI,IAAI,CAAC,QAAQ,KAAK,SAAS,EAAE;gBAC/B,OAAO,CAAC,CAAC;aACV;SACF;QAED,OAAO,SAAS,CAAC;IACnB,CAAC;IAEO,oCAAoC,CAC1C,KAA6B;QAE7B,MAAM,iBAAiB,GACrB,IAAI,CAAC,6CAA6C,CAAC,KAAK,CAAC,CAAC;QAE5D,IAAI,iBAAiB,KAAK,SAAS,EAAE;YACnC,OAAO,SAAS,CAAC;SAClB;QAED,MAAM,gBAAgB,GAAG,KAAK,CAAC,KAAK,CAAC,iBAAiB,CAAC,CAAC;QACxD,IAAI,IAAA,yBAAS,EAAC,gBAAgB,CAAC,EAAE;YAC/B,MAAM,2BAA2B,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAC/D,gBAAgB,CAAC,EAAE,CACpB,CAAC;YACF,OAAO,2BAA2B,CAAC;SACpC;QAED,OAAO,SAAS,CAAC;IACnB,CAAC;IAEO,oDAAoD,CAC1D,QAAkB,EAClB,QAAqB;QAErB,MAAM,eAAe,GAAG,+BAA+B,CACrD,QAAQ,EACR,QAAQ,CAAC,QAAQ,CAClB,CAAC;QACF,IAAA,+BAAsB,EACpB,eAAe,KAAK,SAAS,EAC7B,yCAAyC,CAC1C,CAAC;QAEF,qCAAqC;QACrC,OAAO;YACL,IAAI,gDAAuC;YAC3C,eAAe;SAChB,CAAC;IACJ,CAAC;IAEO,gCAAgC,CACtC,KAA6B,EAC7B,iBAAgC;QAEhC,uFAAuF;QACvF,IAAI,iBAAiB,CAAC,MAAM,GAAG,CAAC,EAAE;YAChC,OAAO,qCAAqC,CAC1C,KAAK,CAAC,QAAQ,EACd,iBAAiB,CAAC,iBAAiB,CAAC,MAAM,GAAG,CAAC,CAAC,CAChD,CAAC;SACH;QAED,4FAA4F;QAC5F,uDAAuD;QACvD,IAAI,CAAC,IAAA,oCAAoB,EAAC,KAAK,CAAC,EAAE;YAChC,MAAM,IAAI,KAAK,CACb,oGAAoG,CACrG,CAAC;SACH;QAED,wDAAwD;QACxD,OAAO;YACL,IAAI,6CAAqC;YACzC,eAAe,EAAE,IAAI,CAAC,mCAAmC,CAAC,KAAK,CAAC;YAChE,YAAY,0CAAkC;SAC/C,CAAC;IACJ,CAAC;IAEO,oBAAoB,CAC1B,KAA6B,EAC7B,qBAA6B;QAE7B,MAAM,QAAQ,GAAG,KAAK,CAAC,KAAK,CAAC,KAAK,CAAC,KAAK,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC;QACrD,IAAI,CAAC,IAAA,yBAAS,EAAC,QAAQ,CAAC,EAAE;YACxB,OAAO,KAAK,CAAC;SACd;QAED,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC;QAC5D,IAAI,QAAQ,CAAC,MAAM,4BAAkB,EAAE;YACrC,OAAO,KAAK,CAAC;SACd;QAED,MAAM,cAAc,GAAG,KAAK,CAAC,KAAK,CAAC,qBAAqB,GAAG,CAAC,CAAY,CAAC;QACzE,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,cAAc,CAAC,EAAE,CAAC,CAAC;QAElE,8CAA8C;QAC9C,IAAA,+BAAsB,EACpB,QAAQ,CAAC,QAAQ,KAAK,SAAS,EAC/B,kDAAkD,CACnD,CAAC;QAEF,OAAO,IAAI,CAAC,eAAe,CACzB,KAAK,EACL,qBAAqB,GAAG,CAAC,EACzB,QAAQ,CAAC,QAAQ,CAClB,CAAC;IACJ,CAAC;IAEO,kBAAkB,CACxB,KAA6B,EAC7B,SAAiB,EACjB,eAA4B;QAE5B,MAAM,YAAY,GAAG,eAAe,CAAC,QAAQ,CAAC;QAE9C,8CAA8C;QAC9C,IAAA,+BAAsB,EACpB,YAAY,KAAK,SAAS,EAC1B,sCAAsC,CACvC,CAAC;QAEF,OAAO,IAAI,CAAC,eAAe,CAAC,KAAK,EAAE,SAAS,EAAE,YAAY,CAAC,CAAC;IAC9D,CAAC;IAEO,eAAe,CACrB,KAA6B,EAC7B,QAAgB,EAChB,QAAwB;QAExB,KAAK,IAAI,CAAC,GAAG,QAAQ,EAAE,CAAC,GAAG,KAAK,CAAC,KAAK,CAAC,MAAM,EAAE,CAAC,EAAE,EAAE;YAClD,MAAM,IAAI,GAAG,KAAK,CAAC,KAAK,CAAC,CAAC,CAAC,CAAC;YAE5B,IAAI,CAAC,IAAA,yBAAS,EAAC,IAAI,CAAC,EAAE;gBACpB,OAAO,KAAK,CAAC;aACd;YAED,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,IAAI,CAAC,EAAE,CAAC,CAAC;YAExD,IAAI,QAAQ,CAAC,QAAQ,KAAK,SAAS,EAAE;gBACnC,SAAS;aACV;YAED,IAAI,CAAC,QAAQ,CAAC,MAAM,CAAC,QAAQ,CAAC,QAAQ,CAAC,EAAE;gBACvC,OAAO,KAAK,CAAC;aACd;SACF;QAED,OAAO,IAAI,CAAC;IACd,CAAC;IAEO,0BAA0B,CAChC,KAA6B,EAC7B,qBAA6B;QAE7B,MAAM,IAAI,GAAG,KAAK,CAAC,KAAK,CAAC,qBAAqB,CAAiB,CAAC;QAEhE,IAAI,CAAC,IAAA,6BAAW,EAAC,KAAK,CAAC,UAAU,EAAE,IAAI,CAAC,UAAU,CAAC,EAAE;YACnD,OAAO,KAAK,CAAC;SACd;QAED,IACE,KAAK,CAAC,IAAI,CAAC,IAAI,gCAAwB;YACvC,IAAI,CAAC,IAAI,CAAC,IAAI,gCAAwB,EACtC;YACA,OAAO,IAAI,CAAC;SACb;QAED,yEAAyE;QACzE,sBAAsB;QACtB,IAAI,KAAK,CAAC,UAAU,CAAC,MAAM,GAAG,CAAC,EAAE;YAC/B,OAAO,IAAI,CAAC;SACb;QAED,OAAO,IAAI,CAAC,oBAAoB,CAAC,KAAK,EAAE,qBAAqB,CAAC,CAAC;IACjE,CAAC;IAEO,uBAAuB,CAC7B,KAA6B,EAC7B,qBAA6B;QAE7B,IAAI,CAAC,IAAA,kCAAkB,EAAC,KAAK,CAAC,EAAE;YAC9B,OAAO,KAAK,CAAC;SACd;QAED,MAAM,QAAQ,GAAG,KAAK,CAAC,KAAK,CAAC,qBAAqB,GAAG,CAAC,CAAC,CAAC;QACxD,IAAI,CAAC,IAAA,yBAAS,EAAC,QAAQ,CAAC,EAAE;YACxB,OAAO,KAAK,CAAC;SACd;QAED,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC;QAC5D,IAAI,QAAQ,CAAC,MAAM,kCAAwB,EAAE;YAC3C,OAAO,KAAK,CAAC;SACd;QAED,MAAM,QAAQ,GAAG,KAAK,CAAC,KAAK,CAAC,qBAAqB,CAAC,CAAC;QACpD,IAAI,IAAA,yBAAS,EAAC,QAAQ,CAAC,EAAE;YACvB,OAAO,KAAK,CAAC;SACd;QAED,IAAI,IAAA,iCAAiB,EAAC,QAAQ,CAAC,EAAE;YAC/B,OAAO,KAAK,CAAC;SACd;QAED,iFAAiF;QACjF,IAAI,QAAQ,CAAC,QAAQ,KAAK,SAAS,EAAE;YACnC,OAAO,KAAK,CAAC;SACd;QAED,IAAI,QAAQ,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI,iCAAyB,EAAE;YAC5D,OAAO,KAAK,CAAC;SACd;QAED,IAAI,CAAC,IAAA,6BAAW,EAAC,KAAK,CAAC,UAAU,EAAE,QAAQ,CAAC,UAAU,CAAC,EAAE;YACvD,OAAO,KAAK,CAAC;SACd;QAED,KAAK,IAAI,CAAC,GAAG,qBAAqB,GAAG,CAAC,EAAE,CAAC,GAAG,KAAK,CAAC,KAAK,CAAC,MAAM,EAAE,CAAC,EAAE,EAAE;YACnE,MAAM,IAAI,GAAG,KAAK,CAAC,KAAK,CAAC,CAAC,CAAC,CAAC;YAC5B,IAAI,CAAC,IAAA,yBAAS,EAAC,IAAI,CAAC,EAAE;gBACpB,OAAO,KAAK,CAAC;aACd;YAED,MAAM,IAAI,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,IAAI,CAAC,EAAE,CAAC,CAAC;YAEpD,kFAAkF;YAClF,IAAI,IAAI,CAAC,QAAQ,KAAK,SAAS,EAAE;gBAC/B,OAAO,KAAK,CAAC;aACd;YAED,IACE,IAAI,CAAC,QAAQ,mCAA2B;gBACxC,IAAI,CAAC,QAAQ,oCAA4B,EACzC;gBACA,OAAO,KAAK,CAAC;aACd;SACF;QAED,MAAM,QAAQ,GAAG,KAAK,CAAC,KAAK,CAAC,KAAK,CAAC,KAAK,CAAC,MAAM,GAAG,CAAC,CAAY,CAAC;QAChE,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC;QAE5D,OAAO,QAAQ,CAAC,MAAM,4BAAkB,CAAC;IAC3C,CAAC;IAEO,+BAA+B,CACrC,KAA6B,EAC7B,aAAqB;QAErB,IAAI,KAAK,CAAC,UAAU,CAAC,MAAM,GAAG,CAAC,EAAE;YAC/B,OAAO,KAAK,CAAC;SACd;QAED,IAAI,KAAK,CAAC,IAAI,CAAC,IAAI,4BAAoB,EAAE;YACvC,OAAO,KAAK,CAAC;SACd;QAED,MAAM,IAAI,GAAG,KAAK,CAAC,KAAK,CAAC,aAAa,CAAiB,CAAC;QACxD,IAAI,IAAI,CAAC,IAAI,CAAC,IAAI,gCAAwB,EAAE;YAC1C,OAAO,KAAK,CAAC;SACd;QAED,OAAO,IAAI,CAAC,oBAAoB,CAAC,KAAK,EAAE,aAAa,CAAC,CAAC;IACzD,CAAC;IAEO,kBAAkB,CAAC,UAAsB;QAC/C,OAAO,IAAI,wBAAU,CAAC,UAAU,CAAC,CAAC,iBAAiB,EAAE,CAAC;IACxD,CAAC;CACF;AArpDD,sCAqpDC;AAED,SAAgB,qCAAqC,CACnD,QAAkB,EAClB,IAAiB;IAEjB,wEAAwE;IACxE,2EAA2E;IAC3E,WAAW;IACX,IAAI,IAAI,CAAC,QAAQ,KAAK,SAAS,EAAE;QAC/B,MAAM,QAAQ,GAAG,QAAQ,CAAC,QAAQ,CAAC,QAAQ,CAAC;QAC5C,OAAO;YACL,IAAI,gEAAuD;YAC3D,EAAE,EAAE,IAAI,CAAC,EAAE;YACX,eAAe,EAAE;gBACf,UAAU,EAAE,QAAQ,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI,CAAC,UAAU;gBACtD,aAAa,EAAE,QAAQ,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI,CAAC,OAAO;gBACtD,QAAQ,EAAE,QAAQ,CAAC,QAAQ,CAAC,IAAI;gBAChC,QAAQ,EAAE,SAAS;gBACnB,IAAI,EAAE,QAAQ,CAAC,QAAQ,CAAC,QAAQ,CAAC,qBAAqB,EAAE;gBACxD,KAAK,EAAE,CAAC,QAAQ,CAAC,MAAM,EAAE,QAAQ,CAAC,MAAM,GAAG,QAAQ,CAAC,MAAM,CAAC;aAC5D;SACF,CAAC;KACH;IAED,MAAM,IAAI,GAAG,IAAI,CAAC,QAAQ,EAAE,qBAAqB,EAAE,CAAC;IAEpD,IAAI,IAAI,KAAK,SAAS,EAAE;QACtB,MAAM,eAAe,GAAG,+BAA+B,CACrD,QAAQ,EACR,IAAI,CAAC,QAAQ,CACd,CAAC;QACF,IAAA,+BAAsB,EACpB,eAAe,KAAK,SAAS,EAC7B,yCAAyC,CAC1C,CAAC;QAEF,OAAO;YACL,IAAI,6CAAqC;YACzC,eAAe;YACf,YAAY,EAAE,IAAI,CAAC,IAAI;SACxB,CAAC;KACH;IAED,IAAA,+BAAsB,EACpB,IAAI,CAAC,QAAQ,KAAK,SAAS,EAC3B,6CAA6C,CAC9C,CAAC;IAEF,OAAO;QACL,IAAI,6CAAqC;QACzC,eAAe,EAAE;YACf,QAAQ,EAAE,SAAS;YACnB,QAAQ,EAAE,QAAQ,CAAC,QAAQ,CAAC,IAAI;YAChC,UAAU,EAAE,IAAI,CAAC,QAAQ,CAAC,IAAI,CAAC,UAAU;YACzC,aAAa,EAAE,IAAI,CAAC,QAAQ,CAAC,IAAI,CAAC,OAAO;YACzC,IAAI,EAAE,IAAI,CAAC,QAAQ,CAAC,qBAAqB,EAAE;YAC3C,KAAK,EAAE;gBACL,IAAI,CAAC,QAAQ,CAAC,MAAM;gBACpB,IAAI,CAAC,QAAQ,CAAC,MAAM,GAAG,IAAI,CAAC,QAAQ,CAAC,MAAM;aAC5C;SACF;QACD,YAAY,uCAA+B;KAC5C,CAAC;AACJ,CAAC;AA9DD,sFA8DC;AAED,SAAS,+BAA+B,CACtC,QAAkB,EAClB,QAAyB;IAEzB,IAAI,QAAQ,KAAK,SAAS,EAAE;QAC1B,OAAO,SAAS,CAAC;KAClB;IAED,MAAM,IAAI,GAAG,QAAQ,CAAC,qBAAqB,EAAE,CAAC;IAE9C,IAAI,IAAI,KAAK,SAAS,EAAE;QACtB,OAAO,SAAS,CAAC;KAClB;IAED,IAAI,QAAQ,GAAG,IAAI,CAAC,IAAI,CAAC;IAEzB,IAAI,IAAI,CAAC,IAAI,6CAAqC,EAAE;QAClD,QAAQ,GAAG,gDAAyB,CAAC;KACtC;SAAM,IAAI,IAAI,CAAC,IAAI,0CAAkC,EAAE;QACtD,QAAQ,GAAG,6CAAsB,CAAC;KACnC;SAAM,IAAI,IAAI,CAAC,IAAI,yCAAiC,EAAE;QACrD,QAAQ,GAAG,4CAAqB,CAAC;KAClC;IAED,OAAO;QACL,QAAQ,EAAE,QAAQ;QAClB,QAAQ,EACN,IAAI,CAAC,IAAI,+CAAuC;YAC9C,CAAC,CAAC,SAAS;YACX,CAAC,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI;QAC5B,UAAU,EAAE,IAAI,CAAC,QAAQ,CAAC,IAAI,CAAC,UAAU;QACzC,aAAa,EAAE,IAAI,CAAC,QAAQ,CAAC,IAAI,CAAC,OAAO;QACzC,IAAI,EAAE,QAAQ,CAAC,qBAAqB,EAAE;QACtC,KAAK,EAAE,CAAC,QAAQ,CAAC,MAAM,EAAE,QAAQ,CAAC,MAAM,GAAG,QAAQ,CAAC,MAAM,CAAC;KAC5D,CAAC;AACJ,CAAC"}
++{"version":3,"file":"error-inferrer.js","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/error-inferrer.ts"],"names":[],"mappings":""}
 \ No newline at end of file
 diff --git a/internal/hardhat-network/stack-traces/library-utils.d.ts b/internal/hardhat-network/stack-traces/library-utils.d.ts
 index 276b7c9d5556f1d7f62ddb07330bfb47f9dfaed8..39203ae37a9b40e9b87695d3edac78aab5602afe 100644
@@ -1748,98 +2437,175 @@ index 20ac80eaddd2143758710ce259d5d7884abceaf5..6d25b62e5639cd34c35adcae5219b681
 \ No newline at end of file
 +{"version":3,"file":"library-utils.js","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/library-utils.ts"],"names":[],"mappings":";;;AAAA,8CAA6D;AAEpD,sGAFA,2BAAqB,OAEA"}
 \ No newline at end of file
+diff --git a/internal/hardhat-network/stack-traces/mapped-inlined-internal-functions-heuristics.d.ts b/internal/hardhat-network/stack-traces/mapped-inlined-internal-functions-heuristics.d.ts
+index fdde317a3ffe13c19f352b6a4f422fd0e0d33db4..1e4a964378e177d48b6b24e74f077f53fe8d8d64 100644
+--- a/internal/hardhat-network/stack-traces/mapped-inlined-internal-functions-heuristics.d.ts
++++ b/internal/hardhat-network/stack-traces/mapped-inlined-internal-functions-heuristics.d.ts
+@@ -1,24 +1 @@
+-/**
+- * This file includes Solidity tracing heuristics for solc starting with version
+- * 0.6.9.
+- *
+- * This solc version introduced a significant change to how sourcemaps are
+- * handled for inline yul/internal functions. These were mapped to the
+- * unmapped/-1 file before, which lead to many unmapped reverts. Now, they are
+- * mapped to the part of the Solidity source that lead to their inlining.
+- *
+- * This change is a very positive change, as errors would point to the correct
+- * line by default. The only problem is that we used to rely very heavily on
+- * unmapped reverts to decide when our error detection heuristics were to be
+- * run. In fact, this heuristics were first introduced because of unmapped
+- * reverts.
+- *
+- * Instead of synthetically completing stack traces when unmapped reverts occur,
+- * we now start from complete stack traces and adjust them if we can provide
+- * more meaningful errors.
+- */
+-import { DecodedEvmMessageTrace } from "./message-trace";
+-import { SolidityStackTrace } from "./solidity-stack-trace";
+-export declare function stackTraceMayRequireAdjustments(stackTrace: SolidityStackTrace, decodedTrace: DecodedEvmMessageTrace): boolean;
+-export declare function adjustStackTrace(stackTrace: SolidityStackTrace, decodedTrace: DecodedEvmMessageTrace): SolidityStackTrace;
+ //# sourceMappingURL=mapped-inlined-internal-functions-heuristics.d.ts.map
+\ No newline at end of file
+diff --git a/internal/hardhat-network/stack-traces/mapped-inlined-internal-functions-heuristics.d.ts.map b/internal/hardhat-network/stack-traces/mapped-inlined-internal-functions-heuristics.d.ts.map
+index 73423597f1d64209a394c4aff597b8e96cb588fd..826865bc869bea0e406c7ff6b87ea9813f334ff8 100644
+--- a/internal/hardhat-network/stack-traces/mapped-inlined-internal-functions-heuristics.d.ts.map
++++ b/internal/hardhat-network/stack-traces/mapped-inlined-internal-functions-heuristics.d.ts.map
+@@ -1 +1 @@
+-{"version":3,"file":"mapped-inlined-internal-functions-heuristics.d.ts","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/mapped-inlined-internal-functions-heuristics.ts"],"names":[],"mappings":"AAAA;;;;;;;;;;;;;;;;;;GAkBG;AAIH,OAAO,EACL,sBAAsB,EAIvB,MAAM,iBAAiB,CAAC;AAEzB,OAAO,EACL,kBAAkB,EAEnB,MAAM,wBAAwB,CAAC;AAIhC,wBAAgB,+BAA+B,CAC7C,UAAU,EAAE,kBAAkB,EAC9B,YAAY,EAAE,sBAAsB,GACnC,OAAO,CAgBT;AAED,wBAAgB,gBAAgB,CAC9B,UAAU,EAAE,kBAAkB,EAC9B,YAAY,EAAE,sBAAsB,GACnC,kBAAkB,CAmCpB"}
+\ No newline at end of file
++{"version":3,"file":"mapped-inlined-internal-functions-heuristics.d.ts","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/mapped-inlined-internal-functions-heuristics.ts"],"names":[],"mappings":""}
+\ No newline at end of file
 diff --git a/internal/hardhat-network/stack-traces/mapped-inlined-internal-functions-heuristics.js b/internal/hardhat-network/stack-traces/mapped-inlined-internal-functions-heuristics.js
-index 8783fd3bc38c59336b3e40ec8df9ea2bd31a53dd..d5701e7a323422dba8c449aaa5b5e6405c11d470 100644
+index 8783fd3bc38c59336b3e40ec8df9ea2bd31a53dd..33646d9e5c8e99d483287ed5bce54417e8161c56 100644
 --- a/internal/hardhat-network/stack-traces/mapped-inlined-internal-functions-heuristics.js
 +++ b/internal/hardhat-network/stack-traces/mapped-inlined-internal-functions-heuristics.js
-@@ -25,15 +25,13 @@ Object.defineProperty(exports, "__esModule", { value: true });
- exports.adjustStackTrace = exports.stackTraceMayRequireAdjustments = void 0;
- const semver_1 = __importDefault(require("semver"));
- const message_trace_1 = require("./message-trace");
+@@ -1,116 +1,2 @@
+ "use strict";
+-/**
+- * This file includes Solidity tracing heuristics for solc starting with version
+- * 0.6.9.
+- *
+- * This solc version introduced a significant change to how sourcemaps are
+- * handled for inline yul/internal functions. These were mapped to the
+- * unmapped/-1 file before, which lead to many unmapped reverts. Now, they are
+- * mapped to the part of the Solidity source that lead to their inlining.
+- *
+- * This change is a very positive change, as errors would point to the correct
+- * line by default. The only problem is that we used to rely very heavily on
+- * unmapped reverts to decide when our error detection heuristics were to be
+- * run. In fact, this heuristics were first introduced because of unmapped
+- * reverts.
+- *
+- * Instead of synthetically completing stack traces when unmapped reverts occur,
+- * we now start from complete stack traces and adjust them if we can provide
+- * more meaningful errors.
+- */
+-var __importDefault = (this && this.__importDefault) || function (mod) {
+-    return (mod && mod.__esModule) ? mod : { "default": mod };
+-};
+-Object.defineProperty(exports, "__esModule", { value: true });
+-exports.adjustStackTrace = exports.stackTraceMayRequireAdjustments = void 0;
+-const semver_1 = __importDefault(require("semver"));
+-const message_trace_1 = require("./message-trace");
 -const opcodes_1 = require("./opcodes");
 -const solidity_stack_trace_1 = require("./solidity-stack-trace");
- const FIRST_SOLC_VERSION_WITH_MAPPED_SMALL_INTERNAL_FUNCTIONS = "0.6.9";
- function stackTraceMayRequireAdjustments(stackTrace, decodedTrace) {
-     if (stackTrace.length === 0) {
-         return false;
-     }
-     const lastFrame = stackTrace[stackTrace.length - 1];
+-const FIRST_SOLC_VERSION_WITH_MAPPED_SMALL_INTERNAL_FUNCTIONS = "0.6.9";
+-function stackTraceMayRequireAdjustments(stackTrace, decodedTrace) {
+-    if (stackTrace.length === 0) {
+-        return false;
+-    }
+-    const lastFrame = stackTrace[stackTrace.length - 1];
 -    return (lastFrame.type === solidity_stack_trace_1.StackTraceEntryType.REVERT_ERROR &&
-+    return (lastFrame.type === 4 /* StackTraceEntryType.REVERT_ERROR */ &&
-         !lastFrame.isInvalidOpcodeError &&
-         lastFrame.message.isEmpty() &&
-         semver_1.default.gte(decodedTrace.bytecode.compilerVersion, FIRST_SOLC_VERSION_WITH_MAPPED_SMALL_INTERNAL_FUNCTIONS));
-@@ -46,7 +44,7 @@ function adjustStackTrace(stackTrace, decodedTrace) {
-         return [
-             ...start,
-             {
+-        !lastFrame.isInvalidOpcodeError &&
+-        lastFrame.message.isEmpty() &&
+-        semver_1.default.gte(decodedTrace.bytecode.compilerVersion, FIRST_SOLC_VERSION_WITH_MAPPED_SMALL_INTERNAL_FUNCTIONS));
+-}
+-exports.stackTraceMayRequireAdjustments = stackTraceMayRequireAdjustments;
+-function adjustStackTrace(stackTrace, decodedTrace) {
+-    const start = stackTrace.slice(0, -1);
+-    const [revert] = stackTrace.slice(-1);
+-    if (isNonContractAccountCalledError(decodedTrace)) {
+-        return [
+-            ...start,
+-            {
 -                type: solidity_stack_trace_1.StackTraceEntryType.NONCONTRACT_ACCOUNT_CALLED_ERROR,
-+                type: 14 /* StackTraceEntryType.NONCONTRACT_ACCOUNT_CALLED_ERROR */,
-                 sourceReference: revert.sourceReference,
-             },
-         ];
-@@ -55,7 +53,7 @@ function adjustStackTrace(stackTrace, decodedTrace) {
-         return [
-             ...start,
-             {
+-                sourceReference: revert.sourceReference,
+-            },
+-        ];
+-    }
+-    if (isConstructorInvalidParamsError(decodedTrace)) {
+-        return [
+-            ...start,
+-            {
 -                type: solidity_stack_trace_1.StackTraceEntryType.INVALID_PARAMS_ERROR,
-+                type: 8 /* StackTraceEntryType.INVALID_PARAMS_ERROR */,
-                 sourceReference: revert.sourceReference,
-             },
-         ];
-@@ -64,7 +62,7 @@ function adjustStackTrace(stackTrace, decodedTrace) {
-         return [
-             ...start,
-             {
+-                sourceReference: revert.sourceReference,
+-            },
+-        ];
+-    }
+-    if (isCallInvalidParamsError(decodedTrace)) {
+-        return [
+-            ...start,
+-            {
 -                type: solidity_stack_trace_1.StackTraceEntryType.INVALID_PARAMS_ERROR,
-+                type: 8 /* StackTraceEntryType.INVALID_PARAMS_ERROR */,
-                 sourceReference: revert.sourceReference,
-             },
-         ];
-@@ -74,26 +72,26 @@ function adjustStackTrace(stackTrace, decodedTrace) {
- exports.adjustStackTrace = adjustStackTrace;
- function isNonContractAccountCalledError(decodedTrace) {
-     return matchOpcodes(decodedTrace, -9, [
+-                sourceReference: revert.sourceReference,
+-            },
+-        ];
+-    }
+-    return stackTrace;
+-}
+-exports.adjustStackTrace = adjustStackTrace;
+-function isNonContractAccountCalledError(decodedTrace) {
+-    return matchOpcodes(decodedTrace, -9, [
 -        opcodes_1.Opcode.EXTCODESIZE,
 -        opcodes_1.Opcode.ISZERO,
 -        opcodes_1.Opcode.DUP1,
 -        opcodes_1.Opcode.ISZERO,
-+        59 /* Opcode.EXTCODESIZE */,
-+        21 /* Opcode.ISZERO */,
-+        128 /* Opcode.DUP1 */,
-+        21 /* Opcode.ISZERO */,
-     ]);
- }
- function isConstructorInvalidParamsError(decodedTrace) {
-     if (!(0, message_trace_1.isDecodedCreateTrace)(decodedTrace)) {
-         return false;
-     }
+-    ]);
+-}
+-function isConstructorInvalidParamsError(decodedTrace) {
+-    if (!(0, message_trace_1.isDecodedCreateTrace)(decodedTrace)) {
+-        return false;
+-    }
 -    return (matchOpcodes(decodedTrace, -20, [opcodes_1.Opcode.CODESIZE]) &&
 -        matchOpcodes(decodedTrace, -15, [opcodes_1.Opcode.CODECOPY]) &&
 -        matchOpcodes(decodedTrace, -7, [opcodes_1.Opcode.LT, opcodes_1.Opcode.ISZERO]));
-+    return (matchOpcodes(decodedTrace, -20, [56 /* Opcode.CODESIZE */]) &&
-+        matchOpcodes(decodedTrace, -15, [57 /* Opcode.CODECOPY */]) &&
-+        matchOpcodes(decodedTrace, -7, [16 /* Opcode.LT */, 21 /* Opcode.ISZERO */]));
- }
- function isCallInvalidParamsError(decodedTrace) {
-     if (!(0, message_trace_1.isDecodedCallTrace)(decodedTrace)) {
-         return false;
-     }
+-}
+-function isCallInvalidParamsError(decodedTrace) {
+-    if (!(0, message_trace_1.isDecodedCallTrace)(decodedTrace)) {
+-        return false;
+-    }
 -    return (matchOpcodes(decodedTrace, -11, [opcodes_1.Opcode.CALLDATASIZE]) &&
 -        matchOpcodes(decodedTrace, -7, [opcodes_1.Opcode.LT, opcodes_1.Opcode.ISZERO]));
-+    return (matchOpcodes(decodedTrace, -11, [54 /* Opcode.CALLDATASIZE */]) &&
-+        matchOpcodes(decodedTrace, -7, [16 /* Opcode.LT */, 21 /* Opcode.ISZERO */]));
- }
- function matchOpcode(decodedTrace, stepIndex, opcode) {
-     const [step] = decodedTrace.steps.slice(stepIndex, stepIndex + 1);
+-}
+-function matchOpcode(decodedTrace, stepIndex, opcode) {
+-    const [step] = decodedTrace.steps.slice(stepIndex, stepIndex + 1);
+-    if (step === undefined || !(0, message_trace_1.isEvmStep)(step)) {
+-        return false;
+-    }
+-    const instruction = decodedTrace.bytecode.getInstruction(step.pc);
+-    return instruction.opcode === opcode;
+-}
+-function matchOpcodes(decodedTrace, firstStepIndex, opcodes) {
+-    let index = firstStepIndex;
+-    for (const opcode of opcodes) {
+-        if (!matchOpcode(decodedTrace, index, opcode)) {
+-            return false;
+-        }
+-        index += 1;
+-    }
+-    return true;
+-}
+ //# sourceMappingURL=mapped-inlined-internal-functions-heuristics.js.map
+\ No newline at end of file
 diff --git a/internal/hardhat-network/stack-traces/mapped-inlined-internal-functions-heuristics.js.map b/internal/hardhat-network/stack-traces/mapped-inlined-internal-functions-heuristics.js.map
-index 832dcd0591d709d8a1ce313748cab6fcf1078b47..4491aba1101f2c7122ff8f94c5615b9ada86fc93 100644
+index 832dcd0591d709d8a1ce313748cab6fcf1078b47..bab1e7622a6625c106f0315dd45c052d6b2bade3 100644
 --- a/internal/hardhat-network/stack-traces/mapped-inlined-internal-functions-heuristics.js.map
 +++ b/internal/hardhat-network/stack-traces/mapped-inlined-internal-functions-heuristics.js.map
 @@ -1 +1 @@
 -{"version":3,"file":"mapped-inlined-internal-functions-heuristics.js","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/mapped-inlined-internal-functions-heuristics.ts"],"names":[],"mappings":";AAAA;;;;;;;;;;;;;;;;;;GAkBG;;;;;;AAEH,oDAA4B;AAE5B,mDAKyB;AACzB,uCAAmC;AACnC,iEAGgC;AAEhC,MAAM,uDAAuD,GAAG,OAAO,CAAC;AAExE,SAAgB,+BAA+B,CAC7C,UAA8B,EAC9B,YAAoC;IAEpC,IAAI,UAAU,CAAC,MAAM,KAAK,CAAC,EAAE;QAC3B,OAAO,KAAK,CAAC;KACd;IAED,MAAM,SAAS,GAAG,UAAU,CAAC,UAAU,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC;IAEpD,OAAO,CACL,SAAS,CAAC,IAAI,KAAK,0CAAmB,CAAC,YAAY;QACnD,CAAC,SAAS,CAAC,oBAAoB;QAC/B,SAAS,CAAC,OAAO,CAAC,OAAO,EAAE;QAC3B,gBAAM,CAAC,GAAG,CACR,YAAY,CAAC,QAAQ,CAAC,eAAe,EACrC,uDAAuD,CACxD,CACF,CAAC;AACJ,CAAC;AAnBD,0EAmBC;AAED,SAAgB,gBAAgB,CAC9B,UAA8B,EAC9B,YAAoC;IAEpC,MAAM,KAAK,GAAG,UAAU,CAAC,KAAK,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC;IACtC,MAAM,CAAC,MAAM,CAAC,GAAG,UAAU,CAAC,KAAK,CAAC,CAAC,CAAC,CAAC,CAAC;IAEtC,IAAI,+BAA+B,CAAC,YAAY,CAAC,EAAE;QACjD,OAAO;YACL,GAAG,KAAK;YACR;gBACE,IAAI,EAAE,0CAAmB,CAAC,gCAAgC;gBAC1D,eAAe,EAAE,MAAM,CAAC,eAAgB;aACzC;SACF,CAAC;KACH;IAED,IAAI,+BAA+B,CAAC,YAAY,CAAC,EAAE;QACjD,OAAO;YACL,GAAG,KAAK;YACR;gBACE,IAAI,EAAE,0CAAmB,CAAC,oBAAoB;gBAC9C,eAAe,EAAE,MAAM,CAAC,eAAgB;aACzC;SACF,CAAC;KACH;IAED,IAAI,wBAAwB,CAAC,YAAY,CAAC,EAAE;QAC1C,OAAO;YACL,GAAG,KAAK;YACR;gBACE,IAAI,EAAE,0CAAmB,CAAC,oBAAoB;gBAC9C,eAAe,EAAE,MAAM,CAAC,eAAgB;aACzC;SACF,CAAC;KACH;IAED,OAAO,UAAU,CAAC;AACpB,CAAC;AAtCD,4CAsCC;AAED,SAAS,+BAA+B,CACtC,YAAoC;IAEpC,OAAO,YAAY,CAAC,YAAY,EAAE,CAAC,CAAC,EAAE;QACpC,gBAAM,CAAC,WAAW;QAClB,gBAAM,CAAC,MAAM;QACb,gBAAM,CAAC,IAAI;QACX,gBAAM,CAAC,MAAM;KACd,CAAC,CAAC;AACL,CAAC;AAED,SAAS,+BAA+B,CAAC,YAAoC;IAC3E,IAAI,CAAC,IAAA,oCAAoB,EAAC,YAAY,CAAC,EAAE;QACvC,OAAO,KAAK,CAAC;KACd;IAED,OAAO,CACL,YAAY,CAAC,YAAY,EAAE,CAAC,EAAE,EAAE,CAAC,gBAAM,CAAC,QAAQ,CAAC,CAAC;QAClD,YAAY,CAAC,YAAY,EAAE,CAAC,EAAE,EAAE,CAAC,gBAAM,CAAC,QAAQ,CAAC,CAAC;QAClD,YAAY,CAAC,YAAY,EAAE,CAAC,CAAC,EAAE,CAAC,gBAAM,CAAC,EAAE,EAAE,gBAAM,CAAC,MAAM,CAAC,CAAC,CAC3D,CAAC;AACJ,CAAC;AAED,SAAS,wBAAwB,CAAC,YAAoC;IACpE,IAAI,CAAC,IAAA,kCAAkB,EAAC,YAAY,CAAC,EAAE;QACrC,OAAO,KAAK,CAAC;KACd;IAED,OAAO,CACL,YAAY,CAAC,YAAY,EAAE,CAAC,EAAE,EAAE,CAAC,gBAAM,CAAC,YAAY,CAAC,CAAC;QACtD,YAAY,CAAC,YAAY,EAAE,CAAC,CAAC,EAAE,CAAC,gBAAM,CAAC,EAAE,EAAE,gBAAM,CAAC,MAAM,CAAC,CAAC,CAC3D,CAAC;AACJ,CAAC;AAED,SAAS,WAAW,CAClB,YAAoC,EACpC,SAAiB,EACjB,MAAc;IAEd,MAAM,CAAC,IAAI,CAAC,GAAG,YAAY,CAAC,KAAK,CAAC,KAAK,CAAC,SAAS,EAAE,SAAS,GAAG,CAAC,CAAC,CAAC;IAElE,IAAI,IAAI,KAAK,SAAS,IAAI,CAAC,IAAA,yBAAS,EAAC,IAAI,CAAC,EAAE;QAC1C,OAAO,KAAK,CAAC;KACd;IAED,MAAM,WAAW,GAAG,YAAY,CAAC,QAAQ,CAAC,cAAc,CAAC,IAAI,CAAC,EAAE,CAAC,CAAC;IAElE,OAAO,WAAW,CAAC,MAAM,KAAK,MAAM,CAAC;AACvC,CAAC;AAED,SAAS,YAAY,CACnB,YAAoC,EACpC,cAAsB,EACtB,OAAiB;IAEjB,IAAI,KAAK,GAAG,cAAc,CAAC;IAC3B,KAAK,MAAM,MAAM,IAAI,OAAO,EAAE;QAC5B,IAAI,CAAC,WAAW,CAAC,YAAY,EAAE,KAAK,EAAE,MAAM,CAAC,EAAE;YAC7C,OAAO,KAAK,CAAC;SACd;QAED,KAAK,IAAI,CAAC,CAAC;KACZ;IAED,OAAO,IAAI,CAAC;AACd,CAAC"}
 \ No newline at end of file
-+{"version":3,"file":"mapped-inlined-internal-functions-heuristics.js","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/mapped-inlined-internal-functions-heuristics.ts"],"names":[],"mappings":";AAAA;;;;;;;;;;;;;;;;;;GAkBG;;;;;;AAEH,oDAA4B;AAE5B,mDAKyB;AAOzB,MAAM,uDAAuD,GAAG,OAAO,CAAC;AAExE,SAAgB,+BAA+B,CAC7C,UAA8B,EAC9B,YAAoC;IAEpC,IAAI,UAAU,CAAC,MAAM,KAAK,CAAC,EAAE;QAC3B,OAAO,KAAK,CAAC;KACd;IAED,MAAM,SAAS,GAAG,UAAU,CAAC,UAAU,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC;IAEpD,OAAO,CACL,SAAS,CAAC,IAAI,6CAAqC;QACnD,CAAC,SAAS,CAAC,oBAAoB;QAC/B,SAAS,CAAC,OAAO,CAAC,OAAO,EAAE;QAC3B,gBAAM,CAAC,GAAG,CACR,YAAY,CAAC,QAAQ,CAAC,eAAe,EACrC,uDAAuD,CACxD,CACF,CAAC;AACJ,CAAC;AAnBD,0EAmBC;AAED,SAAgB,gBAAgB,CAC9B,UAA8B,EAC9B,YAAoC;IAEpC,MAAM,KAAK,GAAG,UAAU,CAAC,KAAK,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC;IACtC,MAAM,CAAC,MAAM,CAAC,GAAG,UAAU,CAAC,KAAK,CAAC,CAAC,CAAC,CAAC,CAAC;IAEtC,IAAI,+BAA+B,CAAC,YAAY,CAAC,EAAE;QACjD,OAAO;YACL,GAAG,KAAK;YACR;gBACE,IAAI,+DAAsD;gBAC1D,eAAe,EAAE,MAAM,CAAC,eAAgB;aACzC;SACF,CAAC;KACH;IAED,IAAI,+BAA+B,CAAC,YAAY,CAAC,EAAE;QACjD,OAAO;YACL,GAAG,KAAK;YACR;gBACE,IAAI,kDAA0C;gBAC9C,eAAe,EAAE,MAAM,CAAC,eAAgB;aACzC;SACF,CAAC;KACH;IAED,IAAI,wBAAwB,CAAC,YAAY,CAAC,EAAE;QAC1C,OAAO;YACL,GAAG,KAAK;YACR;gBACE,IAAI,kDAA0C;gBAC9C,eAAe,EAAE,MAAM,CAAC,eAAgB;aACzC;SACF,CAAC;KACH;IAED,OAAO,UAAU,CAAC;AACpB,CAAC;AAtCD,4CAsCC;AAED,SAAS,+BAA+B,CACtC,YAAoC;IAEpC,OAAO,YAAY,CAAC,YAAY,EAAE,CAAC,CAAC,EAAE;;;;;KAKrC,CAAC,CAAC;AACL,CAAC;AAED,SAAS,+BAA+B,CAAC,YAAoC;IAC3E,IAAI,CAAC,IAAA,oCAAoB,EAAC,YAAY,CAAC,EAAE;QACvC,OAAO,KAAK,CAAC;KACd;IAED,OAAO,CACL,YAAY,CAAC,YAAY,EAAE,CAAC,EAAE,EAAE,0BAAiB,CAAC;QAClD,YAAY,CAAC,YAAY,EAAE,CAAC,EAAE,EAAE,0BAAiB,CAAC;QAClD,YAAY,CAAC,YAAY,EAAE,CAAC,CAAC,EAAE,4CAA0B,CAAC,CAC3D,CAAC;AACJ,CAAC;AAED,SAAS,wBAAwB,CAAC,YAAoC;IACpE,IAAI,CAAC,IAAA,kCAAkB,EAAC,YAAY,CAAC,EAAE;QACrC,OAAO,KAAK,CAAC;KACd;IAED,OAAO,CACL,YAAY,CAAC,YAAY,EAAE,CAAC,EAAE,EAAE,8BAAqB,CAAC;QACtD,YAAY,CAAC,YAAY,EAAE,CAAC,CAAC,EAAE,4CAA0B,CAAC,CAC3D,CAAC;AACJ,CAAC;AAED,SAAS,WAAW,CAClB,YAAoC,EACpC,SAAiB,EACjB,MAAc;IAEd,MAAM,CAAC,IAAI,CAAC,GAAG,YAAY,CAAC,KAAK,CAAC,KAAK,CAAC,SAAS,EAAE,SAAS,GAAG,CAAC,CAAC,CAAC;IAElE,IAAI,IAAI,KAAK,SAAS,IAAI,CAAC,IAAA,yBAAS,EAAC,IAAI,CAAC,EAAE;QAC1C,OAAO,KAAK,CAAC;KACd;IAED,MAAM,WAAW,GAAG,YAAY,CAAC,QAAQ,CAAC,cAAc,CAAC,IAAI,CAAC,EAAE,CAAC,CAAC;IAElE,OAAO,WAAW,CAAC,MAAM,KAAK,MAAM,CAAC;AACvC,CAAC;AAED,SAAS,YAAY,CACnB,YAAoC,EACpC,cAAsB,EACtB,OAAiB;IAEjB,IAAI,KAAK,GAAG,cAAc,CAAC;IAC3B,KAAK,MAAM,MAAM,IAAI,OAAO,EAAE;QAC5B,IAAI,CAAC,WAAW,CAAC,YAAY,EAAE,KAAK,EAAE,MAAM,CAAC,EAAE;YAC7C,OAAO,KAAK,CAAC;SACd;QAED,KAAK,IAAI,CAAC,CAAC;KACZ;IAED,OAAO,IAAI,CAAC;AACd,CAAC"}
++{"version":3,"file":"mapped-inlined-internal-functions-heuristics.js","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/mapped-inlined-internal-functions-heuristics.ts"],"names":[],"mappings":""}
 \ No newline at end of file
 diff --git a/internal/hardhat-network/stack-traces/message-trace.d.ts b/internal/hardhat-network/stack-traces/message-trace.d.ts
 index b20acd2945424cb558cf88147a124ac2c75f03c0..e552175dc6febe4eb388f3e78cd5070cf0e81896 100644
@@ -3034,11 +3800,28 @@ index 9a8272264f21d996492dc1efdeddf2619211adc1..23ca8748ee87ec1b5e77b525f7c40bb5
 \ No newline at end of file
 +{"version":3,"file":"opcodes.js","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/opcodes.ts"],"names":[],"mappings":";;;AAAA,4CAO8B;AAL5B,6FAAA,MAAM,OAAA;AACN,6FAAA,MAAM,OAAA;AACN,6FAAA,MAAM,OAAA;AACN,+FAAA,QAAQ,OAAA;AACR,qGAAA,cAAc,OAAA"}
 \ No newline at end of file
+diff --git a/internal/hardhat-network/stack-traces/solidity-errors.d.ts.map b/internal/hardhat-network/stack-traces/solidity-errors.d.ts.map
+index ccd8d4b72fb5e5e6e2f62abc441ebe99afdf524d..2516fa45654651d473676c8ce3021a65db904dba 100644
+--- a/internal/hardhat-network/stack-traces/solidity-errors.d.ts.map
++++ b/internal/hardhat-network/stack-traces/solidity-errors.d.ts.map
+@@ -1 +1 @@
+-{"version":3,"file":"solidity-errors.d.ts","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/solidity-errors.ts"],"names":[],"mappings":";AAGA,OAAO,EAGL,kBAAkB,EAOnB,MAAM,wBAAwB,CAAC;AAEhC,QAAA,MAAM,OAAO,eAA2C,CAAC;AAEzD,wBAAgB,eAAe,IAAI,MAAM,CAAC,QAAQ,EAAE,CAWnD;AAED,wBAAsB,gCAAgC,CACpD,CAAC,EAAE,MAAM,OAAO,CAAC,GAAG,CAAC,EACrB,mBAAmB,EAAE,MAAM,gBAmB5B;AAED,wBAAgB,wBAAwB,CACtC,eAAe,EAAE,MAAM,EACvB,UAAU,EAAE,kBAAkB,EAC9B,aAAa,CAAC,EAAE,MAAM,CAAC,QAAQ,EAAE,GAChC,aAAa,CA0Cf;AA+ND,qBAAa,aAAc,SAAQ,KAAK;IACtC,SAAgB,UAAU,EAAE,kBAAkB,CAAC;gBAEnC,OAAO,EAAE,MAAM,EAAE,UAAU,EAAE,kBAAkB;IAKpD,CAAC,OAAO,CAAC,IAAI,MAAM;IAInB,OAAO,IAAI,MAAM;CAKzB"}
+\ No newline at end of file
++{"version":3,"file":"solidity-errors.d.ts","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/solidity-errors.ts"],"names":[],"mappings":";AAIA,OAAO,EAGL,kBAAkB,EAOnB,MAAM,wBAAwB,CAAC;AAEhC,QAAA,MAAM,OAAO,eAA2C,CAAC;AAEzD,wBAAgB,eAAe,IAAI,MAAM,CAAC,QAAQ,EAAE,CAWnD;AAED,wBAAsB,gCAAgC,CACpD,CAAC,EAAE,MAAM,OAAO,CAAC,GAAG,CAAC,EACrB,mBAAmB,EAAE,MAAM,gBAmB5B;AAED,wBAAgB,wBAAwB,CACtC,eAAe,EAAE,MAAM,EACvB,UAAU,EAAE,kBAAkB,EAC9B,aAAa,CAAC,EAAE,MAAM,CAAC,QAAQ,EAAE,GAChC,aAAa,CA0Cf;AA+ND,qBAAa,aAAc,SAAQ,KAAK;IACtC,SAAgB,UAAU,EAAE,kBAAkB,CAAC;gBAEnC,OAAO,EAAE,MAAM,EAAE,UAAU,EAAE,kBAAkB;IAKpD,CAAC,OAAO,CAAC,IAAI,MAAM;IAInB,OAAO,IAAI,MAAM;CAKzB"}
+\ No newline at end of file
 diff --git a/internal/hardhat-network/stack-traces/solidity-errors.js b/internal/hardhat-network/stack-traces/solidity-errors.js
-index ca2d8a67f611966c92fc50687f3208eb5ef0224c..ac4814e281f824b55149814e252fe289b14f988f 100644
+index ca2d8a67f611966c92fc50687f3208eb5ef0224c..d18de107203cb932a74ab9736df21993cae0c39b 100644
 --- a/internal/hardhat-network/stack-traces/solidity-errors.js
 +++ b/internal/hardhat-network/stack-traces/solidity-errors.js
-@@ -62,45 +62,45 @@ function encodeSolidityStackTrace(fallbackMessage, stackTrace, previousStack) {
+@@ -2,6 +2,7 @@
+ Object.defineProperty(exports, "__esModule", { value: true });
+ exports.SolidityError = exports.encodeSolidityStackTrace = exports.wrapWithSolidityErrorsCorrection = exports.getCurrentStack = void 0;
+ const ethereumjs_util_1 = require("@nomicfoundation/ethereumjs-util");
++const return_data_1 = require("../provider/return-data");
+ const panic_errors_1 = require("./panic-errors");
+ const solidity_stack_trace_1 = require("./solidity-stack-trace");
+ const inspect = Symbol.for("nodejs.util.inspect.custom");
+@@ -62,45 +63,45 @@ function encodeSolidityStackTrace(fallbackMessage, stackTrace, previousStack) {
  exports.encodeSolidityStackTrace = encodeSolidityStackTrace;
  function encodeStackTraceEntry(stackTraceEntry) {
      switch (stackTraceEntry.type) {
@@ -3108,7 +3891,7 @@ index ca2d8a67f611966c92fc50687f3208eb5ef0224c..ac4814e281f824b55149814e252fe289
              if (stackTraceEntry.sourceReference === undefined) {
                  return new SolidityCallSite(undefined, solidity_stack_trace_1.UNRECOGNIZED_CONTRACT_NAME, solidity_stack_trace_1.UNKNOWN_FUNCTION_NAME, undefined);
              }
-@@ -114,30 +114,30 @@ function sourceReferenceToSolidityCallsite(sourceReference) {
+@@ -114,66 +115,68 @@ function sourceReferenceToSolidityCallsite(sourceReference) {
  }
  function getMessageFromLastStackTraceEntry(stackTraceEntry) {
      switch (stackTraceEntry.type) {
@@ -3147,21 +3930,40 @@ index ca2d8a67f611966c92fc50687f3208eb5ef0224c..ac4814e281f824b55149814e252fe289
              return `Transaction reverted: library was called directly`;
 -        case solidity_stack_trace_1.StackTraceEntryType.UNRECOGNIZED_CREATE_ERROR:
 -        case solidity_stack_trace_1.StackTraceEntryType.UNRECOGNIZED_CONTRACT_ERROR:
+-            if (stackTraceEntry.message.isErrorReturnData()) {
+-                return `VM Exception while processing transaction: reverted with reason string '${stackTraceEntry.message.decodeError()}'`;
 +        case 17 /* StackTraceEntryType.UNRECOGNIZED_CREATE_ERROR */:
 +        case 18 /* StackTraceEntryType.UNRECOGNIZED_CONTRACT_ERROR */:
-             if (stackTraceEntry.message.isErrorReturnData()) {
-                 return `VM Exception while processing transaction: reverted with reason string '${stackTraceEntry.message.decodeError()}'`;
++            let returnData = new return_data_1.ReturnData(stackTraceEntry.returnData);
++            if (returnData.isErrorReturnData()) {
++                return `VM Exception while processing transaction: reverted with reason string '${new return_data_1.ReturnData(stackTraceEntry.returnData).decodeError()}'`;
              }
-@@ -153,7 +153,7 @@ function getMessageFromLastStackTraceEntry(stackTraceEntry) {
+-            if (stackTraceEntry.message.isPanicReturnData()) {
+-                const message = (0, panic_errors_1.panicErrorCodeToMessage)(stackTraceEntry.message.decodePanic());
++            if (returnData.isPanicReturnData()) {
++                const message = (0, panic_errors_1.panicErrorCodeToMessage)(returnData.decodePanic());
+                 return `VM Exception while processing transaction: ${message}`;
+             }
+-            if (!stackTraceEntry.message.isEmpty()) {
+-                const returnData = Buffer.from(stackTraceEntry.message.value).toString("hex");
+-                return `VM Exception while processing transaction: reverted with an unrecognized custom error (return data: 0x${returnData})`;
++            if (!returnData.isEmpty()) {
++                const buffer = Buffer.from(returnData.value).toString("hex");
++                return `VM Exception while processing transaction: reverted with an unrecognized custom error (return data: 0x${buffer})`;
+             }
+             if (stackTraceEntry.isInvalidOpcodeError) {
                  return "VM Exception while processing transaction: invalid opcode";
              }
              return "Transaction reverted without a reason string";
 -        case solidity_stack_trace_1.StackTraceEntryType.REVERT_ERROR:
+-            if (stackTraceEntry.message.isErrorReturnData()) {
+-                return `VM Exception while processing transaction: reverted with reason string '${stackTraceEntry.message.decodeError()}'`;
 +        case 4 /* StackTraceEntryType.REVERT_ERROR */:
-             if (stackTraceEntry.message.isErrorReturnData()) {
-                 return `VM Exception while processing transaction: reverted with reason string '${stackTraceEntry.message.decodeError()}'`;
++            returnData = new return_data_1.ReturnData(stackTraceEntry.returnData);
++            if (returnData.isErrorReturnData()) {
++                return `VM Exception while processing transaction: reverted with reason string '${returnData.decodeError()}'`;
              }
-@@ -161,19 +161,19 @@ function getMessageFromLastStackTraceEntry(stackTraceEntry) {
+             if (stackTraceEntry.isInvalidOpcodeError) {
                  return "VM Exception while processing transaction: invalid opcode";
              }
              return "Transaction reverted without a reason string";
@@ -3188,13 +3990,13 @@ index ca2d8a67f611966c92fc50687f3208eb5ef0224c..ac4814e281f824b55149814e252fe289
      }
  }
 diff --git a/internal/hardhat-network/stack-traces/solidity-errors.js.map b/internal/hardhat-network/stack-traces/solidity-errors.js.map
-index e9275a95977a89047a4db66e67b7d9d8aa85691c..dd3fb71638600dcfdbc9de2b59ace18357f2e890 100644
+index e9275a95977a89047a4db66e67b7d9d8aa85691c..06de54500b26ddf5a7757cb959e0e2e6fd161eb6 100644
 --- a/internal/hardhat-network/stack-traces/solidity-errors.js.map
 +++ b/internal/hardhat-network/stack-traces/solidity-errors.js.map
 @@ -1 +1 @@
 -{"version":3,"file":"solidity-errors.js","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/solidity-errors.ts"],"names":[],"mappings":";;;AAAA,sEAA6E;AAE7E,iDAAyD;AACzD,iEAUgC;AAEhC,MAAM,OAAO,GAAG,MAAM,CAAC,GAAG,CAAC,4BAA4B,CAAC,CAAC;AAEzD,SAAgB,eAAe;IAC7B,MAAM,yBAAyB,GAAG,KAAK,CAAC,iBAAiB,CAAC;IAE1D,KAAK,CAAC,iBAAiB,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,EAAE,CAAC,CAAC,CAAC;IAEtC,MAAM,KAAK,GAAG,IAAI,KAAK,EAAE,CAAC;IAC1B,MAAM,KAAK,GAAsB,KAAK,CAAC,KAAY,CAAC;IAEpD,KAAK,CAAC,iBAAiB,GAAG,yBAAyB,CAAC;IAEpD,OAAO,KAAK,CAAC;AACf,CAAC;AAXD,0CAWC;AAEM,KAAK,UAAU,gCAAgC,CACpD,CAAqB,EACrB,mBAA2B;IAE3B,MAAM,gBAAgB,GAAG,eAAe,EAAE,CAAC,KAAK,CAAC,mBAAmB,CAAC,CAAC;IAEtE,IAAI;QACF,OAAO,MAAM,CAAC,EAAE,CAAC;KAClB;IAAC,OAAO,KAAU,EAAE;QACnB,IAAI,KAAK,CAAC,UAAU,KAAK,SAAS,EAAE;YAClC,sFAAsF;YACtF,MAAM,KAAK,CAAC;SACb;QAED,sFAAsF;QACtF,MAAM,wBAAwB,CAC5B,KAAK,CAAC,OAAO,EACb,KAAK,CAAC,UAAU,EAChB,gBAAgB,CACjB,CAAC;KACH;AACH,CAAC;AArBD,4EAqBC;AAED,SAAgB,wBAAwB,CACtC,eAAuB,EACvB,UAA8B,EAC9B,aAAiC;IAEjC,IAAI,KAAK,CAAC,iBAAiB,KAAK,SAAS,EAAE;QACzC,yDAAyD;QACzD,OAAO,CAAC,6BAA6B,CAAC,CAAC;KACxC;IAED,MAAM,yBAAyB,GAAG,KAAK,CAAC,iBAAiB,CAAC;IAC1D,KAAK,CAAC,iBAAiB,GAAG,CAAC,KAAK,EAAE,KAAK,EAAE,EAAE;QACzC,IAAI,aAAa,KAAK,SAAS,EAAE;YAC/B,KAAK,GAAG,aAAa,CAAC;SACvB;aAAM;YACL,kDAAkD;YAClD,KAAK,CAAC,MAAM,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;SACpB;QAED,KAAK,MAAM,KAAK,IAAI,UAAU,EAAE;YAC9B,MAAM,QAAQ,GAAG,qBAAqB,CAAC,KAAK,CAAC,CAAC;YAC9C,IAAI,QAAQ,KAAK,SAAS,EAAE;gBAC1B,SAAS;aACV;YAED,KAAK,CAAC,OAAO,CAAC,QAAQ,CAAC,CAAC;SACzB;QAED,OAAO,yBAA0B,CAAC,KAAK,EAAE,KAAK,CAAC,CAAC;IAClD,CAAC,CAAC;IAEF,MAAM,GAAG,GAAG,iCAAiC,CAC3C,UAAU,CAAC,UAAU,CAAC,MAAM,GAAG,CAAC,CAAC,CAClC,CAAC;IAEF,MAAM,aAAa,GAAG,IAAI,aAAa,CACrC,GAAG,KAAK,SAAS,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,eAAe,EACzC,UAAU,CACX,CAAC;IAEF,kDAAkD;IAClD,aAAa,CAAC,KAAK,GAAG,aAAa,CAAC,KAAK,CAAC;IAE1C,KAAK,CAAC,iBAAiB,GAAG,yBAAyB,CAAC;IAEpD,OAAO,aAAa,CAAC;AACvB,CAAC;AA9CD,4DA8CC;AAED,SAAS,qBAAqB,CAC5B,eAAwC;IAExC,QAAQ,eAAe,CAAC,IAAI,EAAE;QAC5B,KAAK,0CAAmB,CAAC,4CAA4C,CAAC;QACtE,KAAK,0CAAmB,CAAC,iCAAiC;YACxD,OAAO,iCAAiC,CAAC;gBACvC,GAAG,eAAe,CAAC,eAAe;gBAClC,QAAQ,EAAE,iDAA0B;aACrC,CAAC,CAAC;QAEL,KAAK,0CAAmB,CAAC,eAAe,CAAC;QACzC,KAAK,0CAAmB,CAAC,YAAY,CAAC;QACtC,KAAK,0CAAmB,CAAC,YAAY,CAAC;QACtC,KAAK,0CAAmB,CAAC,0BAA0B,CAAC;QACpD,KAAK,0CAAmB,CAAC,oBAAoB,CAAC;QAC9C,KAAK,0CAAmB,CAAC,0BAA0B,CAAC;QACpD,KAAK,0CAAmB,CAAC,yCAAyC,CAAC;QACnE,KAAK,0CAAmB,CAAC,qBAAqB,CAAC;QAC/C,KAAK,0CAAmB,CAAC,gCAAgC,CAAC;QAC1D,KAAK,0CAAmB,CAAC,iBAAiB,CAAC;QAC3C,KAAK,0CAAmB,CAAC,yBAAyB;YAChD,OAAO,iCAAiC,CAAC,eAAe,CAAC,eAAe,CAAC,CAAC;QAE5E,KAAK,0CAAmB,CAAC,mCAAmC;YAC1D,OAAO,IAAI,gBAAgB,CACzB,SAAS,EACT,iDAA0B,EAC1B,gDAAyB,EACzB,SAAS,CACV,CAAC;QAEJ,KAAK,0CAAmB,CAAC,qCAAqC;YAC5D,OAAO,IAAI,gBAAgB,CACzB,IAAA,4BAAW,EAAC,eAAe,CAAC,OAAO,CAAC,EACpC,iDAA0B,EAC1B,4CAAqB,EACrB,SAAS,CACV,CAAC;QAEJ,KAAK,0CAAmB,CAAC,gBAAgB;YACvC,OAAO,IAAI,gBAAgB,CACzB,SAAS,EACT,uBAAuB,eAAe,CAAC,UAAU,GAAG,EACpD,+CAAwB,EACxB,SAAS,CACV,CAAC;QAEJ,KAAK,0CAAmB,CAAC,yBAAyB;YAChD,OAAO,IAAI,gBAAgB,CACzB,SAAS,EACT,iDAA0B,EAC1B,gDAAyB,EACzB,SAAS,CACV,CAAC;QAEJ,KAAK,0CAAmB,CAAC,2BAA2B;YAClD,OAAO,IAAI,gBAAgB,CACzB,IAAA,4BAAW,EAAC,eAAe,CAAC,OAAO,CAAC,EACpC,iDAA0B,EAC1B,4CAAqB,EACrB,SAAS,CACV,CAAC;QAEJ,KAAK,0CAAmB,CAAC,iCAAiC;YACxD,OAAO,IAAI,gBAAgB,CACzB,eAAe,CAAC,eAAe,CAAC,UAAU,EAC1C,eAAe,CAAC,eAAe,CAAC,QAAQ,EACxC,YAAY,eAAe,CAAC,EAAE,EAAE,EAChC,SAAS,CACV,CAAC;QACJ,KAAK,0CAAmB,CAAC,kCAAkC;YACzD,IAAI,eAAe,CAAC,eAAe,KAAK,SAAS,EAAE;gBACjD,OAAO,iCAAiC,CACtC,eAAe,CAAC,eAAe,CAChC,CAAC;aACH;YAED,OAAO,IAAI,gBAAgB,CACzB,SAAS,EACT,iDAA0B,EAC1B,4CAAqB,EACrB,SAAS,CACV,CAAC;QAEJ,KAAK,0CAAmB,CAAC,qBAAqB,CAAC;QAC/C,KAAK,0CAAmB,CAAC,wBAAwB,CAAC;QAClD,KAAK,0CAAmB,CAAC,WAAW,CAAC;QACrC,KAAK,0CAAmB,CAAC,gCAAgC;YACvD,IAAI,eAAe,CAAC,eAAe,KAAK,SAAS,EAAE;gBACjD,OAAO,IAAI,gBAAgB,CACzB,SAAS,EACT,iDAA0B,EAC1B,4CAAqB,EACrB,SAAS,CACV,CAAC;aACH;YAED,OAAO,iCAAiC,CAAC,eAAe,CAAC,eAAe,CAAC,CAAC;KAC7E;AACH,CAAC;AAED,SAAS,iCAAiC,CACxC,eAAgC;IAEhC,OAAO,IAAI,gBAAgB,CACzB,eAAe,CAAC,UAAU,EAC1B,eAAe,CAAC,QAAQ,EACxB,eAAe,CAAC,QAAQ,KAAK,SAAS;QACpC,CAAC,CAAC,eAAe,CAAC,QAAQ;QAC1B,CAAC,CAAC,4CAAqB,EACzB,eAAe,CAAC,IAAI,CACrB,CAAC;AACJ,CAAC;AAED,SAAS,iCAAiC,CACxC,eAAwC;IAExC,QAAQ,eAAe,CAAC,IAAI,EAAE;QAC5B,KAAK,0CAAmB,CAAC,gBAAgB;YACvC,OAAO,4CAA4C,eAAe,CAAC,UAAU,SAAS,CAAC;QAEzF,KAAK,0CAAmB,CAAC,0BAA0B;YACjD,OAAO,oEAAoE,eAAe,CAAC,KAAK,CAAC,QAAQ,CACvG,EAAE,CACH,EAAE,CAAC;QAEN,KAAK,0CAAmB,CAAC,oBAAoB;YAC3C,OAAO,qEAAqE,CAAC;QAE/E,KAAK,0CAAmB,CAAC,0BAA0B;YACjD,OAAO,oFAAoF,eAAe,CAAC,KAAK,CAAC,QAAQ,CACvH,EAAE,CACH,EAAE,CAAC;QAEN,KAAK,0CAAmB,CAAC,yCAAyC;YAChE,OAAO,iHAAiH,eAAe,CAAC,KAAK,CAAC,QAAQ,CACpJ,EAAE,CACH,EAAE,CAAC;QAEN,KAAK,0CAAmB,CAAC,4CAA4C;YACnE,OAAO,6FAA6F,CAAC;QAEvG,KAAK,0CAAmB,CAAC,iCAAiC;YACxD,OAAO,yGAAyG,CAAC;QAEnH,KAAK,0CAAmB,CAAC,qBAAqB;YAC5C,OAAO,sEAAsE,CAAC;QAEhF,KAAK,0CAAmB,CAAC,gCAAgC;YACvD,OAAO,+DAA+D,CAAC;QAEzE,KAAK,0CAAmB,CAAC,iBAAiB;YACxC,OAAO,uDAAuD,CAAC;QAEjE,KAAK,0CAAmB,CAAC,yBAAyB;YAChD,OAAO,mDAAmD,CAAC;QAE7D,KAAK,0CAAmB,CAAC,yBAAyB,CAAC;QACnD,KAAK,0CAAmB,CAAC,2BAA2B;YAClD,IAAI,eAAe,CAAC,OAAO,CAAC,iBAAiB,EAAE,EAAE;gBAC/C,OAAO,2EAA2E,eAAe,CAAC,OAAO,CAAC,WAAW,EAAE,GAAG,CAAC;aAC5H;YAED,IAAI,eAAe,CAAC,OAAO,CAAC,iBAAiB,EAAE,EAAE;gBAC/C,MAAM,OAAO,GAAG,IAAA,sCAAuB,EACrC,eAAe,CAAC,OAAO,CAAC,WAAW,EAAE,CACtC,CAAC;gBACF,OAAO,8CAA8C,OAAO,EAAE,CAAC;aAChE;YAED,IAAI,CAAC,eAAe,CAAC,OAAO,CAAC,OAAO,EAAE,EAAE;gBACtC,MAAM,UAAU,GAAG,MAAM,CAAC,IAAI,CAAC,eAAe,CAAC,OAAO,CAAC,KAAK,CAAC,CAAC,QAAQ,CACpE,KAAK,CACN,CAAC;gBAEF,OAAO,yGAAyG,UAAU,GAAG,CAAC;aAC/H;YAED,IAAI,eAAe,CAAC,oBAAoB,EAAE;gBACxC,OAAO,2DAA2D,CAAC;aACpE;YAED,OAAO,8CAA8C,CAAC;QAExD,KAAK,0CAAmB,CAAC,YAAY;YACnC,IAAI,eAAe,CAAC,OAAO,CAAC,iBAAiB,EAAE,EAAE;gBAC/C,OAAO,2EAA2E,eAAe,CAAC,OAAO,CAAC,WAAW,EAAE,GAAG,CAAC;aAC5H;YAED,IAAI,eAAe,CAAC,oBAAoB,EAAE;gBACxC,OAAO,2DAA2D,CAAC;aACpE;YAED,OAAO,8CAA8C,CAAC;QAExD,KAAK,0CAAmB,CAAC,WAAW;YAClC,MAAM,YAAY,GAAG,IAAA,sCAAuB,EAAC,eAAe,CAAC,SAAS,CAAC,CAAC;YACxE,OAAO,8CAA8C,YAAY,EAAE,CAAC;QAEtE,KAAK,0CAAmB,CAAC,YAAY;YACnC,OAAO,8CAA8C,eAAe,CAAC,OAAO,EAAE,CAAC;QAEjF,KAAK,0CAAmB,CAAC,qBAAqB;YAC5C,sCAAsC;YACtC,OAAO,6DAA6D,CAAC;QAEvE,KAAK,0CAAmB,CAAC,gCAAgC;YACvD,OAAO,0MAA0M,CAAC;QAEpN,KAAK,0CAAmB,CAAC,wBAAwB;YAC/C,OAAO,2EAA2E,CAAC;QAErF,KAAK,0CAAmB,CAAC,kCAAkC;YACzD,OAAO,oFAAoF,CAAC;KAC/F;AACH,CAAC;AAED,qEAAqE;AACrE,+EAA+E;AAC/E,gCAAgC;AAChC,MAAa,aAAc,SAAQ,KAAK;IAGtC,YAAY,OAAe,EAAE,UAA8B;QACzD,KAAK,CAAC,OAAO,CAAC,CAAC;QACf,IAAI,CAAC,UAAU,GAAG,UAAU,CAAC;IAC/B,CAAC;IAEM,CAAC,OAAO,CAAC;QACd,OAAO,IAAI,CAAC,OAAO,EAAE,CAAC;IACxB,CAAC;IAEM,OAAO;QACZ,OAAO,IAAI,CAAC,KAAK,KAAK,SAAS;YAC7B,CAAC,CAAC,IAAI,CAAC,KAAK;YACZ,CAAC,CAAC,4CAA4C,CAAC;IACnD,CAAC;CACF;AAjBD,sCAiBC;AAED,MAAM,gBAAgB;IACpB,YACU,WAA+B,EAC/B,SAA6B,EAC7B,aAAiC,EACjC,KAAyB;QAHzB,gBAAW,GAAX,WAAW,CAAoB;QAC/B,cAAS,GAAT,SAAS,CAAoB;QAC7B,kBAAa,GAAb,aAAa,CAAoB;QACjC,UAAK,GAAL,KAAK,CAAoB;IAChC,CAAC;IAEG,eAAe;QACpB,OAAO,IAAI,CAAC;IACd,CAAC;IAEM,aAAa;QAClB,OAAO,SAAS,CAAC;IACnB,CAAC;IAEM,WAAW;QAChB,OAAO,IAAI,CAAC,WAAW,IAAI,SAAS,CAAC;IACvC,CAAC;IAEM,WAAW;QAChB,OAAO,SAAS,CAAC;IACnB,CAAC;IAEM,eAAe;QACpB,kDAAkD;QAClD,IAAI,IAAI,CAAC,SAAS,KAAK,SAAS,EAAE;YAChC,OAAO,IAAI,CAAC,aAAa,IAAI,IAAI,CAAC;SACnC;QAED,OAAO,IAAI,CAAC;IACd,CAAC;IAEM,aAAa;QAClB,OAAO,IAAI,CAAC,KAAK,KAAK,SAAS,CAAC,CAAC,CAAC,IAAI,CAAC,KAAK,CAAC,CAAC,CAAC,IAAI,CAAC;IACtD,CAAC;IAEM,aAAa;QAClB,IAAI,IAAI,CAAC,SAAS,KAAK,SAAS,EAAE;YAChC,OAAO,IAAI,CAAC,aAAa,IAAI,IAAI,CAAC;SACnC;QAED,OAAO,IAAI,CAAC;IACd,CAAC;IAEM,WAAW;QAChB,OAAO,CAAC,CAAC;IACX,CAAC;IAEM,eAAe;QACpB,OAAO,CAAC,CAAC;IACX,CAAC;IAEM,wBAAwB;QAC7B,OAAO,EAAE,CAAC;IACZ,CAAC;IAEM,OAAO;QACZ,OAAO,SAAS,CAAC;IACnB,CAAC;IAEM,WAAW;QAChB,OAAO,IAAI,CAAC,SAAS,IAAI,IAAI,CAAC;IAChC,CAAC;IAEM,OAAO;QACZ,OAAO,KAAK,CAAC;IACf,CAAC;IAEM,aAAa;QAClB,OAAO,KAAK,CAAC;IACf,CAAC;IAEM,MAAM;QACX,OAAO,KAAK,CAAC;IACf,CAAC;IAEM,QAAQ;QACb,OAAO,KAAK,CAAC;IACf,CAAC;IAEM,YAAY;QACjB,OAAO,KAAK,CAAC;IACf,CAAC;IAEM,UAAU;QACf,OAAO,KAAK,CAAC;IACf,CAAC;IAEM,aAAa;QAClB,OAAO,EAAE,CAAC;IACZ,CAAC;IAEM,wBAAwB;QAC7B,OAAO,CAAC,CAAC;IACX,CAAC;IAEM,sBAAsB;QAC3B,OAAO,CAAC,CAAC;IACX,CAAC;IAEM,QAAQ;QACb,OAAO,oBAAoB,CAAC;IAC9B,CAAC;CACF"}
 \ No newline at end of file
-+{"version":3,"file":"solidity-errors.js","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/solidity-errors.ts"],"names":[],"mappings":";;;AAAA,sEAA6E;AAE7E,iDAAyD;AACzD,iEAUgC;AAEhC,MAAM,OAAO,GAAG,MAAM,CAAC,GAAG,CAAC,4BAA4B,CAAC,CAAC;AAEzD,SAAgB,eAAe;IAC7B,MAAM,yBAAyB,GAAG,KAAK,CAAC,iBAAiB,CAAC;IAE1D,KAAK,CAAC,iBAAiB,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,EAAE,CAAC,CAAC,CAAC;IAEtC,MAAM,KAAK,GAAG,IAAI,KAAK,EAAE,CAAC;IAC1B,MAAM,KAAK,GAAsB,KAAK,CAAC,KAAY,CAAC;IAEpD,KAAK,CAAC,iBAAiB,GAAG,yBAAyB,CAAC;IAEpD,OAAO,KAAK,CAAC;AACf,CAAC;AAXD,0CAWC;AAEM,KAAK,UAAU,gCAAgC,CACpD,CAAqB,EACrB,mBAA2B;IAE3B,MAAM,gBAAgB,GAAG,eAAe,EAAE,CAAC,KAAK,CAAC,mBAAmB,CAAC,CAAC;IAEtE,IAAI;QACF,OAAO,MAAM,CAAC,EAAE,CAAC;KAClB;IAAC,OAAO,KAAU,EAAE;QACnB,IAAI,KAAK,CAAC,UAAU,KAAK,SAAS,EAAE;YAClC,sFAAsF;YACtF,MAAM,KAAK,CAAC;SACb;QAED,sFAAsF;QACtF,MAAM,wBAAwB,CAC5B,KAAK,CAAC,OAAO,EACb,KAAK,CAAC,UAAU,EAChB,gBAAgB,CACjB,CAAC;KACH;AACH,CAAC;AArBD,4EAqBC;AAED,SAAgB,wBAAwB,CACtC,eAAuB,EACvB,UAA8B,EAC9B,aAAiC;IAEjC,IAAI,KAAK,CAAC,iBAAiB,KAAK,SAAS,EAAE;QACzC,yDAAyD;QACzD,OAAO,CAAC,6BAA6B,CAAC,CAAC;KACxC;IAED,MAAM,yBAAyB,GAAG,KAAK,CAAC,iBAAiB,CAAC;IAC1D,KAAK,CAAC,iBAAiB,GAAG,CAAC,KAAK,EAAE,KAAK,EAAE,EAAE;QACzC,IAAI,aAAa,KAAK,SAAS,EAAE;YAC/B,KAAK,GAAG,aAAa,CAAC;SACvB;aAAM;YACL,kDAAkD;YAClD,KAAK,CAAC,MAAM,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;SACpB;QAED,KAAK,MAAM,KAAK,IAAI,UAAU,EAAE;YAC9B,MAAM,QAAQ,GAAG,qBAAqB,CAAC,KAAK,CAAC,CAAC;YAC9C,IAAI,QAAQ,KAAK,SAAS,EAAE;gBAC1B,SAAS;aACV;YAED,KAAK,CAAC,OAAO,CAAC,QAAQ,CAAC,CAAC;SACzB;QAED,OAAO,yBAA0B,CAAC,KAAK,EAAE,KAAK,CAAC,CAAC;IAClD,CAAC,CAAC;IAEF,MAAM,GAAG,GAAG,iCAAiC,CAC3C,UAAU,CAAC,UAAU,CAAC,MAAM,GAAG,CAAC,CAAC,CAClC,CAAC;IAEF,MAAM,aAAa,GAAG,IAAI,aAAa,CACrC,GAAG,KAAK,SAAS,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,eAAe,EACzC,UAAU,CACX,CAAC;IAEF,kDAAkD;IAClD,aAAa,CAAC,KAAK,GAAG,aAAa,CAAC,KAAK,CAAC;IAE1C,KAAK,CAAC,iBAAiB,GAAG,yBAAyB,CAAC;IAEpD,OAAO,aAAa,CAAC;AACvB,CAAC;AA9CD,4DA8CC;AAED,SAAS,qBAAqB,CAC5B,eAAwC;IAExC,QAAQ,eAAe,CAAC,IAAI,EAAE;QAC5B,+EAAsE;QACtE;YACE,OAAO,iCAAiC,CAAC;gBACvC,GAAG,eAAe,CAAC,eAAe;gBAClC,QAAQ,EAAE,iDAA0B;aACrC,CAAC,CAAC;QAEL,iDAAyC;QACzC,8CAAsC;QACtC,8CAAsC;QACtC,4DAAoD;QACpD,sDAA8C;QAC9C,4DAAoD;QACpD,4EAAmE;QACnE,wDAA+C;QAC/C,mEAA0D;QAC1D,oDAA2C;QAC3C;YACE,OAAO,iCAAiC,CAAC,eAAe,CAAC,eAAe,CAAC,CAAC;QAE5E;YACE,OAAO,IAAI,gBAAgB,CACzB,SAAS,EACT,iDAA0B,EAC1B,gDAAyB,EACzB,SAAS,CACV,CAAC;QAEJ;YACE,OAAO,IAAI,gBAAgB,CACzB,IAAA,4BAAW,EAAC,eAAe,CAAC,OAAO,CAAC,EACpC,iDAA0B,EAC1B,4CAAqB,EACrB,SAAS,CACV,CAAC;QAEJ;YACE,OAAO,IAAI,gBAAgB,CACzB,SAAS,EACT,uBAAuB,eAAe,CAAC,UAAU,GAAG,EACpD,+CAAwB,EACxB,SAAS,CACV,CAAC;QAEJ;YACE,OAAO,IAAI,gBAAgB,CACzB,SAAS,EACT,iDAA0B,EAC1B,gDAAyB,EACzB,SAAS,CACV,CAAC;QAEJ;YACE,OAAO,IAAI,gBAAgB,CACzB,IAAA,4BAAW,EAAC,eAAe,CAAC,OAAO,CAAC,EACpC,iDAA0B,EAC1B,4CAAqB,EACrB,SAAS,CACV,CAAC;QAEJ;YACE,OAAO,IAAI,gBAAgB,CACzB,eAAe,CAAC,eAAe,CAAC,UAAU,EAC1C,eAAe,CAAC,eAAe,CAAC,QAAQ,EACxC,YAAY,eAAe,CAAC,EAAE,EAAE,EAChC,SAAS,CACV,CAAC;QACJ;YACE,IAAI,eAAe,CAAC,eAAe,KAAK,SAAS,EAAE;gBACjD,OAAO,iCAAiC,CACtC,eAAe,CAAC,eAAe,CAChC,CAAC;aACH;YAED,OAAO,IAAI,gBAAgB,CACzB,SAAS,EACT,iDAA0B,EAC1B,4CAAqB,EACrB,SAAS,CACV,CAAC;QAEJ,wDAA+C;QAC/C,2DAAkD;QAClD,6CAAqC;QACrC;YACE,IAAI,eAAe,CAAC,eAAe,KAAK,SAAS,EAAE;gBACjD,OAAO,IAAI,gBAAgB,CACzB,SAAS,EACT,iDAA0B,EAC1B,4CAAqB,EACrB,SAAS,CACV,CAAC;aACH;YAED,OAAO,iCAAiC,CAAC,eAAe,CAAC,eAAe,CAAC,CAAC;KAC7E;AACH,CAAC;AAED,SAAS,iCAAiC,CACxC,eAAgC;IAEhC,OAAO,IAAI,gBAAgB,CACzB,eAAe,CAAC,UAAU,EAC1B,eAAe,CAAC,QAAQ,EACxB,eAAe,CAAC,QAAQ,KAAK,SAAS;QACpC,CAAC,CAAC,eAAe,CAAC,QAAQ;QAC1B,CAAC,CAAC,4CAAqB,EACzB,eAAe,CAAC,IAAI,CACrB,CAAC;AACJ,CAAC;AAED,SAAS,iCAAiC,CACxC,eAAwC;IAExC,QAAQ,eAAe,CAAC,IAAI,EAAE;QAC5B;YACE,OAAO,4CAA4C,eAAe,CAAC,UAAU,SAAS,CAAC;QAEzF;YACE,OAAO,oEAAoE,eAAe,CAAC,KAAK,CAAC,QAAQ,CACvG,EAAE,CACH,EAAE,CAAC;QAEN;YACE,OAAO,qEAAqE,CAAC;QAE/E;YACE,OAAO,oFAAoF,eAAe,CAAC,KAAK,CAAC,QAAQ,CACvH,EAAE,CACH,EAAE,CAAC;QAEN;YACE,OAAO,iHAAiH,eAAe,CAAC,KAAK,CAAC,QAAQ,CACpJ,EAAE,CACH,EAAE,CAAC;QAEN;YACE,OAAO,6FAA6F,CAAC;QAEvG;YACE,OAAO,yGAAyG,CAAC;QAEnH;YACE,OAAO,sEAAsE,CAAC;QAEhF;YACE,OAAO,+DAA+D,CAAC;QAEzE;YACE,OAAO,uDAAuD,CAAC;QAEjE;YACE,OAAO,mDAAmD,CAAC;QAE7D,4DAAmD;QACnD;YACE,IAAI,eAAe,CAAC,OAAO,CAAC,iBAAiB,EAAE,EAAE;gBAC/C,OAAO,2EAA2E,eAAe,CAAC,OAAO,CAAC,WAAW,EAAE,GAAG,CAAC;aAC5H;YAED,IAAI,eAAe,CAAC,OAAO,CAAC,iBAAiB,EAAE,EAAE;gBAC/C,MAAM,OAAO,GAAG,IAAA,sCAAuB,EACrC,eAAe,CAAC,OAAO,CAAC,WAAW,EAAE,CACtC,CAAC;gBACF,OAAO,8CAA8C,OAAO,EAAE,CAAC;aAChE;YAED,IAAI,CAAC,eAAe,CAAC,OAAO,CAAC,OAAO,EAAE,EAAE;gBACtC,MAAM,UAAU,GAAG,MAAM,CAAC,IAAI,CAAC,eAAe,CAAC,OAAO,CAAC,KAAK,CAAC,CAAC,QAAQ,CACpE,KAAK,CACN,CAAC;gBAEF,OAAO,yGAAyG,UAAU,GAAG,CAAC;aAC/H;YAED,IAAI,eAAe,CAAC,oBAAoB,EAAE;gBACxC,OAAO,2DAA2D,CAAC;aACpE;YAED,OAAO,8CAA8C,CAAC;QAExD;YACE,IAAI,eAAe,CAAC,OAAO,CAAC,iBAAiB,EAAE,EAAE;gBAC/C,OAAO,2EAA2E,eAAe,CAAC,OAAO,CAAC,WAAW,EAAE,GAAG,CAAC;aAC5H;YAED,IAAI,eAAe,CAAC,oBAAoB,EAAE;gBACxC,OAAO,2DAA2D,CAAC;aACpE;YAED,OAAO,8CAA8C,CAAC;QAExD;YACE,MAAM,YAAY,GAAG,IAAA,sCAAuB,EAAC,eAAe,CAAC,SAAS,CAAC,CAAC;YACxE,OAAO,8CAA8C,YAAY,EAAE,CAAC;QAEtE;YACE,OAAO,8CAA8C,eAAe,CAAC,OAAO,EAAE,CAAC;QAEjF;YACE,sCAAsC;YACtC,OAAO,6DAA6D,CAAC;QAEvE;YACE,OAAO,0MAA0M,CAAC;QAEpN;YACE,OAAO,2EAA2E,CAAC;QAErF;YACE,OAAO,oFAAoF,CAAC;KAC/F;AACH,CAAC;AAED,qEAAqE;AACrE,+EAA+E;AAC/E,gCAAgC;AAChC,MAAa,aAAc,SAAQ,KAAK;IAGtC,YAAY,OAAe,EAAE,UAA8B;QACzD,KAAK,CAAC,OAAO,CAAC,CAAC;QACf,IAAI,CAAC,UAAU,GAAG,UAAU,CAAC;IAC/B,CAAC;IAEM,CAAC,OAAO,CAAC;QACd,OAAO,IAAI,CAAC,OAAO,EAAE,CAAC;IACxB,CAAC;IAEM,OAAO;QACZ,OAAO,IAAI,CAAC,KAAK,KAAK,SAAS;YAC7B,CAAC,CAAC,IAAI,CAAC,KAAK;YACZ,CAAC,CAAC,4CAA4C,CAAC;IACnD,CAAC;CACF;AAjBD,sCAiBC;AAED,MAAM,gBAAgB;IACpB,YACU,WAA+B,EAC/B,SAA6B,EAC7B,aAAiC,EACjC,KAAyB;QAHzB,gBAAW,GAAX,WAAW,CAAoB;QAC/B,cAAS,GAAT,SAAS,CAAoB;QAC7B,kBAAa,GAAb,aAAa,CAAoB;QACjC,UAAK,GAAL,KAAK,CAAoB;IAChC,CAAC;IAEG,eAAe;QACpB,OAAO,IAAI,CAAC;IACd,CAAC;IAEM,aAAa;QAClB,OAAO,SAAS,CAAC;IACnB,CAAC;IAEM,WAAW;QAChB,OAAO,IAAI,CAAC,WAAW,IAAI,SAAS,CAAC;IACvC,CAAC;IAEM,WAAW;QAChB,OAAO,SAAS,CAAC;IACnB,CAAC;IAEM,eAAe;QACpB,kDAAkD;QAClD,IAAI,IAAI,CAAC,SAAS,KAAK,SAAS,EAAE;YAChC,OAAO,IAAI,CAAC,aAAa,IAAI,IAAI,CAAC;SACnC;QAED,OAAO,IAAI,CAAC;IACd,CAAC;IAEM,aAAa;QAClB,OAAO,IAAI,CAAC,KAAK,KAAK,SAAS,CAAC,CAAC,CAAC,IAAI,CAAC,KAAK,CAAC,CAAC,CAAC,IAAI,CAAC;IACtD,CAAC;IAEM,aAAa;QAClB,IAAI,IAAI,CAAC,SAAS,KAAK,SAAS,EAAE;YAChC,OAAO,IAAI,CAAC,aAAa,IAAI,IAAI,CAAC;SACnC;QAED,OAAO,IAAI,CAAC;IACd,CAAC;IAEM,WAAW;QAChB,OAAO,CAAC,CAAC;IACX,CAAC;IAEM,eAAe;QACpB,OAAO,CAAC,CAAC;IACX,CAAC;IAEM,wBAAwB;QAC7B,OAAO,EAAE,CAAC;IACZ,CAAC;IAEM,OAAO;QACZ,OAAO,SAAS,CAAC;IACnB,CAAC;IAEM,WAAW;QAChB,OAAO,IAAI,CAAC,SAAS,IAAI,IAAI,CAAC;IAChC,CAAC;IAEM,OAAO;QACZ,OAAO,KAAK,CAAC;IACf,CAAC;IAEM,aAAa;QAClB,OAAO,KAAK,CAAC;IACf,CAAC;IAEM,MAAM;QACX,OAAO,KAAK,CAAC;IACf,CAAC;IAEM,QAAQ;QACb,OAAO,KAAK,CAAC;IACf,CAAC;IAEM,YAAY;QACjB,OAAO,KAAK,CAAC;IACf,CAAC;IAEM,UAAU;QACf,OAAO,KAAK,CAAC;IACf,CAAC;IAEM,aAAa;QAClB,OAAO,EAAE,CAAC;IACZ,CAAC;IAEM,wBAAwB;QAC7B,OAAO,CAAC,CAAC;IACX,CAAC;IAEM,sBAAsB;QAC3B,OAAO,CAAC,CAAC;IACX,CAAC;IAEM,QAAQ;QACb,OAAO,oBAAoB,CAAC;IAC9B,CAAC;CACF"}
++{"version":3,"file":"solidity-errors.js","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/solidity-errors.ts"],"names":[],"mappings":";;;AAAA,sEAA6E;AAE7E,yDAAqD;AACrD,iDAAyD;AACzD,iEAUgC;AAEhC,MAAM,OAAO,GAAG,MAAM,CAAC,GAAG,CAAC,4BAA4B,CAAC,CAAC;AAEzD,SAAgB,eAAe;IAC7B,MAAM,yBAAyB,GAAG,KAAK,CAAC,iBAAiB,CAAC;IAE1D,KAAK,CAAC,iBAAiB,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,EAAE,CAAC,CAAC,CAAC;IAEtC,MAAM,KAAK,GAAG,IAAI,KAAK,EAAE,CAAC;IAC1B,MAAM,KAAK,GAAsB,KAAK,CAAC,KAAY,CAAC;IAEpD,KAAK,CAAC,iBAAiB,GAAG,yBAAyB,CAAC;IAEpD,OAAO,KAAK,CAAC;AACf,CAAC;AAXD,0CAWC;AAEM,KAAK,UAAU,gCAAgC,CACpD,CAAqB,EACrB,mBAA2B;IAE3B,MAAM,gBAAgB,GAAG,eAAe,EAAE,CAAC,KAAK,CAAC,mBAAmB,CAAC,CAAC;IAEtE,IAAI;QACF,OAAO,MAAM,CAAC,EAAE,CAAC;KAClB;IAAC,OAAO,KAAU,EAAE;QACnB,IAAI,KAAK,CAAC,UAAU,KAAK,SAAS,EAAE;YAClC,sFAAsF;YACtF,MAAM,KAAK,CAAC;SACb;QAED,sFAAsF;QACtF,MAAM,wBAAwB,CAC5B,KAAK,CAAC,OAAO,EACb,KAAK,CAAC,UAAU,EAChB,gBAAgB,CACjB,CAAC;KACH;AACH,CAAC;AArBD,4EAqBC;AAED,SAAgB,wBAAwB,CACtC,eAAuB,EACvB,UAA8B,EAC9B,aAAiC;IAEjC,IAAI,KAAK,CAAC,iBAAiB,KAAK,SAAS,EAAE;QACzC,yDAAyD;QACzD,OAAO,CAAC,6BAA6B,CAAC,CAAC;KACxC;IAED,MAAM,yBAAyB,GAAG,KAAK,CAAC,iBAAiB,CAAC;IAC1D,KAAK,CAAC,iBAAiB,GAAG,CAAC,KAAK,EAAE,KAAK,EAAE,EAAE;QACzC,IAAI,aAAa,KAAK,SAAS,EAAE;YAC/B,KAAK,GAAG,aAAa,CAAC;SACvB;aAAM;YACL,kDAAkD;YAClD,KAAK,CAAC,MAAM,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;SACpB;QAED,KAAK,MAAM,KAAK,IAAI,UAAU,EAAE;YAC9B,MAAM,QAAQ,GAAG,qBAAqB,CAAC,KAAK,CAAC,CAAC;YAC9C,IAAI,QAAQ,KAAK,SAAS,EAAE;gBAC1B,SAAS;aACV;YAED,KAAK,CAAC,OAAO,CAAC,QAAQ,CAAC,CAAC;SACzB;QAED,OAAO,yBAA0B,CAAC,KAAK,EAAE,KAAK,CAAC,CAAC;IAClD,CAAC,CAAC;IAEF,MAAM,GAAG,GAAG,iCAAiC,CAC3C,UAAU,CAAC,UAAU,CAAC,MAAM,GAAG,CAAC,CAAC,CAClC,CAAC;IAEF,MAAM,aAAa,GAAG,IAAI,aAAa,CACrC,GAAG,KAAK,SAAS,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,eAAe,EACzC,UAAU,CACX,CAAC;IAEF,kDAAkD;IAClD,aAAa,CAAC,KAAK,GAAG,aAAa,CAAC,KAAK,CAAC;IAE1C,KAAK,CAAC,iBAAiB,GAAG,yBAAyB,CAAC;IAEpD,OAAO,aAAa,CAAC;AACvB,CAAC;AA9CD,4DA8CC;AAED,SAAS,qBAAqB,CAC5B,eAAwC;IAExC,QAAQ,eAAe,CAAC,IAAI,EAAE;QAC5B,+EAAsE;QACtE;YACE,OAAO,iCAAiC,CAAC;gBACvC,GAAG,eAAe,CAAC,eAAe;gBAClC,QAAQ,EAAE,iDAA0B;aACrC,CAAC,CAAC;QAEL,iDAAyC;QACzC,8CAAsC;QACtC,8CAAsC;QACtC,4DAAoD;QACpD,sDAA8C;QAC9C,4DAAoD;QACpD,4EAAmE;QACnE,wDAA+C;QAC/C,mEAA0D;QAC1D,oDAA2C;QAC3C;YACE,OAAO,iCAAiC,CAAC,eAAe,CAAC,eAAe,CAAC,CAAC;QAE5E;YACE,OAAO,IAAI,gBAAgB,CACzB,SAAS,EACT,iDAA0B,EAC1B,gDAAyB,EACzB,SAAS,CACV,CAAC;QAEJ;YACE,OAAO,IAAI,gBAAgB,CACzB,IAAA,4BAAW,EAAC,eAAe,CAAC,OAAO,CAAC,EACpC,iDAA0B,EAC1B,4CAAqB,EACrB,SAAS,CACV,CAAC;QAEJ;YACE,OAAO,IAAI,gBAAgB,CACzB,SAAS,EACT,uBAAuB,eAAe,CAAC,UAAU,GAAG,EACpD,+CAAwB,EACxB,SAAS,CACV,CAAC;QAEJ;YACE,OAAO,IAAI,gBAAgB,CACzB,SAAS,EACT,iDAA0B,EAC1B,gDAAyB,EACzB,SAAS,CACV,CAAC;QAEJ;YACE,OAAO,IAAI,gBAAgB,CACzB,IAAA,4BAAW,EAAC,eAAe,CAAC,OAAO,CAAC,EACpC,iDAA0B,EAC1B,4CAAqB,EACrB,SAAS,CACV,CAAC;QAEJ;YACE,OAAO,IAAI,gBAAgB,CACzB,eAAe,CAAC,eAAe,CAAC,UAAU,EAC1C,eAAe,CAAC,eAAe,CAAC,QAAQ,EACxC,YAAY,eAAe,CAAC,EAAE,EAAE,EAChC,SAAS,CACV,CAAC;QACJ;YACE,IAAI,eAAe,CAAC,eAAe,KAAK,SAAS,EAAE;gBACjD,OAAO,iCAAiC,CACtC,eAAe,CAAC,eAAe,CAChC,CAAC;aACH;YAED,OAAO,IAAI,gBAAgB,CACzB,SAAS,EACT,iDAA0B,EAC1B,4CAAqB,EACrB,SAAS,CACV,CAAC;QAEJ,wDAA+C;QAC/C,2DAAkD;QAClD,6CAAqC;QACrC;YACE,IAAI,eAAe,CAAC,eAAe,KAAK,SAAS,EAAE;gBACjD,OAAO,IAAI,gBAAgB,CACzB,SAAS,EACT,iDAA0B,EAC1B,4CAAqB,EACrB,SAAS,CACV,CAAC;aACH;YAED,OAAO,iCAAiC,CAAC,eAAe,CAAC,eAAe,CAAC,CAAC;KAC7E;AACH,CAAC;AAED,SAAS,iCAAiC,CACxC,eAAgC;IAEhC,OAAO,IAAI,gBAAgB,CACzB,eAAe,CAAC,UAAU,EAC1B,eAAe,CAAC,QAAQ,EACxB,eAAe,CAAC,QAAQ,KAAK,SAAS;QACpC,CAAC,CAAC,eAAe,CAAC,QAAQ;QAC1B,CAAC,CAAC,4CAAqB,EACzB,eAAe,CAAC,IAAI,CACrB,CAAC;AACJ,CAAC;AAED,SAAS,iCAAiC,CACxC,eAAwC;IAExC,QAAQ,eAAe,CAAC,IAAI,EAAE;QAC5B;YACE,OAAO,4CAA4C,eAAe,CAAC,UAAU,SAAS,CAAC;QAEzF;YACE,OAAO,oEAAoE,eAAe,CAAC,KAAK,CAAC,QAAQ,CACvG,EAAE,CACH,EAAE,CAAC;QAEN;YACE,OAAO,qEAAqE,CAAC;QAE/E;YACE,OAAO,oFAAoF,eAAe,CAAC,KAAK,CAAC,QAAQ,CACvH,EAAE,CACH,EAAE,CAAC;QAEN;YACE,OAAO,iHAAiH,eAAe,CAAC,KAAK,CAAC,QAAQ,CACpJ,EAAE,CACH,EAAE,CAAC;QAEN;YACE,OAAO,6FAA6F,CAAC;QAEvG;YACE,OAAO,yGAAyG,CAAC;QAEnH;YACE,OAAO,sEAAsE,CAAC;QAEhF;YACE,OAAO,+DAA+D,CAAC;QAEzE;YACE,OAAO,uDAAuD,CAAC;QAEjE;YACE,OAAO,mDAAmD,CAAC;QAE7D,4DAAmD;QACnD;YACE,IAAI,UAAU,GAAG,IAAI,wBAAU,CAAC,eAAe,CAAC,UAAU,CAAC,CAAC;YAC5D,IAAI,UAAU,CAAC,iBAAiB,EAAE,EAAE;gBAClC,OAAO,2EAA2E,IAAI,wBAAU,CAC9F,eAAe,CAAC,UAAU,CAC3B,CAAC,WAAW,EAAE,GAAG,CAAC;aACpB;YAED,IAAI,UAAU,CAAC,iBAAiB,EAAE,EAAE;gBAClC,MAAM,OAAO,GAAG,IAAA,sCAAuB,EAAC,UAAU,CAAC,WAAW,EAAE,CAAC,CAAC;gBAClE,OAAO,8CAA8C,OAAO,EAAE,CAAC;aAChE;YAED,IAAI,CAAC,UAAU,CAAC,OAAO,EAAE,EAAE;gBACzB,MAAM,MAAM,GAAG,MAAM,CAAC,IAAI,CAAC,UAAU,CAAC,KAAK,CAAC,CAAC,QAAQ,CAAC,KAAK,CAAC,CAAC;gBAE7D,OAAO,yGAAyG,MAAM,GAAG,CAAC;aAC3H;YAED,IAAI,eAAe,CAAC,oBAAoB,EAAE;gBACxC,OAAO,2DAA2D,CAAC;aACpE;YAED,OAAO,8CAA8C,CAAC;QAExD;YACE,UAAU,GAAG,IAAI,wBAAU,CAAC,eAAe,CAAC,UAAU,CAAC,CAAC;YACxD,IAAI,UAAU,CAAC,iBAAiB,EAAE,EAAE;gBAClC,OAAO,2EAA2E,UAAU,CAAC,WAAW,EAAE,GAAG,CAAC;aAC/G;YAED,IAAI,eAAe,CAAC,oBAAoB,EAAE;gBACxC,OAAO,2DAA2D,CAAC;aACpE;YAED,OAAO,8CAA8C,CAAC;QAExD;YACE,MAAM,YAAY,GAAG,IAAA,sCAAuB,EAAC,eAAe,CAAC,SAAS,CAAC,CAAC;YACxE,OAAO,8CAA8C,YAAY,EAAE,CAAC;QAEtE;YACE,OAAO,8CAA8C,eAAe,CAAC,OAAO,EAAE,CAAC;QAEjF;YACE,sCAAsC;YACtC,OAAO,6DAA6D,CAAC;QAEvE;YACE,OAAO,0MAA0M,CAAC;QAEpN;YACE,OAAO,2EAA2E,CAAC;QAErF;YACE,OAAO,oFAAoF,CAAC;KAC/F;AACH,CAAC;AAED,qEAAqE;AACrE,+EAA+E;AAC/E,gCAAgC;AAChC,MAAa,aAAc,SAAQ,KAAK;IAGtC,YAAY,OAAe,EAAE,UAA8B;QACzD,KAAK,CAAC,OAAO,CAAC,CAAC;QACf,IAAI,CAAC,UAAU,GAAG,UAAU,CAAC;IAC/B,CAAC;IAEM,CAAC,OAAO,CAAC;QACd,OAAO,IAAI,CAAC,OAAO,EAAE,CAAC;IACxB,CAAC;IAEM,OAAO;QACZ,OAAO,IAAI,CAAC,KAAK,KAAK,SAAS;YAC7B,CAAC,CAAC,IAAI,CAAC,KAAK;YACZ,CAAC,CAAC,4CAA4C,CAAC;IACnD,CAAC;CACF;AAjBD,sCAiBC;AAED,MAAM,gBAAgB;IACpB,YACU,WAA+B,EAC/B,SAA6B,EAC7B,aAAiC,EACjC,KAAyB;QAHzB,gBAAW,GAAX,WAAW,CAAoB;QAC/B,cAAS,GAAT,SAAS,CAAoB;QAC7B,kBAAa,GAAb,aAAa,CAAoB;QACjC,UAAK,GAAL,KAAK,CAAoB;IAChC,CAAC;IAEG,eAAe;QACpB,OAAO,IAAI,CAAC;IACd,CAAC;IAEM,aAAa;QAClB,OAAO,SAAS,CAAC;IACnB,CAAC;IAEM,WAAW;QAChB,OAAO,IAAI,CAAC,WAAW,IAAI,SAAS,CAAC;IACvC,CAAC;IAEM,WAAW;QAChB,OAAO,SAAS,CAAC;IACnB,CAAC;IAEM,eAAe;QACpB,kDAAkD;QAClD,IAAI,IAAI,CAAC,SAAS,KAAK,SAAS,EAAE;YAChC,OAAO,IAAI,CAAC,aAAa,IAAI,IAAI,CAAC;SACnC;QAED,OAAO,IAAI,CAAC;IACd,CAAC;IAEM,aAAa;QAClB,OAAO,IAAI,CAAC,KAAK,KAAK,SAAS,CAAC,CAAC,CAAC,IAAI,CAAC,KAAK,CAAC,CAAC,CAAC,IAAI,CAAC;IACtD,CAAC;IAEM,aAAa;QAClB,IAAI,IAAI,CAAC,SAAS,KAAK,SAAS,EAAE;YAChC,OAAO,IAAI,CAAC,aAAa,IAAI,IAAI,CAAC;SACnC;QAED,OAAO,IAAI,CAAC;IACd,CAAC;IAEM,WAAW;QAChB,OAAO,CAAC,CAAC;IACX,CAAC;IAEM,eAAe;QACpB,OAAO,CAAC,CAAC;IACX,CAAC;IAEM,wBAAwB;QAC7B,OAAO,EAAE,CAAC;IACZ,CAAC;IAEM,OAAO;QACZ,OAAO,SAAS,CAAC;IACnB,CAAC;IAEM,WAAW;QAChB,OAAO,IAAI,CAAC,SAAS,IAAI,IAAI,CAAC;IAChC,CAAC;IAEM,OAAO;QACZ,OAAO,KAAK,CAAC;IACf,CAAC;IAEM,aAAa;QAClB,OAAO,KAAK,CAAC;IACf,CAAC;IAEM,MAAM;QACX,OAAO,KAAK,CAAC;IACf,CAAC;IAEM,QAAQ;QACb,OAAO,KAAK,CAAC;IACf,CAAC;IAEM,YAAY;QACjB,OAAO,KAAK,CAAC;IACf,CAAC;IAEM,UAAU;QACf,OAAO,KAAK,CAAC;IACf,CAAC;IAEM,aAAa;QAClB,OAAO,EAAE,CAAC;IACZ,CAAC;IAEM,wBAAwB;QAC7B,OAAO,CAAC,CAAC;IACX,CAAC;IAEM,sBAAsB;QAC3B,OAAO,CAAC,CAAC;IACX,CAAC;IAEM,QAAQ;QACb,OAAO,oBAAoB,CAAC;IAC9B,CAAC;CACF"}
 \ No newline at end of file
 diff --git a/internal/hardhat-network/stack-traces/solidity-stack-trace.d.ts b/internal/hardhat-network/stack-traces/solidity-stack-trace.d.ts
 index 0b02c8693471f15331948901c41a8cd0644c77ed..a1af980f929578e995ba53f0bcafbec9c83b550e 100644
@@ -3437,110 +4239,219 @@ index 6ad6da5477e18ca76ce848b091cea6bfd5e92f91..759e442a1db6a9bdb20f2b5ad197b2d6
 \ No newline at end of file
 +{"version":3,"file":"solidity-stack-trace.js","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/solidity-stack-trace.ts"],"names":[],"mappings":";;;AA2BA,4CAW8B;AAR5B,kHAAA,2BAA2B,OAAA;AAC3B,6GAAA,sBAAsB,OAAA;AACtB,4GAAA,qBAAqB,OAAA;AACrB,gHAAA,yBAAyB,OAAA;AACzB,iHAAA,0BAA0B,OAAA;AAC1B,4GAAA,qBAAqB,OAAA;AACrB,+GAAA,wBAAwB,OAAA;AACxB,iHAAA,0BAA0B,OAAA"}
 \ No newline at end of file
+diff --git a/internal/hardhat-network/stack-traces/solidityTracer.d.ts b/internal/hardhat-network/stack-traces/solidityTracer.d.ts
+index c60da6822b44d02950224a722182a6e9377e0665..ec70c6203ad15fce4602e7c83cf3d3072e399266 100644
+--- a/internal/hardhat-network/stack-traces/solidityTracer.d.ts
++++ b/internal/hardhat-network/stack-traces/solidityTracer.d.ts
+@@ -1,14 +1,2 @@
+-import { MessageTrace } from "./message-trace";
+-import { SolidityStackTrace } from "./solidity-stack-trace";
+-export declare class SolidityTracer {
+-    private _errorInferrer;
+-    getStackTrace(maybeDecodedMessageTrace: MessageTrace): SolidityStackTrace;
+-    private _getCallMessageStackTrace;
+-    private _getUnrecognizedMessageStackTrace;
+-    private _getCreateMessageStackTrace;
+-    private _getPrecompileMessageStackTrace;
+-    private _traceEvmExecution;
+-    private _rawTraceEvmExecution;
+-    private _getLastSubtrace;
+-}
++export { SolidityTracer } from "@nomicfoundation/edr";
+ //# sourceMappingURL=solidityTracer.d.ts.map
+\ No newline at end of file
+diff --git a/internal/hardhat-network/stack-traces/solidityTracer.d.ts.map b/internal/hardhat-network/stack-traces/solidityTracer.d.ts.map
+index 05b6b71285607f687ab5c943ea7f6b3521aed1e1..f8b2673d231d56650ca7765a42c1a1830d3d2036 100644
+--- a/internal/hardhat-network/stack-traces/solidityTracer.d.ts.map
++++ b/internal/hardhat-network/stack-traces/solidityTracer.d.ts.map
+@@ -1 +1 @@
+-{"version":3,"file":"solidityTracer.d.ts","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/solidityTracer.ts"],"names":[],"mappings":"AAcA,OAAO,EAWL,YAAY,EAEb,MAAM,iBAAiB,CAAC;AAGzB,OAAO,EACL,kBAAkB,EAGnB,MAAM,wBAAwB,CAAC;AAEhC,qBAAa,cAAc;IACzB,OAAO,CAAC,cAAc,CAAuB;IAEtC,aAAa,CAClB,wBAAwB,EAAE,YAAY,GACrC,kBAAkB;IAoBrB,OAAO,CAAC,yBAAyB;IAajC,OAAO,CAAC,iCAAiC;IA2DzC,OAAO,CAAC,2BAA2B;IAanC,OAAO,CAAC,+BAA+B;IAWvC,OAAO,CAAC,kBAAkB;IAY1B,OAAO,CAAC,qBAAqB;IAwE7B,OAAO,CAAC,gBAAgB;CAazB"}
+\ No newline at end of file
++{"version":3,"file":"solidityTracer.d.ts","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/solidityTracer.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,cAAc,EAAE,MAAM,sBAAsB,CAAC"}
+\ No newline at end of file
 diff --git a/internal/hardhat-network/stack-traces/solidityTracer.js b/internal/hardhat-network/stack-traces/solidityTracer.js
-index 08f4e6bf80b81fed910dccc3052b9c886fd0338e..a634f68d9a67550ca52cd3b81788775b8c7ec514 100644
+index 08f4e6bf80b81fed910dccc3052b9c886fd0338e..85aa01b907a665b4b9196d3990e0a54dd4235fa0 100644
 --- a/internal/hardhat-network/stack-traces/solidityTracer.js
 +++ b/internal/hardhat-network/stack-traces/solidityTracer.js
-@@ -3,13 +3,9 @@ Object.defineProperty(exports, "__esModule", { value: true });
+@@ -1,167 +1,6 @@
+ "use strict";
+ Object.defineProperty(exports, "__esModule", { value: true });
  exports.SolidityTracer = void 0;
- const ethereumjs_util_1 = require("@nomicfoundation/ethereumjs-util");
- const return_data_1 = require("../provider/return-data");
+-const ethereumjs_util_1 = require("@nomicfoundation/ethereumjs-util");
+-const return_data_1 = require("../provider/return-data");
 -const exit_1 = require("../provider/vm/exit");
- const error_inferrer_1 = require("./error-inferrer");
- const mapped_inlined_internal_functions_heuristics_1 = require("./mapped-inlined-internal-functions-heuristics");
- const message_trace_1 = require("./message-trace");
+-const error_inferrer_1 = require("./error-inferrer");
+-const mapped_inlined_internal_functions_heuristics_1 = require("./mapped-inlined-internal-functions-heuristics");
+-const message_trace_1 = require("./message-trace");
 -const model_1 = require("./model");
 -const opcodes_1 = require("./opcodes");
 -const solidity_stack_trace_1 = require("./solidity-stack-trace");
- class SolidityTracer {
-     constructor() {
-         this._errorInferrer = new error_inferrer_1.ErrorInferrer();
-@@ -46,30 +42,30 @@ class SolidityTracer {
-                 let unrecognizedEntry;
-                 if ((0, message_trace_1.isCreateTrace)(trace)) {
-                     unrecognizedEntry = {
+-class SolidityTracer {
+-    constructor() {
+-        this._errorInferrer = new error_inferrer_1.ErrorInferrer();
+-    }
+-    getStackTrace(maybeDecodedMessageTrace) {
+-        if (!maybeDecodedMessageTrace.exit.isError()) {
+-            return [];
+-        }
+-        if ((0, message_trace_1.isPrecompileTrace)(maybeDecodedMessageTrace)) {
+-            return this._getPrecompileMessageStackTrace(maybeDecodedMessageTrace);
+-        }
+-        if ((0, message_trace_1.isDecodedCreateTrace)(maybeDecodedMessageTrace)) {
+-            return this._getCreateMessageStackTrace(maybeDecodedMessageTrace);
+-        }
+-        if ((0, message_trace_1.isDecodedCallTrace)(maybeDecodedMessageTrace)) {
+-            return this._getCallMessageStackTrace(maybeDecodedMessageTrace);
+-        }
+-        return this._getUnrecognizedMessageStackTrace(maybeDecodedMessageTrace);
+-    }
+-    _getCallMessageStackTrace(trace) {
+-        const inferredError = this._errorInferrer.inferBeforeTracingCallMessage(trace);
+-        if (inferredError !== undefined) {
+-            return inferredError;
+-        }
+-        return this._traceEvmExecution(trace);
+-    }
+-    _getUnrecognizedMessageStackTrace(trace) {
+-        const subtrace = this._getLastSubtrace(trace);
+-        if (subtrace !== undefined) {
+-            // This is not a very exact heuristic, but most of the time it will be right, as solidity
+-            // reverts if a call fails, and most contracts are in solidity
+-            if (subtrace.exit.isError() &&
+-                (0, ethereumjs_util_1.equalsBytes)(trace.returnData, subtrace.returnData)) {
+-                let unrecognizedEntry;
+-                if ((0, message_trace_1.isCreateTrace)(trace)) {
+-                    unrecognizedEntry = {
 -                        type: solidity_stack_trace_1.StackTraceEntryType.UNRECOGNIZED_CREATE_CALLSTACK_ENTRY,
-+                        type: 1 /* StackTraceEntryType.UNRECOGNIZED_CREATE_CALLSTACK_ENTRY */,
-                     };
-                 }
-                 else {
-                     unrecognizedEntry = {
+-                    };
+-                }
+-                else {
+-                    unrecognizedEntry = {
 -                        type: solidity_stack_trace_1.StackTraceEntryType.UNRECOGNIZED_CONTRACT_CALLSTACK_ENTRY,
-+                        type: 2 /* StackTraceEntryType.UNRECOGNIZED_CONTRACT_CALLSTACK_ENTRY */,
-                         address: trace.address,
-                     };
-                 }
-                 return [unrecognizedEntry, ...this.getStackTrace(subtrace)];
-             }
-         }
+-                        address: trace.address,
+-                    };
+-                }
+-                return [unrecognizedEntry, ...this.getStackTrace(subtrace)];
+-            }
+-        }
 -        if (trace.exit.kind === exit_1.ExitCode.CODESIZE_EXCEEDS_MAXIMUM) {
-+        if (trace.exit.kind === 6 /* ExitCode.CODESIZE_EXCEEDS_MAXIMUM */) {
-             return [
-                 {
+-            return [
+-                {
 -                    type: solidity_stack_trace_1.StackTraceEntryType.CONTRACT_TOO_LARGE_ERROR,
-+                    type: 21 /* StackTraceEntryType.CONTRACT_TOO_LARGE_ERROR */,
-                 },
-             ];
-         }
+-                },
+-            ];
+-        }
 -        const isInvalidOpcodeError = trace.exit.kind === exit_1.ExitCode.INVALID_OPCODE;
-+        const isInvalidOpcodeError = trace.exit.kind === 4 /* ExitCode.INVALID_OPCODE */;
-         if ((0, message_trace_1.isCreateTrace)(trace)) {
-             return [
-                 {
+-        if ((0, message_trace_1.isCreateTrace)(trace)) {
+-            return [
+-                {
 -                    type: solidity_stack_trace_1.StackTraceEntryType.UNRECOGNIZED_CREATE_ERROR,
-+                    type: 17 /* StackTraceEntryType.UNRECOGNIZED_CREATE_ERROR */,
-                     message: new return_data_1.ReturnData(trace.returnData),
-                     isInvalidOpcodeError,
-                 },
-@@ -77,7 +73,7 @@ class SolidityTracer {
-         }
-         return [
-             {
+-                    message: new return_data_1.ReturnData(trace.returnData),
+-                    isInvalidOpcodeError,
+-                },
+-            ];
+-        }
+-        return [
+-            {
 -                type: solidity_stack_trace_1.StackTraceEntryType.UNRECOGNIZED_CONTRACT_ERROR,
-+                type: 18 /* StackTraceEntryType.UNRECOGNIZED_CONTRACT_ERROR */,
-                 address: trace.address,
-                 message: new return_data_1.ReturnData(trace.returnData),
-                 isInvalidOpcodeError,
-@@ -94,7 +90,7 @@ class SolidityTracer {
-     _getPrecompileMessageStackTrace(trace) {
-         return [
-             {
+-                address: trace.address,
+-                message: new return_data_1.ReturnData(trace.returnData),
+-                isInvalidOpcodeError,
+-            },
+-        ];
+-    }
+-    _getCreateMessageStackTrace(trace) {
+-        const inferredError = this._errorInferrer.inferBeforeTracingCreateMessage(trace);
+-        if (inferredError !== undefined) {
+-            return inferredError;
+-        }
+-        return this._traceEvmExecution(trace);
+-    }
+-    _getPrecompileMessageStackTrace(trace) {
+-        return [
+-            {
 -                type: solidity_stack_trace_1.StackTraceEntryType.PRECOMPILE_ERROR,
-+                type: 3 /* StackTraceEntryType.PRECOMPILE_ERROR */,
-                 precompile: trace.precompile,
-             },
-         ];
-@@ -118,11 +114,11 @@ class SolidityTracer {
-             const nextStep = trace.steps[stepIndex + 1];
-             if ((0, message_trace_1.isEvmStep)(step)) {
-                 const inst = trace.bytecode.getInstruction(step.pc);
+-                precompile: trace.precompile,
+-            },
+-        ];
+-    }
+-    _traceEvmExecution(trace) {
+-        const stackTrace = this._rawTraceEvmExecution(trace);
+-        if ((0, mapped_inlined_internal_functions_heuristics_1.stackTraceMayRequireAdjustments)(stackTrace, trace)) {
+-            return (0, mapped_inlined_internal_functions_heuristics_1.adjustStackTrace)(stackTrace, trace);
+-        }
+-        return stackTrace;
+-    }
+-    _rawTraceEvmExecution(trace) {
+-        const stacktrace = [];
+-        let subtracesSeen = 0;
+-        // There was a jump into a function according to the sourcemaps
+-        let jumpedIntoFunction = false;
+-        const functionJumpdests = [];
+-        let lastSubmessageData;
+-        for (let stepIndex = 0; stepIndex < trace.steps.length; stepIndex++) {
+-            const step = trace.steps[stepIndex];
+-            const nextStep = trace.steps[stepIndex + 1];
+-            if ((0, message_trace_1.isEvmStep)(step)) {
+-                const inst = trace.bytecode.getInstruction(step.pc);
 -                if (inst.jumpType === model_1.JumpType.INTO_FUNCTION &&
-+                if (inst.jumpType === 1 /* JumpType.INTO_FUNCTION */ &&
-                     nextStep !== undefined) {
-                     const nextEvmStep = nextStep; // A jump can't be followed by a subtrace
-                     const nextInst = trace.bytecode.getInstruction(nextEvmStep.pc);
+-                    nextStep !== undefined) {
+-                    const nextEvmStep = nextStep; // A jump can't be followed by a subtrace
+-                    const nextInst = trace.bytecode.getInstruction(nextEvmStep.pc);
 -                    if (nextInst !== undefined && nextInst.opcode === opcodes_1.Opcode.JUMPDEST) {
-+                    if (nextInst !== undefined && nextInst.opcode === 91 /* Opcode.JUMPDEST */) {
-                         stacktrace.push((0, error_inferrer_1.instructionToCallstackStackTraceEntry)(trace.bytecode, inst));
-                         if (nextInst.location !== undefined) {
-                             jumpedIntoFunction = true;
-@@ -130,7 +126,7 @@ class SolidityTracer {
-                         functionJumpdests.push(nextInst);
-                     }
-                 }
+-                        stacktrace.push((0, error_inferrer_1.instructionToCallstackStackTraceEntry)(trace.bytecode, inst));
+-                        if (nextInst.location !== undefined) {
+-                            jumpedIntoFunction = true;
+-                        }
+-                        functionJumpdests.push(nextInst);
+-                    }
+-                }
 -                else if (inst.jumpType === model_1.JumpType.OUTOF_FUNCTION) {
-+                else if (inst.jumpType === 2 /* JumpType.OUTOF_FUNCTION */) {
-                     stacktrace.pop();
-                     functionJumpdests.pop();
-                 }
+-                    stacktrace.pop();
+-                    functionJumpdests.pop();
+-                }
+-            }
+-            else {
+-                subtracesSeen += 1;
+-                // If there are more subtraces, this one didn't terminate the execution
+-                if (subtracesSeen < trace.numberOfSubtraces) {
+-                    continue;
+-                }
+-                const submessageTrace = this.getStackTrace(step);
+-                lastSubmessageData = {
+-                    messageTrace: step,
+-                    stepIndex,
+-                    stacktrace: submessageTrace,
+-                };
+-            }
+-        }
+-        const stacktraceWithInferredError = this._errorInferrer.inferAfterTracing(trace, stacktrace, functionJumpdests, jumpedIntoFunction, lastSubmessageData);
+-        return this._errorInferrer.filterRedundantFrames(stacktraceWithInferredError);
+-    }
+-    _getLastSubtrace(trace) {
+-        if (trace.numberOfSubtraces < 1) {
+-            return undefined;
+-        }
+-        let i = trace.steps.length - 1;
+-        while ((0, message_trace_1.isEvmStep)(trace.steps[i])) {
+-            i -= 1;
+-        }
+-        return trace.steps[i];
+-    }
+-}
+-exports.SolidityTracer = SolidityTracer;
++var edr_1 = require("@nomicfoundation/edr");
++Object.defineProperty(exports, "SolidityTracer", { enumerable: true, get: function () { return edr_1.SolidityTracer; } });
+ //# sourceMappingURL=solidityTracer.js.map
+\ No newline at end of file
 diff --git a/internal/hardhat-network/stack-traces/solidityTracer.js.map b/internal/hardhat-network/stack-traces/solidityTracer.js.map
-index 8aa9ffe76723470f68ffd824d9cac39de6494962..c5b56943a49e2538394684566b5a857f7363d1cc 100644
+index 8aa9ffe76723470f68ffd824d9cac39de6494962..0837a5735f1f96f8f772c6e01ec68c003a03448a 100644
 --- a/internal/hardhat-network/stack-traces/solidityTracer.js.map
 +++ b/internal/hardhat-network/stack-traces/solidityTracer.js.map
 @@ -1 +1 @@
 -{"version":3,"file":"solidityTracer.js","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/solidityTracer.ts"],"names":[],"mappings":";;;AAAA,sEAA+D;AAE/D,yDAAqD;AACrD,8CAA+C;AAE/C,qDAI0B;AAC1B,iHAGwD;AACxD,mDAayB;AACzB,mCAAgD;AAChD,uCAAmC;AACnC,iEAIgC;AAEhC,MAAa,cAAc;IAA3B;QACU,mBAAc,GAAG,IAAI,8BAAa,EAAE,CAAC;IAyN/C,CAAC;IAvNQ,aAAa,CAClB,wBAAsC;QAEtC,IAAI,CAAC,wBAAwB,CAAC,IAAI,CAAC,OAAO,EAAE,EAAE;YAC5C,OAAO,EAAE,CAAC;SACX;QAED,IAAI,IAAA,iCAAiB,EAAC,wBAAwB,CAAC,EAAE;YAC/C,OAAO,IAAI,CAAC,+BAA+B,CAAC,wBAAwB,CAAC,CAAC;SACvE;QAED,IAAI,IAAA,oCAAoB,EAAC,wBAAwB,CAAC,EAAE;YAClD,OAAO,IAAI,CAAC,2BAA2B,CAAC,wBAAwB,CAAC,CAAC;SACnE;QAED,IAAI,IAAA,kCAAkB,EAAC,wBAAwB,CAAC,EAAE;YAChD,OAAO,IAAI,CAAC,yBAAyB,CAAC,wBAAwB,CAAC,CAAC;SACjE;QAED,OAAO,IAAI,CAAC,iCAAiC,CAAC,wBAAwB,CAAC,CAAC;IAC1E,CAAC;IAEO,yBAAyB,CAC/B,KAA8B;QAE9B,MAAM,aAAa,GACjB,IAAI,CAAC,cAAc,CAAC,6BAA6B,CAAC,KAAK,CAAC,CAAC;QAE3D,IAAI,aAAa,KAAK,SAAS,EAAE;YAC/B,OAAO,aAAa,CAAC;SACtB;QAED,OAAO,IAAI,CAAC,kBAAkB,CAAC,KAAK,CAAC,CAAC;IACxC,CAAC;IAEO,iCAAiC,CACvC,KAAsB;QAEtB,MAAM,QAAQ,GAAG,IAAI,CAAC,gBAAgB,CAAC,KAAK,CAAC,CAAC;QAE9C,IAAI,QAAQ,KAAK,SAAS,EAAE;YAC1B,yFAAyF;YACzF,8DAA8D;YAC9D,IACE,QAAQ,CAAC,IAAI,CAAC,OAAO,EAAE;gBACvB,IAAA,6BAAW,EAAC,KAAK,CAAC,UAAU,EAAE,QAAQ,CAAC,UAAU,CAAC,EAClD;gBACA,IAAI,iBAA0C,CAAC;gBAE/C,IAAI,IAAA,6BAAa,EAAC,KAAK,CAAC,EAAE;oBACxB,iBAAiB,GAAG;wBAClB,IAAI,EAAE,0CAAmB,CAAC,mCAAmC;qBAC9D,CAAC;iBACH;qBAAM;oBACL,iBAAiB,GAAG;wBAClB,IAAI,EAAE,0CAAmB,CAAC,qCAAqC;wBAC/D,OAAO,EAAE,KAAK,CAAC,OAAO;qBACvB,CAAC;iBACH;gBAED,OAAO,CAAC,iBAAiB,EAAE,GAAG,IAAI,CAAC,aAAa,CAAC,QAAQ,CAAC,CAAC,CAAC;aAC7D;SACF;QAED,IAAI,KAAK,CAAC,IAAI,CAAC,IAAI,KAAK,eAAQ,CAAC,wBAAwB,EAAE;YACzD,OAAO;gBACL;oBACE,IAAI,EAAE,0CAAmB,CAAC,wBAAwB;iBACnD;aACF,CAAC;SACH;QAED,MAAM,oBAAoB,GAAG,KAAK,CAAC,IAAI,CAAC,IAAI,KAAK,eAAQ,CAAC,cAAc,CAAC;QAEzE,IAAI,IAAA,6BAAa,EAAC,KAAK,CAAC,EAAE;YACxB,OAAO;gBACL;oBACE,IAAI,EAAE,0CAAmB,CAAC,yBAAyB;oBACnD,OAAO,EAAE,IAAI,wBAAU,CAAC,KAAK,CAAC,UAAU,CAAC;oBACzC,oBAAoB;iBACrB;aACF,CAAC;SACH;QAED,OAAO;YACL;gBACE,IAAI,EAAE,0CAAmB,CAAC,2BAA2B;gBACrD,OAAO,EAAE,KAAK,CAAC,OAAO;gBACtB,OAAO,EAAE,IAAI,wBAAU,CAAC,KAAK,CAAC,UAAU,CAAC;gBACzC,oBAAoB;aACrB;SACF,CAAC;IACJ,CAAC;IAEO,2BAA2B,CACjC,KAAgC;QAEhC,MAAM,aAAa,GACjB,IAAI,CAAC,cAAc,CAAC,+BAA+B,CAAC,KAAK,CAAC,CAAC;QAE7D,IAAI,aAAa,KAAK,SAAS,EAAE;YAC/B,OAAO,aAAa,CAAC;SACtB;QAED,OAAO,IAAI,CAAC,kBAAkB,CAAC,KAAK,CAAC,CAAC;IACxC,CAAC;IAEO,+BAA+B,CACrC,KAA6B;QAE7B,OAAO;YACL;gBACE,IAAI,EAAE,0CAAmB,CAAC,gBAAgB;gBAC1C,UAAU,EAAE,KAAK,CAAC,UAAU;aAC7B;SACF,CAAC;IACJ,CAAC;IAEO,kBAAkB,CACxB,KAA6B;QAE7B,MAAM,UAAU,GAAG,IAAI,CAAC,qBAAqB,CAAC,KAAK,CAAC,CAAC;QAErD,IAAI,IAAA,8EAA+B,EAAC,UAAU,EAAE,KAAK,CAAC,EAAE;YACtD,OAAO,IAAA,+DAAgB,EAAC,UAAU,EAAE,KAAK,CAAC,CAAC;SAC5C;QAED,OAAO,UAAU,CAAC;IACpB,CAAC;IAEO,qBAAqB,CAC3B,KAA6B;QAE7B,MAAM,UAAU,GAAuB,EAAE,CAAC;QAE1C,IAAI,aAAa,GAAG,CAAC,CAAC;QAEtB,+DAA+D;QAC/D,IAAI,kBAAkB,GAAG,KAAK,CAAC;QAE/B,MAAM,iBAAiB,GAAkB,EAAE,CAAC;QAE5C,IAAI,kBAA8C,CAAC;QAEnD,KAAK,IAAI,SAAS,GAAG,CAAC,EAAE,SAAS,GAAG,KAAK,CAAC,KAAK,CAAC,MAAM,EAAE,SAAS,EAAE,EAAE;YACnE,MAAM,IAAI,GAAG,KAAK,CAAC,KAAK,CAAC,SAAS,CAAC,CAAC;YACpC,MAAM,QAAQ,GAAG,KAAK,CAAC,KAAK,CAAC,SAAS,GAAG,CAAC,CAAC,CAAC;YAE5C,IAAI,IAAA,yBAAS,EAAC,IAAI,CAAC,EAAE;gBACnB,MAAM,IAAI,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,IAAI,CAAC,EAAE,CAAC,CAAC;gBAEpD,IACE,IAAI,CAAC,QAAQ,KAAK,gBAAQ,CAAC,aAAa;oBACxC,QAAQ,KAAK,SAAS,EACtB;oBACA,MAAM,WAAW,GAAG,QAAmB,CAAC,CAAC,yCAAyC;oBAClF,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,WAAW,CAAC,EAAE,CAAC,CAAC;oBAE/D,IAAI,QAAQ,KAAK,SAAS,IAAI,QAAQ,CAAC,MAAM,KAAK,gBAAM,CAAC,QAAQ,EAAE;wBACjE,UAAU,CAAC,IAAI,CACb,IAAA,sDAAqC,EAAC,KAAK,CAAC,QAAQ,EAAE,IAAI,CAAC,CAC5D,CAAC;wBACF,IAAI,QAAQ,CAAC,QAAQ,KAAK,SAAS,EAAE;4BACnC,kBAAkB,GAAG,IAAI,CAAC;yBAC3B;wBACD,iBAAiB,CAAC,IAAI,CAAC,QAAQ,CAAC,CAAC;qBAClC;iBACF;qBAAM,IAAI,IAAI,CAAC,QAAQ,KAAK,gBAAQ,CAAC,cAAc,EAAE;oBACpD,UAAU,CAAC,GAAG,EAAE,CAAC;oBACjB,iBAAiB,CAAC,GAAG,EAAE,CAAC;iBACzB;aACF;iBAAM;gBACL,aAAa,IAAI,CAAC,CAAC;gBAEnB,uEAAuE;gBACvE,IAAI,aAAa,GAAG,KAAK,CAAC,iBAAiB,EAAE;oBAC3C,SAAS;iBACV;gBAED,MAAM,eAAe,GAAG,IAAI,CAAC,aAAa,CAAC,IAAI,CAAC,CAAC;gBAEjD,kBAAkB,GAAG;oBACnB,YAAY,EAAE,IAAI;oBAClB,SAAS;oBACT,UAAU,EAAE,eAAe;iBAC5B,CAAC;aACH;SACF;QAED,MAAM,2BAA2B,GAAG,IAAI,CAAC,cAAc,CAAC,iBAAiB,CACvE,KAAK,EACL,UAAU,EACV,iBAAiB,EACjB,kBAAkB,EAClB,kBAAkB,CACnB,CAAC;QAEF,OAAO,IAAI,CAAC,cAAc,CAAC,qBAAqB,CAC9C,2BAA2B,CAC5B,CAAC;IACJ,CAAC;IAEO,gBAAgB,CAAC,KAAsB;QAC7C,IAAI,KAAK,CAAC,iBAAiB,GAAG,CAAC,EAAE;YAC/B,OAAO,SAAS,CAAC;SAClB;QAED,IAAI,CAAC,GAAG,KAAK,CAAC,KAAK,CAAC,MAAM,GAAG,CAAC,CAAC;QAE/B,OAAO,IAAA,yBAAS,EAAC,KAAK,CAAC,KAAK,CAAC,CAAC,CAAC,CAAC,EAAE;YAChC,CAAC,IAAI,CAAC,CAAC;SACR;QAED,OAAO,KAAK,CAAC,KAAK,CAAC,CAAC,CAAiB,CAAC;IACxC,CAAC;CACF;AA1ND,wCA0NC"}
 \ No newline at end of file
-+{"version":3,"file":"solidityTracer.js","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/solidityTracer.ts"],"names":[],"mappings":";;;AAAA,sEAA+D;AAE/D,yDAAqD;AAGrD,qDAI0B;AAC1B,iHAGwD;AACxD,mDAayB;AASzB,MAAa,cAAc;IAA3B;QACU,mBAAc,GAAG,IAAI,8BAAa,EAAE,CAAC;IAyN/C,CAAC;IAvNQ,aAAa,CAClB,wBAAsC;QAEtC,IAAI,CAAC,wBAAwB,CAAC,IAAI,CAAC,OAAO,EAAE,EAAE;YAC5C,OAAO,EAAE,CAAC;SACX;QAED,IAAI,IAAA,iCAAiB,EAAC,wBAAwB,CAAC,EAAE;YAC/C,OAAO,IAAI,CAAC,+BAA+B,CAAC,wBAAwB,CAAC,CAAC;SACvE;QAED,IAAI,IAAA,oCAAoB,EAAC,wBAAwB,CAAC,EAAE;YAClD,OAAO,IAAI,CAAC,2BAA2B,CAAC,wBAAwB,CAAC,CAAC;SACnE;QAED,IAAI,IAAA,kCAAkB,EAAC,wBAAwB,CAAC,EAAE;YAChD,OAAO,IAAI,CAAC,yBAAyB,CAAC,wBAAwB,CAAC,CAAC;SACjE;QAED,OAAO,IAAI,CAAC,iCAAiC,CAAC,wBAAwB,CAAC,CAAC;IAC1E,CAAC;IAEO,yBAAyB,CAC/B,KAA8B;QAE9B,MAAM,aAAa,GACjB,IAAI,CAAC,cAAc,CAAC,6BAA6B,CAAC,KAAK,CAAC,CAAC;QAE3D,IAAI,aAAa,KAAK,SAAS,EAAE;YAC/B,OAAO,aAAa,CAAC;SACtB;QAED,OAAO,IAAI,CAAC,kBAAkB,CAAC,KAAK,CAAC,CAAC;IACxC,CAAC;IAEO,iCAAiC,CACvC,KAAsB;QAEtB,MAAM,QAAQ,GAAG,IAAI,CAAC,gBAAgB,CAAC,KAAK,CAAC,CAAC;QAE9C,IAAI,QAAQ,KAAK,SAAS,EAAE;YAC1B,yFAAyF;YACzF,8DAA8D;YAC9D,IACE,QAAQ,CAAC,IAAI,CAAC,OAAO,EAAE;gBACvB,IAAA,6BAAW,EAAC,KAAK,CAAC,UAAU,EAAE,QAAQ,CAAC,UAAU,CAAC,EAClD;gBACA,IAAI,iBAA0C,CAAC;gBAE/C,IAAI,IAAA,6BAAa,EAAC,KAAK,CAAC,EAAE;oBACxB,iBAAiB,GAAG;wBAClB,IAAI,iEAAyD;qBAC9D,CAAC;iBACH;qBAAM;oBACL,iBAAiB,GAAG;wBAClB,IAAI,mEAA2D;wBAC/D,OAAO,EAAE,KAAK,CAAC,OAAO;qBACvB,CAAC;iBACH;gBAED,OAAO,CAAC,iBAAiB,EAAE,GAAG,IAAI,CAAC,aAAa,CAAC,QAAQ,CAAC,CAAC,CAAC;aAC7D;SACF;QAED,IAAI,KAAK,CAAC,IAAI,CAAC,IAAI,8CAAsC,EAAE;YACzD,OAAO;gBACL;oBACE,IAAI,uDAA8C;iBACnD;aACF,CAAC;SACH;QAED,MAAM,oBAAoB,GAAG,KAAK,CAAC,IAAI,CAAC,IAAI,oCAA4B,CAAC;QAEzE,IAAI,IAAA,6BAAa,EAAC,KAAK,CAAC,EAAE;YACxB,OAAO;gBACL;oBACE,IAAI,wDAA+C;oBACnD,OAAO,EAAE,IAAI,wBAAU,CAAC,KAAK,CAAC,UAAU,CAAC;oBACzC,oBAAoB;iBACrB;aACF,CAAC;SACH;QAED,OAAO;YACL;gBACE,IAAI,0DAAiD;gBACrD,OAAO,EAAE,KAAK,CAAC,OAAO;gBACtB,OAAO,EAAE,IAAI,wBAAU,CAAC,KAAK,CAAC,UAAU,CAAC;gBACzC,oBAAoB;aACrB;SACF,CAAC;IACJ,CAAC;IAEO,2BAA2B,CACjC,KAAgC;QAEhC,MAAM,aAAa,GACjB,IAAI,CAAC,cAAc,CAAC,+BAA+B,CAAC,KAAK,CAAC,CAAC;QAE7D,IAAI,aAAa,KAAK,SAAS,EAAE;YAC/B,OAAO,aAAa,CAAC;SACtB;QAED,OAAO,IAAI,CAAC,kBAAkB,CAAC,KAAK,CAAC,CAAC;IACxC,CAAC;IAEO,+BAA+B,CACrC,KAA6B;QAE7B,OAAO;YACL;gBACE,IAAI,8CAAsC;gBAC1C,UAAU,EAAE,KAAK,CAAC,UAAU;aAC7B;SACF,CAAC;IACJ,CAAC;IAEO,kBAAkB,CACxB,KAA6B;QAE7B,MAAM,UAAU,GAAG,IAAI,CAAC,qBAAqB,CAAC,KAAK,CAAC,CAAC;QAErD,IAAI,IAAA,8EAA+B,EAAC,UAAU,EAAE,KAAK,CAAC,EAAE;YACtD,OAAO,IAAA,+DAAgB,EAAC,UAAU,EAAE,KAAK,CAAC,CAAC;SAC5C;QAED,OAAO,UAAU,CAAC;IACpB,CAAC;IAEO,qBAAqB,CAC3B,KAA6B;QAE7B,MAAM,UAAU,GAAuB,EAAE,CAAC;QAE1C,IAAI,aAAa,GAAG,CAAC,CAAC;QAEtB,+DAA+D;QAC/D,IAAI,kBAAkB,GAAG,KAAK,CAAC;QAE/B,MAAM,iBAAiB,GAAkB,EAAE,CAAC;QAE5C,IAAI,kBAA8C,CAAC;QAEnD,KAAK,IAAI,SAAS,GAAG,CAAC,EAAE,SAAS,GAAG,KAAK,CAAC,KAAK,CAAC,MAAM,EAAE,SAAS,EAAE,EAAE;YACnE,MAAM,IAAI,GAAG,KAAK,CAAC,KAAK,CAAC,SAAS,CAAC,CAAC;YACpC,MAAM,QAAQ,GAAG,KAAK,CAAC,KAAK,CAAC,SAAS,GAAG,CAAC,CAAC,CAAC;YAE5C,IAAI,IAAA,yBAAS,EAAC,IAAI,CAAC,EAAE;gBACnB,MAAM,IAAI,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,IAAI,CAAC,EAAE,CAAC,CAAC;gBAEpD,IACE,IAAI,CAAC,QAAQ,mCAA2B;oBACxC,QAAQ,KAAK,SAAS,EACtB;oBACA,MAAM,WAAW,GAAG,QAAmB,CAAC,CAAC,yCAAyC;oBAClF,MAAM,QAAQ,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,WAAW,CAAC,EAAE,CAAC,CAAC;oBAE/D,IAAI,QAAQ,KAAK,SAAS,IAAI,QAAQ,CAAC,MAAM,6BAAoB,EAAE;wBACjE,UAAU,CAAC,IAAI,CACb,IAAA,sDAAqC,EAAC,KAAK,CAAC,QAAQ,EAAE,IAAI,CAAC,CAC5D,CAAC;wBACF,IAAI,QAAQ,CAAC,QAAQ,KAAK,SAAS,EAAE;4BACnC,kBAAkB,GAAG,IAAI,CAAC;yBAC3B;wBACD,iBAAiB,CAAC,IAAI,CAAC,QAAQ,CAAC,CAAC;qBAClC;iBACF;qBAAM,IAAI,IAAI,CAAC,QAAQ,oCAA4B,EAAE;oBACpD,UAAU,CAAC,GAAG,EAAE,CAAC;oBACjB,iBAAiB,CAAC,GAAG,EAAE,CAAC;iBACzB;aACF;iBAAM;gBACL,aAAa,IAAI,CAAC,CAAC;gBAEnB,uEAAuE;gBACvE,IAAI,aAAa,GAAG,KAAK,CAAC,iBAAiB,EAAE;oBAC3C,SAAS;iBACV;gBAED,MAAM,eAAe,GAAG,IAAI,CAAC,aAAa,CAAC,IAAI,CAAC,CAAC;gBAEjD,kBAAkB,GAAG;oBACnB,YAAY,EAAE,IAAI;oBAClB,SAAS;oBACT,UAAU,EAAE,eAAe;iBAC5B,CAAC;aACH;SACF;QAED,MAAM,2BAA2B,GAAG,IAAI,CAAC,cAAc,CAAC,iBAAiB,CACvE,KAAK,EACL,UAAU,EACV,iBAAiB,EACjB,kBAAkB,EAClB,kBAAkB,CACnB,CAAC;QAEF,OAAO,IAAI,CAAC,cAAc,CAAC,qBAAqB,CAC9C,2BAA2B,CAC5B,CAAC;IACJ,CAAC;IAEO,gBAAgB,CAAC,KAAsB;QAC7C,IAAI,KAAK,CAAC,iBAAiB,GAAG,CAAC,EAAE;YAC/B,OAAO,SAAS,CAAC;SAClB;QAED,IAAI,CAAC,GAAG,KAAK,CAAC,KAAK,CAAC,MAAM,GAAG,CAAC,CAAC;QAE/B,OAAO,IAAA,yBAAS,EAAC,KAAK,CAAC,KAAK,CAAC,CAAC,CAAC,CAAC,EAAE;YAChC,CAAC,IAAI,CAAC,CAAC;SACR;QAED,OAAO,KAAK,CAAC,KAAK,CAAC,CAAC,CAAiB,CAAC;IACxC,CAAC;CACF;AA1ND,wCA0NC"}
++{"version":3,"file":"solidityTracer.js","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/solidityTracer.ts"],"names":[],"mappings":";;;AAAA,4CAAsD;AAA7C,qGAAA,cAAc,OAAA"}
 \ No newline at end of file
 diff --git a/internal/hardhat-network/stack-traces/vm-trace-decoder.d.ts b/internal/hardhat-network/stack-traces/vm-trace-decoder.d.ts
 index 9ab9469708c0ddcded9aed839acf9c5f0c260543..4d0acc22312db19e8b3b731d6bb9063c778d81c8 100644
@@ -5107,14 +6018,14 @@ index 7a479a62cfad681807b6408449458dfcd6960fe7..0f176f37fa6994a051065364d584f22a
 +import { ContractsIdentifier } from "@nomicfoundation/edr";
 +export { ContractsIdentifier };
 diff --git a/src/internal/hardhat-network/stack-traces/debug.ts b/src/internal/hardhat-network/stack-traces/debug.ts
-index 03c423f31895ca495059bba42b5568ea10cbaeb7..deb288dbb81580e991f5b057da1d92528b82205c 100644
+index 03c423f31895ca495059bba42b5568ea10cbaeb7..ba3cfaaa83f4d094c2f34b839bd9abd7e0106845 100644
 --- a/src/internal/hardhat-network/stack-traces/debug.ts
 +++ b/src/internal/hardhat-network/stack-traces/debug.ts
 @@ -1,6 +1,7 @@
  import { bytesToHex as bufferToHex } from "@nomicfoundation/ethereumjs-util";
  import chalk from "chalk";
  
-+import { stackTraceEntryTypeToString } from "@nomicfoundation/edr";
++import { ReturnData, stackTraceEntryTypeToString } from "@nomicfoundation/edr";
  import {
    CallMessageTrace,
    CreateMessageTrace,
@@ -5157,6 +6068,15 @@ index 03c423f31895ca495059bba42b5568ea10cbaeb7..deb288dbb81580e991f5b057da1d9252
              location
            );
          }
+@@ -190,7 +191,7 @@ function flattenSourceReference(sourceReference?: SourceReference) {
+ export function printStackTrace(trace: SolidityStackTrace) {
+   const withDecodedMessages = trace.map((entry) =>
+     entry.type === StackTraceEntryType.REVERT_ERROR
+-      ? { ...entry, message: entry.message.decodeError() }
++      ? { ...entry, message: new ReturnData(entry.returnData).decodeError() }
+       : entry
+   );
+ 
 @@ -202,7 +203,7 @@ export function printStackTrace(trace: SolidityStackTrace) {
  
    const withTextualType = withHexAddress.map((entry) => ({
@@ -5167,26 +6087,1855 @@ index 03c423f31895ca495059bba42b5568ea10cbaeb7..deb288dbb81580e991f5b057da1d9252
  
    const withFlattenedSourceReferences = withTextualType.map((entry) => ({
 diff --git a/src/internal/hardhat-network/stack-traces/error-inferrer.ts b/src/internal/hardhat-network/stack-traces/error-inferrer.ts
-index e185841f421641b2fe9a7fa34aeaf7b0813723cb..95698cada44b39bf4f1c591b7a8ef6f5ca2a3df2 100644
+index e185841f421641b2fe9a7fa34aeaf7b0813723cb..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 100644
 --- a/src/internal/hardhat-network/stack-traces/error-inferrer.ts
 +++ b/src/internal/hardhat-network/stack-traces/error-inferrer.ts
-@@ -641,9 +641,13 @@ export class ErrorInferrer {
-       );
- 
-       if (calledFunction !== undefined) {
+@@ -1,1845 +0,0 @@
+-/* eslint "@typescript-eslint/no-non-null-assertion": "error" */
+-import { defaultAbiCoder as abi } from "@ethersproject/abi";
+-import { equalsBytes } from "@nomicfoundation/ethereumjs-util";
+-import semver from "semver";
+-
+-import { assertHardhatInvariant } from "../../core/errors";
+-import { AbiHelpers } from "../../util/abi-helpers";
+-import { ReturnData } from "../provider/return-data";
+-import { ExitCode } from "../provider/vm/exit";
+-
+-import {
+-  DecodedCallMessageTrace,
+-  DecodedCreateMessageTrace,
+-  DecodedEvmMessageTrace,
+-  EvmStep,
+-  isCreateTrace,
+-  isDecodedCallTrace,
+-  isDecodedCreateTrace,
+-  isEvmStep,
+-  isPrecompileTrace,
+-  MessageTrace,
+-} from "./message-trace";
+-import {
+-  Bytecode,
+-  ContractFunction,
+-  ContractFunctionType,
+-  ContractType,
+-  Instruction,
+-  JumpType,
+-  SourceLocation,
+-} from "./model";
+-import { isCall, isCreate, Opcode } from "./opcodes";
+-import {
+-  CallFailedErrorStackTraceEntry,
+-  CallstackEntryStackTraceEntry,
+-  CONSTRUCTOR_FUNCTION_NAME,
+-  CustomErrorStackTraceEntry,
+-  FALLBACK_FUNCTION_NAME,
+-  InternalFunctionCallStackEntry,
+-  OtherExecutionErrorStackTraceEntry,
+-  PanicErrorStackTraceEntry,
+-  RECEIVE_FUNCTION_NAME,
+-  RevertErrorStackTraceEntry,
+-  SolidityStackTrace,
+-  SolidityStackTraceEntry,
+-  SourceReference,
+-  StackTraceEntryType,
+-  UnmappedSolc063RevertErrorStackTraceEntry,
+-} from "./solidity-stack-trace";
+-
+-const FIRST_SOLC_VERSION_CREATE_PARAMS_VALIDATION = "0.5.9";
+-const FIRST_SOLC_VERSION_RECEIVE_FUNCTION = "0.6.0";
+-const FIRST_SOLC_VERSION_WITH_UNMAPPED_REVERTS = "0.6.3";
+-
+-export interface SubmessageData {
+-  messageTrace: MessageTrace;
+-  stacktrace: SolidityStackTrace;
+-  stepIndex: number;
+-}
+-
+-/* eslint-disable @nomicfoundation/hardhat-internal-rules/only-hardhat-error */
+-
+-export class ErrorInferrer {
+-  public inferBeforeTracingCallMessage(
+-    trace: DecodedCallMessageTrace
+-  ): SolidityStackTrace | undefined {
+-    if (this._isDirectLibraryCall(trace)) {
+-      return this._getDirectLibraryCallErrorStackTrace(trace);
+-    }
+-
+-    const calledFunction = trace.bytecode.contract.getFunctionFromSelector(
+-      trace.calldata.slice(0, 4)
+-    );
+-
+-    if (
+-      calledFunction !== undefined &&
+-      this._isFunctionNotPayableError(trace, calledFunction)
+-    ) {
+-      return [
+-        {
+-          type: StackTraceEntryType.FUNCTION_NOT_PAYABLE_ERROR,
+-          sourceReference: this._getFunctionStartSourceReference(
+-            trace,
+-            calledFunction
+-          ),
+-          value: trace.value,
+-        },
+-      ];
+-    }
+-
+-    if (this._isMissingFunctionAndFallbackError(trace, calledFunction)) {
+-      if (this._emptyCalldataAndNoReceive(trace)) {
+-        return [
+-          {
+-            type: StackTraceEntryType.MISSING_FALLBACK_OR_RECEIVE_ERROR,
+-            sourceReference:
+-              this._getContractStartWithoutFunctionSourceReference(trace),
+-          },
+-        ];
+-      }
+-
+-      return [
+-        {
+-          type: StackTraceEntryType.UNRECOGNIZED_FUNCTION_WITHOUT_FALLBACK_ERROR,
+-          sourceReference:
+-            this._getContractStartWithoutFunctionSourceReference(trace),
+-        },
+-      ];
+-    }
+-
+-    if (this._isFallbackNotPayableError(trace, calledFunction)) {
+-      if (this._emptyCalldataAndNoReceive(trace)) {
+-        return [
+-          {
+-            type: StackTraceEntryType.FALLBACK_NOT_PAYABLE_AND_NO_RECEIVE_ERROR,
+-            sourceReference: this._getFallbackStartSourceReference(trace),
+-            value: trace.value,
+-          },
+-        ];
+-      }
+-
+-      return [
+-        {
+-          type: StackTraceEntryType.FALLBACK_NOT_PAYABLE_ERROR,
+-          sourceReference: this._getFallbackStartSourceReference(trace),
+-          value: trace.value,
+-        },
+-      ];
+-    }
+-  }
+-
+-  public inferBeforeTracingCreateMessage(
+-    trace: DecodedCreateMessageTrace
+-  ): SolidityStackTrace | undefined {
+-    if (this._isConstructorNotPayableError(trace)) {
+-      return [
+-        {
+-          type: StackTraceEntryType.FUNCTION_NOT_PAYABLE_ERROR,
+-          sourceReference: this._getConstructorStartSourceReference(trace),
+-          value: trace.value,
+-        },
+-      ];
+-    }
+-
+-    if (this._isConstructorInvalidArgumentsError(trace)) {
+-      return [
+-        {
+-          type: StackTraceEntryType.INVALID_PARAMS_ERROR,
+-          sourceReference: this._getConstructorStartSourceReference(trace),
+-        },
+-      ];
+-    }
+-  }
+-
+-  public inferAfterTracing(
+-    trace: DecodedEvmMessageTrace,
+-    stacktrace: SolidityStackTrace,
+-    functionJumpdests: Instruction[],
+-    jumpedIntoFunction: boolean,
+-    lastSubmessageData: SubmessageData | undefined
+-  ): SolidityStackTrace {
+-    return (
+-      this._checkLastSubmessage(trace, stacktrace, lastSubmessageData) ??
+-      this._checkFailedLastCall(trace, stacktrace) ??
+-      this._checkLastInstruction(
+-        trace,
+-        stacktrace,
+-        functionJumpdests,
+-        jumpedIntoFunction
+-      ) ??
+-      this._checkNonContractCalled(trace, stacktrace) ??
+-      this._checkSolidity063UnmappedRevert(trace, stacktrace) ??
+-      this._checkContractTooLarge(trace) ??
+-      this._otherExecutionErrorStacktrace(trace, stacktrace)
+-    );
+-  }
+-
+-  public filterRedundantFrames(
+-    stacktrace: SolidityStackTrace
+-  ): SolidityStackTrace {
+-    return stacktrace.filter((frame, i) => {
+-      if (i + 1 === stacktrace.length) {
+-        return true;
+-      }
+-
+-      const nextFrame = stacktrace[i + 1];
+-
+-      // we can only filter frames if we know their sourceReference
+-      // and the one from the next frame
+-      if (
+-        frame.sourceReference === undefined ||
+-        nextFrame.sourceReference === undefined
+-      ) {
+-        return true;
+-      }
+-
+-      // look TWO frames ahead to determine if this is a specific occurrence of
+-      // a redundant CALLSTACK_ENTRY frame observed when using Solidity 0.8.5:
+-      if (
+-        frame.type === StackTraceEntryType.CALLSTACK_ENTRY &&
+-        i + 2 < stacktrace.length &&
+-        stacktrace[i + 2].sourceReference !== undefined &&
+-        stacktrace[i + 2].type === StackTraceEntryType.RETURNDATA_SIZE_ERROR
+-      ) {
+-        // ! below for tsc. we confirmed existence in the enclosing conditional.
+-        const thatSrcRef = stacktrace[i + 2].sourceReference;
+-        if (
+-          thatSrcRef !== undefined &&
+-          frame.sourceReference.range[0] === thatSrcRef.range[0] &&
+-          frame.sourceReference.range[1] === thatSrcRef.range[1] &&
+-          frame.sourceReference.line === thatSrcRef.line
+-        ) {
+-          return false;
+-        }
+-      }
+-
+-      // constructors contain the whole contract, so we ignore them
+-      if (
+-        frame.sourceReference.function === "constructor" &&
+-        nextFrame.sourceReference.function !== "constructor"
+-      ) {
+-        return true;
+-      }
+-
+-      // this is probably a recursive call
+-      if (
+-        i > 0 &&
+-        frame.type === nextFrame.type &&
+-        frame.sourceReference.range[0] === nextFrame.sourceReference.range[0] &&
+-        frame.sourceReference.range[1] === nextFrame.sourceReference.range[1] &&
+-        frame.sourceReference.line === nextFrame.sourceReference.line
+-      ) {
+-        return true;
+-      }
+-
+-      if (
+-        frame.sourceReference.range[0] <= nextFrame.sourceReference.range[0] &&
+-        frame.sourceReference.range[1] >= nextFrame.sourceReference.range[1]
+-      ) {
+-        return false;
+-      }
+-
+-      return true;
+-    });
+-  }
+-
+-  // Heuristics
+-
+-  /**
+-   * Check if the last submessage can be used to generate the stack trace.
+-   */
+-  private _checkLastSubmessage(
+-    trace: DecodedEvmMessageTrace,
+-    stacktrace: SolidityStackTrace,
+-    lastSubmessageData: SubmessageData | undefined
+-  ): SolidityStackTrace | undefined {
+-    if (lastSubmessageData === undefined) {
+-      return undefined;
+-    }
+-
+-    const inferredStacktrace = [...stacktrace];
+-
+-    // get the instruction before the submessage and add it to the stack trace
+-    const callStep = trace.steps[lastSubmessageData.stepIndex - 1];
+-
+-    if (!isEvmStep(callStep)) {
+-      throw new Error(
+-        "This should not happen: MessageTrace should be preceded by a EVM step"
+-      );
+-    }
+-
+-    const callInst = trace.bytecode.getInstruction(callStep.pc);
+-    const callStackFrame = instructionToCallstackStackTraceEntry(
+-      trace.bytecode,
+-      callInst
+-    );
+-
+-    const lastMessageFailed = lastSubmessageData.messageTrace.exit.isError();
+-    if (lastMessageFailed) {
+-      // add the call/create that generated the message to the stack trace
+-      inferredStacktrace.push(callStackFrame);
+-
+-      if (
+-        this._isSubtraceErrorPropagated(trace, lastSubmessageData.stepIndex) ||
+-        this._isProxyErrorPropagated(trace, lastSubmessageData.stepIndex)
+-      ) {
+-        inferredStacktrace.push(...lastSubmessageData.stacktrace);
+-
+-        if (
+-          this._isContractCallRunOutOfGasError(
+-            trace,
+-            lastSubmessageData.stepIndex
+-          )
+-        ) {
+-          const lastFrame = inferredStacktrace.pop();
+-          assertHardhatInvariant(
+-            lastFrame !== undefined,
+-            "Expected inferred stack trace to have at least one frame"
+-          );
+-          inferredStacktrace.push({
+-            type: StackTraceEntryType.CONTRACT_CALL_RUN_OUT_OF_GAS_ERROR,
+-            sourceReference: lastFrame.sourceReference,
+-          });
+-        }
+-
+-        return this._fixInitialModifier(trace, inferredStacktrace);
+-      }
+-    } else {
+-      const isReturnDataSizeError = this._failsRightAfterCall(
+-        trace,
+-        lastSubmessageData.stepIndex
+-      );
+-      if (isReturnDataSizeError) {
+-        inferredStacktrace.push({
+-          type: StackTraceEntryType.RETURNDATA_SIZE_ERROR,
+-          sourceReference: callStackFrame.sourceReference,
+-        });
+-
+-        return this._fixInitialModifier(trace, inferredStacktrace);
+-      }
+-    }
+-  }
+-
+-  /**
+-   * Check if the last call/create that was done failed.
+-   */
+-  private _checkFailedLastCall(
+-    trace: DecodedEvmMessageTrace,
+-    stacktrace: SolidityStackTrace
+-  ): SolidityStackTrace | undefined {
+-    for (let stepIndex = trace.steps.length - 2; stepIndex >= 0; stepIndex--) {
+-      const step = trace.steps[stepIndex];
+-      const nextStep = trace.steps[stepIndex + 1];
+-
+-      if (!isEvmStep(step)) {
+-        return;
+-      }
+-
+-      const inst = trace.bytecode.getInstruction(step.pc);
+-
+-      const isCallOrCreate = isCall(inst.opcode) || isCreate(inst.opcode);
+-
+-      if (isCallOrCreate && isEvmStep(nextStep)) {
+-        if (this._isCallFailedError(trace, stepIndex, inst)) {
+-          const inferredStacktrace = [
+-            ...stacktrace,
+-            this._callInstructionToCallFailedToExecuteStackTraceEntry(
+-              trace.bytecode,
+-              inst
+-            ),
+-          ];
+-
+-          return this._fixInitialModifier(trace, inferredStacktrace);
+-        }
+-      }
+-    }
+-  }
+-
+-  /**
+-   * Check if the execution stopped with a revert or an invalid opcode.
+-   */
+-  private _checkRevertOrInvalidOpcode(
+-    trace: DecodedEvmMessageTrace,
+-    stacktrace: SolidityStackTrace,
+-    lastInstruction: Instruction,
+-    functionJumpdests: Instruction[],
+-    jumpedIntoFunction: boolean
+-  ): SolidityStackTrace | undefined {
+-    if (
+-      lastInstruction.opcode !== Opcode.REVERT &&
+-      lastInstruction.opcode !== Opcode.INVALID
+-    ) {
+-      return;
+-    }
+-
+-    const inferredStacktrace = [...stacktrace];
+-
+-    if (
+-      lastInstruction.location !== undefined &&
+-      (!isDecodedCallTrace(trace) || jumpedIntoFunction)
+-    ) {
+-      // There should always be a function here, but that's not the case with optimizations.
+-      //
+-      // If this is a create trace, we already checked args and nonpayable failures before
+-      // calling this function.
+-      //
+-      // If it's a call trace, we already jumped into a function. But optimizations can happen.
+-      const failingFunction = lastInstruction.location.getContainingFunction();
+-
+-      // If the failure is in a modifier we add an entry with the function/constructor
+-      if (
+-        failingFunction !== undefined &&
+-        failingFunction.type === ContractFunctionType.MODIFIER
+-      ) {
+-        inferredStacktrace.push(
+-          this._getEntryBeforeFailureInModifier(trace, functionJumpdests)
+-        );
+-      }
+-    }
+-
+-    const panicStacktrace = this._checkPanic(
+-      trace,
+-      inferredStacktrace,
+-      lastInstruction
+-    );
+-    if (panicStacktrace !== undefined) {
+-      return panicStacktrace;
+-    }
+-
+-    const customErrorStacktrace = this._checkCustomErrors(
+-      trace,
+-      inferredStacktrace,
+-      lastInstruction
+-    );
+-    if (customErrorStacktrace !== undefined) {
+-      return customErrorStacktrace;
+-    }
+-
+-    if (
+-      lastInstruction.location !== undefined &&
+-      (!isDecodedCallTrace(trace) || jumpedIntoFunction)
+-    ) {
+-      const failingFunction = lastInstruction.location.getContainingFunction();
+-
+-      if (failingFunction !== undefined) {
+-        inferredStacktrace.push(
+-          this._instructionWithinFunctionToRevertStackTraceEntry(
+-            trace,
+-            lastInstruction
+-          )
+-        );
+-      } else if (isDecodedCallTrace(trace)) {
+-        // This is here because of the optimizations
+-        const functionSelector =
+-          trace.bytecode.contract.getFunctionFromSelector(
+-            trace.calldata.slice(0, 4)
+-          );
+-
+-        // in general this shouldn't happen, but it does when viaIR is enabled,
+-        // "optimizerSteps": "u" is used, and the called function is fallback or
+-        // receive
+-        if (functionSelector === undefined) {
+-          return;
+-        }
+-
+-        inferredStacktrace.push({
+-          type: StackTraceEntryType.REVERT_ERROR,
+-          sourceReference: this._getFunctionStartSourceReference(
+-            trace,
+-            functionSelector
+-          ),
+-          message: new ReturnData(trace.returnData),
+-          isInvalidOpcodeError: lastInstruction.opcode === Opcode.INVALID,
+-        });
+-      } else {
+-        // This is here because of the optimizations
+-        inferredStacktrace.push({
+-          type: StackTraceEntryType.REVERT_ERROR,
+-          sourceReference: this._getConstructorStartSourceReference(trace),
+-          message: new ReturnData(trace.returnData),
+-          isInvalidOpcodeError: lastInstruction.opcode === Opcode.INVALID,
+-        });
+-      }
+-
+-      return this._fixInitialModifier(trace, inferredStacktrace);
+-    }
+-
+-    // If the revert instruction is not mapped but there is return data,
+-    // we add the frame anyway, sith the best sourceReference we can get
+-    if (lastInstruction.location === undefined && trace.returnData.length > 0) {
+-      const revertFrame: RevertErrorStackTraceEntry = {
+-        type: StackTraceEntryType.REVERT_ERROR,
+-        sourceReference:
+-          this._getLastSourceReference(trace) ??
+-          this._getContractStartWithoutFunctionSourceReference(trace),
+-        message: new ReturnData(trace.returnData),
+-        isInvalidOpcodeError: lastInstruction.opcode === Opcode.INVALID,
+-      };
+-      inferredStacktrace.push(revertFrame);
+-
+-      return this._fixInitialModifier(trace, inferredStacktrace);
+-    }
+-  }
+-
+-  /**
+-   * Check if the trace reverted with a panic error.
+-   */
+-  private _checkPanic(
+-    trace: DecodedEvmMessageTrace,
+-    stacktrace: SolidityStackTrace,
+-    lastInstruction: Instruction
+-  ): SolidityStackTrace | undefined {
+-    if (!this._isPanicReturnData(trace.returnData)) {
+-      return;
+-    }
+-
+-    // If the last frame is an internal function, it means that the trace
+-    // jumped there to return the panic. If that's the case, we remove that
+-    // frame.
+-    const lastFrame = stacktrace[stacktrace.length - 1];
+-    if (
+-      lastFrame?.type === StackTraceEntryType.INTERNAL_FUNCTION_CALLSTACK_ENTRY
+-    ) {
+-      stacktrace.splice(-1);
+-    }
+-
+-    const panicReturnData = new ReturnData(trace.returnData);
+-    const errorCode = panicReturnData.decodePanic();
+-
+-    // if the error comes from a call to a zero-initialized function,
+-    // we remove the last frame, which represents the call, to avoid
+-    // having duplicated frames
+-    if (errorCode === 0x51n) {
+-      stacktrace.splice(-1);
+-    }
+-
+-    const inferredStacktrace = [...stacktrace];
+-    inferredStacktrace.push(
+-      this._instructionWithinFunctionToPanicStackTraceEntry(
+-        trace,
+-        lastInstruction,
+-        errorCode
+-      )
+-    );
+-
+-    return this._fixInitialModifier(trace, inferredStacktrace);
+-  }
+-
+-  private _checkCustomErrors(
+-    trace: DecodedEvmMessageTrace,
+-    stacktrace: SolidityStackTrace,
+-    lastInstruction: Instruction
+-  ): SolidityStackTrace | undefined {
+-    const returnData = new ReturnData(trace.returnData);
+-
+-    if (returnData.isEmpty() || returnData.isErrorReturnData()) {
+-      // if there is no return data, or if it's a Error(string),
+-      // then it can't be a custom error
+-      return;
+-    }
+-
+-    const rawReturnData = Buffer.from(returnData.value).toString("hex");
+-    let errorMessage = `reverted with an unrecognized custom error (return data: 0x${rawReturnData})`;
+-
+-    for (const customError of trace.bytecode.contract.customErrors) {
+-      if (returnData.matchesSelector(customError.selector)) {
+-        // if the return data matches a custom error in the called contract,
+-        // we format the message using the returnData and the custom error instance
+-        const decodedValues = abi.decode(
+-          customError.paramTypes,
+-          returnData.value.slice(4)
+-        );
+-
+-        const params = AbiHelpers.formatValues([...decodedValues]);
+-        errorMessage = `reverted with custom error '${customError.name}(${params})'`;
+-        break;
+-      }
+-    }
+-
+-    const inferredStacktrace = [...stacktrace];
+-    inferredStacktrace.push(
+-      this._instructionWithinFunctionToCustomErrorStackTraceEntry(
+-        trace,
+-        lastInstruction,
+-        errorMessage
+-      )
+-    );
+-
+-    return this._fixInitialModifier(trace, inferredStacktrace);
+-  }
+-
+-  /**
+-   * Check last instruction to try to infer the error.
+-   */
+-  private _checkLastInstruction(
+-    trace: DecodedEvmMessageTrace,
+-    stacktrace: SolidityStackTrace,
+-    functionJumpdests: Instruction[],
+-    jumpedIntoFunction: boolean
+-  ): SolidityStackTrace | undefined {
+-    if (trace.steps.length === 0) {
+-      return;
+-    }
+-
+-    const lastStep = trace.steps[trace.steps.length - 1];
+-
+-    if (!isEvmStep(lastStep)) {
+-      throw new Error(
+-        "This should not happen: MessageTrace ends with a subtrace"
+-      );
+-    }
+-
+-    const lastInstruction = trace.bytecode.getInstruction(lastStep.pc);
+-
+-    const revertOrInvalidStacktrace = this._checkRevertOrInvalidOpcode(
+-      trace,
+-      stacktrace,
+-      lastInstruction,
+-      functionJumpdests,
+-      jumpedIntoFunction
+-    );
+-
+-    if (revertOrInvalidStacktrace !== undefined) {
+-      return revertOrInvalidStacktrace;
+-    }
+-
+-    if (isDecodedCallTrace(trace) && !jumpedIntoFunction) {
+-      if (
+-        this._hasFailedInsideTheFallbackFunction(trace) ||
+-        this._hasFailedInsideTheReceiveFunction(trace)
+-      ) {
+-        return [
+-          this._instructionWithinFunctionToRevertStackTraceEntry(
+-            trace,
+-            lastInstruction
+-          ),
+-        ];
+-      }
+-
+-      // Sometimes we do fail inside of a function but there's no jump into
+-      if (lastInstruction.location !== undefined) {
+-        const failingFunction =
+-          lastInstruction.location.getContainingFunction();
+-        if (failingFunction !== undefined) {
+-          return [
+-            {
+-              type: StackTraceEntryType.REVERT_ERROR,
+-              sourceReference: this._getFunctionStartSourceReference(
+-                trace,
+-                failingFunction
+-              ),
+-              message: new ReturnData(trace.returnData),
+-              isInvalidOpcodeError: lastInstruction.opcode === Opcode.INVALID,
+-            },
+-          ];
+-        }
+-      }
+-
+-      const calledFunction = trace.bytecode.contract.getFunctionFromSelector(
+-        trace.calldata.slice(0, 4)
+-      );
+-
+-      if (calledFunction !== undefined) {
 -        const isValidCalldata = calledFunction.isValidCalldata(
 -          trace.calldata.slice(4)
 -        );
-+        const isValidCalldata =
-+          // if we don't know the param types, we just assume that the call is valid
-+          calledFunction.paramTypes === undefined ||
-+          AbiHelpers.isValidCalldata(
-+            calledFunction.paramTypes,
-+            trace.calldata.slice(4)
-+          );
- 
-         if (!isValidCalldata) {
-           return [
+-
+-        if (!isValidCalldata) {
+-          return [
+-            {
+-              type: StackTraceEntryType.INVALID_PARAMS_ERROR,
+-              sourceReference: this._getFunctionStartSourceReference(
+-                trace,
+-                calledFunction
+-              ),
+-            },
+-          ];
+-        }
+-      }
+-
+-      if (this._solidity063MaybeUnmappedRevert(trace)) {
+-        const revertFrame =
+-          this._solidity063GetFrameForUnmappedRevertBeforeFunction(trace);
+-
+-        if (revertFrame !== undefined) {
+-          return [revertFrame];
+-        }
+-      }
+-
+-      return [this._getOtherErrorBeforeCalledFunctionStackTraceEntry(trace)];
+-    }
+-  }
+-
+-  private _checkNonContractCalled(
+-    trace: DecodedEvmMessageTrace,
+-    stacktrace: SolidityStackTrace
+-  ): SolidityStackTrace | undefined {
+-    if (this._isCalledNonContractAccountError(trace)) {
+-      const sourceReference = this._getLastSourceReference(trace);
+-
+-      // We are sure this is not undefined because there was at least a call instruction
+-      assertHardhatInvariant(
+-        sourceReference !== undefined,
+-        "Expected source reference to be defined"
+-      );
+-
+-      const nonContractCalledFrame: SolidityStackTraceEntry = {
+-        type: StackTraceEntryType.NONCONTRACT_ACCOUNT_CALLED_ERROR,
+-        sourceReference,
+-      };
+-
+-      return [...stacktrace, nonContractCalledFrame];
+-    }
+-  }
+-
+-  private _checkSolidity063UnmappedRevert(
+-    trace: DecodedEvmMessageTrace,
+-    stacktrace: SolidityStackTrace
+-  ): SolidityStackTrace | undefined {
+-    if (this._solidity063MaybeUnmappedRevert(trace)) {
+-      const revertFrame =
+-        this._solidity063GetFrameForUnmappedRevertWithinFunction(trace);
+-
+-      if (revertFrame !== undefined) {
+-        return [...stacktrace, revertFrame];
+-      }
+-    }
+-  }
+-
+-  private _checkContractTooLarge(
+-    trace: DecodedEvmMessageTrace
+-  ): SolidityStackTrace | undefined {
+-    if (isCreateTrace(trace) && this._isContractTooLargeError(trace)) {
+-      return [
+-        {
+-          type: StackTraceEntryType.CONTRACT_TOO_LARGE_ERROR,
+-          sourceReference: this._getConstructorStartSourceReference(trace),
+-        },
+-      ];
+-    }
+-  }
+-
+-  private _otherExecutionErrorStacktrace(
+-    trace: DecodedEvmMessageTrace,
+-    stacktrace: SolidityStackTrace
+-  ): SolidityStackTrace {
+-    const otherExecutionErrorFrame: SolidityStackTraceEntry = {
+-      type: StackTraceEntryType.OTHER_EXECUTION_ERROR,
+-      sourceReference: this._getLastSourceReference(trace),
+-    };
+-
+-    return [...stacktrace, otherExecutionErrorFrame];
+-  }
+-
+-  // Helpers
+-
+-  private _fixInitialModifier(
+-    trace: DecodedEvmMessageTrace,
+-    stacktrace: SolidityStackTrace
+-  ): SolidityStackTrace {
+-    const firstEntry = stacktrace[0];
+-    if (
+-      firstEntry !== undefined &&
+-      firstEntry.type === StackTraceEntryType.CALLSTACK_ENTRY &&
+-      firstEntry.functionType === ContractFunctionType.MODIFIER
+-    ) {
+-      return [
+-        this._getEntryBeforeInitialModifierCallstackEntry(trace),
+-        ...stacktrace,
+-      ];
+-    }
+-
+-    return stacktrace;
+-  }
+-
+-  private _isDirectLibraryCall(trace: DecodedCallMessageTrace): boolean {
+-    return (
+-      trace.depth === 0 && trace.bytecode.contract.type === ContractType.LIBRARY
+-    );
+-  }
+-
+-  private _getDirectLibraryCallErrorStackTrace(
+-    trace: DecodedCallMessageTrace
+-  ): SolidityStackTrace {
+-    const func = trace.bytecode.contract.getFunctionFromSelector(
+-      trace.calldata.slice(0, 4)
+-    );
+-
+-    if (func !== undefined) {
+-      return [
+-        {
+-          type: StackTraceEntryType.DIRECT_LIBRARY_CALL_ERROR,
+-          sourceReference: this._getFunctionStartSourceReference(trace, func),
+-        },
+-      ];
+-    }
+-
+-    return [
+-      {
+-        type: StackTraceEntryType.DIRECT_LIBRARY_CALL_ERROR,
+-        sourceReference:
+-          this._getContractStartWithoutFunctionSourceReference(trace),
+-      },
+-    ];
+-  }
+-
+-  private _isFunctionNotPayableError(
+-    trace: DecodedCallMessageTrace,
+-    calledFunction: ContractFunction
+-  ): boolean {
+-    // This error doesn't return data
+-    if (trace.returnData.length > 0) {
+-      return false;
+-    }
+-
+-    if (trace.value <= 0n) {
+-      return false;
+-    }
+-
+-    // Libraries don't have a nonpayable check
+-    if (trace.bytecode.contract.type === ContractType.LIBRARY) {
+-      return false;
+-    }
+-
+-    return calledFunction.isPayable === undefined || !calledFunction.isPayable;
+-  }
+-
+-  private _getFunctionStartSourceReference(
+-    trace: DecodedEvmMessageTrace,
+-    func: ContractFunction
+-  ): SourceReference {
+-    return {
+-      sourceName: func.location.file.sourceName,
+-      sourceContent: func.location.file.content,
+-      contract: trace.bytecode.contract.name,
+-      function: func.name,
+-      line: func.location.getStartingLineNumber(),
+-      range: [
+-        func.location.offset,
+-        func.location.offset + func.location.length,
+-      ],
+-    };
+-  }
+-
+-  private _isMissingFunctionAndFallbackError(
+-    trace: DecodedCallMessageTrace,
+-    calledFunction: ContractFunction | undefined
+-  ): boolean {
+-    // This error doesn't return data
+-    if (trace.returnData.length > 0) {
+-      return false;
+-    }
+-
+-    // the called function exists in the contract
+-    if (calledFunction !== undefined) {
+-      return false;
+-    }
+-
+-    // there's a receive function and no calldata
+-    if (
+-      trace.calldata.length === 0 &&
+-      trace.bytecode.contract.receive !== undefined
+-    ) {
+-      return false;
+-    }
+-
+-    return trace.bytecode.contract.fallback === undefined;
+-  }
+-
+-  private _emptyCalldataAndNoReceive(trace: DecodedCallMessageTrace): boolean {
+-    // this only makes sense when receive functions are available
+-    if (
+-      semver.lt(
+-        trace.bytecode.compilerVersion,
+-        FIRST_SOLC_VERSION_RECEIVE_FUNCTION
+-      )
+-    ) {
+-      return false;
+-    }
+-
+-    return (
+-      trace.calldata.length === 0 &&
+-      trace.bytecode.contract.receive === undefined
+-    );
+-  }
+-
+-  private _getContractStartWithoutFunctionSourceReference(
+-    trace: DecodedEvmMessageTrace
+-  ): SourceReference {
+-    const location = trace.bytecode.contract.location;
+-    return {
+-      sourceName: location.file.sourceName,
+-      sourceContent: location.file.content,
+-      contract: trace.bytecode.contract.name,
+-      line: location.getStartingLineNumber(),
+-      range: [location.offset, location.offset + location.length],
+-    };
+-  }
+-
+-  private _isFallbackNotPayableError(
+-    trace: DecodedCallMessageTrace,
+-    calledFunction: ContractFunction | undefined
+-  ): boolean {
+-    if (calledFunction !== undefined) {
+-      return false;
+-    }
+-
+-    // This error doesn't return data
+-    if (trace.returnData.length > 0) {
+-      return false;
+-    }
+-
+-    if (trace.value <= 0n) {
+-      return false;
+-    }
+-
+-    if (trace.bytecode.contract.fallback === undefined) {
+-      return false;
+-    }
+-
+-    const isPayable = trace.bytecode.contract.fallback.isPayable;
+-
+-    return isPayable === undefined || !isPayable;
+-  }
+-
+-  private _getFallbackStartSourceReference(
+-    trace: DecodedCallMessageTrace
+-  ): SourceReference {
+-    const func = trace.bytecode.contract.fallback;
+-
+-    if (func === undefined) {
+-      throw new Error(
+-        "This shouldn't happen: trying to get fallback source reference from a contract without fallback"
+-      );
+-    }
+-
+-    return {
+-      sourceName: func.location.file.sourceName,
+-      sourceContent: func.location.file.content,
+-      contract: trace.bytecode.contract.name,
+-      function: FALLBACK_FUNCTION_NAME,
+-      line: func.location.getStartingLineNumber(),
+-      range: [
+-        func.location.offset,
+-        func.location.offset + func.location.length,
+-      ],
+-    };
+-  }
+-
+-  private _isConstructorNotPayableError(
+-    trace: DecodedCreateMessageTrace
+-  ): boolean {
+-    // This error doesn't return data
+-    if (trace.returnData.length > 0) {
+-      return false;
+-    }
+-
+-    const constructor = trace.bytecode.contract.constructorFunction;
+-
+-    // This function is only matters with contracts that have constructors defined. The ones that
+-    // don't are abstract contracts, or their constructor doesn't take any argument.
+-    if (constructor === undefined) {
+-      return false;
+-    }
+-
+-    return (
+-      trace.value > 0n &&
+-      (constructor.isPayable === undefined || !constructor.isPayable)
+-    );
+-  }
+-
+-  /**
+-   * Returns a source reference pointing to the constructor if it exists, or to the contract
+-   * otherwise.
+-   */
+-  private _getConstructorStartSourceReference(
+-    trace: DecodedCreateMessageTrace
+-  ): SourceReference {
+-    const contract = trace.bytecode.contract;
+-    const constructor = contract.constructorFunction;
+-
+-    const line =
+-      constructor !== undefined
+-        ? constructor.location.getStartingLineNumber()
+-        : contract.location.getStartingLineNumber();
+-
+-    return {
+-      sourceName: contract.location.file.sourceName,
+-      sourceContent: contract.location.file.content,
+-      contract: contract.name,
+-      function: CONSTRUCTOR_FUNCTION_NAME,
+-      line,
+-      range: [
+-        contract.location.offset,
+-        contract.location.offset + contract.location.length,
+-      ],
+-    };
+-  }
+-
+-  private _isConstructorInvalidArgumentsError(
+-    trace: DecodedCreateMessageTrace
+-  ): boolean {
+-    // This error doesn't return data
+-    if (trace.returnData.length > 0) {
+-      return false;
+-    }
+-
+-    const contract = trace.bytecode.contract;
+-    const constructor = contract.constructorFunction;
+-
+-    // This function is only matters with contracts that have constructors defined. The ones that
+-    // don't are abstract contracts, or their constructor doesn't take any argument.
+-    if (constructor === undefined) {
+-      return false;
+-    }
+-
+-    if (
+-      semver.lt(
+-        trace.bytecode.compilerVersion,
+-        FIRST_SOLC_VERSION_CREATE_PARAMS_VALIDATION
+-      )
+-    ) {
+-      return false;
+-    }
+-
+-    const lastStep = trace.steps[trace.steps.length - 1];
+-    if (!isEvmStep(lastStep)) {
+-      return false;
+-    }
+-
+-    const lastInst = trace.bytecode.getInstruction(lastStep.pc);
+-    if (lastInst.opcode !== Opcode.REVERT || lastInst.location !== undefined) {
+-      return false;
+-    }
+-
+-    let hasReadDeploymentCodeSize = false;
+-
+-    // eslint-disable-next-line @typescript-eslint/prefer-for-of
+-    for (let stepIndex = 0; stepIndex < trace.steps.length; stepIndex++) {
+-      const step = trace.steps[stepIndex];
+-      if (!isEvmStep(step)) {
+-        return false;
+-      }
+-
+-      const inst = trace.bytecode.getInstruction(step.pc);
+-
+-      if (
+-        inst.location !== undefined &&
+-        !contract.location.equals(inst.location) &&
+-        !constructor.location.equals(inst.location)
+-      ) {
+-        return false;
+-      }
+-
+-      if (inst.opcode === Opcode.CODESIZE && isCreateTrace(trace)) {
+-        hasReadDeploymentCodeSize = true;
+-      }
+-    }
+-
+-    return hasReadDeploymentCodeSize;
+-  }
+-
+-  private _getEntryBeforeInitialModifierCallstackEntry(
+-    trace: DecodedEvmMessageTrace
+-  ): SolidityStackTraceEntry {
+-    if (isDecodedCreateTrace(trace)) {
+-      return {
+-        type: StackTraceEntryType.CALLSTACK_ENTRY,
+-        sourceReference: this._getConstructorStartSourceReference(trace),
+-        functionType: ContractFunctionType.CONSTRUCTOR,
+-      };
+-    }
+-
+-    const calledFunction = trace.bytecode.contract.getFunctionFromSelector(
+-      trace.calldata.slice(0, 4)
+-    );
+-
+-    if (calledFunction !== undefined) {
+-      return {
+-        type: StackTraceEntryType.CALLSTACK_ENTRY,
+-        sourceReference: this._getFunctionStartSourceReference(
+-          trace,
+-          calledFunction
+-        ),
+-        functionType: ContractFunctionType.FUNCTION,
+-      };
+-    }
+-
+-    // If it failed or made a call from within a modifier, and the selector doesn't match
+-    // any function, it must have a fallback.
+-    return {
+-      type: StackTraceEntryType.CALLSTACK_ENTRY,
+-      sourceReference: this._getFallbackStartSourceReference(trace),
+-      functionType: ContractFunctionType.FALLBACK,
+-    };
+-  }
+-
+-  private _getLastSourceReference(
+-    trace: DecodedEvmMessageTrace
+-  ): SourceReference | undefined {
+-    for (let i = trace.steps.length - 1; i >= 0; i--) {
+-      const step = trace.steps[i];
+-      if (!isEvmStep(step)) {
+-        continue;
+-      }
+-
+-      const inst = trace.bytecode.getInstruction(step.pc);
+-
+-      if (inst.location === undefined) {
+-        continue;
+-      }
+-
+-      const sourceReference = sourceLocationToSourceReference(
+-        trace.bytecode,
+-        inst.location
+-      );
+-
+-      if (sourceReference !== undefined) {
+-        return sourceReference;
+-      }
+-    }
+-
+-    return undefined;
+-  }
+-
+-  private _hasFailedInsideTheFallbackFunction(
+-    trace: DecodedCallMessageTrace
+-  ): boolean {
+-    const contract = trace.bytecode.contract;
+-
+-    if (contract.fallback === undefined) {
+-      return false;
+-    }
+-
+-    return this._hasFailedInsideFunction(trace, contract.fallback);
+-  }
+-
+-  private _hasFailedInsideTheReceiveFunction(
+-    trace: DecodedCallMessageTrace
+-  ): boolean {
+-    const contract = trace.bytecode.contract;
+-
+-    if (contract.receive === undefined) {
+-      return false;
+-    }
+-
+-    return this._hasFailedInsideFunction(trace, contract.receive);
+-  }
+-
+-  private _hasFailedInsideFunction(
+-    trace: DecodedCallMessageTrace,
+-    func: ContractFunction
+-  ) {
+-    const lastStep = trace.steps[trace.steps.length - 1] as EvmStep;
+-    const lastInstruction = trace.bytecode.getInstruction(lastStep.pc);
+-
+-    return (
+-      lastInstruction.location !== undefined &&
+-      lastInstruction.opcode === Opcode.REVERT &&
+-      func.location.contains(lastInstruction.location)
+-    );
+-  }
+-
+-  private _instructionWithinFunctionToRevertStackTraceEntry(
+-    trace: DecodedEvmMessageTrace,
+-    inst: Instruction
+-  ): RevertErrorStackTraceEntry {
+-    const sourceReference = sourceLocationToSourceReference(
+-      trace.bytecode,
+-      inst.location
+-    );
+-    assertHardhatInvariant(
+-      sourceReference !== undefined,
+-      "Expected source reference to be defined"
+-    );
+-
+-    return {
+-      type: StackTraceEntryType.REVERT_ERROR,
+-      sourceReference,
+-      message: new ReturnData(trace.returnData),
+-      isInvalidOpcodeError: inst.opcode === Opcode.INVALID,
+-    };
+-  }
+-
+-  private _instructionWithinFunctionToUnmappedSolc063RevertErrorStackTraceEntry(
+-    trace: DecodedEvmMessageTrace,
+-    inst: Instruction
+-  ): UnmappedSolc063RevertErrorStackTraceEntry {
+-    const sourceReference = sourceLocationToSourceReference(
+-      trace.bytecode,
+-      inst.location
+-    );
+-
+-    return {
+-      type: StackTraceEntryType.UNMAPPED_SOLC_0_6_3_REVERT_ERROR,
+-      sourceReference,
+-    };
+-  }
+-
+-  private _instructionWithinFunctionToPanicStackTraceEntry(
+-    trace: DecodedEvmMessageTrace,
+-    inst: Instruction,
+-    errorCode: bigint
+-  ): PanicErrorStackTraceEntry {
+-    const lastSourceReference = this._getLastSourceReference(trace);
+-    return {
+-      type: StackTraceEntryType.PANIC_ERROR,
+-      sourceReference:
+-        sourceLocationToSourceReference(trace.bytecode, inst.location) ??
+-        lastSourceReference,
+-      errorCode,
+-    };
+-  }
+-
+-  private _instructionWithinFunctionToCustomErrorStackTraceEntry(
+-    trace: DecodedEvmMessageTrace,
+-    inst: Instruction,
+-    message: string
+-  ): CustomErrorStackTraceEntry {
+-    const lastSourceReference = this._getLastSourceReference(trace);
+-
+-    assertHardhatInvariant(
+-      lastSourceReference !== undefined,
+-      "Expected last source reference to be defined"
+-    );
+-
+-    return {
+-      type: StackTraceEntryType.CUSTOM_ERROR,
+-      sourceReference:
+-        sourceLocationToSourceReference(trace.bytecode, inst.location) ??
+-        lastSourceReference,
+-      message,
+-    };
+-  }
+-
+-  private _solidity063MaybeUnmappedRevert(trace: DecodedEvmMessageTrace) {
+-    if (trace.steps.length === 0) {
+-      return false;
+-    }
+-
+-    const lastStep = trace.steps[trace.steps.length - 1];
+-    if (!isEvmStep(lastStep)) {
+-      return false;
+-    }
+-
+-    const lastInst = trace.bytecode.getInstruction(lastStep.pc);
+-
+-    return (
+-      semver.satisfies(
+-        trace.bytecode.compilerVersion,
+-        `^${FIRST_SOLC_VERSION_WITH_UNMAPPED_REVERTS}`
+-      ) && lastInst.opcode === Opcode.REVERT
+-    );
+-  }
+-
+-  // Solidity 0.6.3 unmapped reverts special handling
+-  // For more info: https://github.com/ethereum/solidity/issues/9006
+-  private _solidity063GetFrameForUnmappedRevertBeforeFunction(
+-    trace: DecodedCallMessageTrace
+-  ) {
+-    let revertFrame =
+-      this._solidity063GetFrameForUnmappedRevertWithinFunction(trace);
+-
+-    if (
+-      revertFrame === undefined ||
+-      revertFrame.sourceReference === undefined
+-    ) {
+-      if (
+-        trace.bytecode.contract.receive === undefined ||
+-        trace.calldata.length > 0
+-      ) {
+-        if (trace.bytecode.contract.fallback !== undefined) {
+-          // Failed within the fallback
+-          const location = trace.bytecode.contract.fallback.location;
+-          revertFrame = {
+-            type: StackTraceEntryType.UNMAPPED_SOLC_0_6_3_REVERT_ERROR,
+-            sourceReference: {
+-              contract: trace.bytecode.contract.name,
+-              function: FALLBACK_FUNCTION_NAME,
+-              sourceName: location.file.sourceName,
+-              sourceContent: location.file.content,
+-              line: location.getStartingLineNumber(),
+-              range: [location.offset, location.offset + location.length],
+-            },
+-          };
+-
+-          this._solidity063CorrectLineNumber(revertFrame);
+-        }
+-      } else {
+-        // Failed within the receive function
+-        const location = trace.bytecode.contract.receive.location;
+-        revertFrame = {
+-          type: StackTraceEntryType.UNMAPPED_SOLC_0_6_3_REVERT_ERROR,
+-          sourceReference: {
+-            contract: trace.bytecode.contract.name,
+-            function: RECEIVE_FUNCTION_NAME,
+-            sourceName: location.file.sourceName,
+-            sourceContent: location.file.content,
+-            line: location.getStartingLineNumber(),
+-            range: [location.offset, location.offset + location.length],
+-          },
+-        };
+-
+-        this._solidity063CorrectLineNumber(revertFrame);
+-      }
+-    }
+-    return revertFrame;
+-  }
+-
+-  private _getOtherErrorBeforeCalledFunctionStackTraceEntry(
+-    trace: DecodedCallMessageTrace
+-  ): OtherExecutionErrorStackTraceEntry {
+-    return {
+-      type: StackTraceEntryType.OTHER_EXECUTION_ERROR,
+-      sourceReference:
+-        this._getContractStartWithoutFunctionSourceReference(trace),
+-    };
+-  }
+-
+-  private _isCalledNonContractAccountError(
+-    trace: DecodedEvmMessageTrace
+-  ): boolean {
+-    // We could change this to checking that the last valid location maps to a call, but
+-    // it's way more complex as we need to get the ast node from that location.
+-
+-    const lastIndex = this._getLastInstructionWithValidLocationStepIndex(trace);
+-    if (lastIndex === undefined || lastIndex === 0) {
+-      return false;
+-    }
+-
+-    const lastStep = trace.steps[lastIndex] as EvmStep; // We know this is an EVM step
+-    const lastInst = trace.bytecode.getInstruction(lastStep.pc);
+-    if (lastInst.opcode !== Opcode.ISZERO) {
+-      return false;
+-    }
+-
+-    const prevStep = trace.steps[lastIndex - 1] as EvmStep; // We know this is an EVM step
+-    const prevInst = trace.bytecode.getInstruction(prevStep.pc);
+-    return prevInst.opcode === Opcode.EXTCODESIZE;
+-  }
+-
+-  private _solidity063GetFrameForUnmappedRevertWithinFunction(
+-    trace: DecodedEvmMessageTrace
+-  ): UnmappedSolc063RevertErrorStackTraceEntry | undefined {
+-    // If we are within a function there's a last valid location. It may
+-    // be the entire contract.
+-    const prevInst = this._getLastInstructionWithValidLocation(trace);
+-    const lastStep = trace.steps[trace.steps.length - 1] as EvmStep;
+-    const nextInstPc = lastStep.pc + 1;
+-    const hasNextInst = trace.bytecode.hasInstruction(nextInstPc);
+-
+-    if (hasNextInst) {
+-      const nextInst = trace.bytecode.getInstruction(nextInstPc);
+-      const prevLoc = prevInst?.location;
+-      const nextLoc = nextInst.location;
+-      const prevFunc = prevLoc?.getContainingFunction();
+-      const nextFunc = nextLoc?.getContainingFunction();
+-
+-      // This is probably a require. This means that we have the exact
+-      // line, but the stack trace may be degraded (e.g. missing our
+-      // synthetic call frames when failing in a modifier) so we still
+-      // add this frame as UNMAPPED_SOLC_0_6_3_REVERT_ERROR
+-      if (
+-        prevFunc !== undefined &&
+-        nextLoc !== undefined &&
+-        prevLoc !== undefined &&
+-        prevLoc.equals(nextLoc)
+-      ) {
+-        return this._instructionWithinFunctionToUnmappedSolc063RevertErrorStackTraceEntry(
+-          trace,
+-          nextInst
+-        );
+-      }
+-
+-      let revertFrame: UnmappedSolc063RevertErrorStackTraceEntry | undefined;
+-
+-      // If the previous and next location don't match, we try to use the
+-      // previous one if it's inside a function, otherwise we use the next one
+-      if (prevFunc !== undefined && prevInst !== undefined) {
+-        revertFrame =
+-          this._instructionWithinFunctionToUnmappedSolc063RevertErrorStackTraceEntry(
+-            trace,
+-            prevInst
+-          );
+-      } else if (nextFunc !== undefined) {
+-        revertFrame =
+-          this._instructionWithinFunctionToUnmappedSolc063RevertErrorStackTraceEntry(
+-            trace,
+-            nextInst
+-          );
+-      }
+-
+-      if (revertFrame !== undefined) {
+-        this._solidity063CorrectLineNumber(revertFrame);
+-      }
+-
+-      return revertFrame;
+-    }
+-
+-    if (isCreateTrace(trace) && prevInst !== undefined) {
+-      // Solidity is smart enough to stop emitting extra instructions after
+-      // an unconditional revert happens in a constructor. If this is the case
+-      // we just return a special error.
+-      const constructorRevertFrame: UnmappedSolc063RevertErrorStackTraceEntry =
+-        this._instructionWithinFunctionToUnmappedSolc063RevertErrorStackTraceEntry(
+-          trace,
+-          prevInst
+-        );
+-
+-      // When the latest instruction is not within a function we need
+-      // some default sourceReference to show to the user
+-      if (constructorRevertFrame.sourceReference === undefined) {
+-        const location = trace.bytecode.contract.location;
+-        const defaultSourceReference: SourceReference = {
+-          function: CONSTRUCTOR_FUNCTION_NAME,
+-          contract: trace.bytecode.contract.name,
+-          sourceName: location.file.sourceName,
+-          sourceContent: location.file.content,
+-          line: location.getStartingLineNumber(),
+-          range: [location.offset, location.offset + location.length],
+-        };
+-
+-        if (trace.bytecode.contract.constructorFunction !== undefined) {
+-          defaultSourceReference.line =
+-            trace.bytecode.contract.constructorFunction.location.getStartingLineNumber();
+-        }
+-
+-        constructorRevertFrame.sourceReference = defaultSourceReference;
+-      } else {
+-        this._solidity063CorrectLineNumber(constructorRevertFrame);
+-      }
+-
+-      return constructorRevertFrame;
+-    }
+-
+-    if (prevInst !== undefined) {
+-      // We may as well just be in a function or modifier and just happen
+-      // to be at the last instruction of the runtime bytecode.
+-      // In this case we just return whatever the last mapped intruction
+-      // points to.
+-      const latestInstructionRevertFrame: UnmappedSolc063RevertErrorStackTraceEntry =
+-        this._instructionWithinFunctionToUnmappedSolc063RevertErrorStackTraceEntry(
+-          trace,
+-          prevInst
+-        );
+-
+-      if (latestInstructionRevertFrame.sourceReference !== undefined) {
+-        this._solidity063CorrectLineNumber(latestInstructionRevertFrame);
+-      }
+-      return latestInstructionRevertFrame;
+-    }
+-  }
+-
+-  private _isContractTooLargeError(trace: DecodedCreateMessageTrace) {
+-    return trace.exit.kind === ExitCode.CODESIZE_EXCEEDS_MAXIMUM;
+-  }
+-
+-  private _solidity063CorrectLineNumber(
+-    revertFrame: UnmappedSolc063RevertErrorStackTraceEntry
+-  ) {
+-    if (revertFrame.sourceReference === undefined) {
+-      return;
+-    }
+-
+-    const lines = revertFrame.sourceReference.sourceContent.split("\n");
+-
+-    const currentLine = lines[revertFrame.sourceReference.line - 1];
+-
+-    if (currentLine.includes("require") || currentLine.includes("revert")) {
+-      return;
+-    }
+-
+-    const nextLines = lines.slice(revertFrame.sourceReference.line);
+-    const firstNonEmptyLine = nextLines.findIndex((l) => l.trim() !== "");
+-
+-    if (firstNonEmptyLine === -1) {
+-      return;
+-    }
+-
+-    const nextLine = nextLines[firstNonEmptyLine];
+-
+-    if (nextLine.includes("require") || nextLine.includes("revert")) {
+-      revertFrame.sourceReference.line += 1 + firstNonEmptyLine;
+-    }
+-  }
+-
+-  private _getLastInstructionWithValidLocationStepIndex(
+-    trace: DecodedEvmMessageTrace
+-  ): number | undefined {
+-    for (let i = trace.steps.length - 1; i >= 0; i--) {
+-      const step = trace.steps[i];
+-
+-      if (!isEvmStep(step)) {
+-        return undefined;
+-      }
+-
+-      const inst = trace.bytecode.getInstruction(step.pc);
+-
+-      if (inst.location !== undefined) {
+-        return i;
+-      }
+-    }
+-
+-    return undefined;
+-  }
+-
+-  private _getLastInstructionWithValidLocation(
+-    trace: DecodedEvmMessageTrace
+-  ): Instruction | undefined {
+-    const lastLocationIndex =
+-      this._getLastInstructionWithValidLocationStepIndex(trace);
+-
+-    if (lastLocationIndex === undefined) {
+-      return undefined;
+-    }
+-
+-    const lastLocationStep = trace.steps[lastLocationIndex];
+-    if (isEvmStep(lastLocationStep)) {
+-      const lastInstructionWithLocation = trace.bytecode.getInstruction(
+-        lastLocationStep.pc
+-      );
+-      return lastInstructionWithLocation;
+-    }
+-
+-    return undefined;
+-  }
+-
+-  private _callInstructionToCallFailedToExecuteStackTraceEntry(
+-    bytecode: Bytecode,
+-    callInst: Instruction
+-  ): CallFailedErrorStackTraceEntry {
+-    const sourceReference = sourceLocationToSourceReference(
+-      bytecode,
+-      callInst.location
+-    );
+-    assertHardhatInvariant(
+-      sourceReference !== undefined,
+-      "Expected source reference to be defined"
+-    );
+-
+-    // Calls only happen within functions
+-    return {
+-      type: StackTraceEntryType.CALL_FAILED_ERROR,
+-      sourceReference,
+-    };
+-  }
+-
+-  private _getEntryBeforeFailureInModifier(
+-    trace: DecodedEvmMessageTrace,
+-    functionJumpdests: Instruction[]
+-  ): CallstackEntryStackTraceEntry | InternalFunctionCallStackEntry {
+-    // If there's a jumpdest, this modifier belongs to the last function that it represents
+-    if (functionJumpdests.length > 0) {
+-      return instructionToCallstackStackTraceEntry(
+-        trace.bytecode,
+-        functionJumpdests[functionJumpdests.length - 1]
+-      );
+-    }
+-
+-    // This function is only called after we jumped into the initial function in call traces, so
+-    // there should always be at least a function jumpdest.
+-    if (!isDecodedCreateTrace(trace)) {
+-      throw new Error(
+-        "This shouldn't happen: a call trace has no functionJumpdest but has already jumped into a function"
+-      );
+-    }
+-
+-    // If there's no jump dest, we point to the constructor.
+-    return {
+-      type: StackTraceEntryType.CALLSTACK_ENTRY,
+-      sourceReference: this._getConstructorStartSourceReference(trace),
+-      functionType: ContractFunctionType.CONSTRUCTOR,
+-    };
+-  }
+-
+-  private _failsRightAfterCall(
+-    trace: DecodedEvmMessageTrace,
+-    callSubtraceStepIndex: number
+-  ): boolean {
+-    const lastStep = trace.steps[trace.steps.length - 1];
+-    if (!isEvmStep(lastStep)) {
+-      return false;
+-    }
+-
+-    const lastInst = trace.bytecode.getInstruction(lastStep.pc);
+-    if (lastInst.opcode !== Opcode.REVERT) {
+-      return false;
+-    }
+-
+-    const callOpcodeStep = trace.steps[callSubtraceStepIndex - 1] as EvmStep;
+-    const callInst = trace.bytecode.getInstruction(callOpcodeStep.pc);
+-
+-    // Calls are always made from within functions
+-    assertHardhatInvariant(
+-      callInst.location !== undefined,
+-      "Expected call instruction location to be defined"
+-    );
+-
+-    return this._isLastLocation(
+-      trace,
+-      callSubtraceStepIndex + 1,
+-      callInst.location
+-    );
+-  }
+-
+-  private _isCallFailedError(
+-    trace: DecodedEvmMessageTrace,
+-    instIndex: number,
+-    callInstruction: Instruction
+-  ): boolean {
+-    const callLocation = callInstruction.location;
+-
+-    // Calls are always made from within functions
+-    assertHardhatInvariant(
+-      callLocation !== undefined,
+-      "Expected call location to be defined"
+-    );
+-
+-    return this._isLastLocation(trace, instIndex, callLocation);
+-  }
+-
+-  private _isLastLocation(
+-    trace: DecodedEvmMessageTrace,
+-    fromStep: number,
+-    location: SourceLocation
+-  ): boolean {
+-    for (let i = fromStep; i < trace.steps.length; i++) {
+-      const step = trace.steps[i];
+-
+-      if (!isEvmStep(step)) {
+-        return false;
+-      }
+-
+-      const stepInst = trace.bytecode.getInstruction(step.pc);
+-
+-      if (stepInst.location === undefined) {
+-        continue;
+-      }
+-
+-      if (!location.equals(stepInst.location)) {
+-        return false;
+-      }
+-    }
+-
+-    return true;
+-  }
+-
+-  private _isSubtraceErrorPropagated(
+-    trace: DecodedEvmMessageTrace,
+-    callSubtraceStepIndex: number
+-  ): boolean {
+-    const call = trace.steps[callSubtraceStepIndex] as MessageTrace;
+-
+-    if (!equalsBytes(trace.returnData, call.returnData)) {
+-      return false;
+-    }
+-
+-    if (
+-      trace.exit.kind === ExitCode.OUT_OF_GAS &&
+-      call.exit.kind === ExitCode.OUT_OF_GAS
+-    ) {
+-      return true;
+-    }
+-
+-    // If the return data is not empty, and it's still the same, we assume it
+-    // is being propagated
+-    if (trace.returnData.length > 0) {
+-      return true;
+-    }
+-
+-    return this._failsRightAfterCall(trace, callSubtraceStepIndex);
+-  }
+-
+-  private _isProxyErrorPropagated(
+-    trace: DecodedEvmMessageTrace,
+-    callSubtraceStepIndex: number
+-  ): boolean {
+-    if (!isDecodedCallTrace(trace)) {
+-      return false;
+-    }
+-
+-    const callStep = trace.steps[callSubtraceStepIndex - 1];
+-    if (!isEvmStep(callStep)) {
+-      return false;
+-    }
+-
+-    const callInst = trace.bytecode.getInstruction(callStep.pc);
+-    if (callInst.opcode !== Opcode.DELEGATECALL) {
+-      return false;
+-    }
+-
+-    const subtrace = trace.steps[callSubtraceStepIndex];
+-    if (isEvmStep(subtrace)) {
+-      return false;
+-    }
+-
+-    if (isPrecompileTrace(subtrace)) {
+-      return false;
+-    }
+-
+-    // If we can't recognize the implementation we'd better don't consider it as such
+-    if (subtrace.bytecode === undefined) {
+-      return false;
+-    }
+-
+-    if (subtrace.bytecode.contract.type === ContractType.LIBRARY) {
+-      return false;
+-    }
+-
+-    if (!equalsBytes(trace.returnData, subtrace.returnData)) {
+-      return false;
+-    }
+-
+-    for (let i = callSubtraceStepIndex + 1; i < trace.steps.length; i++) {
+-      const step = trace.steps[i];
+-      if (!isEvmStep(step)) {
+-        return false;
+-      }
+-
+-      const inst = trace.bytecode.getInstruction(step.pc);
+-
+-      // All the remaining locations should be valid, as they are part of the inline asm
+-      if (inst.location === undefined) {
+-        return false;
+-      }
+-
+-      if (
+-        inst.jumpType === JumpType.INTO_FUNCTION ||
+-        inst.jumpType === JumpType.OUTOF_FUNCTION
+-      ) {
+-        return false;
+-      }
+-    }
+-
+-    const lastStep = trace.steps[trace.steps.length - 1] as EvmStep;
+-    const lastInst = trace.bytecode.getInstruction(lastStep.pc);
+-
+-    return lastInst.opcode === Opcode.REVERT;
+-  }
+-
+-  private _isContractCallRunOutOfGasError(
+-    trace: DecodedEvmMessageTrace,
+-    callStepIndex: number
+-  ): boolean {
+-    if (trace.returnData.length > 0) {
+-      return false;
+-    }
+-
+-    if (trace.exit.kind !== ExitCode.REVERT) {
+-      return false;
+-    }
+-
+-    const call = trace.steps[callStepIndex] as MessageTrace;
+-    if (call.exit.kind !== ExitCode.OUT_OF_GAS) {
+-      return false;
+-    }
+-
+-    return this._failsRightAfterCall(trace, callStepIndex);
+-  }
+-
+-  private _isPanicReturnData(returnData: Uint8Array): boolean {
+-    return new ReturnData(returnData).isPanicReturnData();
+-  }
+-}
+-
+-export function instructionToCallstackStackTraceEntry(
+-  bytecode: Bytecode,
+-  inst: Instruction
+-): CallstackEntryStackTraceEntry | InternalFunctionCallStackEntry {
+-  // This means that a jump is made from within an internal solc function.
+-  // These are normally made from yul code, so they don't map to any Solidity
+-  // function
+-  if (inst.location === undefined) {
+-    const location = bytecode.contract.location;
+-    return {
+-      type: StackTraceEntryType.INTERNAL_FUNCTION_CALLSTACK_ENTRY,
+-      pc: inst.pc,
+-      sourceReference: {
+-        sourceName: bytecode.contract.location.file.sourceName,
+-        sourceContent: bytecode.contract.location.file.content,
+-        contract: bytecode.contract.name,
+-        function: undefined,
+-        line: bytecode.contract.location.getStartingLineNumber(),
+-        range: [location.offset, location.offset + location.length],
+-      },
+-    };
+-  }
+-
+-  const func = inst.location?.getContainingFunction();
+-
+-  if (func !== undefined) {
+-    const sourceReference = sourceLocationToSourceReference(
+-      bytecode,
+-      inst.location
+-    );
+-    assertHardhatInvariant(
+-      sourceReference !== undefined,
+-      "Expected source reference to be defined"
+-    );
+-
+-    return {
+-      type: StackTraceEntryType.CALLSTACK_ENTRY,
+-      sourceReference,
+-      functionType: func.type,
+-    };
+-  }
+-
+-  assertHardhatInvariant(
+-    inst.location !== undefined,
+-    "Expected instruction location to be defined"
+-  );
+-
+-  return {
+-    type: StackTraceEntryType.CALLSTACK_ENTRY,
+-    sourceReference: {
+-      function: undefined,
+-      contract: bytecode.contract.name,
+-      sourceName: inst.location.file.sourceName,
+-      sourceContent: inst.location.file.content,
+-      line: inst.location.getStartingLineNumber(),
+-      range: [
+-        inst.location.offset,
+-        inst.location.offset + inst.location.length,
+-      ],
+-    },
+-    functionType: ContractFunctionType.FUNCTION,
+-  };
+-}
+-
+-function sourceLocationToSourceReference(
+-  bytecode: Bytecode,
+-  location?: SourceLocation
+-): SourceReference | undefined {
+-  if (location === undefined) {
+-    return undefined;
+-  }
+-
+-  const func = location.getContainingFunction();
+-
+-  if (func === undefined) {
+-    return undefined;
+-  }
+-
+-  let funcName = func.name;
+-
+-  if (func.type === ContractFunctionType.CONSTRUCTOR) {
+-    funcName = CONSTRUCTOR_FUNCTION_NAME;
+-  } else if (func.type === ContractFunctionType.FALLBACK) {
+-    funcName = FALLBACK_FUNCTION_NAME;
+-  } else if (func.type === ContractFunctionType.RECEIVE) {
+-    funcName = RECEIVE_FUNCTION_NAME;
+-  }
+-
+-  return {
+-    function: funcName,
+-    contract:
+-      func.type === ContractFunctionType.FREE_FUNCTION
+-        ? undefined
+-        : bytecode.contract.name,
+-    sourceName: func.location.file.sourceName,
+-    sourceContent: func.location.file.content,
+-    line: location.getStartingLineNumber(),
+-    range: [location.offset, location.offset + location.length],
+-  };
+-}
 diff --git a/src/internal/hardhat-network/stack-traces/library-utils.ts b/src/internal/hardhat-network/stack-traces/library-utils.ts
 index 9f45bebdcde3092695f44efcd3e6b06222d344bb..de1a0538791e8653a788ba02fd1e006cb8501ef9 100644
 --- a/src/internal/hardhat-network/stack-traces/library-utils.ts
@@ -5286,6 +8035,174 @@ index 9f45bebdcde3092695f44efcd3e6b06222d344bb..de1a0538791e8653a788ba02fd1e006c
 -  return code;
 -}
 +export { linkHexStringBytecode };
+diff --git a/src/internal/hardhat-network/stack-traces/mapped-inlined-internal-functions-heuristics.ts b/src/internal/hardhat-network/stack-traces/mapped-inlined-internal-functions-heuristics.ts
+index 73bf02f93455786471288001151fbaf96ea5975f..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 100644
+--- a/src/internal/hardhat-network/stack-traces/mapped-inlined-internal-functions-heuristics.ts
++++ b/src/internal/hardhat-network/stack-traces/mapped-inlined-internal-functions-heuristics.ts
+@@ -1,163 +0,0 @@
+-/**
+- * This file includes Solidity tracing heuristics for solc starting with version
+- * 0.6.9.
+- *
+- * This solc version introduced a significant change to how sourcemaps are
+- * handled for inline yul/internal functions. These were mapped to the
+- * unmapped/-1 file before, which lead to many unmapped reverts. Now, they are
+- * mapped to the part of the Solidity source that lead to their inlining.
+- *
+- * This change is a very positive change, as errors would point to the correct
+- * line by default. The only problem is that we used to rely very heavily on
+- * unmapped reverts to decide when our error detection heuristics were to be
+- * run. In fact, this heuristics were first introduced because of unmapped
+- * reverts.
+- *
+- * Instead of synthetically completing stack traces when unmapped reverts occur,
+- * we now start from complete stack traces and adjust them if we can provide
+- * more meaningful errors.
+- */
+-
+-import semver from "semver";
+-
+-import {
+-  DecodedEvmMessageTrace,
+-  isDecodedCallTrace,
+-  isDecodedCreateTrace,
+-  isEvmStep,
+-} from "./message-trace";
+-import { Opcode } from "./opcodes";
+-import {
+-  SolidityStackTrace,
+-  StackTraceEntryType,
+-} from "./solidity-stack-trace";
+-
+-const FIRST_SOLC_VERSION_WITH_MAPPED_SMALL_INTERNAL_FUNCTIONS = "0.6.9";
+-
+-export function stackTraceMayRequireAdjustments(
+-  stackTrace: SolidityStackTrace,
+-  decodedTrace: DecodedEvmMessageTrace
+-): boolean {
+-  if (stackTrace.length === 0) {
+-    return false;
+-  }
+-
+-  const lastFrame = stackTrace[stackTrace.length - 1];
+-
+-  return (
+-    lastFrame.type === StackTraceEntryType.REVERT_ERROR &&
+-    !lastFrame.isInvalidOpcodeError &&
+-    lastFrame.message.isEmpty() &&
+-    semver.gte(
+-      decodedTrace.bytecode.compilerVersion,
+-      FIRST_SOLC_VERSION_WITH_MAPPED_SMALL_INTERNAL_FUNCTIONS
+-    )
+-  );
+-}
+-
+-export function adjustStackTrace(
+-  stackTrace: SolidityStackTrace,
+-  decodedTrace: DecodedEvmMessageTrace
+-): SolidityStackTrace {
+-  const start = stackTrace.slice(0, -1);
+-  const [revert] = stackTrace.slice(-1);
+-
+-  if (isNonContractAccountCalledError(decodedTrace)) {
+-    return [
+-      ...start,
+-      {
+-        type: StackTraceEntryType.NONCONTRACT_ACCOUNT_CALLED_ERROR,
+-        sourceReference: revert.sourceReference!,
+-      },
+-    ];
+-  }
+-
+-  if (isConstructorInvalidParamsError(decodedTrace)) {
+-    return [
+-      ...start,
+-      {
+-        type: StackTraceEntryType.INVALID_PARAMS_ERROR,
+-        sourceReference: revert.sourceReference!,
+-      },
+-    ];
+-  }
+-
+-  if (isCallInvalidParamsError(decodedTrace)) {
+-    return [
+-      ...start,
+-      {
+-        type: StackTraceEntryType.INVALID_PARAMS_ERROR,
+-        sourceReference: revert.sourceReference!,
+-      },
+-    ];
+-  }
+-
+-  return stackTrace;
+-}
+-
+-function isNonContractAccountCalledError(
+-  decodedTrace: DecodedEvmMessageTrace
+-): boolean {
+-  return matchOpcodes(decodedTrace, -9, [
+-    Opcode.EXTCODESIZE,
+-    Opcode.ISZERO,
+-    Opcode.DUP1,
+-    Opcode.ISZERO,
+-  ]);
+-}
+-
+-function isConstructorInvalidParamsError(decodedTrace: DecodedEvmMessageTrace) {
+-  if (!isDecodedCreateTrace(decodedTrace)) {
+-    return false;
+-  }
+-
+-  return (
+-    matchOpcodes(decodedTrace, -20, [Opcode.CODESIZE]) &&
+-    matchOpcodes(decodedTrace, -15, [Opcode.CODECOPY]) &&
+-    matchOpcodes(decodedTrace, -7, [Opcode.LT, Opcode.ISZERO])
+-  );
+-}
+-
+-function isCallInvalidParamsError(decodedTrace: DecodedEvmMessageTrace) {
+-  if (!isDecodedCallTrace(decodedTrace)) {
+-    return false;
+-  }
+-
+-  return (
+-    matchOpcodes(decodedTrace, -11, [Opcode.CALLDATASIZE]) &&
+-    matchOpcodes(decodedTrace, -7, [Opcode.LT, Opcode.ISZERO])
+-  );
+-}
+-
+-function matchOpcode(
+-  decodedTrace: DecodedEvmMessageTrace,
+-  stepIndex: number,
+-  opcode: Opcode
+-): boolean {
+-  const [step] = decodedTrace.steps.slice(stepIndex, stepIndex + 1);
+-
+-  if (step === undefined || !isEvmStep(step)) {
+-    return false;
+-  }
+-
+-  const instruction = decodedTrace.bytecode.getInstruction(step.pc);
+-
+-  return instruction.opcode === opcode;
+-}
+-
+-function matchOpcodes(
+-  decodedTrace: DecodedEvmMessageTrace,
+-  firstStepIndex: number,
+-  opcodes: Opcode[]
+-): boolean {
+-  let index = firstStepIndex;
+-  for (const opcode of opcodes) {
+-    if (!matchOpcode(decodedTrace, index, opcode)) {
+-      return false;
+-    }
+-
+-    index += 1;
+-  }
+-
+-  return true;
+-}
 diff --git a/src/internal/hardhat-network/stack-traces/message-trace.ts b/src/internal/hardhat-network/stack-traces/message-trace.ts
 index ddfe86ce4d1ff90969db10bc6bd1f0f6667a5715..f4da68574666d43e9c0494e00db3f6415b23d086 100644
 --- a/src/internal/hardhat-network/stack-traces/message-trace.ts
@@ -6148,6 +9065,63 @@ index e0602c17fb8c0c48b740d5e6bb8925cfaba67740..54329f2587d8cb398d7567840ce7295f
 +  isCreate,
 +  opcodeToString,
 +} from "@nomicfoundation/edr";
+diff --git a/src/internal/hardhat-network/stack-traces/solidity-errors.ts b/src/internal/hardhat-network/stack-traces/solidity-errors.ts
+index 2cca42213c32090c323601076e526983c0c317a3..0440a355f08dbb22eff81e0fc37a223fb8856746 100644
+--- a/src/internal/hardhat-network/stack-traces/solidity-errors.ts
++++ b/src/internal/hardhat-network/stack-traces/solidity-errors.ts
+@@ -1,5 +1,6 @@
+ import { bytesToHex as bufferToHex } from "@nomicfoundation/ethereumjs-util";
+ 
++import { ReturnData } from "../provider/return-data";
+ import { panicErrorCodeToMessage } from "./panic-errors";
+ import {
+   CONSTRUCTOR_FUNCTION_NAME,
+@@ -259,23 +260,22 @@ function getMessageFromLastStackTraceEntry(
+ 
+     case StackTraceEntryType.UNRECOGNIZED_CREATE_ERROR:
+     case StackTraceEntryType.UNRECOGNIZED_CONTRACT_ERROR:
+-      if (stackTraceEntry.message.isErrorReturnData()) {
+-        return `VM Exception while processing transaction: reverted with reason string '${stackTraceEntry.message.decodeError()}'`;
++      let returnData = new ReturnData(stackTraceEntry.returnData);
++      if (returnData.isErrorReturnData()) {
++        return `VM Exception while processing transaction: reverted with reason string '${new ReturnData(
++          stackTraceEntry.returnData
++        ).decodeError()}'`;
+       }
+ 
+-      if (stackTraceEntry.message.isPanicReturnData()) {
+-        const message = panicErrorCodeToMessage(
+-          stackTraceEntry.message.decodePanic()
+-        );
++      if (returnData.isPanicReturnData()) {
++        const message = panicErrorCodeToMessage(returnData.decodePanic());
+         return `VM Exception while processing transaction: ${message}`;
+       }
+ 
+-      if (!stackTraceEntry.message.isEmpty()) {
+-        const returnData = Buffer.from(stackTraceEntry.message.value).toString(
+-          "hex"
+-        );
++      if (!returnData.isEmpty()) {
++        const buffer = Buffer.from(returnData.value).toString("hex");
+ 
+-        return `VM Exception while processing transaction: reverted with an unrecognized custom error (return data: 0x${returnData})`;
++        return `VM Exception while processing transaction: reverted with an unrecognized custom error (return data: 0x${buffer})`;
+       }
+ 
+       if (stackTraceEntry.isInvalidOpcodeError) {
+@@ -285,8 +285,9 @@ function getMessageFromLastStackTraceEntry(
+       return "Transaction reverted without a reason string";
+ 
+     case StackTraceEntryType.REVERT_ERROR:
+-      if (stackTraceEntry.message.isErrorReturnData()) {
+-        return `VM Exception while processing transaction: reverted with reason string '${stackTraceEntry.message.decodeError()}'`;
++      returnData = new ReturnData(stackTraceEntry.returnData);
++      if (returnData.isErrorReturnData()) {
++        return `VM Exception while processing transaction: reverted with reason string '${returnData.decodeError()}'`;
+       }
+ 
+       if (stackTraceEntry.isInvalidOpcodeError) {
 diff --git a/src/internal/hardhat-network/stack-traces/solidity-stack-trace.ts b/src/internal/hardhat-network/stack-traces/solidity-stack-trace.ts
 index e531a44cbee7daa9b41f31b6b64e7ae677b2abe4..381230dc7ddc356ce3b368ea0e57f90394ec5ce7 100644
 --- a/src/internal/hardhat-network/stack-traces/solidity-stack-trace.ts
@@ -6408,6 +9382,267 @@ index e531a44cbee7daa9b41f31b6b64e7ae677b2abe4..381230dc7ddc356ce3b368ea0e57f903
  
  export type SolidityStackTraceEntry =
    | CallstackEntryStackTraceEntry
+diff --git a/src/internal/hardhat-network/stack-traces/solidityTracer.ts b/src/internal/hardhat-network/stack-traces/solidityTracer.ts
+index 3f92ee08c8e6e9a720ec34e5dd228d7f340a43d3..bae2308ef4b46f64c3a76b300e1a9fb961ae4572 100644
+--- a/src/internal/hardhat-network/stack-traces/solidityTracer.ts
++++ b/src/internal/hardhat-network/stack-traces/solidityTracer.ts
+@@ -1,255 +1 @@
+-import { equalsBytes } from "@nomicfoundation/ethereumjs-util";
+-
+-import { ReturnData } from "../provider/return-data";
+-import { ExitCode } from "../provider/vm/exit";
+-
+-import {
+-  ErrorInferrer,
+-  instructionToCallstackStackTraceEntry,
+-  SubmessageData,
+-} from "./error-inferrer";
+-import {
+-  adjustStackTrace,
+-  stackTraceMayRequireAdjustments,
+-} from "./mapped-inlined-internal-functions-heuristics";
+-import {
+-  DecodedCallMessageTrace,
+-  DecodedCreateMessageTrace,
+-  DecodedEvmMessageTrace,
+-  EvmMessageTrace,
+-  EvmStep,
+-  isCreateTrace,
+-  isDecodedCallTrace,
+-  isDecodedCreateTrace,
+-  isEvmStep,
+-  isPrecompileTrace,
+-  MessageTrace,
+-  PrecompileMessageTrace,
+-} from "./message-trace";
+-import { Instruction, JumpType } from "./model";
+-import { Opcode } from "./opcodes";
+-import {
+-  SolidityStackTrace,
+-  SolidityStackTraceEntry,
+-  StackTraceEntryType,
+-} from "./solidity-stack-trace";
+-
+-export class SolidityTracer {
+-  private _errorInferrer = new ErrorInferrer();
+-
+-  public getStackTrace(
+-    maybeDecodedMessageTrace: MessageTrace
+-  ): SolidityStackTrace {
+-    if (!maybeDecodedMessageTrace.exit.isError()) {
+-      return [];
+-    }
+-
+-    if (isPrecompileTrace(maybeDecodedMessageTrace)) {
+-      return this._getPrecompileMessageStackTrace(maybeDecodedMessageTrace);
+-    }
+-
+-    if (isDecodedCreateTrace(maybeDecodedMessageTrace)) {
+-      return this._getCreateMessageStackTrace(maybeDecodedMessageTrace);
+-    }
+-
+-    if (isDecodedCallTrace(maybeDecodedMessageTrace)) {
+-      return this._getCallMessageStackTrace(maybeDecodedMessageTrace);
+-    }
+-
+-    return this._getUnrecognizedMessageStackTrace(maybeDecodedMessageTrace);
+-  }
+-
+-  private _getCallMessageStackTrace(
+-    trace: DecodedCallMessageTrace
+-  ): SolidityStackTrace {
+-    const inferredError =
+-      this._errorInferrer.inferBeforeTracingCallMessage(trace);
+-
+-    if (inferredError !== undefined) {
+-      return inferredError;
+-    }
+-
+-    return this._traceEvmExecution(trace);
+-  }
+-
+-  private _getUnrecognizedMessageStackTrace(
+-    trace: EvmMessageTrace
+-  ): SolidityStackTrace {
+-    const subtrace = this._getLastSubtrace(trace);
+-
+-    if (subtrace !== undefined) {
+-      // This is not a very exact heuristic, but most of the time it will be right, as solidity
+-      // reverts if a call fails, and most contracts are in solidity
+-      if (
+-        subtrace.exit.isError() &&
+-        equalsBytes(trace.returnData, subtrace.returnData)
+-      ) {
+-        let unrecognizedEntry: SolidityStackTraceEntry;
+-
+-        if (isCreateTrace(trace)) {
+-          unrecognizedEntry = {
+-            type: StackTraceEntryType.UNRECOGNIZED_CREATE_CALLSTACK_ENTRY,
+-          };
+-        } else {
+-          unrecognizedEntry = {
+-            type: StackTraceEntryType.UNRECOGNIZED_CONTRACT_CALLSTACK_ENTRY,
+-            address: trace.address,
+-          };
+-        }
+-
+-        return [unrecognizedEntry, ...this.getStackTrace(subtrace)];
+-      }
+-    }
+-
+-    if (trace.exit.kind === ExitCode.CODESIZE_EXCEEDS_MAXIMUM) {
+-      return [
+-        {
+-          type: StackTraceEntryType.CONTRACT_TOO_LARGE_ERROR,
+-        },
+-      ];
+-    }
+-
+-    const isInvalidOpcodeError = trace.exit.kind === ExitCode.INVALID_OPCODE;
+-
+-    if (isCreateTrace(trace)) {
+-      return [
+-        {
+-          type: StackTraceEntryType.UNRECOGNIZED_CREATE_ERROR,
+-          message: new ReturnData(trace.returnData),
+-          isInvalidOpcodeError,
+-        },
+-      ];
+-    }
+-
+-    return [
+-      {
+-        type: StackTraceEntryType.UNRECOGNIZED_CONTRACT_ERROR,
+-        address: trace.address,
+-        message: new ReturnData(trace.returnData),
+-        isInvalidOpcodeError,
+-      },
+-    ];
+-  }
+-
+-  private _getCreateMessageStackTrace(
+-    trace: DecodedCreateMessageTrace
+-  ): SolidityStackTrace {
+-    const inferredError =
+-      this._errorInferrer.inferBeforeTracingCreateMessage(trace);
+-
+-    if (inferredError !== undefined) {
+-      return inferredError;
+-    }
+-
+-    return this._traceEvmExecution(trace);
+-  }
+-
+-  private _getPrecompileMessageStackTrace(
+-    trace: PrecompileMessageTrace
+-  ): SolidityStackTrace {
+-    return [
+-      {
+-        type: StackTraceEntryType.PRECOMPILE_ERROR,
+-        precompile: trace.precompile,
+-      },
+-    ];
+-  }
+-
+-  private _traceEvmExecution(
+-    trace: DecodedEvmMessageTrace
+-  ): SolidityStackTrace {
+-    const stackTrace = this._rawTraceEvmExecution(trace);
+-
+-    if (stackTraceMayRequireAdjustments(stackTrace, trace)) {
+-      return adjustStackTrace(stackTrace, trace);
+-    }
+-
+-    return stackTrace;
+-  }
+-
+-  private _rawTraceEvmExecution(
+-    trace: DecodedEvmMessageTrace
+-  ): SolidityStackTrace {
+-    const stacktrace: SolidityStackTrace = [];
+-
+-    let subtracesSeen = 0;
+-
+-    // There was a jump into a function according to the sourcemaps
+-    let jumpedIntoFunction = false;
+-
+-    const functionJumpdests: Instruction[] = [];
+-
+-    let lastSubmessageData: SubmessageData | undefined;
+-
+-    for (let stepIndex = 0; stepIndex < trace.steps.length; stepIndex++) {
+-      const step = trace.steps[stepIndex];
+-      const nextStep = trace.steps[stepIndex + 1];
+-
+-      if (isEvmStep(step)) {
+-        const inst = trace.bytecode.getInstruction(step.pc);
+-
+-        if (
+-          inst.jumpType === JumpType.INTO_FUNCTION &&
+-          nextStep !== undefined
+-        ) {
+-          const nextEvmStep = nextStep as EvmStep; // A jump can't be followed by a subtrace
+-          const nextInst = trace.bytecode.getInstruction(nextEvmStep.pc);
+-
+-          if (nextInst !== undefined && nextInst.opcode === Opcode.JUMPDEST) {
+-            stacktrace.push(
+-              instructionToCallstackStackTraceEntry(trace.bytecode, inst)
+-            );
+-            if (nextInst.location !== undefined) {
+-              jumpedIntoFunction = true;
+-            }
+-            functionJumpdests.push(nextInst);
+-          }
+-        } else if (inst.jumpType === JumpType.OUTOF_FUNCTION) {
+-          stacktrace.pop();
+-          functionJumpdests.pop();
+-        }
+-      } else {
+-        subtracesSeen += 1;
+-
+-        // If there are more subtraces, this one didn't terminate the execution
+-        if (subtracesSeen < trace.numberOfSubtraces) {
+-          continue;
+-        }
+-
+-        const submessageTrace = this.getStackTrace(step);
+-
+-        lastSubmessageData = {
+-          messageTrace: step,
+-          stepIndex,
+-          stacktrace: submessageTrace,
+-        };
+-      }
+-    }
+-
+-    const stacktraceWithInferredError = this._errorInferrer.inferAfterTracing(
+-      trace,
+-      stacktrace,
+-      functionJumpdests,
+-      jumpedIntoFunction,
+-      lastSubmessageData
+-    );
+-
+-    return this._errorInferrer.filterRedundantFrames(
+-      stacktraceWithInferredError
+-    );
+-  }
+-
+-  private _getLastSubtrace(trace: EvmMessageTrace): MessageTrace | undefined {
+-    if (trace.numberOfSubtraces < 1) {
+-      return undefined;
+-    }
+-
+-    let i = trace.steps.length - 1;
+-
+-    while (isEvmStep(trace.steps[i])) {
+-      i -= 1;
+-    }
+-
+-    return trace.steps[i] as MessageTrace;
+-  }
+-}
++export { SolidityTracer } from "@nomicfoundation/edr";
 diff --git a/src/internal/hardhat-network/stack-traces/source-maps.ts b/src/internal/hardhat-network/stack-traces/source-maps.ts
 deleted file mode 100644
 index 8ff03b3c7337cb0da035004844c850bf89745669..0000000000000000000000000000000000000000

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
 
 patchedDependencies:
   hardhat@2.22.6:
-    hash: ffvd4pz4lzkbqiqsohd5g45pmi
+    hash: dn25digh7dcj6zffsxj5ebhse4
     path: patches/hardhat@2.22.6.patch
 
 importers:
@@ -66,7 +66,7 @@ importers:
         version: 4.4.1
       hardhat:
         specifier: 2.22.6
-        version: 2.22.6(patch_hash=ffvd4pz4lzkbqiqsohd5g45pmi)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.0.4))(typescript@5.0.4)
+        version: 2.22.6(patch_hash=dn25digh7dcj6zffsxj5ebhse4)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.0.4))(typescript@5.0.4)
       lodash:
         specifier: ^4.17.11
         version: 4.17.21
@@ -186,7 +186,7 @@ importers:
         version: 7.0.1
       hardhat:
         specifier: 2.22.6
-        version: 2.22.6(patch_hash=ffvd4pz4lzkbqiqsohd5g45pmi)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.0.4))(typescript@5.0.4)
+        version: 2.22.6(patch_hash=dn25digh7dcj6zffsxj5ebhse4)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.0.4))(typescript@5.0.4)
       mocha:
         specifier: ^10.0.0
         version: 10.3.0
@@ -216,10 +216,10 @@ importers:
     devDependencies:
       '@defi-wonderland/smock':
         specifier: ^2.4.0
-        version: 2.4.0(@ethersproject/abi@5.7.0)(@ethersproject/abstract-provider@5.7.0)(@ethersproject/abstract-signer@5.7.0)(@nomiclabs/hardhat-ethers@2.2.3(ethers@5.7.2)(hardhat@2.22.6(patch_hash=ffvd4pz4lzkbqiqsohd5g45pmi)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4)))(ethers@5.7.2)(hardhat@2.22.6(patch_hash=ffvd4pz4lzkbqiqsohd5g45pmi)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4))
+        version: 2.4.0(@ethersproject/abi@5.7.0)(@ethersproject/abstract-provider@5.7.0)(@ethersproject/abstract-signer@5.7.0)(@nomiclabs/hardhat-ethers@2.2.3(ethers@5.7.2)(hardhat@2.22.6(patch_hash=dn25digh7dcj6zffsxj5ebhse4)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4)))(ethers@5.7.2)(hardhat@2.22.6(patch_hash=dn25digh7dcj6zffsxj5ebhse4)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4))
       '@nomiclabs/hardhat-ethers':
         specifier: ^2.2.3
-        version: 2.2.3(ethers@5.7.2)(hardhat@2.22.6(patch_hash=ffvd4pz4lzkbqiqsohd5g45pmi)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4))
+        version: 2.2.3(ethers@5.7.2)(hardhat@2.22.6(patch_hash=dn25digh7dcj6zffsxj5ebhse4)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4))
       chai:
         specifier: ^4.3.6
         version: 4.4.1
@@ -228,7 +228,7 @@ importers:
         version: 5.7.2
       hardhat:
         specifier: 2.22.6
-        version: 2.22.6(patch_hash=ffvd4pz4lzkbqiqsohd5g45pmi)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.0.4))(typescript@5.0.4)
+        version: 2.22.6(patch_hash=dn25digh7dcj6zffsxj5ebhse4)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.0.4))(typescript@5.0.4)
       mocha:
         specifier: ^10.0.0
         version: 10.3.0
@@ -3082,16 +3082,16 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@defi-wonderland/smock@2.4.0(@ethersproject/abi@5.7.0)(@ethersproject/abstract-provider@5.7.0)(@ethersproject/abstract-signer@5.7.0)(@nomiclabs/hardhat-ethers@2.2.3(ethers@5.7.2)(hardhat@2.22.6(patch_hash=ffvd4pz4lzkbqiqsohd5g45pmi)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4)))(ethers@5.7.2)(hardhat@2.22.6(patch_hash=ffvd4pz4lzkbqiqsohd5g45pmi)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4))':
+  '@defi-wonderland/smock@2.4.0(@ethersproject/abi@5.7.0)(@ethersproject/abstract-provider@5.7.0)(@ethersproject/abstract-signer@5.7.0)(@nomiclabs/hardhat-ethers@2.2.3(ethers@5.7.2)(hardhat@2.22.6(patch_hash=dn25digh7dcj6zffsxj5ebhse4)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4)))(ethers@5.7.2)(hardhat@2.22.6(patch_hash=dn25digh7dcj6zffsxj5ebhse4)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4))':
     dependencies:
       '@ethersproject/abi': 5.7.0
       '@ethersproject/abstract-provider': 5.7.0
       '@ethersproject/abstract-signer': 5.7.0
       '@nomicfoundation/ethereumjs-util': 9.0.4
-      '@nomiclabs/hardhat-ethers': 2.2.3(ethers@5.7.2)(hardhat@2.22.6(patch_hash=ffvd4pz4lzkbqiqsohd5g45pmi)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4))
+      '@nomiclabs/hardhat-ethers': 2.2.3(ethers@5.7.2)(hardhat@2.22.6(patch_hash=dn25digh7dcj6zffsxj5ebhse4)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4))
       diff: 5.0.0
       ethers: 5.7.2
-      hardhat: 2.22.6(patch_hash=ffvd4pz4lzkbqiqsohd5g45pmi)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.0.4))(typescript@5.0.4)
+      hardhat: 2.22.6(patch_hash=dn25digh7dcj6zffsxj5ebhse4)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.0.4))(typescript@5.0.4)
       lodash.isequal: 4.5.0
       lodash.isequalwith: 4.4.0
       rxjs: 7.8.1
@@ -3602,10 +3602,10 @@ snapshots:
       '@nomicfoundation/solidity-analyzer-win32-ia32-msvc': 0.1.1
       '@nomicfoundation/solidity-analyzer-win32-x64-msvc': 0.1.1
 
-  '@nomiclabs/hardhat-ethers@2.2.3(ethers@5.7.2)(hardhat@2.22.6(patch_hash=ffvd4pz4lzkbqiqsohd5g45pmi)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4))':
+  '@nomiclabs/hardhat-ethers@2.2.3(ethers@5.7.2)(hardhat@2.22.6(patch_hash=dn25digh7dcj6zffsxj5ebhse4)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4))':
     dependencies:
       ethers: 5.7.2
-      hardhat: 2.22.6(patch_hash=ffvd4pz4lzkbqiqsohd5g45pmi)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.0.4))(typescript@5.0.4)
+      hardhat: 2.22.6(patch_hash=dn25digh7dcj6zffsxj5ebhse4)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.0.4))(typescript@5.0.4)
 
   '@scure/base@1.1.5': {}
 
@@ -4872,7 +4872,7 @@ snapshots:
 
   hard-rejection@2.1.0: {}
 
-  hardhat@2.22.6(patch_hash=ffvd4pz4lzkbqiqsohd5g45pmi)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.0.4))(typescript@5.0.4):
+  hardhat@2.22.6(patch_hash=dn25digh7dcj6zffsxj5ebhse4)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.0.4))(typescript@5.0.4):
     dependencies:
       '@ethersproject/abi': 5.7.0
       '@metamask/eth-sig-util': 4.0.1


### PR DESCRIPTION
What says on the tin; this is the last meaningful piece of logic that was needed to be ported. What's remaining is the debug printing and then we can finally start cleaning up the JS cruft that we amassed during the porting.

I know I could be more succinct and polish it further but I figured that it's a 1:1 rewrite of these three files so one could compare them side-to-side and the time can be better spent finally tidying it all up :pray: 

## Scope

This ports the most important three remaining files from Hardhat:
- https://github.com/NomicFoundation/hardhat/blob/main/packages/hardhat-core/src/internal/hardhat-network/stack-traces/mapped-inlined-internal-functions-heuristics.ts
- https://github.com/NomicFoundation/hardhat/blob/main/packages/hardhat-core/src/internal/hardhat-network/stack-traces/error-inferrer.ts
- https://github.com/NomicFoundation/hardhat/blob/main/packages/hardhat-core/src/internal/hardhat-network/stack-traces/solidityTracer.ts

## Context

### Changes to the original data
The main heuristics employed by the `ErrorInferrer` class often shallow copy the stack trace, modifies them and if the heuristic is "accepted", it is returned *or* the old stack trace is returned as is from the function calls. However, some `...StackTraceEntry` `#[napi(object)]`s have a `ClassInstance` field, which makes it impossible to directly implement `Clone` for them. To work around that, I considered the following options:
- keep track of the changes and only apply them if the heuristic was considered "accepted" - that's a less direct translation and would require more involved bookkeeping
- wrap each entry in an `Rc` (the entries were read only) but that would require a lot of work as the `Either24<...>` would not be compatible/convertible at the napi boundary and so we would need a lot more converting back and forth
- modify the stack entry to not include class instances

I followed the last approach, since we only had 3 out of 24 entries that did that and it only used a helper `ReturnData` class, which is responsible for checking whether the return data buffer is the built-in `Error` or `Panic` error and decode it accordingly. Instead, we store the return data buffer directly in the entry and only ever construct the `ReturnData` helper at the use sites.

See https://github.com/NomicFoundation/edr/pull/593/commits/a50bd294786b2257c612dcac3583e32d134dcb48 and https://github.com/NomicFoundation/edr/pull/593/commits/542241315f8729577bca77b82e7ddbbe7df27fff.

### N-API memory safety/UB

I tried to document in https://github.com/NomicFoundation/edr/pull/593/commits/66e0fa8064e2eb5d4edf4ff6aa9619a9a68b7d0e what exactly makes using the `ClassInstance` and now (since this PR) `Reference` potentially dangerous, see the doc comments for more in-depth context.

Thankfully, we will soon not have to expose the classes that created the need for the JS-facing `ClassInstance`/`Reference`s in the first place, so we can start next by removing those and simplifying the references and relationship between the data.

## Other resources
Companion branch: https://github.com/NomicFoundation/hardhat/tree/refactor/port-stack-trace-error-inferrer
Pulled commit from the branch for the patch here:
- https://github.com/NomicFoundation/hardhat/commit/fc7f3ab32e51fed39a41c943923368ade43a9fba
- https://github.com/NomicFoundation/hardhat/commit/ab8e8cedfe399f687d19e32344b0f316f21c125f
- https://github.com/NomicFoundation/hardhat/commit/c9ec023d08e25ff11b899f721dcc845daa428a38
- https://github.com/NomicFoundation/hardhat/commit/243b2a76be55f9ac90bc0522f4c4100b60b0d192
- https://github.com/NomicFoundation/hardhat/commit/cc0ff8069444a8c98b014bc72191e5b0ec8fbac3
- https://github.com/NomicFoundation/hardhat/commit/cb1e10ff142964e0afaecf4753bc82398810195f