### PR TITLE
refactor: decouple Logger and Provider generics

### DIFF
--- a/crates/edr_napi/src/provider.rs
+++ b/crates/edr_napi/src/provider.rs
@@ -12,7 +12,7 @@ use self::config::ProviderConfig;
 use crate::{
     call_override::CallOverrideCallback,
     context::EdrContext,
-    logger::{Logger, LoggerConfig, LoggerError},
+    logger::{Logger, LoggerConfig},
     subscribe::SubscriberCallback,
     trace::RawTrace,
 };
@@ -20,7 +20,7 @@ use crate::{
 /// A JSON-RPC provider for Ethereum.
 #[napi]
 pub struct Provider {
-    provider: Arc<edr_provider::Provider<LoggerError>>,
+    provider: Arc<edr_provider::Provider>,
     runtime: runtime::Handle,
     #[cfg(feature = "scenarios")]
     scenario_file: Option<napi::tokio::sync::Mutex<napi::tokio::fs::File>>,

--- a/crates/edr_provider/src/console_log.rs
+++ b/crates/edr_provider/src/console_log.rs
@@ -49,7 +49,6 @@ impl ConsoleLogCollector {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use core::fmt::Debug;
 
     use anyhow::Context;
     use edr_eth::{
@@ -65,11 +64,8 @@ pub(crate) mod tests {
         pub expected_call_data: Bytes,
     }
 
-    pub fn deploy_console_log_contract<
-        LoggerErrorT: Debug + Send + Sync + 'static,
-        TimerT: Clone + TimeSinceEpoch,
-    >(
-        provider_data: &mut ProviderData<LoggerErrorT, TimerT>,
+    pub fn deploy_console_log_contract<TimerT: Clone + TimeSinceEpoch>(
+        provider_data: &mut ProviderData<TimerT>,
     ) -> anyhow::Result<ConsoleLogTransaction> {
         // Compiled with solc 0.8.17, without optimizations
         /*

--- a/crates/edr_provider/src/data/call.rs
+++ b/crates/edr_provider/src/data/call.rs
@@ -1,5 +1,3 @@
-use core::fmt::Debug;
-
 use edr_eth::{
     block::{BlobGas, Header},
     chain_spec::L1ChainSpec,
@@ -42,9 +40,9 @@ where
 }
 
 /// Execute a transaction as a call. Returns the gas used and the output.
-pub(super) fn run_call<'a, 'evm, DebugDataT, LoggerErrorT: Debug>(
+pub(super) fn run_call<'a, 'evm, DebugDataT>(
     args: RunCallArgs<'a, 'evm, DebugDataT>,
-) -> Result<ExecutionResult<L1ChainSpec>, ProviderError<LoggerErrorT>>
+) -> Result<ExecutionResult<L1ChainSpec>, ProviderError>
 where
     'a: 'evm,
 {

--- a/crates/edr_provider/src/data/gas.rs
+++ b/crates/edr_provider/src/data/gas.rs
@@ -1,4 +1,3 @@
-use core::fmt::Debug;
 use std::cmp;
 
 use edr_eth::{
@@ -38,9 +37,7 @@ pub(super) struct CheckGasLimitArgs<'a> {
 /// Test if the transaction successfully executes with the given gas limit.
 /// Returns true on success and return false if the transaction runs out of gas
 /// or funds or reverts. Returns an error for any other halt reason.
-pub(super) fn check_gas_limit<LoggerErrorT: Debug>(
-    args: CheckGasLimitArgs<'_>,
-) -> Result<bool, ProviderError<LoggerErrorT>> {
+pub(super) fn check_gas_limit(args: CheckGasLimitArgs<'_>) -> Result<bool, ProviderError> {
     let CheckGasLimitArgs {
         blockchain,
         header,
@@ -88,9 +85,9 @@ pub(super) struct BinarySearchEstimationArgs<'a> {
 /// Search for a tight upper bound on the gas limit that will allow the
 /// transaction to execute. Matches Hardhat logic, except it's iterative, not
 /// recursive.
-pub(super) fn binary_search_estimation<LoggerErrorT: Debug>(
+pub(super) fn binary_search_estimation(
     args: BinarySearchEstimationArgs<'_>,
-) -> Result<u64, ProviderError<LoggerErrorT>> {
+) -> Result<u64, ProviderError> {
     const MAX_ITERATIONS: usize = 20;
 
     let BinarySearchEstimationArgs {
@@ -160,10 +157,10 @@ fn min_difference(lower_bound: u64) -> u64 {
 }
 
 /// Compute miner rewards for percentiles.
-pub(super) fn compute_rewards<LoggerErrorT: Debug>(
+pub(super) fn compute_rewards(
     block: &dyn SyncBlock<L1ChainSpec, Error = BlockchainError<L1ChainSpec>>,
     reward_percentiles: &[RewardPercentile],
-) -> Result<Vec<U256>, ProviderError<LoggerErrorT>> {
+) -> Result<Vec<U256>, ProviderError> {
     if block.transactions().is_empty() {
         return Ok(reward_percentiles.iter().map(|_| U256::ZERO).collect());
     }

--- a/crates/edr_provider/src/error.rs
+++ b/crates/edr_provider/src/error.rs
@@ -22,7 +22,7 @@ use edr_rpc_eth::{client::RpcClientError, jsonrpc};
 use crate::{data::CreationError, IntervalConfigConversionError};
 
 #[derive(Debug, thiserror::Error)]
-pub enum ProviderError<LoggerErrorT> {
+pub enum ProviderError {
     /// Account override conversion error.
     #[error(transparent)]
     AccountOverrideConversionError(#[from] AccountOverrideConversionError),
@@ -112,8 +112,8 @@ pub enum ProviderError<LoggerErrorT> {
     #[error("Invalid transaction type {0}.")]
     InvalidTransactionType(u8),
     /// An error occurred while logging.
-    #[error("Failed to log: {0:?}")]
-    Logger(LoggerErrorT),
+    #[error("Failed to log: {0}")]
+    Logger(Box<dyn std::error::Error + Send + Sync>),
     /// An error occurred while adding a pending transaction to the mem pool.
     #[error(transparent)]
     MemPoolAddTransaction(#[from] MemPoolAddTransactionError<StateError>),
@@ -213,8 +213,8 @@ pub enum ProviderError<LoggerErrorT> {
     UnsupportedMethod { method_name: String },
 }
 
-impl<LoggerErrorT: Debug> From<ProviderError<LoggerErrorT>> for jsonrpc::Error {
-    fn from(value: ProviderError<LoggerErrorT>) -> Self {
+impl From<ProviderError> for jsonrpc::Error {
+    fn from(value: ProviderError) -> Self {
         const INVALID_INPUT: i16 = -32000;
         const INTERNAL_ERROR: i16 = -32603;
         const INVALID_PARAMS: i16 = -32602;

--- a/crates/edr_provider/src/requests/debug.rs
+++ b/crates/edr_provider/src/requests/debug.rs
@@ -15,11 +15,11 @@ use crate::{
     ProviderError,
 };
 
-pub fn handle_debug_trace_transaction<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
-    data: &mut ProviderData<LoggerErrorT, TimerT>,
+pub fn handle_debug_trace_transaction<TimerT: Clone + TimeSinceEpoch>(
+    data: &mut ProviderData<TimerT>,
     transaction_hash: B256,
     config: Option<DebugTraceConfig>,
-) -> Result<(DebugTraceResult, Vec<Trace<L1ChainSpec>>), ProviderError<LoggerErrorT>> {
+) -> Result<(DebugTraceResult, Vec<Trace<L1ChainSpec>>), ProviderError> {
     let DebugTraceResultWithTraces { result, traces } = data
         .debug_trace_transaction(
             &transaction_hash,
@@ -35,12 +35,12 @@ pub fn handle_debug_trace_transaction<LoggerErrorT: Debug, TimerT: Clone + TimeS
     Ok((result, traces))
 }
 
-pub fn handle_debug_trace_call<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
-    data: &mut ProviderData<LoggerErrorT, TimerT>,
+pub fn handle_debug_trace_call<TimerT: Clone + TimeSinceEpoch>(
+    data: &mut ProviderData<TimerT>,
     call_request: CallRequest,
     block_spec: Option<BlockSpec>,
     config: Option<DebugTraceConfig>,
-) -> Result<(DebugTraceResult, Vec<Trace<L1ChainSpec>>), ProviderError<LoggerErrorT>> {
+) -> Result<(DebugTraceResult, Vec<Trace<L1ChainSpec>>), ProviderError> {
     let block_spec = resolve_block_spec_for_call_request(block_spec);
     validate_call_request(data.spec_id(), &call_request, &block_spec)?;
 

--- a/crates/edr_provider/src/requests/eth/accounts.rs
+++ b/crates/edr_provider/src/requests/eth/accounts.rs
@@ -1,13 +1,11 @@
-use core::fmt::Debug;
-
 use edr_eth::Address;
 
 use crate::{data::ProviderData, time::TimeSinceEpoch, ProviderError};
 
 /// `require_canonical`: whether the server should additionally raise a JSON-RPC
 /// error if the block is not in the canonical chain
-pub fn handle_accounts_request<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
-    data: &ProviderData<LoggerErrorT, TimerT>,
-) -> Result<Vec<Address>, ProviderError<LoggerErrorT>> {
+pub fn handle_accounts_request<TimerT: Clone + TimeSinceEpoch>(
+    data: &ProviderData<TimerT>,
+) -> Result<Vec<Address>, ProviderError> {
     Ok(data.accounts().copied().collect())
 }

--- a/crates/edr_provider/src/requests/eth/blockchain.rs
+++ b/crates/edr_provider/src/requests/eth/blockchain.rs
@@ -1,5 +1,3 @@
-use core::fmt::Debug;
-
 use edr_eth::{Address, BlockSpec, U256, U64};
 
 use crate::{
@@ -7,23 +5,23 @@ use crate::{
     ProviderError,
 };
 
-pub fn handle_block_number_request<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
-    data: &ProviderData<LoggerErrorT, TimerT>,
-) -> Result<U64, ProviderError<LoggerErrorT>> {
+pub fn handle_block_number_request<TimerT: Clone + TimeSinceEpoch>(
+    data: &ProviderData<TimerT>,
+) -> Result<U64, ProviderError> {
     Ok(U64::from(data.last_block_number()))
 }
 
-pub fn handle_chain_id_request<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
-    data: &ProviderData<LoggerErrorT, TimerT>,
-) -> Result<U64, ProviderError<LoggerErrorT>> {
+pub fn handle_chain_id_request<TimerT: Clone + TimeSinceEpoch>(
+    data: &ProviderData<TimerT>,
+) -> Result<U64, ProviderError> {
     Ok(U64::from(data.chain_id()))
 }
 
-pub fn handle_get_transaction_count_request<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
-    data: &mut ProviderData<LoggerErrorT, TimerT>,
+pub fn handle_get_transaction_count_request<TimerT: Clone + TimeSinceEpoch>(
+    data: &mut ProviderData<TimerT>,
     address: Address,
     block_spec: Option<BlockSpec>,
-) -> Result<U256, ProviderError<LoggerErrorT>> {
+) -> Result<U256, ProviderError> {
     if let Some(block_spec) = block_spec.as_ref() {
         validate_post_merge_block_tags(data.spec_id(), block_spec)?;
     }

--- a/crates/edr_provider/src/requests/eth/call.rs
+++ b/crates/edr_provider/src/requests/eth/call.rs
@@ -1,5 +1,3 @@
-use core::fmt::Debug;
-
 use edr_eth::{chain_spec::L1ChainSpec, BlockSpec, Bytes, SpecId, U256};
 use edr_evm::{state::StateOverrides, trace::Trace, transaction};
 use edr_rpc_eth::{CallRequest, StateOverrideOptions};
@@ -9,12 +7,12 @@ use crate::{
     ProviderError, TransactionFailure,
 };
 
-pub fn handle_call_request<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
-    data: &mut ProviderData<LoggerErrorT, TimerT>,
+pub fn handle_call_request<TimerT: Clone + TimeSinceEpoch>(
+    data: &mut ProviderData<TimerT>,
     request: CallRequest,
     block_spec: Option<BlockSpec>,
     state_overrides: Option<StateOverrideOptions>,
-) -> Result<(Bytes, Trace<L1ChainSpec>), ProviderError<LoggerErrorT>> {
+) -> Result<(Bytes, Trace<L1ChainSpec>), ProviderError> {
     let block_spec = resolve_block_spec_for_call_request(block_spec);
     validate_call_request(data.spec_id(), &request, &block_spec)?;
 
@@ -50,12 +48,12 @@ pub(crate) fn resolve_block_spec_for_call_request(block_spec: Option<BlockSpec>)
     block_spec.unwrap_or_else(BlockSpec::latest)
 }
 
-pub(crate) fn resolve_call_request<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
-    data: &mut ProviderData<LoggerErrorT, TimerT>,
+pub(crate) fn resolve_call_request<TimerT: Clone + TimeSinceEpoch>(
+    data: &mut ProviderData<TimerT>,
     request: CallRequest,
     block_spec: &BlockSpec,
     state_overrides: &StateOverrides,
-) -> Result<transaction::Signed, ProviderError<LoggerErrorT>> {
+) -> Result<transaction::Signed, ProviderError> {
     resolve_call_request_inner(
         data,
         request,
@@ -74,22 +72,20 @@ pub(crate) fn resolve_call_request<LoggerErrorT: Debug, TimerT: Clone + TimeSinc
     )
 }
 
-pub(crate) fn resolve_call_request_inner<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
-    data: &mut ProviderData<LoggerErrorT, TimerT>,
+pub(crate) fn resolve_call_request_inner<TimerT: Clone + TimeSinceEpoch>(
+    data: &mut ProviderData<TimerT>,
     request: CallRequest,
     block_spec: &BlockSpec,
     state_overrides: &StateOverrides,
-    default_gas_price_fn: impl FnOnce(
-        &ProviderData<LoggerErrorT, TimerT>,
-    ) -> Result<U256, ProviderError<LoggerErrorT>>,
+    default_gas_price_fn: impl FnOnce(&ProviderData<TimerT>) -> Result<U256, ProviderError>,
     max_fees_fn: impl FnOnce(
-        &ProviderData<LoggerErrorT, TimerT>,
+        &ProviderData<TimerT>,
         // max_fee_per_gas
         Option<U256>,
         // max_priority_fee_per_gas
         Option<U256>,
-    ) -> Result<(U256, U256), ProviderError<LoggerErrorT>>,
-) -> Result<transaction::Signed, ProviderError<LoggerErrorT>> {
+    ) -> Result<(U256, U256), ProviderError>,
+) -> Result<transaction::Signed, ProviderError> {
     let CallRequest {
         from,
         to,

--- a/crates/edr_provider/src/requests/eth/config.rs
+++ b/crates/edr_provider/src/requests/eth/config.rs
@@ -1,55 +1,50 @@
-use core::fmt::Debug;
-
 use edr_eth::{Address, U256, U64};
 
 use crate::{data::ProviderData, time::TimeSinceEpoch, ProviderError};
 
-pub fn handle_blob_base_fee<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
-    data: &ProviderData<LoggerErrorT, TimerT>,
-) -> Result<U256, ProviderError<LoggerErrorT>> {
+pub fn handle_blob_base_fee<TimerT: Clone + TimeSinceEpoch>(
+    data: &ProviderData<TimerT>,
+) -> Result<U256, ProviderError> {
     let base_fee = data.next_block_base_fee_per_blob_gas()?.unwrap_or_default();
 
     Ok(base_fee)
 }
 
-pub fn handle_gas_price<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
-    data: &ProviderData<LoggerErrorT, TimerT>,
-) -> Result<U256, ProviderError<LoggerErrorT>> {
+pub fn handle_gas_price<TimerT: Clone + TimeSinceEpoch>(
+    data: &ProviderData<TimerT>,
+) -> Result<U256, ProviderError> {
     data.gas_price()
 }
 
-pub fn handle_coinbase_request<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
-    data: &ProviderData<LoggerErrorT, TimerT>,
-) -> Result<Address, ProviderError<LoggerErrorT>> {
+pub fn handle_coinbase_request<TimerT: Clone + TimeSinceEpoch>(
+    data: &ProviderData<TimerT>,
+) -> Result<Address, ProviderError> {
     Ok(data.coinbase())
 }
 
-pub fn handle_max_priority_fee_per_gas<LoggerErrorT: Debug>(
-) -> Result<U256, ProviderError<LoggerErrorT>> {
+pub fn handle_max_priority_fee_per_gas() -> Result<U256, ProviderError> {
     // 1 gwei
     Ok(U256::from(1_000_000_000))
 }
 
-pub fn handle_mining<LoggerErrorT: Debug>() -> Result<bool, ProviderError<LoggerErrorT>> {
+pub fn handle_mining() -> Result<bool, ProviderError> {
     Ok(false)
 }
 
-pub fn handle_net_listening_request<LoggerErrorT: Debug>(
-) -> Result<bool, ProviderError<LoggerErrorT>> {
+pub fn handle_net_listening_request() -> Result<bool, ProviderError> {
     Ok(true)
 }
 
-pub fn handle_net_peer_count_request<LoggerErrorT: Debug>(
-) -> Result<U64, ProviderError<LoggerErrorT>> {
+pub fn handle_net_peer_count_request() -> Result<U64, ProviderError> {
     Ok(U64::from(0))
 }
 
-pub fn handle_net_version_request<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
-    data: &ProviderData<LoggerErrorT, TimerT>,
-) -> Result<String, ProviderError<LoggerErrorT>> {
+pub fn handle_net_version_request<TimerT: Clone + TimeSinceEpoch>(
+    data: &ProviderData<TimerT>,
+) -> Result<String, ProviderError> {
     Ok(data.network_id())
 }
 
-pub fn handle_syncing<LoggerErrorT: Debug>() -> Result<bool, ProviderError<LoggerErrorT>> {
+pub fn handle_syncing() -> Result<bool, ProviderError> {
     Ok(false)
 }

--- a/crates/edr_provider/src/requests/eth/evm.rs
+++ b/crates/edr_provider/src/requests/eth/evm.rs
@@ -1,4 +1,3 @@
-use core::fmt::Debug;
 use std::num::NonZeroU64;
 
 use edr_eth::{block::BlockOptions, chain_spec::L1ChainSpec, U64};
@@ -6,20 +5,20 @@ use edr_evm::trace::Trace;
 
 use crate::{data::ProviderData, time::TimeSinceEpoch, ProviderError, Timestamp};
 
-pub fn handle_increase_time_request<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
-    data: &mut ProviderData<LoggerErrorT, TimerT>,
+pub fn handle_increase_time_request<TimerT: Clone + TimeSinceEpoch>(
+    data: &mut ProviderData<TimerT>,
     increment: Timestamp,
-) -> Result<String, ProviderError<LoggerErrorT>> {
+) -> Result<String, ProviderError> {
     let new_block_time = data.increase_block_time(increment.into());
 
     // This RPC call is an exception: it returns a number as a string decimal
     Ok(new_block_time.to_string())
 }
 
-pub fn handle_mine_request<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
-    data: &mut ProviderData<LoggerErrorT, TimerT>,
+pub fn handle_mine_request<TimerT: Clone + TimeSinceEpoch>(
+    data: &mut ProviderData<TimerT>,
     timestamp: Option<Timestamp>,
-) -> Result<(String, Vec<Trace<L1ChainSpec>>), ProviderError<LoggerErrorT>> {
+) -> Result<(String, Vec<Trace<L1ChainSpec>>), ProviderError> {
     let mine_block_result = data.mine_and_commit_block(BlockOptions {
         timestamp: timestamp.map(Into::into),
         ..BlockOptions::default()
@@ -36,26 +35,26 @@ pub fn handle_mine_request<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
     Ok((result, traces))
 }
 
-pub fn handle_revert_request<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
-    data: &mut ProviderData<LoggerErrorT, TimerT>,
+pub fn handle_revert_request<TimerT: Clone + TimeSinceEpoch>(
+    data: &mut ProviderData<TimerT>,
     snapshot_id: U64,
-) -> Result<bool, ProviderError<LoggerErrorT>> {
+) -> Result<bool, ProviderError> {
     Ok(data.revert_to_snapshot(snapshot_id.as_limbs()[0]))
 }
 
-pub fn handle_set_automine_request<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
-    data: &mut ProviderData<LoggerErrorT, TimerT>,
+pub fn handle_set_automine_request<TimerT: Clone + TimeSinceEpoch>(
+    data: &mut ProviderData<TimerT>,
     automine: bool,
-) -> Result<bool, ProviderError<LoggerErrorT>> {
+) -> Result<bool, ProviderError> {
     data.set_auto_mining(automine);
 
     Ok(true)
 }
 
-pub fn handle_set_block_gas_limit_request<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
-    data: &mut ProviderData<LoggerErrorT, TimerT>,
+pub fn handle_set_block_gas_limit_request<TimerT: Clone + TimeSinceEpoch>(
+    data: &mut ProviderData<TimerT>,
     gas_limit: U64,
-) -> Result<bool, ProviderError<LoggerErrorT>> {
+) -> Result<bool, ProviderError> {
     let gas_limit = NonZeroU64::new(gas_limit.as_limbs()[0])
         .ok_or(ProviderError::SetBlockGasLimitMustBeGreaterThanZero)?;
 
@@ -64,22 +63,19 @@ pub fn handle_set_block_gas_limit_request<LoggerErrorT: Debug, TimerT: Clone + T
     Ok(true)
 }
 
-pub fn handle_set_next_block_timestamp_request<
-    LoggerErrorT: Debug,
-    TimerT: Clone + TimeSinceEpoch,
->(
-    data: &mut ProviderData<LoggerErrorT, TimerT>,
+pub fn handle_set_next_block_timestamp_request<TimerT: Clone + TimeSinceEpoch>(
+    data: &mut ProviderData<TimerT>,
     timestamp: Timestamp,
-) -> Result<String, ProviderError<LoggerErrorT>> {
+) -> Result<String, ProviderError> {
     let new_timestamp = data.set_next_block_timestamp(timestamp.into())?;
 
     // This RPC call is an exception: it returns a number as a string decimal
     Ok(new_timestamp.to_string())
 }
 
-pub fn handle_snapshot_request<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
-    data: &mut ProviderData<LoggerErrorT, TimerT>,
-) -> Result<U64, ProviderError<LoggerErrorT>> {
+pub fn handle_snapshot_request<TimerT: Clone + TimeSinceEpoch>(
+    data: &mut ProviderData<TimerT>,
+) -> Result<U64, ProviderError> {
     let snapshot_id = data.make_snapshot();
 
     Ok(U64::from(snapshot_id))

--- a/crates/edr_provider/src/requests/eth/mine.rs
+++ b/crates/edr_provider/src/requests/eth/mine.rs
@@ -1,4 +1,3 @@
-use core::fmt::Debug;
 use std::sync::Arc;
 
 use tokio::{runtime, sync::Mutex};
@@ -8,15 +7,12 @@ use crate::{
     ProviderError,
 };
 
-pub fn handle_set_interval_mining<
-    LoggerErrorT: Debug + Send + Sync + 'static,
-    TimerT: Clone + TimeSinceEpoch,
->(
-    data: Arc<Mutex<ProviderData<LoggerErrorT, TimerT>>>,
-    interval_miner: &mut Option<IntervalMiner<LoggerErrorT>>,
+pub fn handle_set_interval_mining<TimerT: Clone + TimeSinceEpoch>(
+    data: Arc<Mutex<ProviderData<TimerT>>>,
+    interval_miner: &mut Option<IntervalMiner>,
     runtime: runtime::Handle,
     config: requests::IntervalConfig,
-) -> Result<bool, ProviderError<LoggerErrorT>> {
+) -> Result<bool, ProviderError> {
     let config: Option<IntervalConfig> = config.try_into()?;
     *interval_miner = config.map(|config| IntervalMiner::new(runtime, config, data.clone()));
 

--- a/crates/edr_provider/src/requests/eth/sign.rs
+++ b/crates/edr_provider/src/requests/eth/sign.rs
@@ -1,22 +1,20 @@
-use core::fmt::Debug;
-
 use alloy_dyn_abi::eip712::TypedData;
 use edr_eth::{Address, Bytes};
 
 use crate::{data::ProviderData, time::TimeSinceEpoch, ProviderError};
 
-pub fn handle_sign_request<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
-    data: &ProviderData<LoggerErrorT, TimerT>,
+pub fn handle_sign_request<TimerT: Clone + TimeSinceEpoch>(
+    data: &ProviderData<TimerT>,
     message: Bytes,
     address: Address,
-) -> Result<Bytes, ProviderError<LoggerErrorT>> {
+) -> Result<Bytes, ProviderError> {
     Ok((&data.sign(&address, message)?).into())
 }
 
-pub fn handle_sign_typed_data_v4<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
-    data: &ProviderData<LoggerErrorT, TimerT>,
+pub fn handle_sign_typed_data_v4<TimerT: Clone + TimeSinceEpoch>(
+    data: &ProviderData<TimerT>,
     address: Address,
     message: TypedData,
-) -> Result<Bytes, ProviderError<LoggerErrorT>> {
+) -> Result<Bytes, ProviderError> {
     Ok((&data.sign_typed_data_v4(&address, &message)?).into())
 }

--- a/crates/edr_provider/src/requests/eth/state.rs
+++ b/crates/edr_provider/src/requests/eth/state.rs
@@ -1,5 +1,3 @@
-use core::fmt::Debug;
-
 use edr_eth::{utils::u256_to_padded_hex, Address, BlockSpec, Bytes, U256};
 
 use crate::{
@@ -7,11 +5,11 @@ use crate::{
     ProviderError,
 };
 
-pub fn handle_get_balance_request<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
-    data: &mut ProviderData<LoggerErrorT, TimerT>,
+pub fn handle_get_balance_request<TimerT: Clone + TimeSinceEpoch>(
+    data: &mut ProviderData<TimerT>,
     address: Address,
     block_spec: Option<BlockSpec>,
-) -> Result<U256, ProviderError<LoggerErrorT>> {
+) -> Result<U256, ProviderError> {
     if let Some(block_spec) = block_spec.as_ref() {
         validate_post_merge_block_tags(data.spec_id(), block_spec)?;
     }
@@ -19,11 +17,11 @@ pub fn handle_get_balance_request<LoggerErrorT: Debug, TimerT: Clone + TimeSince
     data.balance(address, block_spec.as_ref())
 }
 
-pub fn handle_get_code_request<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
-    data: &mut ProviderData<LoggerErrorT, TimerT>,
+pub fn handle_get_code_request<TimerT: Clone + TimeSinceEpoch>(
+    data: &mut ProviderData<TimerT>,
     address: Address,
     block_spec: Option<BlockSpec>,
-) -> Result<Bytes, ProviderError<LoggerErrorT>> {
+) -> Result<Bytes, ProviderError> {
     if let Some(block_spec) = block_spec.as_ref() {
         validate_post_merge_block_tags(data.spec_id(), block_spec)?;
     }
@@ -31,12 +29,12 @@ pub fn handle_get_code_request<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpo
     data.get_code(address, block_spec.as_ref())
 }
 
-pub fn handle_get_storage_at_request<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
-    data: &mut ProviderData<LoggerErrorT, TimerT>,
+pub fn handle_get_storage_at_request<TimerT: Clone + TimeSinceEpoch>(
+    data: &mut ProviderData<TimerT>,
     address: Address,
     index: U256,
     block_spec: Option<BlockSpec>,
-) -> Result<String, ProviderError<LoggerErrorT>> {
+) -> Result<String, ProviderError> {
     if let Some(block_spec) = block_spec.as_ref() {
         validate_post_merge_block_tags(data.spec_id(), block_spec)?;
     }

--- a/crates/edr_provider/src/requests/eth/web3.rs
+++ b/crates/edr_provider/src/requests/eth/web3.rs
@@ -1,5 +1,3 @@
-use core::fmt::Debug;
-
 use edr_eth::{Bytes, B256};
 use sha3::{Digest, Keccak256};
 
@@ -13,14 +11,11 @@ pub fn client_version() -> String {
     )
 }
 
-pub fn handle_web3_client_version_request<LoggerErrorT: Debug>(
-) -> Result<String, ProviderError<LoggerErrorT>> {
+pub fn handle_web3_client_version_request() -> Result<String, ProviderError> {
     Ok(client_version())
 }
 
-pub fn handle_web3_sha3_request<LoggerErrorT: Debug>(
-    message: Bytes,
-) -> Result<B256, ProviderError<LoggerErrorT>> {
+pub fn handle_web3_sha3_request(message: Bytes) -> Result<B256, ProviderError> {
     let hash = Keccak256::digest(&message[..]);
     Ok(B256::from_slice(&hash[..]))
 }

--- a/crates/edr_provider/src/requests/hardhat/accounts.rs
+++ b/crates/edr_provider/src/requests/hardhat/accounts.rs
@@ -1,24 +1,19 @@
-use core::fmt::Debug;
-
 use edr_eth::Address;
 
 use crate::{data::ProviderData, time::TimeSinceEpoch, ProviderError};
 
-pub fn handle_impersonate_account_request<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
-    data: &mut ProviderData<LoggerErrorT, TimerT>,
+pub fn handle_impersonate_account_request<TimerT: Clone + TimeSinceEpoch>(
+    data: &mut ProviderData<TimerT>,
     address: Address,
-) -> Result<bool, ProviderError<LoggerErrorT>> {
+) -> Result<bool, ProviderError> {
     data.impersonate_account(address);
 
     Ok(true)
 }
 
-pub fn handle_stop_impersonating_account_request<
-    LoggerErrorT: Debug,
-    TimerT: Clone + TimeSinceEpoch,
->(
-    data: &mut ProviderData<LoggerErrorT, TimerT>,
+pub fn handle_stop_impersonating_account_request<TimerT: Clone + TimeSinceEpoch>(
+    data: &mut ProviderData<TimerT>,
     address: Address,
-) -> Result<bool, ProviderError<LoggerErrorT>> {
+) -> Result<bool, ProviderError> {
     Ok(data.stop_impersonating_account(address))
 }

--- a/crates/edr_provider/src/requests/hardhat/config.rs
+++ b/crates/edr_provider/src/requests/hardhat/config.rs
@@ -1,5 +1,3 @@
-use core::fmt::Debug;
-
 use edr_eth::{Address, B256, U256};
 
 use crate::{
@@ -9,15 +7,15 @@ use crate::{
     ProviderError,
 };
 
-pub fn handle_get_automine_request<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
-    data: &ProviderData<LoggerErrorT, TimerT>,
-) -> Result<bool, ProviderError<LoggerErrorT>> {
+pub fn handle_get_automine_request<TimerT: Clone + TimeSinceEpoch>(
+    data: &ProviderData<TimerT>,
+) -> Result<bool, ProviderError> {
     Ok(data.is_auto_mining())
 }
 
-pub fn handle_metadata_request<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
-    data: &ProviderData<LoggerErrorT, TimerT>,
-) -> Result<Metadata, ProviderError<LoggerErrorT>> {
+pub fn handle_metadata_request<TimerT: Clone + TimeSinceEpoch>(
+    data: &ProviderData<TimerT>,
+) -> Result<Metadata, ProviderError> {
     Ok(Metadata {
         client_version: client_version(),
         chain_id: data.chain_id(),
@@ -28,40 +26,37 @@ pub fn handle_metadata_request<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpo
     })
 }
 
-pub fn handle_set_coinbase_request<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
-    data: &mut ProviderData<LoggerErrorT, TimerT>,
+pub fn handle_set_coinbase_request<TimerT: Clone + TimeSinceEpoch>(
+    data: &mut ProviderData<TimerT>,
     coinbase: Address,
-) -> Result<bool, ProviderError<LoggerErrorT>> {
+) -> Result<bool, ProviderError> {
     data.set_coinbase(coinbase);
 
     Ok(true)
 }
 
-pub fn handle_set_min_gas_price<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
-    data: &mut ProviderData<LoggerErrorT, TimerT>,
+pub fn handle_set_min_gas_price<TimerT: Clone + TimeSinceEpoch>(
+    data: &mut ProviderData<TimerT>,
     min_gas_price: U256,
-) -> Result<bool, ProviderError<LoggerErrorT>> {
+) -> Result<bool, ProviderError> {
     data.set_min_gas_price(min_gas_price)?;
 
     Ok(true)
 }
 
-pub fn handle_set_next_block_base_fee_per_gas_request<
-    LoggerErrorT: Debug,
-    TimerT: Clone + TimeSinceEpoch,
->(
-    data: &mut ProviderData<LoggerErrorT, TimerT>,
+pub fn handle_set_next_block_base_fee_per_gas_request<TimerT: Clone + TimeSinceEpoch>(
+    data: &mut ProviderData<TimerT>,
     base_fee_per_gas: U256,
-) -> Result<bool, ProviderError<LoggerErrorT>> {
+) -> Result<bool, ProviderError> {
     data.set_next_block_base_fee_per_gas(base_fee_per_gas)?;
 
     Ok(true)
 }
 
-pub fn handle_set_prev_randao_request<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
-    data: &mut ProviderData<LoggerErrorT, TimerT>,
+pub fn handle_set_prev_randao_request<TimerT: Clone + TimeSinceEpoch>(
+    data: &mut ProviderData<TimerT>,
     prev_randao: B256,
-) -> Result<bool, ProviderError<LoggerErrorT>> {
+) -> Result<bool, ProviderError> {
     data.set_next_prev_randao(prev_randao)?;
 
     Ok(true)

--- a/crates/edr_provider/src/requests/hardhat/log.rs
+++ b/crates/edr_provider/src/requests/hardhat/log.rs
@@ -1,11 +1,9 @@
-use core::fmt::Debug;
-
 use crate::{data::ProviderData, time::TimeSinceEpoch, ProviderError};
 
-pub fn handle_set_logging_enabled_request<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
-    data: &mut ProviderData<LoggerErrorT, TimerT>,
+pub fn handle_set_logging_enabled_request<TimerT: Clone + TimeSinceEpoch>(
+    data: &mut ProviderData<TimerT>,
     is_enabled: bool,
-) -> Result<bool, ProviderError<LoggerErrorT>> {
+) -> Result<bool, ProviderError> {
     data.logger_mut().set_is_enabled(is_enabled);
     Ok(true)
 }

--- a/crates/edr_provider/src/requests/hardhat/miner.rs
+++ b/crates/edr_provider/src/requests/hardhat/miner.rs
@@ -1,21 +1,19 @@
-use core::fmt::Debug;
-
 use edr_eth::chain_spec::L1ChainSpec;
 use edr_evm::trace::Trace;
 
 use crate::{data::ProviderData, time::TimeSinceEpoch, ProviderError};
 
-pub fn handle_interval_mine_request<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
-    data: &mut ProviderData<LoggerErrorT, TimerT>,
-) -> Result<bool, ProviderError<LoggerErrorT>> {
+pub fn handle_interval_mine_request<TimerT: Clone + TimeSinceEpoch>(
+    data: &mut ProviderData<TimerT>,
+) -> Result<bool, ProviderError> {
     data.interval_mine()
 }
 
-pub fn handle_mine<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
-    data: &mut ProviderData<LoggerErrorT, TimerT>,
+pub fn handle_mine<TimerT: Clone + TimeSinceEpoch>(
+    data: &mut ProviderData<TimerT>,
     number_of_blocks: Option<u64>,
     interval: Option<u64>,
-) -> Result<(bool, Vec<Trace<L1ChainSpec>>), ProviderError<LoggerErrorT>> {
+) -> Result<(bool, Vec<Trace<L1ChainSpec>>), ProviderError> {
     let number_of_blocks = number_of_blocks.unwrap_or(1);
     let interval = interval.unwrap_or(1);
 

--- a/crates/edr_provider/src/requests/hardhat/state.rs
+++ b/crates/edr_provider/src/requests/hardhat/state.rs
@@ -1,45 +1,43 @@
-use core::fmt::Debug;
-
 use edr_eth::{Address, Bytes, U256};
 
 use crate::{data::ProviderData, time::TimeSinceEpoch, ProviderError};
 
-pub fn handle_set_balance<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
-    data: &mut ProviderData<LoggerErrorT, TimerT>,
+pub fn handle_set_balance<TimerT: Clone + TimeSinceEpoch>(
+    data: &mut ProviderData<TimerT>,
     address: Address,
     balance: U256,
-) -> Result<bool, ProviderError<LoggerErrorT>> {
+) -> Result<bool, ProviderError> {
     data.set_balance(address, balance)?;
 
     Ok(true)
 }
 
-pub fn handle_set_code<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
-    data: &mut ProviderData<LoggerErrorT, TimerT>,
+pub fn handle_set_code<TimerT: Clone + TimeSinceEpoch>(
+    data: &mut ProviderData<TimerT>,
     address: Address,
     code: Bytes,
-) -> Result<bool, ProviderError<LoggerErrorT>> {
+) -> Result<bool, ProviderError> {
     data.set_code(address, code)?;
 
     Ok(true)
 }
 
-pub fn handle_set_nonce<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
-    data: &mut ProviderData<LoggerErrorT, TimerT>,
+pub fn handle_set_nonce<TimerT: Clone + TimeSinceEpoch>(
+    data: &mut ProviderData<TimerT>,
     address: Address,
     nonce: u64,
-) -> Result<bool, ProviderError<LoggerErrorT>> {
+) -> Result<bool, ProviderError> {
     data.set_nonce(address, nonce)?;
 
     Ok(true)
 }
 
-pub fn handle_set_storage_at<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
-    data: &mut ProviderData<LoggerErrorT, TimerT>,
+pub fn handle_set_storage_at<TimerT: Clone + TimeSinceEpoch>(
+    data: &mut ProviderData<TimerT>,
     address: Address,
     index: U256,
     value: U256,
-) -> Result<bool, ProviderError<LoggerErrorT>> {
+) -> Result<bool, ProviderError> {
     data.set_account_storage_slot(address, index, value)?;
 
     Ok(true)

--- a/crates/edr_provider/src/requests/hardhat/transactions.rs
+++ b/crates/edr_provider/src/requests/hardhat/transactions.rs
@@ -1,13 +1,11 @@
-use core::fmt::Debug;
-
 use edr_eth::B256;
 
 use crate::{data::ProviderData, time::TimeSinceEpoch, ProviderError};
 
-pub fn handle_drop_transaction<LoggerErrorT: Debug, TimerT: Clone + TimeSinceEpoch>(
-    data: &mut ProviderData<LoggerErrorT, TimerT>,
+pub fn handle_drop_transaction<TimerT: Clone + TimeSinceEpoch>(
+    data: &mut ProviderData<TimerT>,
     transaction_hash: B256,
-) -> Result<bool, ProviderError<LoggerErrorT>> {
+) -> Result<bool, ProviderError> {
     let was_removed = data.remove_pending_transaction(&transaction_hash).is_some();
     if was_removed {
         return Ok(true);

--- a/crates/edr_provider/src/requests/serde.rs
+++ b/crates/edr_provider/src/requests/serde.rs
@@ -103,9 +103,7 @@ impl<'a> InvalidRequestReason<'a> {
     }
 
     /// Converts the invalid request reason into a provider error.
-    pub fn provider_error<LoggerErrorT: Debug>(
-        &self,
-    ) -> Option<(String, ProviderError<LoggerErrorT>)> {
+    pub fn provider_error(&self) -> Option<(String, ProviderError)> {
         match self {
             InvalidRequestReason::InvalidJson { .. } => None,
             InvalidRequestReason::InvalidStorageKey {

--- a/crates/edr_provider/src/test_utils.rs
+++ b/crates/edr_provider/src/test_utils.rs
@@ -1,4 +1,4 @@
-use std::{convert::Infallible, num::NonZeroU64, time::SystemTime};
+use std::{num::NonZeroU64, time::SystemTime};
 
 use edr_eth::{
     block::BlobGas, signature::secret_key_from_str, transaction::EthTransactionRequest,
@@ -69,9 +69,7 @@ pub fn create_test_config_with_fork(fork: Option<ForkConfig>) -> ProviderConfig<
 }
 
 /// Retrieves the pending base fee per gas from the provider data.
-pub fn pending_base_fee(
-    data: &mut ProviderData<Infallible>,
-) -> Result<U256, ProviderError<Infallible>> {
+pub fn pending_base_fee(data: &mut ProviderData) -> Result<U256, ProviderError> {
     let block = data.mine_pending_block()?.block;
 
     let base_fee = block
@@ -84,13 +82,12 @@ pub fn pending_base_fee(
 
 /// Deploys a contract with the provided code. Returns the address of the
 /// contract.
-pub fn deploy_contract<LoggerErrorT, TimerT>(
-    provider: &Provider<LoggerErrorT, TimerT>,
+pub fn deploy_contract<TimerT>(
+    provider: &Provider<TimerT>,
     caller: Address,
     code: Bytes,
 ) -> anyhow::Result<Address>
 where
-    LoggerErrorT: Debug + Send + Sync + 'static,
     TimerT: Clone + TimeSinceEpoch,
 {
     let deploy_transaction = EthTransactionRequest {

--- a/crates/edr_provider/tests/eip4844.rs
+++ b/crates/edr_provider/tests/eip4844.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "test-utils")]
 
-use std::{convert::Infallible, str::FromStr};
+use std::str::FromStr;
 
 use edr_defaults::SECRET_KEYS;
 use edr_eth::{
@@ -538,7 +538,7 @@ async fn block_header() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn blob_hash_opcode() -> anyhow::Result<()> {
     fn assert_blob_hash_opcodes(
-        provider: &Provider<Infallible>,
+        provider: &Provider,
         contract_address: &Address,
         num_blobs: usize,
         nonce: u64,

--- a/crates/edr_provider/tests/timestamp.rs
+++ b/crates/edr_provider/tests/timestamp.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "test-utils")]
 
-use std::{convert::Infallible, sync::Arc};
+use std::sync::Arc;
 
 use edr_eth::{chain_spec::L1ChainSpec, PreEip1898BlockSpec, B256};
 use edr_provider::{
@@ -11,7 +11,7 @@ use edr_provider::{
 use tokio::runtime;
 
 struct TimestampFixture {
-    provider: Provider<Infallible, Arc<MockTime>>,
+    provider: Provider<Arc<MockTime>>,
     mock_timer: Arc<MockTime>,
 }
 

--- a/crates/tools/src/scenario.rs
+++ b/crates/tools/src/scenario.rs
@@ -1,5 +1,4 @@
 use std::{
-    convert::Infallible,
     marker::PhantomData,
     path::{Path, PathBuf},
     sync::Arc,
@@ -176,8 +175,6 @@ struct DisabledLogger<ChainSpecT: ChainSpec> {
 impl<ChainSpecT: ChainSpec> Logger<ChainSpecT> for DisabledLogger<ChainSpecT> {
     type BlockchainError = BlockchainError<L1ChainSpec>;
 
-    type LoggerError = Infallible;
-
     fn is_enabled(&self) -> bool {
         false
     }
@@ -187,8 +184,8 @@ impl<ChainSpecT: ChainSpec> Logger<ChainSpecT> for DisabledLogger<ChainSpecT> {
     fn print_method_logs(
         &mut self,
         _method: &str,
-        _error: Option<&ProviderError<Infallible>>,
-    ) -> Result<(), Infallible> {
+        _error: Option<&ProviderError>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         Ok(())
     }
 }


### PR DESCRIPTION
This change decouples the logger's error type from the provider. This prevents the necessity of knowing the `Logger`'s error type when implementing traits for the provider-related types (errors, data, interval miner, etc.)