### PR TITLE
fix: Fully transpile in Mocha tests to correctly inline const enums

### DIFF
--- a/hardhat-tests/.mocharc.json
+++ b/hardhat-tests/.mocharc.json
@@ -1,5 +1,5 @@
 {
-  "require": "ts-node/register/transpile-only",
+  "require": "ts-node/register",
   "file": "./test/setup.ts",
   "exclude": [
     "test/fixture-projects/**/*.ts",

--- a/hardhat-tests/test/internal/hardhat-network/stack-traces/test.ts
+++ b/hardhat-tests/test/internal/hardhat-network/stack-traces/test.ts
@@ -281,15 +281,9 @@ function compareStackTraces(
 
   // if IR is enabled, we ignore callstack entries in the comparison
   if (isViaIR) {
-    trace = trace.filter((frame) => {
-      // FIXME: For some reason, the const enum from napi-rs is not picked up by TS
-      // and we get undefined instead of the actual value. Just use the number.
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      function assertCallstackEntry<_T extends 0>() {}
-      assertCallstackEntry<StackTraceEntryType.CALLSTACK_ENTRY>();
-
-      return frame.type !== 0;
-    });
+    trace = trace.filter(
+      (frame) => frame.type !== StackTraceEntryType.CALLSTACK_ENTRY
+    );
     description = description.filter(
       (frame) => frame.type !== "CALLSTACK_ENTRY"
     );


### PR DESCRIPTION
It seems transpile-only transpiles per module, however we need to perform full "compilation" in order to correctly see and inline values for const enums.

We use const enums because that's how they are emitted by napi-rs and there's no option to change that. Rather than invest into supporting that or working around it, let's just fully compile the test harness once.

See https://www.typescriptlang.org/tsconfig/#isolatedModules for more context.

See https://github.com/NomicFoundation/edr/pull/589#discussion_r1710243142 for a comment on the original workaround.