### PR TITLE
refactor: Port stack-traces/debug.ts

### DIFF
--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -387,6 +387,8 @@ export interface SourceMap {
   location: SourceMapLocation
   jumpType: JumpType
 }
+export function printMessageTrace(trace: PrecompileMessageTrace | CallMessageTrace | CreateMessageTrace, depth: number): void
+export function printStackTrace(trace: SolidityStackTrace): void
 export interface SubmessageData {
   messageTrace: PrecompileMessageTrace | CallMessageTrace | CreateMessageTrace
   stacktrace: SolidityStackTrace

--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -387,7 +387,7 @@ export interface SourceMap {
   location: SourceMapLocation
   jumpType: JumpType
 }
-export function printMessageTrace(trace: PrecompileMessageTrace | CallMessageTrace | CreateMessageTrace, depth: number): void
+export function printMessageTrace(trace: PrecompileMessageTrace | CallMessageTrace | CreateMessageTrace, depth?: number | undefined | null): void
 export function printStackTrace(trace: SolidityStackTrace): void
 export interface SubmessageData {
   messageTrace: PrecompileMessageTrace | CallMessageTrace | CreateMessageTrace

--- a/crates/edr_napi/index.js
+++ b/crates/edr_napi/index.js
@@ -310,7 +310,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { SpecId, EdrContext, MineOrdering, Provider, Response, SuccessReason, ExceptionalHalt, createModelsAndDecodeBytecodes, linkHexStringBytecode, SourceFile, SourceLocation, ContractFunctionType, ContractFunctionVisibility, ContractFunction, CustomError, Instruction, JumpType, jumpTypeToString, Bytecode, ContractType, Contract, ContractsIdentifier, Exit, ExitCode, Opcode, opcodeToString, isPush, isJump, isCall, isCreate, ReturnData, StackTraceEntryType, stackTraceEntryTypeToString, FALLBACK_FUNCTION_NAME, RECEIVE_FUNCTION_NAME, CONSTRUCTOR_FUNCTION_NAME, UNRECOGNIZED_FUNCTION_NAME, UNKNOWN_FUNCTION_NAME, PRECOMPILE_FUNCTION_NAME, UNRECOGNIZED_CONTRACT_NAME, SolidityTracer, VmTraceDecoder, initializeVmTraceDecoder, VmTracer, RawTrace } = nativeBinding
+const { SpecId, EdrContext, MineOrdering, Provider, Response, SuccessReason, ExceptionalHalt, createModelsAndDecodeBytecodes, linkHexStringBytecode, SourceFile, SourceLocation, ContractFunctionType, ContractFunctionVisibility, ContractFunction, CustomError, Instruction, JumpType, jumpTypeToString, Bytecode, ContractType, Contract, ContractsIdentifier, printMessageTrace, printStackTrace, Exit, ExitCode, Opcode, opcodeToString, isPush, isJump, isCall, isCreate, ReturnData, StackTraceEntryType, stackTraceEntryTypeToString, FALLBACK_FUNCTION_NAME, RECEIVE_FUNCTION_NAME, CONSTRUCTOR_FUNCTION_NAME, UNRECOGNIZED_FUNCTION_NAME, UNKNOWN_FUNCTION_NAME, PRECOMPILE_FUNCTION_NAME, UNRECOGNIZED_CONTRACT_NAME, SolidityTracer, VmTraceDecoder, initializeVmTraceDecoder, VmTracer, RawTrace } = nativeBinding
 
 module.exports.SpecId = SpecId
 module.exports.EdrContext = EdrContext
@@ -334,6 +334,8 @@ module.exports.Bytecode = Bytecode
 module.exports.ContractType = ContractType
 module.exports.Contract = Contract
 module.exports.ContractsIdentifier = ContractsIdentifier
+module.exports.printMessageTrace = printMessageTrace
+module.exports.printStackTrace = printStackTrace
 module.exports.Exit = Exit
 module.exports.ExitCode = ExitCode
 module.exports.Opcode = Opcode

--- a/crates/edr_napi/src/trace.rs
+++ b/crates/edr_napi/src/trace.rs
@@ -22,6 +22,7 @@ mod model;
 mod source_map;
 
 mod contracts_identifier;
+mod debug;
 mod error_inferrer;
 mod exit;
 mod mapped_inlined_internal_functions_heuristics;

--- a/crates/edr_napi/src/trace/debug.rs
+++ b/crates/edr_napi/src/trace/debug.rs
@@ -20,7 +20,7 @@ const MARGIN_SPACE: usize = 6;
 #[napi]
 fn print_message_trace(
     trace: Either3<PrecompileMessageTrace, CallMessageTrace, CreateMessageTrace>,
-    depth: u32,
+    depth: Option<u32>,
     env: Env,
 ) -> napi::Result<()> {
     let trace = match &trace {
@@ -28,6 +28,8 @@ fn print_message_trace(
         Either3::B(call) => Either3::B(call),
         Either3::C(create) => Either3::C(create),
     };
+
+    let depth = depth.unwrap_or(0);
 
     print_message_trace_inner(trace, depth, env)
 }

--- a/crates/edr_napi/src/trace/debug.rs
+++ b/crates/edr_napi/src/trace/debug.rs
@@ -8,12 +8,11 @@ use napi::{
 };
 use napi_derive::napi;
 
-use crate::trace::{model::JumpType, return_data::ReturnData};
-
 use super::{
     message_trace::{CallMessageTrace, CreateMessageTrace, PrecompileMessageTrace},
     solidity_stack_trace::{RevertErrorStackTraceEntry, SolidityStackTrace},
 };
+use crate::trace::{model::JumpType, return_data::ReturnData};
 
 const MARGIN_SPACE: usize = 6;
 
@@ -153,7 +152,8 @@ fn print_create_trace(trace: &CreateMessageTrace, depth: u32, env: Env) -> napi:
 
     if trace.exit.is_error() {
         println!("{margin} error: {}", trace.exit.get_reason());
-        // The return data is the deployed-bytecode if there was no error, so we don't show it
+        // The return data is the deployed-bytecode if there was no error, so we don't
+        // show it
         println!(
             "{margin} returnData: {}",
             hex::encode_prefixed(&*trace.return_data)

--- a/crates/edr_napi/src/trace/debug.rs
+++ b/crates/edr_napi/src/trace/debug.rs
@@ -1,0 +1,327 @@
+//! Port of `hardhat-network/stack-traces/debug.ts` from Hardhat.
+
+use edr_eth::U256;
+use edr_evm::hex;
+use napi::{
+    bindgen_prelude::{Either24, Either3, Either4},
+    Either, Env,
+};
+use napi_derive::napi;
+
+use crate::trace::{model::JumpType, return_data::ReturnData};
+
+use super::{
+    message_trace::{CallMessageTrace, CreateMessageTrace, PrecompileMessageTrace},
+    solidity_stack_trace::{RevertErrorStackTraceEntry, SolidityStackTrace},
+};
+
+const MARGIN_SPACE: usize = 6;
+
+#[napi]
+fn print_message_trace(
+    trace: Either3<PrecompileMessageTrace, CallMessageTrace, CreateMessageTrace>,
+    depth: u32,
+    env: Env,
+) -> napi::Result<()> {
+    let trace = match &trace {
+        Either3::A(precompile) => Either3::A(precompile),
+        Either3::B(call) => Either3::B(call),
+        Either3::C(create) => Either3::C(create),
+    };
+
+    print_message_trace_inner(trace, depth, env)
+}
+
+fn print_message_trace_inner(
+    trace: Either3<&PrecompileMessageTrace, &CallMessageTrace, &CreateMessageTrace>,
+    depth: u32,
+    env: Env,
+) -> napi::Result<()> {
+    println!();
+
+    match trace {
+        Either3::A(precompile) => print_precompile_trace(precompile, depth),
+        Either3::B(call) => print_call_trace(call, depth, env)?,
+        Either3::C(create) => print_create_trace(create, depth, env)?,
+    }
+
+    println!();
+
+    Ok(())
+}
+
+fn print_precompile_trace(trace: &PrecompileMessageTrace, depth: u32) {
+    let margin = " ".repeat(depth as usize * MARGIN_SPACE);
+
+    let value = U256::from_limbs_slice(&trace.value.words);
+
+    println!("{margin}Precompile trace");
+
+    println!("{margin} precompile number: {}", trace.precompile);
+    println!("{margin} value: {value}");
+    println!(
+        "{margin} calldata: {}",
+        hex::encode_prefixed(&*trace.calldata)
+    );
+
+    if trace.exit.is_error() {
+        println!("{margin} error: {}", trace.exit.get_reason());
+    }
+
+    println!(
+        "{margin} returnData: {}",
+        hex::encode_prefixed(&*trace.return_data)
+    );
+}
+
+fn print_call_trace(trace: &CallMessageTrace, depth: u32, env: Env) -> napi::Result<()> {
+    let margin = " ".repeat(depth as usize * MARGIN_SPACE);
+
+    println!("{margin}Call trace");
+
+    if let Some(bytecode) = &trace.bytecode {
+        let contract = bytecode.contract.borrow(env)?;
+        let location = contract.location.borrow(env)?;
+        let file = location.file.borrow(env)?;
+
+        println!(
+            "{margin} calling contract: {}:{}",
+            file.source_name, contract.name
+        );
+    } else {
+        println!(
+            "{margin} unrecognized contract code: {:?}",
+            hex::encode_prefixed(&*trace.code)
+        );
+        println!(
+            "{margin} contract: {}",
+            hex::encode_prefixed(&*trace.address)
+        );
+    }
+
+    println!(
+        "{margin} value: {}",
+        U256::from_limbs_slice(&trace.value.words)
+    );
+    println!(
+        "{margin} calldata: {}",
+        hex::encode_prefixed(&*trace.calldata)
+    );
+
+    if trace.exit.is_error() {
+        println!("{margin} error: {}", trace.exit.get_reason());
+    }
+
+    println!(
+        "{margin} returnData: {}",
+        hex::encode_prefixed(&*trace.return_data)
+    );
+
+    trace_steps(Either::A(trace), depth, env)
+}
+
+fn print_create_trace(trace: &CreateMessageTrace, depth: u32, env: Env) -> napi::Result<()> {
+    let margin = " ".repeat(depth as usize * MARGIN_SPACE);
+
+    println!("{margin}Create trace");
+
+    if let Some(bytecode) = &trace.bytecode {
+        let contract = bytecode.contract.borrow(env)?;
+
+        println!("{margin} deploying contract: {}", contract.name);
+        println!("{margin} code: {}", hex::encode_prefixed(&*trace.code));
+    } else {
+        println!(
+            "{margin} unrecognized deployment code: {}",
+            hex::encode_prefixed(&*trace.code)
+        );
+    }
+
+    println!(
+        "{margin} value: {}",
+        U256::from_limbs_slice(&trace.value.words)
+    );
+
+    if let Some(Either::A(deployed_contract)) = &trace.deployed_contract {
+        println!(
+            "{margin} contract address: {}",
+            hex::encode_prefixed(deployed_contract)
+        );
+    }
+
+    if trace.exit.is_error() {
+        println!("{margin} error: {}", trace.exit.get_reason());
+        // The return data is the deployed-bytecode if there was no error, so we don't show it
+        println!(
+            "{margin} returnData: {}",
+            hex::encode_prefixed(&*trace.return_data)
+        );
+    }
+
+    trace_steps(Either::B(trace), depth, env)?;
+
+    Ok(())
+}
+
+fn trace_steps(
+    trace: Either<&CallMessageTrace, &CreateMessageTrace>,
+    depth: u32,
+    env: Env,
+) -> napi::Result<()> {
+    let margin = " ".repeat(depth as usize * MARGIN_SPACE);
+
+    println!("{margin} steps:");
+    println!();
+
+    let (bytecode, steps) = match &trace {
+        Either::A(call) => (&call.bytecode, &call.steps),
+        Either::B(create) => (&create.bytecode, &create.steps),
+    };
+
+    for step in steps {
+        let step = match step {
+            Either4::A(step) => step,
+            trace @ (Either4::B(..) | Either4::C(..) | Either4::D(..)) => {
+                let trace = match trace {
+                    Either4::A(..) => unreachable!(),
+                    Either4::B(precompile) => Either3::A(precompile),
+                    Either4::C(call) => Either3::B(call),
+                    Either4::D(create) => Either3::C(create),
+                };
+
+                print_message_trace_inner(trace, depth + 1, env)?;
+                continue;
+            }
+        };
+
+        let pc = format!("{:>5}", format!("{:03}", step.pc));
+
+        if let Some(bytecode) = bytecode {
+            let inst = bytecode.get_instruction_inner(step.pc)?;
+            let inst = inst.borrow(env)?;
+
+            let location = inst
+                .location
+                .as_ref()
+                .map(|inst_location| {
+                    let inst_location = inst_location.borrow(env)?;
+                    let file = inst_location.file.borrow(env)?;
+
+                    let mut location_str = file.source_name.clone();
+
+                    if let Some(func) = inst_location.get_containing_function_inner(env)? {
+                        let func = func.borrow(env)?;
+                        let location = func.location.borrow(env)?;
+                        let file = location.file.borrow(env)?;
+
+                        let contract_name = func
+                            .contract
+                            .as_ref()
+                            .map(|contract| -> napi::Result<_> {
+                                Ok(contract.borrow(env)?.name.clone())
+                            })
+                            .transpose()?;
+
+                        let source_name = contract_name.unwrap_or_else(|| file.source_name.clone());
+
+                        location_str += &format!(":{source_name}:{}", func.name);
+                    }
+                    location_str +=
+                        &format!("   -  {}:{}", inst_location.offset, inst_location.length);
+
+                    napi::Result::Ok(location_str)
+                })
+                .transpose()?
+                .unwrap_or_default();
+
+            if inst.opcode.is_jump() {
+                let jump = if inst.jump_type == JumpType::NOT_JUMP {
+                    "".to_string()
+                } else {
+                    format!("({})", inst.jump_type.into_static_str())
+                };
+
+                let entry = format!(
+                    "{margin}  {pc}   {opcode} {jump}",
+                    opcode = inst.opcode.into_static_str()
+                );
+
+                println!("{entry:<50}{location}");
+            } else if inst.opcode.is_push() {
+                let entry = format!(
+                    "{margin}  {pc}   {opcode} {push_data}",
+                    opcode = inst.opcode.into_static_str(),
+                    push_data = inst
+                        .push_data
+                        .as_deref()
+                        .map(hex::encode_prefixed)
+                        .unwrap_or_default()
+                );
+
+                println!("{entry:<50}{location}");
+            } else {
+                let entry = format!(
+                    "{margin}  {pc}   {opcode}",
+                    opcode = inst.opcode.into_static_str()
+                );
+
+                println!("{entry:<50}{location}");
+            }
+        } else {
+            println!("{margin}  {pc}");
+        }
+    }
+
+    Ok(())
+}
+
+#[napi]
+fn print_stack_trace(trace: SolidityStackTrace) -> napi::Result<()> {
+    let entry_values = trace
+        .into_iter()
+        .map(|entry| match entry {
+            Either24::A(entry) => serde_json::to_value(entry),
+            Either24::B(entry) => serde_json::to_value(entry),
+            Either24::C(entry) => serde_json::to_value(entry),
+            Either24::D(entry) => serde_json::to_value(entry),
+            Either24::F(entry) => serde_json::to_value(entry),
+            Either24::G(entry) => serde_json::to_value(entry),
+            Either24::H(entry) => serde_json::to_value(entry),
+            Either24::I(entry) => serde_json::to_value(entry),
+            Either24::J(entry) => serde_json::to_value(entry),
+            Either24::K(entry) => serde_json::to_value(entry),
+            Either24::L(entry) => serde_json::to_value(entry),
+            Either24::M(entry) => serde_json::to_value(entry),
+            Either24::N(entry) => serde_json::to_value(entry),
+            Either24::O(entry) => serde_json::to_value(entry),
+            Either24::P(entry) => serde_json::to_value(entry),
+            Either24::Q(entry) => serde_json::to_value(entry),
+            Either24::R(entry) => serde_json::to_value(entry),
+            Either24::S(entry) => serde_json::to_value(entry),
+            Either24::T(entry) => serde_json::to_value(entry),
+            Either24::U(entry) => serde_json::to_value(entry),
+            Either24::V(entry) => serde_json::to_value(entry),
+            Either24::W(entry) => serde_json::to_value(entry),
+            Either24::X(entry) => serde_json::to_value(entry),
+            // Decode the error message from the return data
+            Either24::E(entry @ RevertErrorStackTraceEntry { .. }) => {
+                use serde::de::Error;
+
+                let decoded_error_msg = ReturnData::new(entry.return_data.clone())
+                    .decode_error()
+                    .map_err(|e| {
+                    serde_json::Error::custom(format_args!("Error decoding return data: {e}"))
+                })?;
+
+                let mut value = serde_json::to_value(entry)?;
+                value["message"] = decoded_error_msg.into();
+                Ok(value)
+            }
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| napi::Error::from_reason(format!("Error converting to JSON: {e}")))?;
+
+    println!("{}", serde_json::to_string_pretty(&entry_values)?);
+
+    Ok(())
+}

--- a/crates/edr_napi/src/trace/model.rs
+++ b/crates/edr_napi/src/trace/model.rs
@@ -10,6 +10,7 @@ use napi::{
     Either, Env, JsObject,
 };
 use napi_derive::napi;
+use serde::Serialize;
 use serde_json::Value;
 
 use super::opcodes::Opcode;
@@ -153,7 +154,7 @@ impl SourceLocation {
     }
 }
 
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Serialize)]
 #[allow(non_camel_case_types)] // intentionally mimicks the original case in TS
 #[allow(clippy::upper_case_acronyms)]
 #[napi]
@@ -294,6 +295,12 @@ pub enum JumpType {
     INTO_FUNCTION,
     OUTOF_FUNCTION,
     INTERNAL_JUMP,
+}
+
+impl JumpType {
+    pub fn into_static_str(self) -> &'static str {
+        self.into()
+    }
 }
 
 #[napi]

--- a/crates/edr_napi/src/trace/opcodes.rs
+++ b/crates/edr_napi/src/trace/opcodes.rs
@@ -327,21 +327,33 @@ impl Opcode {
     pub fn push_len(self) -> u8 {
         self as u8 - Opcode::PUSH1 as u8 + 1
     }
+
+    pub fn is_jump(self) -> bool {
+        matches!(self, Opcode::JUMP | Opcode::JUMPI)
+    }
+
+    pub fn is_push(self) -> bool {
+        self >= Opcode::PUSH1 && self <= Opcode::PUSH32
+    }
+
+    pub fn into_static_str(self) -> &'static str {
+        self.into()
+    }
 }
 
 #[napi]
 pub fn opcode_to_string(opcode: Opcode) -> &'static str {
-    opcode.into()
+    opcode.into_static_str()
 }
 
 #[napi]
 pub fn is_push(opcode: Opcode) -> bool {
-    opcode >= Opcode::PUSH1 && opcode <= Opcode::PUSH32
+    opcode.is_push()
 }
 
 #[napi]
 pub fn is_jump(opcode: Opcode) -> bool {
-    opcode == Opcode::JUMP || opcode == Opcode::JUMPI
+    opcode.is_jump()
 }
 
 #[napi]

--- a/patches/gen-hardhat-patches.sh
+++ b/patches/gen-hardhat-patches.sh
@@ -46,7 +46,8 @@ COMMITS=(
   cc0ff8069444a8c98b014bc72191e5b0ec8fbac3
   # Finish porting ErrorInferrer and SolidityTracer
   cb1e10ff142964e0afaecf4753bc82398810195f
-
+  # Port debug.ts
+  ebff4c53e0d4c290e7e2f11f2559c6d1b79ee628
 )
 
 for commit in "${COMMITS[@]}"; do

--- a/patches/hardhat@2.22.6.patch
+++ b/patches/hardhat@2.22.6.patch
@@ -967,80 +967,196 @@ index ea3db2d854dbfe213045cba3bd985fa9b558747e..d6cda6c576d233bfc0f94c1b1d9e8949
 \ No newline at end of file
 +{"version":3,"file":"contracts-identifier.js","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/contracts-identifier.ts"],"names":[],"mappings":";;;AAAA,8CAA2D;AAClD,oGADA,yBAAmB,OACA"}
 \ No newline at end of file
+diff --git a/internal/hardhat-network/stack-traces/debug.d.ts b/internal/hardhat-network/stack-traces/debug.d.ts
+index d08d9bf9fa298084d84ead93fd5027b97d909aeb..7aa8aae7f5cffadd535c4afd86749f935849b548 100644
+--- a/internal/hardhat-network/stack-traces/debug.d.ts
++++ b/internal/hardhat-network/stack-traces/debug.d.ts
+@@ -1,8 +1,2 @@
+-import { CallMessageTrace, CreateMessageTrace, MessageTrace, PrecompileMessageTrace } from "./message-trace";
+-import { SolidityStackTrace } from "./solidity-stack-trace";
+-export declare function printMessageTrace(trace: MessageTrace, depth?: number): void;
+-export declare function printCreateTrace(trace: CreateMessageTrace, depth: number): void;
+-export declare function printPrecompileTrace(trace: PrecompileMessageTrace, depth: number): void;
+-export declare function printCallTrace(trace: CallMessageTrace, depth: number): void;
+-export declare function printStackTrace(trace: SolidityStackTrace): void;
++export { printMessageTrace, printStackTrace } from "@nomicfoundation/edr";
+ //# sourceMappingURL=debug.d.ts.map
+\ No newline at end of file
 diff --git a/internal/hardhat-network/stack-traces/debug.d.ts.map b/internal/hardhat-network/stack-traces/debug.d.ts.map
-index 967ed191a2c3239b887083f0afe66c002a218713..42078f494e72169d6e769239a02159db2ffaee19 100644
+index 967ed191a2c3239b887083f0afe66c002a218713..9d3494cba7fe27ae85cfa798d4969aa13c849850 100644
 --- a/internal/hardhat-network/stack-traces/debug.d.ts.map
 +++ b/internal/hardhat-network/stack-traces/debug.d.ts.map
 @@ -1 +1 @@
 -{"version":3,"file":"debug.d.ts","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/debug.ts"],"names":[],"mappings":"AAGA,OAAO,EACL,gBAAgB,EAChB,kBAAkB,EAIlB,YAAY,EACZ,sBAAsB,EACvB,MAAM,iBAAiB,CAAC;AAGzB,OAAO,EACL,kBAAkB,EAGnB,MAAM,wBAAwB,CAAC;AAIhC,wBAAgB,iBAAiB,CAAC,KAAK,EAAE,YAAY,EAAE,KAAK,SAAI,QAY/D;AAED,wBAAgB,gBAAgB,CAAC,KAAK,EAAE,kBAAkB,EAAE,KAAK,EAAE,MAAM,QAgCxE;AAED,wBAAgB,oBAAoB,CAClC,KAAK,EAAE,sBAAsB,EAC7B,KAAK,EAAE,MAAM,QAcd;AAED,wBAAgB,cAAc,CAAC,KAAK,EAAE,gBAAgB,EAAE,KAAK,EAAE,MAAM,QAyBpE;AA4ED,wBAAgB,eAAe,CAAC,KAAK,EAAE,kBAAkB,QA8BxD"}
 \ No newline at end of file
-+{"version":3,"file":"debug.d.ts","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/debug.ts"],"names":[],"mappings":"AAIA,OAAO,EACL,gBAAgB,EAChB,kBAAkB,EAIlB,YAAY,EACZ,sBAAsB,EACvB,MAAM,iBAAiB,CAAC;AAGzB,OAAO,EACL,kBAAkB,EAGnB,MAAM,wBAAwB,CAAC;AAIhC,wBAAgB,iBAAiB,CAAC,KAAK,EAAE,YAAY,EAAE,KAAK,SAAI,QAY/D;AAED,wBAAgB,gBAAgB,CAAC,KAAK,EAAE,kBAAkB,EAAE,KAAK,EAAE,MAAM,QAgCxE;AAED,wBAAgB,oBAAoB,CAClC,KAAK,EAAE,sBAAsB,EAC7B,KAAK,EAAE,MAAM,QAcd;AAED,wBAAgB,cAAc,CAAC,KAAK,EAAE,gBAAgB,EAAE,KAAK,EAAE,MAAM,QAyBpE;AA4ED,wBAAgB,eAAe,CAAC,KAAK,EAAE,kBAAkB,QA8BxD"}
++{"version":3,"file":"debug.d.ts","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/debug.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,iBAAiB,EAAE,eAAe,EAAE,MAAM,sBAAsB,CAAC"}
 \ No newline at end of file
 diff --git a/internal/hardhat-network/stack-traces/debug.js b/internal/hardhat-network/stack-traces/debug.js
-index d0ee28a6c8f2eb4137e9dd9858b0c806896659b0..e70e8fa80e1cc9b3e775d42bf6947d2189988a81 100644
+index d0ee28a6c8f2eb4137e9dd9858b0c806896659b0..c34d3239d2c214aa5097f9dbab4d7128be0cd87c 100644
 --- a/internal/hardhat-network/stack-traces/debug.js
 +++ b/internal/hardhat-network/stack-traces/debug.js
-@@ -6,10 +6,10 @@ Object.defineProperty(exports, "__esModule", { value: true });
- exports.printStackTrace = exports.printCallTrace = exports.printPrecompileTrace = exports.printCreateTrace = exports.printMessageTrace = void 0;
- const ethereumjs_util_1 = require("@nomicfoundation/ethereumjs-util");
- const chalk_1 = __importDefault(require("chalk"));
-+const edr_1 = require("@nomicfoundation/edr");
- const message_trace_1 = require("./message-trace");
- const model_1 = require("./model");
- const opcodes_1 = require("./opcodes");
+@@ -1,148 +1,7 @@
+ "use strict";
+-var __importDefault = (this && this.__importDefault) || function (mod) {
+-    return (mod && mod.__esModule) ? mod : { "default": mod };
+-};
+ Object.defineProperty(exports, "__esModule", { value: true });
+-exports.printStackTrace = exports.printCallTrace = exports.printPrecompileTrace = exports.printCreateTrace = exports.printMessageTrace = void 0;
+-const ethereumjs_util_1 = require("@nomicfoundation/ethereumjs-util");
+-const chalk_1 = __importDefault(require("chalk"));
+-const message_trace_1 = require("./message-trace");
+-const model_1 = require("./model");
+-const opcodes_1 = require("./opcodes");
 -const solidity_stack_trace_1 = require("./solidity-stack-trace");
- const MARGIN_SPACE = 6;
- function printMessageTrace(trace, depth = 0) {
-     console.log("");
-@@ -97,16 +97,16 @@ function traceSteps(trace, depth) {
-                     location += `   -  ${inst.location.offset}:${inst.location.length}`;
-                 }
-                 if ((0, opcodes_1.isJump)(inst.opcode)) {
+-const MARGIN_SPACE = 6;
+-function printMessageTrace(trace, depth = 0) {
+-    console.log("");
+-    if ((0, message_trace_1.isCreateTrace)(trace)) {
+-        printCreateTrace(trace, depth);
+-    }
+-    else if ((0, message_trace_1.isPrecompileTrace)(trace)) {
+-        printPrecompileTrace(trace, depth);
+-    }
+-    else {
+-        printCallTrace(trace, depth);
+-    }
+-    console.log("");
+-}
+-exports.printMessageTrace = printMessageTrace;
+-function printCreateTrace(trace, depth) {
+-    const margin = "".padStart(depth * MARGIN_SPACE);
+-    console.log(`${margin}Create trace`);
+-    if (trace.bytecode !== undefined) {
+-        console.log(`${margin} deploying contract: ${trace.bytecode.contract.location.file.sourceName}:${trace.bytecode.contract.name}`);
+-        console.log(`${margin} code: ${(0, ethereumjs_util_1.bytesToHex)(trace.code)}`);
+-    }
+-    else {
+-        console.log(`${margin} unrecognized deployment code: ${(0, ethereumjs_util_1.bytesToHex)(trace.code)}`);
+-    }
+-    console.log(`${margin} value: ${trace.value.toString(10)}`);
+-    if (trace.deployedContract !== undefined) {
+-        console.log(`${margin} contract address: ${(0, ethereumjs_util_1.bytesToHex)(trace.deployedContract)}`);
+-    }
+-    if (trace.exit.isError()) {
+-        console.log(`${margin} error: ${trace.exit.getReason()}`);
+-        // The return data is the deployed-bytecode if there was no error, so we don't show it
+-        console.log(`${margin} returnData: ${(0, ethereumjs_util_1.bytesToHex)(trace.returnData)}`);
+-    }
+-    traceSteps(trace, depth);
+-}
+-exports.printCreateTrace = printCreateTrace;
+-function printPrecompileTrace(trace, depth) {
+-    const margin = "".padStart(depth * MARGIN_SPACE);
+-    console.log(`${margin}Precompile trace`);
+-    console.log(`${margin} precompile number: ${trace.precompile}`);
+-    console.log(`${margin} value: ${trace.value.toString(10)}`);
+-    console.log(`${margin} calldata: ${(0, ethereumjs_util_1.bytesToHex)(trace.calldata)}`);
+-    if (trace.exit.isError()) {
+-        console.log(`${margin} error: ${trace.exit.getReason()}`);
+-    }
+-    console.log(`${margin} returnData: ${(0, ethereumjs_util_1.bytesToHex)(trace.returnData)}`);
+-}
+-exports.printPrecompileTrace = printPrecompileTrace;
+-function printCallTrace(trace, depth) {
+-    const margin = "".padStart(depth * MARGIN_SPACE);
+-    console.log(`${margin}Call trace`);
+-    if (trace.bytecode !== undefined) {
+-        console.log(`${margin} calling contract: ${trace.bytecode.contract.location.file.sourceName}:${trace.bytecode.contract.name}`);
+-    }
+-    else {
+-        console.log(`${margin} unrecognized contract code: ${(0, ethereumjs_util_1.bytesToHex)(trace.code)}`);
+-        console.log(`${margin} contract: ${(0, ethereumjs_util_1.bytesToHex)(trace.address)}`);
+-    }
+-    console.log(`${margin} value: ${trace.value.toString(10)}`);
+-    console.log(`${margin} calldata: ${(0, ethereumjs_util_1.bytesToHex)(trace.calldata)}`);
+-    if (trace.exit.isError()) {
+-        console.log(`${margin} error: ${trace.exit.getReason()}`);
+-    }
+-    console.log(`${margin} returnData: ${(0, ethereumjs_util_1.bytesToHex)(trace.returnData)}`);
+-    traceSteps(trace, depth);
+-}
+-exports.printCallTrace = printCallTrace;
+-function traceSteps(trace, depth) {
+-    const margin = "".padStart(depth * MARGIN_SPACE);
+-    console.log(`${margin} steps:`);
+-    console.log("");
+-    for (const step of trace.steps) {
+-        if ((0, message_trace_1.isEvmStep)(step)) {
+-            const pc = step.pc.toString(10).padStart(3, "0").padStart(5);
+-            if (trace.bytecode !== undefined) {
+-                const inst = trace.bytecode.getInstruction(step.pc);
+-                let location = "";
+-                if (inst.location !== undefined) {
+-                    location += inst.location.file.sourceName;
+-                    const func = inst.location.getContainingFunction();
+-                    if (func !== undefined) {
+-                        location += `:${func.contract?.name ?? func.location.file.sourceName}:${func.name}`;
+-                    }
+-                    location += `   -  ${inst.location.offset}:${inst.location.length}`;
+-                }
+-                if ((0, opcodes_1.isJump)(inst.opcode)) {
 -                    const jump = inst.jumpType !== model_1.JumpType.NOT_JUMP
 -                        ? chalk_1.default.bold(`(${model_1.JumpType[inst.jumpType]})`)
-+                    const jump = inst.jumpType !== 0 /* JumpType.NOT_JUMP */
-+                        ? chalk_1.default.bold(`(${(0, model_1.jumpTypeToString)(inst.jumpType)})`)
-                         : "";
+-                        : "";
 -                    console.log(`${margin}  ${pc}   ${opcodes_1.Opcode[inst.opcode]} ${jump}`.padEnd(50), location);
-+                    console.log(`${margin}  ${pc}   ${(0, opcodes_1.opcodeToString)(inst.opcode)} ${jump}`.padEnd(50), location);
-                 }
-                 else if ((0, opcodes_1.isPush)(inst.opcode)) {
+-                }
+-                else if ((0, opcodes_1.isPush)(inst.opcode)) {
 -                    console.log(`${margin}  ${pc}   ${opcodes_1.Opcode[inst.opcode]} ${(0, ethereumjs_util_1.bytesToHex)(inst.pushData)}`.padEnd(50), location);
-+                    console.log(`${margin}  ${pc}   ${(0, opcodes_1.opcodeToString)(inst.opcode)} ${(0, ethereumjs_util_1.bytesToHex)(inst.pushData)}`.padEnd(50), location);
-                 }
-                 else {
+-                }
+-                else {
 -                    console.log(`${margin}  ${pc}   ${opcodes_1.Opcode[inst.opcode]}`.padEnd(50), location);
-+                    console.log(`${margin}  ${pc}   ${(0, opcodes_1.opcodeToString)(inst.opcode)}`.padEnd(50), location);
-                 }
-             }
-             else {
-@@ -128,15 +128,15 @@ function flattenSourceReference(sourceReference) {
-     };
- }
- function printStackTrace(trace) {
+-                }
+-            }
+-            else {
+-                console.log(`${margin}  ${pc}`);
+-            }
+-        }
+-        else {
+-            printMessageTrace(step, depth + 1);
+-        }
+-    }
+-}
+-function flattenSourceReference(sourceReference) {
+-    if (sourceReference === undefined) {
+-        return undefined;
+-    }
+-    return {
+-        ...sourceReference,
+-        file: sourceReference.sourceName,
+-    };
+-}
+-function printStackTrace(trace) {
 -    const withDecodedMessages = trace.map((entry) => entry.type === solidity_stack_trace_1.StackTraceEntryType.REVERT_ERROR
 -        ? { ...entry, message: entry.message.decodeError() }
-+    const withDecodedMessages = trace.map((entry) => entry.type === 4 /* StackTraceEntryType.REVERT_ERROR */
-+        ? { ...entry, message: new edr_1.ReturnData(entry.returnData).decodeError() }
-         : entry);
-     const withHexAddress = withDecodedMessages.map((entry) => "address" in entry
-         ? { ...entry, address: (0, ethereumjs_util_1.bytesToHex)(entry.address) }
-         : entry);
-     const withTextualType = withHexAddress.map((entry) => ({
-         ...entry,
+-        : entry);
+-    const withHexAddress = withDecodedMessages.map((entry) => "address" in entry
+-        ? { ...entry, address: (0, ethereumjs_util_1.bytesToHex)(entry.address) }
+-        : entry);
+-    const withTextualType = withHexAddress.map((entry) => ({
+-        ...entry,
 -        type: solidity_stack_trace_1.StackTraceEntryType[entry.type],
-+        type: (0, edr_1.stackTraceEntryTypeToString)(entry.type),
-     }));
-     const withFlattenedSourceReferences = withTextualType.map((entry) => ({
-         ...entry,
+-    }));
+-    const withFlattenedSourceReferences = withTextualType.map((entry) => ({
+-        ...entry,
+-        sourceReference: flattenSourceReference(entry.sourceReference),
+-    }));
+-    console.log(JSON.stringify(withFlattenedSourceReferences, (key, value) => (typeof value === "bigint" ? value.toString() : value), 2));
+-}
+-exports.printStackTrace = printStackTrace;
++exports.printStackTrace = exports.printMessageTrace = void 0;
++var edr_1 = require("@nomicfoundation/edr");
++Object.defineProperty(exports, "printMessageTrace", { enumerable: true, get: function () { return edr_1.printMessageTrace; } });
++Object.defineProperty(exports, "printStackTrace", { enumerable: true, get: function () { return edr_1.printStackTrace; } });
+ //# sourceMappingURL=debug.js.map
+\ No newline at end of file
 diff --git a/internal/hardhat-network/stack-traces/debug.js.map b/internal/hardhat-network/stack-traces/debug.js.map
-index 5687ea1ba89513386b08df144e97e53d5b21af89..3fca97b54b9e95b503d7697d734e280573f90f7c 100644
+index 5687ea1ba89513386b08df144e97e53d5b21af89..3a6d1f3deb7ec862f83a264fb5da34cea0853ce9 100644
 --- a/internal/hardhat-network/stack-traces/debug.js.map
 +++ b/internal/hardhat-network/stack-traces/debug.js.map
 @@ -1 +1 @@
 -{"version":3,"file":"debug.js","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/debug.ts"],"names":[],"mappings":";;;;;;AAAA,sEAA6E;AAC7E,kDAA0B;AAE1B,mDAQyB;AACzB,mCAAmC;AACnC,uCAAmD;AACnD,iEAIgC;AAEhC,MAAM,YAAY,GAAG,CAAC,CAAC;AAEvB,SAAgB,iBAAiB,CAAC,KAAmB,EAAE,KAAK,GAAG,CAAC;IAC9D,OAAO,CAAC,GAAG,CAAC,EAAE,CAAC,CAAC;IAEhB,IAAI,IAAA,6BAAa,EAAC,KAAK,CAAC,EAAE;QACxB,gBAAgB,CAAC,KAAK,EAAE,KAAK,CAAC,CAAC;KAChC;SAAM,IAAI,IAAA,iCAAiB,EAAC,KAAK,CAAC,EAAE;QACnC,oBAAoB,CAAC,KAAK,EAAE,KAAK,CAAC,CAAC;KACpC;SAAM;QACL,cAAc,CAAC,KAAK,EAAE,KAAK,CAAC,CAAC;KAC9B;IAED,OAAO,CAAC,GAAG,CAAC,EAAE,CAAC,CAAC;AAClB,CAAC;AAZD,8CAYC;AAED,SAAgB,gBAAgB,CAAC,KAAyB,EAAE,KAAa;IACvE,MAAM,MAAM,GAAG,EAAE,CAAC,QAAQ,CAAC,KAAK,GAAG,YAAY,CAAC,CAAC;IACjD,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,cAAc,CAAC,CAAC;IAErC,IAAI,KAAK,CAAC,QAAQ,KAAK,SAAS,EAAE;QAChC,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,wBAAwB,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI,CAAC,UAAU,IAAI,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI,EAAE,CACpH,CAAC;QAEF,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,UAAU,IAAA,4BAAW,EAAC,KAAK,CAAC,IAAI,CAAC,EAAE,CAAC,CAAC;KAC3D;SAAM;QACL,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,kCAAkC,IAAA,4BAAW,EAAC,KAAK,CAAC,IAAI,CAAC,EAAE,CACrE,CAAC;KACH;IAED,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,WAAW,KAAK,CAAC,KAAK,CAAC,QAAQ,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC;IAE5D,IAAI,KAAK,CAAC,gBAAgB,KAAK,SAAS,EAAE;QACxC,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,sBAAsB,IAAA,4BAAW,EAAC,KAAK,CAAC,gBAAgB,CAAC,EAAE,CACrE,CAAC;KACH;IAED,IAAI,KAAK,CAAC,IAAI,CAAC,OAAO,EAAE,EAAE;QACxB,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,WAAW,KAAK,CAAC,IAAI,CAAC,SAAS,EAAE,EAAE,CAAC,CAAC;QAE1D,sFAAsF;QACtF,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,gBAAgB,IAAA,4BAAW,EAAC,KAAK,CAAC,UAAU,CAAC,EAAE,CAAC,CAAC;KACvE;IAED,UAAU,CAAC,KAAK,EAAE,KAAK,CAAC,CAAC;AAC3B,CAAC;AAhCD,4CAgCC;AAED,SAAgB,oBAAoB,CAClC,KAA6B,EAC7B,KAAa;IAEb,MAAM,MAAM,GAAG,EAAE,CAAC,QAAQ,CAAC,KAAK,GAAG,YAAY,CAAC,CAAC;IACjD,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,kBAAkB,CAAC,CAAC;IAEzC,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,uBAAuB,KAAK,CAAC,UAAU,EAAE,CAAC,CAAC;IAChE,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,WAAW,KAAK,CAAC,KAAK,CAAC,QAAQ,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC;IAC5D,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,cAAc,IAAA,4BAAW,EAAC,KAAK,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC;IAElE,IAAI,KAAK,CAAC,IAAI,CAAC,OAAO,EAAE,EAAE;QACxB,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,WAAW,KAAK,CAAC,IAAI,CAAC,SAAS,EAAE,EAAE,CAAC,CAAC;KAC3D;IAED,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,gBAAgB,IAAA,4BAAW,EAAC,KAAK,CAAC,UAAU,CAAC,EAAE,CAAC,CAAC;AACxE,CAAC;AAhBD,oDAgBC;AAED,SAAgB,cAAc,CAAC,KAAuB,EAAE,KAAa;IACnE,MAAM,MAAM,GAAG,EAAE,CAAC,QAAQ,CAAC,KAAK,GAAG,YAAY,CAAC,CAAC;IACjD,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,YAAY,CAAC,CAAC;IAEnC,IAAI,KAAK,CAAC,QAAQ,KAAK,SAAS,EAAE;QAChC,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,sBAAsB,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI,CAAC,UAAU,IAAI,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI,EAAE,CAClH,CAAC;KACH;SAAM;QACL,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,gCAAgC,IAAA,4BAAW,EAAC,KAAK,CAAC,IAAI,CAAC,EAAE,CACnE,CAAC;QACF,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,cAAc,IAAA,4BAAW,EAAC,KAAK,CAAC,OAAO,CAAC,EAAE,CAAC,CAAC;KAClE;IAED,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,WAAW,KAAK,CAAC,KAAK,CAAC,QAAQ,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC;IAC5D,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,cAAc,IAAA,4BAAW,EAAC,KAAK,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC;IAElE,IAAI,KAAK,CAAC,IAAI,CAAC,OAAO,EAAE,EAAE;QACxB,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,WAAW,KAAK,CAAC,IAAI,CAAC,SAAS,EAAE,EAAE,CAAC,CAAC;KAC3D;IAED,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,gBAAgB,IAAA,4BAAW,EAAC,KAAK,CAAC,UAAU,CAAC,EAAE,CAAC,CAAC;IAEtE,UAAU,CAAC,KAAK,EAAE,KAAK,CAAC,CAAC;AAC3B,CAAC;AAzBD,wCAyBC;AAED,SAAS,UAAU,CACjB,KAA4C,EAC5C,KAAa;IAEb,MAAM,MAAM,GAAG,EAAE,CAAC,QAAQ,CAAC,KAAK,GAAG,YAAY,CAAC,CAAC;IAEjD,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,SAAS,CAAC,CAAC;IAChC,OAAO,CAAC,GAAG,CAAC,EAAE,CAAC,CAAC;IAEhB,KAAK,MAAM,IAAI,IAAI,KAAK,CAAC,KAAK,EAAE;QAC9B,IAAI,IAAA,yBAAS,EAAC,IAAI,CAAC,EAAE;YACnB,MAAM,EAAE,GAAG,IAAI,CAAC,EAAE,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC,QAAQ,CAAC,CAAC,EAAE,GAAG,CAAC,CAAC,QAAQ,CAAC,CAAC,CAAC,CAAC;YAE7D,IAAI,KAAK,CAAC,QAAQ,KAAK,SAAS,EAAE;gBAChC,MAAM,IAAI,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,IAAI,CAAC,EAAE,CAAC,CAAC;gBAEpD,IAAI,QAAQ,GAAW,EAAE,CAAC;gBAE1B,IAAI,IAAI,CAAC,QAAQ,KAAK,SAAS,EAAE;oBAC/B,QAAQ,IAAI,IAAI,CAAC,QAAQ,CAAC,IAAI,CAAC,UAAU,CAAC;oBAE1C,MAAM,IAAI,GAAG,IAAI,CAAC,QAAQ,CAAC,qBAAqB,EAAE,CAAC;oBACnD,IAAI,IAAI,KAAK,SAAS,EAAE;wBACtB,QAAQ,IAAI,IACV,IAAI,CAAC,QAAQ,EAAE,IAAI,IAAI,IAAI,CAAC,QAAQ,CAAC,IAAI,CAAC,UAC5C,IAAI,IAAI,CAAC,IAAI,EAAE,CAAC;qBACjB;oBAED,QAAQ,IAAI,SAAS,IAAI,CAAC,QAAQ,CAAC,MAAM,IAAI,IAAI,CAAC,QAAQ,CAAC,MAAM,EAAE,CAAC;iBACrE;gBAED,IAAI,IAAA,gBAAM,EAAC,IAAI,CAAC,MAAM,CAAC,EAAE;oBACvB,MAAM,IAAI,GACR,IAAI,CAAC,QAAQ,KAAK,gBAAQ,CAAC,QAAQ;wBACjC,CAAC,CAAC,eAAK,CAAC,IAAI,CAAC,IAAI,gBAAQ,CAAC,IAAI,CAAC,QAAQ,CAAC,GAAG,CAAC;wBAC5C,CAAC,CAAC,EAAE,CAAC;oBAET,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,KAAK,EAAE,MAAM,gBAAM,CAAC,IAAI,CAAC,MAAM,CAAC,IAAI,IAAI,EAAE,CAAC,MAAM,CAAC,EAAE,CAAC,EAC9D,QAAQ,CACT,CAAC;iBACH;qBAAM,IAAI,IAAA,gBAAM,EAAC,IAAI,CAAC,MAAM,CAAC,EAAE;oBAC9B,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,KAAK,EAAE,MAAM,gBAAM,CAAC,IAAI,CAAC,MAAM,CAAC,IAAI,IAAA,4BAAW,EACtD,IAAI,CAAC,QAAS,CACf,EAAE,CAAC,MAAM,CAAC,EAAE,CAAC,EACd,QAAQ,CACT,CAAC;iBACH;qBAAM;oBACL,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,KAAK,EAAE,MAAM,gBAAM,CAAC,IAAI,CAAC,MAAM,CAAC,EAAE,CAAC,MAAM,CAAC,EAAE,CAAC,EACtD,QAAQ,CACT,CAAC;iBACH;aACF;iBAAM;gBACL,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,KAAK,EAAE,EAAE,CAAC,CAAC;aACjC;SACF;aAAM;YACL,iBAAiB,CAAC,IAAI,EAAE,KAAK,GAAG,CAAC,CAAC,CAAC;SACpC;KACF;AACH,CAAC;AAED,SAAS,sBAAsB,CAAC,eAAiC;IAC/D,IAAI,eAAe,KAAK,SAAS,EAAE;QACjC,OAAO,SAAS,CAAC;KAClB;IAED,OAAO;QACL,GAAG,eAAe;QAClB,IAAI,EAAE,eAAe,CAAC,UAAU;KACjC,CAAC;AACJ,CAAC;AAED,SAAgB,eAAe,CAAC,KAAyB;IACvD,MAAM,mBAAmB,GAAG,KAAK,CAAC,GAAG,CAAC,CAAC,KAAK,EAAE,EAAE,CAC9C,KAAK,CAAC,IAAI,KAAK,0CAAmB,CAAC,YAAY;QAC7C,CAAC,CAAC,EAAE,GAAG,KAAK,EAAE,OAAO,EAAE,KAAK,CAAC,OAAO,CAAC,WAAW,EAAE,EAAE;QACpD,CAAC,CAAC,KAAK,CACV,CAAC;IAEF,MAAM,cAAc,GAAG,mBAAmB,CAAC,GAAG,CAAC,CAAC,KAAK,EAAE,EAAE,CACvD,SAAS,IAAI,KAAK;QAChB,CAAC,CAAC,EAAE,GAAG,KAAK,EAAE,OAAO,EAAE,IAAA,4BAAW,EAAC,KAAK,CAAC,OAAO,CAAC,EAAE;QACnD,CAAC,CAAC,KAAK,CACV,CAAC;IAEF,MAAM,eAAe,GAAG,cAAc,CAAC,GAAG,CAAC,CAAC,KAAK,EAAE,EAAE,CAAC,CAAC;QACrD,GAAG,KAAK;QACR,IAAI,EAAE,0CAAmB,CAAC,KAAK,CAAC,IAAI,CAAC;KACtC,CAAC,CAAC,CAAC;IAEJ,MAAM,6BAA6B,GAAG,eAAe,CAAC,GAAG,CAAC,CAAC,KAAK,EAAE,EAAE,CAAC,CAAC;QACpE,GAAG,KAAK;QACR,eAAe,EAAE,sBAAsB,CAAC,KAAK,CAAC,eAAe,CAAC;KAC/D,CAAC,CAAC,CAAC;IAEJ,OAAO,CAAC,GAAG,CACT,IAAI,CAAC,SAAS,CACZ,6BAA6B,EAC7B,CAAC,GAAG,EAAE,KAAK,EAAE,EAAE,CAAC,CAAC,OAAO,KAAK,KAAK,QAAQ,CAAC,CAAC,CAAC,KAAK,CAAC,QAAQ,EAAE,CAAC,CAAC,CAAC,KAAK,CAAC,EACtE,CAAC,CACF,CACF,CAAC;AACJ,CAAC;AA9BD,0CA8BC"}
 \ No newline at end of file
-+{"version":3,"file":"debug.js","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/debug.ts"],"names":[],"mappings":";;;;;;AAAA,sEAA6E;AAC7E,kDAA0B;AAE1B,8CAA+E;AAC/E,mDAQyB;AACzB,mCAAqD;AACrD,uCAA2D;AAO3D,MAAM,YAAY,GAAG,CAAC,CAAC;AAEvB,SAAgB,iBAAiB,CAAC,KAAmB,EAAE,KAAK,GAAG,CAAC;IAC9D,OAAO,CAAC,GAAG,CAAC,EAAE,CAAC,CAAC;IAEhB,IAAI,IAAA,6BAAa,EAAC,KAAK,CAAC,EAAE;QACxB,gBAAgB,CAAC,KAAK,EAAE,KAAK,CAAC,CAAC;KAChC;SAAM,IAAI,IAAA,iCAAiB,EAAC,KAAK,CAAC,EAAE;QACnC,oBAAoB,CAAC,KAAK,EAAE,KAAK,CAAC,CAAC;KACpC;SAAM;QACL,cAAc,CAAC,KAAK,EAAE,KAAK,CAAC,CAAC;KAC9B;IAED,OAAO,CAAC,GAAG,CAAC,EAAE,CAAC,CAAC;AAClB,CAAC;AAZD,8CAYC;AAED,SAAgB,gBAAgB,CAAC,KAAyB,EAAE,KAAa;IACvE,MAAM,MAAM,GAAG,EAAE,CAAC,QAAQ,CAAC,KAAK,GAAG,YAAY,CAAC,CAAC;IACjD,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,cAAc,CAAC,CAAC;IAErC,IAAI,KAAK,CAAC,QAAQ,KAAK,SAAS,EAAE;QAChC,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,wBAAwB,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI,CAAC,UAAU,IAAI,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI,EAAE,CACpH,CAAC;QAEF,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,UAAU,IAAA,4BAAW,EAAC,KAAK,CAAC,IAAI,CAAC,EAAE,CAAC,CAAC;KAC3D;SAAM;QACL,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,kCAAkC,IAAA,4BAAW,EAAC,KAAK,CAAC,IAAI,CAAC,EAAE,CACrE,CAAC;KACH;IAED,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,WAAW,KAAK,CAAC,KAAK,CAAC,QAAQ,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC;IAE5D,IAAI,KAAK,CAAC,gBAAgB,KAAK,SAAS,EAAE;QACxC,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,sBAAsB,IAAA,4BAAW,EAAC,KAAK,CAAC,gBAAgB,CAAC,EAAE,CACrE,CAAC;KACH;IAED,IAAI,KAAK,CAAC,IAAI,CAAC,OAAO,EAAE,EAAE;QACxB,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,WAAW,KAAK,CAAC,IAAI,CAAC,SAAS,EAAE,EAAE,CAAC,CAAC;QAE1D,sFAAsF;QACtF,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,gBAAgB,IAAA,4BAAW,EAAC,KAAK,CAAC,UAAU,CAAC,EAAE,CAAC,CAAC;KACvE;IAED,UAAU,CAAC,KAAK,EAAE,KAAK,CAAC,CAAC;AAC3B,CAAC;AAhCD,4CAgCC;AAED,SAAgB,oBAAoB,CAClC,KAA6B,EAC7B,KAAa;IAEb,MAAM,MAAM,GAAG,EAAE,CAAC,QAAQ,CAAC,KAAK,GAAG,YAAY,CAAC,CAAC;IACjD,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,kBAAkB,CAAC,CAAC;IAEzC,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,uBAAuB,KAAK,CAAC,UAAU,EAAE,CAAC,CAAC;IAChE,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,WAAW,KAAK,CAAC,KAAK,CAAC,QAAQ,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC;IAC5D,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,cAAc,IAAA,4BAAW,EAAC,KAAK,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC;IAElE,IAAI,KAAK,CAAC,IAAI,CAAC,OAAO,EAAE,EAAE;QACxB,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,WAAW,KAAK,CAAC,IAAI,CAAC,SAAS,EAAE,EAAE,CAAC,CAAC;KAC3D;IAED,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,gBAAgB,IAAA,4BAAW,EAAC,KAAK,CAAC,UAAU,CAAC,EAAE,CAAC,CAAC;AACxE,CAAC;AAhBD,oDAgBC;AAED,SAAgB,cAAc,CAAC,KAAuB,EAAE,KAAa;IACnE,MAAM,MAAM,GAAG,EAAE,CAAC,QAAQ,CAAC,KAAK,GAAG,YAAY,CAAC,CAAC;IACjD,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,YAAY,CAAC,CAAC;IAEnC,IAAI,KAAK,CAAC,QAAQ,KAAK,SAAS,EAAE;QAChC,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,sBAAsB,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI,CAAC,UAAU,IAAI,KAAK,CAAC,QAAQ,CAAC,QAAQ,CAAC,IAAI,EAAE,CAClH,CAAC;KACH;SAAM;QACL,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,gCAAgC,IAAA,4BAAW,EAAC,KAAK,CAAC,IAAI,CAAC,EAAE,CACnE,CAAC;QACF,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,cAAc,IAAA,4BAAW,EAAC,KAAK,CAAC,OAAO,CAAC,EAAE,CAAC,CAAC;KAClE;IAED,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,WAAW,KAAK,CAAC,KAAK,CAAC,QAAQ,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC;IAC5D,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,cAAc,IAAA,4BAAW,EAAC,KAAK,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC;IAElE,IAAI,KAAK,CAAC,IAAI,CAAC,OAAO,EAAE,EAAE;QACxB,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,WAAW,KAAK,CAAC,IAAI,CAAC,SAAS,EAAE,EAAE,CAAC,CAAC;KAC3D;IAED,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,gBAAgB,IAAA,4BAAW,EAAC,KAAK,CAAC,UAAU,CAAC,EAAE,CAAC,CAAC;IAEtE,UAAU,CAAC,KAAK,EAAE,KAAK,CAAC,CAAC;AAC3B,CAAC;AAzBD,wCAyBC;AAED,SAAS,UAAU,CACjB,KAA4C,EAC5C,KAAa;IAEb,MAAM,MAAM,GAAG,EAAE,CAAC,QAAQ,CAAC,KAAK,GAAG,YAAY,CAAC,CAAC;IAEjD,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,SAAS,CAAC,CAAC;IAChC,OAAO,CAAC,GAAG,CAAC,EAAE,CAAC,CAAC;IAEhB,KAAK,MAAM,IAAI,IAAI,KAAK,CAAC,KAAK,EAAE;QAC9B,IAAI,IAAA,yBAAS,EAAC,IAAI,CAAC,EAAE;YACnB,MAAM,EAAE,GAAG,IAAI,CAAC,EAAE,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC,QAAQ,CAAC,CAAC,EAAE,GAAG,CAAC,CAAC,QAAQ,CAAC,CAAC,CAAC,CAAC;YAE7D,IAAI,KAAK,CAAC,QAAQ,KAAK,SAAS,EAAE;gBAChC,MAAM,IAAI,GAAG,KAAK,CAAC,QAAQ,CAAC,cAAc,CAAC,IAAI,CAAC,EAAE,CAAC,CAAC;gBAEpD,IAAI,QAAQ,GAAW,EAAE,CAAC;gBAE1B,IAAI,IAAI,CAAC,QAAQ,KAAK,SAAS,EAAE;oBAC/B,QAAQ,IAAI,IAAI,CAAC,QAAQ,CAAC,IAAI,CAAC,UAAU,CAAC;oBAE1C,MAAM,IAAI,GAAG,IAAI,CAAC,QAAQ,CAAC,qBAAqB,EAAE,CAAC;oBACnD,IAAI,IAAI,KAAK,SAAS,EAAE;wBACtB,QAAQ,IAAI,IACV,IAAI,CAAC,QAAQ,EAAE,IAAI,IAAI,IAAI,CAAC,QAAQ,CAAC,IAAI,CAAC,UAC5C,IAAI,IAAI,CAAC,IAAI,EAAE,CAAC;qBACjB;oBAED,QAAQ,IAAI,SAAS,IAAI,CAAC,QAAQ,CAAC,MAAM,IAAI,IAAI,CAAC,QAAQ,CAAC,MAAM,EAAE,CAAC;iBACrE;gBAED,IAAI,IAAA,gBAAM,EAAC,IAAI,CAAC,MAAM,CAAC,EAAE;oBACvB,MAAM,IAAI,GACR,IAAI,CAAC,QAAQ,8BAAsB;wBACjC,CAAC,CAAC,eAAK,CAAC,IAAI,CAAC,IAAI,IAAA,wBAAgB,EAAC,IAAI,CAAC,QAAQ,CAAC,GAAG,CAAC;wBACpD,CAAC,CAAC,EAAE,CAAC;oBAET,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,KAAK,EAAE,MAAM,IAAA,wBAAc,EAAC,IAAI,CAAC,MAAM,CAAC,IAAI,IAAI,EAAE,CAAC,MAAM,CAAC,EAAE,CAAC,EACtE,QAAQ,CACT,CAAC;iBACH;qBAAM,IAAI,IAAA,gBAAM,EAAC,IAAI,CAAC,MAAM,CAAC,EAAE;oBAC9B,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,KAAK,EAAE,MAAM,IAAA,wBAAc,EAAC,IAAI,CAAC,MAAM,CAAC,IAAI,IAAA,4BAAW,EAC9D,IAAI,CAAC,QAAS,CACf,EAAE,CAAC,MAAM,CAAC,EAAE,CAAC,EACd,QAAQ,CACT,CAAC;iBACH;qBAAM;oBACL,OAAO,CAAC,GAAG,CACT,GAAG,MAAM,KAAK,EAAE,MAAM,IAAA,wBAAc,EAAC,IAAI,CAAC,MAAM,CAAC,EAAE,CAAC,MAAM,CAAC,EAAE,CAAC,EAC9D,QAAQ,CACT,CAAC;iBACH;aACF;iBAAM;gBACL,OAAO,CAAC,GAAG,CAAC,GAAG,MAAM,KAAK,EAAE,EAAE,CAAC,CAAC;aACjC;SACF;aAAM;YACL,iBAAiB,CAAC,IAAI,EAAE,KAAK,GAAG,CAAC,CAAC,CAAC;SACpC;KACF;AACH,CAAC;AAED,SAAS,sBAAsB,CAAC,eAAiC;IAC/D,IAAI,eAAe,KAAK,SAAS,EAAE;QACjC,OAAO,SAAS,CAAC;KAClB;IAED,OAAO;QACL,GAAG,eAAe;QAClB,IAAI,EAAE,eAAe,CAAC,UAAU;KACjC,CAAC;AACJ,CAAC;AAED,SAAgB,eAAe,CAAC,KAAyB;IACvD,MAAM,mBAAmB,GAAG,KAAK,CAAC,GAAG,CAAC,CAAC,KAAK,EAAE,EAAE,CAC9C,KAAK,CAAC,IAAI,6CAAqC;QAC7C,CAAC,CAAC,EAAE,GAAG,KAAK,EAAE,OAAO,EAAE,IAAI,gBAAU,CAAC,KAAK,CAAC,UAAU,CAAC,CAAC,WAAW,EAAE,EAAE;QACvE,CAAC,CAAC,KAAK,CACV,CAAC;IAEF,MAAM,cAAc,GAAG,mBAAmB,CAAC,GAAG,CAAC,CAAC,KAAK,EAAE,EAAE,CACvD,SAAS,IAAI,KAAK;QAChB,CAAC,CAAC,EAAE,GAAG,KAAK,EAAE,OAAO,EAAE,IAAA,4BAAW,EAAC,KAAK,CAAC,OAAO,CAAC,EAAE;QACnD,CAAC,CAAC,KAAK,CACV,CAAC;IAEF,MAAM,eAAe,GAAG,cAAc,CAAC,GAAG,CAAC,CAAC,KAAK,EAAE,EAAE,CAAC,CAAC;QACrD,GAAG,KAAK;QACR,IAAI,EAAE,IAAA,iCAA2B,EAAC,KAAK,CAAC,IAAI,CAAC;KAC9C,CAAC,CAAC,CAAC;IAEJ,MAAM,6BAA6B,GAAG,eAAe,CAAC,GAAG,CAAC,CAAC,KAAK,EAAE,EAAE,CAAC,CAAC;QACpE,GAAG,KAAK;QACR,eAAe,EAAE,sBAAsB,CAAC,KAAK,CAAC,eAAe,CAAC;KAC/D,CAAC,CAAC,CAAC;IAEJ,OAAO,CAAC,GAAG,CACT,IAAI,CAAC,SAAS,CACZ,6BAA6B,EAC7B,CAAC,GAAG,EAAE,KAAK,EAAE,EAAE,CAAC,CAAC,OAAO,KAAK,KAAK,QAAQ,CAAC,CAAC,CAAC,KAAK,CAAC,QAAQ,EAAE,CAAC,CAAC,CAAC,KAAK,CAAC,EACtE,CAAC,CACF,CACF,CAAC;AACJ,CAAC;AA9BD,0CA8BC"}
++{"version":3,"file":"debug.js","sourceRoot":"","sources":["../../../src/internal/hardhat-network/stack-traces/debug.ts"],"names":[],"mappings":";;;AAAA,4CAA0E;AAAjE,wGAAA,iBAAiB,OAAA;AAAE,sGAAA,eAAe,OAAA"}
 \ No newline at end of file
 diff --git a/internal/hardhat-network/stack-traces/error-inferrer.d.ts b/internal/hardhat-network/stack-traces/error-inferrer.d.ts
 index b764cdf20700f14f1c40913e05d431beb26456f4..05d16bc67123b73a160dadefac0ab3d8231c3ead 100644
@@ -6018,74 +6134,231 @@ index 7a479a62cfad681807b6408449458dfcd6960fe7..0f176f37fa6994a051065364d584f22a
 +import { ContractsIdentifier } from "@nomicfoundation/edr";
 +export { ContractsIdentifier };
 diff --git a/src/internal/hardhat-network/stack-traces/debug.ts b/src/internal/hardhat-network/stack-traces/debug.ts
-index 03c423f31895ca495059bba42b5568ea10cbaeb7..ba3cfaaa83f4d094c2f34b839bd9abd7e0106845 100644
+index 03c423f31895ca495059bba42b5568ea10cbaeb7..228cdd277e0b12fe360310163d61d8685f1eaecf 100644
 --- a/src/internal/hardhat-network/stack-traces/debug.ts
 +++ b/src/internal/hardhat-network/stack-traces/debug.ts
-@@ -1,6 +1,7 @@
- import { bytesToHex as bufferToHex } from "@nomicfoundation/ethereumjs-util";
- import chalk from "chalk";
- 
-+import { ReturnData, stackTraceEntryTypeToString } from "@nomicfoundation/edr";
- import {
-   CallMessageTrace,
-   CreateMessageTrace,
-@@ -10,8 +11,8 @@ import {
-   MessageTrace,
-   PrecompileMessageTrace,
- } from "./message-trace";
+@@ -1,220 +1 @@
+-import { bytesToHex as bufferToHex } from "@nomicfoundation/ethereumjs-util";
+-import chalk from "chalk";
+-
+-import {
+-  CallMessageTrace,
+-  CreateMessageTrace,
+-  isCreateTrace,
+-  isEvmStep,
+-  isPrecompileTrace,
+-  MessageTrace,
+-  PrecompileMessageTrace,
+-} from "./message-trace";
 -import { JumpType } from "./model";
 -import { isJump, isPush, Opcode } from "./opcodes";
-+import { JumpType, jumpTypeToString } from "./model";
-+import { isJump, isPush, opcodeToString } from "./opcodes";
- import {
-   SolidityStackTrace,
-   SourceReference,
-@@ -147,23 +148,23 @@ function traceSteps(
-         if (isJump(inst.opcode)) {
-           const jump =
-             inst.jumpType !== JumpType.NOT_JUMP
+-import {
+-  SolidityStackTrace,
+-  SourceReference,
+-  StackTraceEntryType,
+-} from "./solidity-stack-trace";
+-
+-const MARGIN_SPACE = 6;
+-
+-export function printMessageTrace(trace: MessageTrace, depth = 0) {
+-  console.log("");
+-
+-  if (isCreateTrace(trace)) {
+-    printCreateTrace(trace, depth);
+-  } else if (isPrecompileTrace(trace)) {
+-    printPrecompileTrace(trace, depth);
+-  } else {
+-    printCallTrace(trace, depth);
+-  }
+-
+-  console.log("");
+-}
+-
+-export function printCreateTrace(trace: CreateMessageTrace, depth: number) {
+-  const margin = "".padStart(depth * MARGIN_SPACE);
+-  console.log(`${margin}Create trace`);
+-
+-  if (trace.bytecode !== undefined) {
+-    console.log(
+-      `${margin} deploying contract: ${trace.bytecode.contract.location.file.sourceName}:${trace.bytecode.contract.name}`
+-    );
+-
+-    console.log(`${margin} code: ${bufferToHex(trace.code)}`);
+-  } else {
+-    console.log(
+-      `${margin} unrecognized deployment code: ${bufferToHex(trace.code)}`
+-    );
+-  }
+-
+-  console.log(`${margin} value: ${trace.value.toString(10)}`);
+-
+-  if (trace.deployedContract !== undefined) {
+-    console.log(
+-      `${margin} contract address: ${bufferToHex(trace.deployedContract)}`
+-    );
+-  }
+-
+-  if (trace.exit.isError()) {
+-    console.log(`${margin} error: ${trace.exit.getReason()}`);
+-
+-    // The return data is the deployed-bytecode if there was no error, so we don't show it
+-    console.log(`${margin} returnData: ${bufferToHex(trace.returnData)}`);
+-  }
+-
+-  traceSteps(trace, depth);
+-}
+-
+-export function printPrecompileTrace(
+-  trace: PrecompileMessageTrace,
+-  depth: number
+-) {
+-  const margin = "".padStart(depth * MARGIN_SPACE);
+-  console.log(`${margin}Precompile trace`);
+-
+-  console.log(`${margin} precompile number: ${trace.precompile}`);
+-  console.log(`${margin} value: ${trace.value.toString(10)}`);
+-  console.log(`${margin} calldata: ${bufferToHex(trace.calldata)}`);
+-
+-  if (trace.exit.isError()) {
+-    console.log(`${margin} error: ${trace.exit.getReason()}`);
+-  }
+-
+-  console.log(`${margin} returnData: ${bufferToHex(trace.returnData)}`);
+-}
+-
+-export function printCallTrace(trace: CallMessageTrace, depth: number) {
+-  const margin = "".padStart(depth * MARGIN_SPACE);
+-  console.log(`${margin}Call trace`);
+-
+-  if (trace.bytecode !== undefined) {
+-    console.log(
+-      `${margin} calling contract: ${trace.bytecode.contract.location.file.sourceName}:${trace.bytecode.contract.name}`
+-    );
+-  } else {
+-    console.log(
+-      `${margin} unrecognized contract code: ${bufferToHex(trace.code)}`
+-    );
+-    console.log(`${margin} contract: ${bufferToHex(trace.address)}`);
+-  }
+-
+-  console.log(`${margin} value: ${trace.value.toString(10)}`);
+-  console.log(`${margin} calldata: ${bufferToHex(trace.calldata)}`);
+-
+-  if (trace.exit.isError()) {
+-    console.log(`${margin} error: ${trace.exit.getReason()}`);
+-  }
+-
+-  console.log(`${margin} returnData: ${bufferToHex(trace.returnData)}`);
+-
+-  traceSteps(trace, depth);
+-}
+-
+-function traceSteps(
+-  trace: CreateMessageTrace | CallMessageTrace,
+-  depth: number
+-) {
+-  const margin = "".padStart(depth * MARGIN_SPACE);
+-
+-  console.log(`${margin} steps:`);
+-  console.log("");
+-
+-  for (const step of trace.steps) {
+-    if (isEvmStep(step)) {
+-      const pc = step.pc.toString(10).padStart(3, "0").padStart(5);
+-
+-      if (trace.bytecode !== undefined) {
+-        const inst = trace.bytecode.getInstruction(step.pc);
+-
+-        let location: string = "";
+-
+-        if (inst.location !== undefined) {
+-          location += inst.location.file.sourceName;
+-
+-          const func = inst.location.getContainingFunction();
+-          if (func !== undefined) {
+-            location += `:${
+-              func.contract?.name ?? func.location.file.sourceName
+-            }:${func.name}`;
+-          }
+-
+-          location += `   -  ${inst.location.offset}:${inst.location.length}`;
+-        }
+-
+-        if (isJump(inst.opcode)) {
+-          const jump =
+-            inst.jumpType !== JumpType.NOT_JUMP
 -              ? chalk.bold(`(${JumpType[inst.jumpType]})`)
-+              ? chalk.bold(`(${jumpTypeToString(inst.jumpType)})`)
-               : "";
- 
-           console.log(
+-              : "";
+-
+-          console.log(
 -            `${margin}  ${pc}   ${Opcode[inst.opcode]} ${jump}`.padEnd(50),
-+            `${margin}  ${pc}   ${opcodeToString(inst.opcode)} ${jump}`.padEnd(50),
-             location
-           );
-         } else if (isPush(inst.opcode)) {
-           console.log(
+-            location
+-          );
+-        } else if (isPush(inst.opcode)) {
+-          console.log(
 -            `${margin}  ${pc}   ${Opcode[inst.opcode]} ${bufferToHex(
-+            `${margin}  ${pc}   ${opcodeToString(inst.opcode)} ${bufferToHex(
-               inst.pushData!
-             )}`.padEnd(50),
-             location
-           );
-         } else {
-           console.log(
+-              inst.pushData!
+-            )}`.padEnd(50),
+-            location
+-          );
+-        } else {
+-          console.log(
 -            `${margin}  ${pc}   ${Opcode[inst.opcode]}`.padEnd(50),
-+            `${margin}  ${pc}   ${opcodeToString(inst.opcode)}`.padEnd(50),
-             location
-           );
-         }
-@@ -190,7 +191,7 @@ function flattenSourceReference(sourceReference?: SourceReference) {
- export function printStackTrace(trace: SolidityStackTrace) {
-   const withDecodedMessages = trace.map((entry) =>
-     entry.type === StackTraceEntryType.REVERT_ERROR
+-            location
+-          );
+-        }
+-      } else {
+-        console.log(`${margin}  ${pc}`);
+-      }
+-    } else {
+-      printMessageTrace(step, depth + 1);
+-    }
+-  }
+-}
+-
+-function flattenSourceReference(sourceReference?: SourceReference) {
+-  if (sourceReference === undefined) {
+-    return undefined;
+-  }
+-
+-  return {
+-    ...sourceReference,
+-    file: sourceReference.sourceName,
+-  };
+-}
+-
+-export function printStackTrace(trace: SolidityStackTrace) {
+-  const withDecodedMessages = trace.map((entry) =>
+-    entry.type === StackTraceEntryType.REVERT_ERROR
 -      ? { ...entry, message: entry.message.decodeError() }
-+      ? { ...entry, message: new ReturnData(entry.returnData).decodeError() }
-       : entry
-   );
- 
-@@ -202,7 +203,7 @@ export function printStackTrace(trace: SolidityStackTrace) {
- 
-   const withTextualType = withHexAddress.map((entry) => ({
-     ...entry,
+-      : entry
+-  );
+-
+-  const withHexAddress = withDecodedMessages.map((entry) =>
+-    "address" in entry
+-      ? { ...entry, address: bufferToHex(entry.address) }
+-      : entry
+-  );
+-
+-  const withTextualType = withHexAddress.map((entry) => ({
+-    ...entry,
 -    type: StackTraceEntryType[entry.type],
-+    type: stackTraceEntryTypeToString(entry.type),
-   }));
- 
-   const withFlattenedSourceReferences = withTextualType.map((entry) => ({
+-  }));
+-
+-  const withFlattenedSourceReferences = withTextualType.map((entry) => ({
+-    ...entry,
+-    sourceReference: flattenSourceReference(entry.sourceReference),
+-  }));
+-
+-  console.log(
+-    JSON.stringify(
+-      withFlattenedSourceReferences,
+-      (key, value) => (typeof value === "bigint" ? value.toString() : value),
+-      2
+-    )
+-  );
+-}
++export { printMessageTrace, printStackTrace } from "@nomicfoundation/edr";
 diff --git a/src/internal/hardhat-network/stack-traces/error-inferrer.ts b/src/internal/hardhat-network/stack-traces/error-inferrer.ts
 index e185841f421641b2fe9a7fa34aeaf7b0813723cb..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 100644
 --- a/src/internal/hardhat-network/stack-traces/error-inferrer.ts

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
 
 patchedDependencies:
   hardhat@2.22.6:
-    hash: dn25digh7dcj6zffsxj5ebhse4
+    hash: q32okhcj77b2rhazxikm6oongi
     path: patches/hardhat@2.22.6.patch
 
 importers:
@@ -66,7 +66,7 @@ importers:
         version: 4.4.1
       hardhat:
         specifier: 2.22.6
-        version: 2.22.6(patch_hash=dn25digh7dcj6zffsxj5ebhse4)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.0.4))(typescript@5.0.4)
+        version: 2.22.6(patch_hash=q32okhcj77b2rhazxikm6oongi)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.0.4))(typescript@5.0.4)
       lodash:
         specifier: ^4.17.11
         version: 4.17.21
@@ -186,7 +186,7 @@ importers:
         version: 7.0.1
       hardhat:
         specifier: 2.22.6
-        version: 2.22.6(patch_hash=dn25digh7dcj6zffsxj5ebhse4)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.0.4))(typescript@5.0.4)
+        version: 2.22.6(patch_hash=q32okhcj77b2rhazxikm6oongi)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.0.4))(typescript@5.0.4)
       mocha:
         specifier: ^10.0.0
         version: 10.3.0
@@ -216,10 +216,10 @@ importers:
     devDependencies:
       '@defi-wonderland/smock':
         specifier: ^2.4.0
-        version: 2.4.0(@ethersproject/abi@5.7.0)(@ethersproject/abstract-provider@5.7.0)(@ethersproject/abstract-signer@5.7.0)(@nomiclabs/hardhat-ethers@2.2.3(ethers@5.7.2)(hardhat@2.22.6(patch_hash=dn25digh7dcj6zffsxj5ebhse4)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4)))(ethers@5.7.2)(hardhat@2.22.6(patch_hash=dn25digh7dcj6zffsxj5ebhse4)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4))
+        version: 2.4.0(@ethersproject/abi@5.7.0)(@ethersproject/abstract-provider@5.7.0)(@ethersproject/abstract-signer@5.7.0)(@nomiclabs/hardhat-ethers@2.2.3(ethers@5.7.2)(hardhat@2.22.6(patch_hash=q32okhcj77b2rhazxikm6oongi)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4)))(ethers@5.7.2)(hardhat@2.22.6(patch_hash=q32okhcj77b2rhazxikm6oongi)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4))
       '@nomiclabs/hardhat-ethers':
         specifier: ^2.2.3
-        version: 2.2.3(ethers@5.7.2)(hardhat@2.22.6(patch_hash=dn25digh7dcj6zffsxj5ebhse4)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4))
+        version: 2.2.3(ethers@5.7.2)(hardhat@2.22.6(patch_hash=q32okhcj77b2rhazxikm6oongi)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4))
       chai:
         specifier: ^4.3.6
         version: 4.4.1
@@ -228,7 +228,7 @@ importers:
         version: 5.7.2
       hardhat:
         specifier: 2.22.6
-        version: 2.22.6(patch_hash=dn25digh7dcj6zffsxj5ebhse4)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.0.4))(typescript@5.0.4)
+        version: 2.22.6(patch_hash=q32okhcj77b2rhazxikm6oongi)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.0.4))(typescript@5.0.4)
       mocha:
         specifier: ^10.0.0
         version: 10.3.0
@@ -3082,16 +3082,16 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@defi-wonderland/smock@2.4.0(@ethersproject/abi@5.7.0)(@ethersproject/abstract-provider@5.7.0)(@ethersproject/abstract-signer@5.7.0)(@nomiclabs/hardhat-ethers@2.2.3(ethers@5.7.2)(hardhat@2.22.6(patch_hash=dn25digh7dcj6zffsxj5ebhse4)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4)))(ethers@5.7.2)(hardhat@2.22.6(patch_hash=dn25digh7dcj6zffsxj5ebhse4)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4))':
+  '@defi-wonderland/smock@2.4.0(@ethersproject/abi@5.7.0)(@ethersproject/abstract-provider@5.7.0)(@ethersproject/abstract-signer@5.7.0)(@nomiclabs/hardhat-ethers@2.2.3(ethers@5.7.2)(hardhat@2.22.6(patch_hash=q32okhcj77b2rhazxikm6oongi)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4)))(ethers@5.7.2)(hardhat@2.22.6(patch_hash=q32okhcj77b2rhazxikm6oongi)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4))':
     dependencies:
       '@ethersproject/abi': 5.7.0
       '@ethersproject/abstract-provider': 5.7.0
       '@ethersproject/abstract-signer': 5.7.0
       '@nomicfoundation/ethereumjs-util': 9.0.4
-      '@nomiclabs/hardhat-ethers': 2.2.3(ethers@5.7.2)(hardhat@2.22.6(patch_hash=dn25digh7dcj6zffsxj5ebhse4)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4))
+      '@nomiclabs/hardhat-ethers': 2.2.3(ethers@5.7.2)(hardhat@2.22.6(patch_hash=q32okhcj77b2rhazxikm6oongi)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4))
       diff: 5.0.0
       ethers: 5.7.2
-      hardhat: 2.22.6(patch_hash=dn25digh7dcj6zffsxj5ebhse4)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.0.4))(typescript@5.0.4)
+      hardhat: 2.22.6(patch_hash=q32okhcj77b2rhazxikm6oongi)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.0.4))(typescript@5.0.4)
       lodash.isequal: 4.5.0
       lodash.isequalwith: 4.4.0
       rxjs: 7.8.1
@@ -3602,10 +3602,10 @@ snapshots:
       '@nomicfoundation/solidity-analyzer-win32-ia32-msvc': 0.1.1
       '@nomicfoundation/solidity-analyzer-win32-x64-msvc': 0.1.1
 
-  '@nomiclabs/hardhat-ethers@2.2.3(ethers@5.7.2)(hardhat@2.22.6(patch_hash=dn25digh7dcj6zffsxj5ebhse4)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4))':
+  '@nomiclabs/hardhat-ethers@2.2.3(ethers@5.7.2)(hardhat@2.22.6(patch_hash=q32okhcj77b2rhazxikm6oongi)(ts-node@10.9.2(typescript@5.0.4))(typescript@5.0.4))':
     dependencies:
       ethers: 5.7.2
-      hardhat: 2.22.6(patch_hash=dn25digh7dcj6zffsxj5ebhse4)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.0.4))(typescript@5.0.4)
+      hardhat: 2.22.6(patch_hash=q32okhcj77b2rhazxikm6oongi)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.0.4))(typescript@5.0.4)
 
   '@scure/base@1.1.5': {}
 
@@ -4872,7 +4872,7 @@ snapshots:
 
   hard-rejection@2.1.0: {}
 
-  hardhat@2.22.6(patch_hash=dn25digh7dcj6zffsxj5ebhse4)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.0.4))(typescript@5.0.4):
+  hardhat@2.22.6(patch_hash=q32okhcj77b2rhazxikm6oongi)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.0.4))(typescript@5.0.4):
     dependencies:
       '@ethersproject/abi': 5.7.0
       '@metamask/eth-sig-util': 4.0.1


### PR DESCRIPTION
Based on #593

This re-implements the structured console.log printing from the original Hardhat.ts file. While not insanely useful on its own, it is the last file that references the underlying compiler model classes, and so this is the last brick that's necessary to cut and reduce the JS API exposure.

To test it, I modified the corresponding `test.ts` file in the Hardhat repo (using local EDR package link) to print both versions one after another (both message and stack traces) for select tests (It's useful to specify `"only": true"` and `"print": true` in the select `test.json` files). They're mostly the same with the exception of not bolding the JUMPs anymore but I didn't want to pull a new dependency for something so small.

To implement printing the entries as JSON in `printStackTrace` I had to add some `Serialize` impls - these are just for the debugging purposes and we do not aim to make this roundtrippable at the moment as there's no real use case for it yet.