### PR TITLE
ci: add workflow for testing Optimism every night

### DIFF
--- a/.github/workflows/test-recent-mainnet-block.yml
+++ b/.github/workflows/test-recent-mainnet-block.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: replay-block
-          args: -u ${{ secrets.ALCHEMY_URL }} --chain-id 1 --chain-type l1
+          args: -u ${{ secrets.ALCHEMY_URL }} -c l1
 
       - name: Notify failures
         if: failure()

--- a/.github/workflows/test-recent-optimism-block.yml
+++ b/.github/workflows/test-recent-optimism-block.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Cache EDR RPC cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             **/edr-cache

--- a/.github/workflows/test-recent-optimism-block.yml
+++ b/.github/workflows/test-recent-optimism-block.yml
@@ -4,7 +4,6 @@ on:
   schedule:
     - cron: "0 */8 * * *"
   workflow_dispatch:
-  push:
 
 defaults:
   run:

--- a/.github/workflows/test-recent-optimism-block.yml
+++ b/.github/workflows/test-recent-optimism-block.yml
@@ -1,4 +1,4 @@
-name: Run a recent full block in the Hardhat Network
+name: Run a recent full Optimism block in the Hardhat Network
 
 on:
   schedule:
@@ -10,8 +10,8 @@ defaults:
     working-directory: packages/hardhat-core
 
 jobs:
-  test-recent-mainnet-block:
-    name: Test recent mainnet block
+  test-recent-optimism-block:
+    name: Test recent Optimism block
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -29,13 +29,13 @@ jobs:
         with:
           path: |
             **/edr-cache
-          key: test-recent-mainnet-block-rpc-cache-v1
+          key: test-recent-optimism-block-rpc-cache-v1
 
       - name: Run test
         uses: actions-rs/cargo@v1
         with:
           command: replay-block
-          args: -u ${{ secrets.ALCHEMY_URL }} --chain-id 1 --chain-type l1
+          args: -u ${{ secrets.ALCHEMY_URL }} --chain-id 10 --chain-type optimism
 
       - name: Notify failures
         if: failure()

--- a/.github/workflows/test-recent-optimism-block.yml
+++ b/.github/workflows/test-recent-optimism-block.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: "0 */8 * * *"
   workflow_dispatch:
+  push:
 
 defaults:
   run:

--- a/.github/workflows/test-recent-optimism-block.yml
+++ b/.github/workflows/test-recent-optimism-block.yml
@@ -14,7 +14,7 @@ jobs:
     name: Test recent Optimism block
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Rust (stable)
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/test-recent-optimism-block.yml
+++ b/.github/workflows/test-recent-optimism-block.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: feat/multichain
 
       - name: Install Rust (stable)
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/test-recent-optimism-block.yml
+++ b/.github/workflows/test-recent-optimism-block.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: replay-block
-          args: -u ${{ secrets.ALCHEMY_URL }} --chain-id 10 --chain-type optimism
+          args: -u ${{ secrets.ALCHEMY_URL }} -c optimism
 
       - name: Notify failures
         if: failure()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3792,6 +3792,7 @@ dependencies = [
  "edr_eth",
  "edr_evm",
  "edr_napi_core",
+ "edr_optimism",
  "edr_provider",
  "edr_rpc_eth",
  "flate2",

--- a/crates/edr_evm/src/test_utils.rs
+++ b/crates/edr_evm/src/test_utils.rs
@@ -172,13 +172,13 @@ pub async fn run_full_block<
 >(
     url: String,
     block_number: u64,
-    chain_id: u64,
 ) -> anyhow::Result<()> {
     let runtime = tokio::runtime::Handle::current();
 
     let rpc_client = EthRpcClient::<ChainSpecT>::new(&url, edr_defaults::CACHE_DIR.into(), None)?;
-    let rpc_client = Arc::new(rpc_client);
+    let chain_id = rpc_client.chain_id().await?;
 
+    let rpc_client = Arc::new(rpc_client);
     let replay_block = {
         let block = rpc_client
             .get_block_by_number_with_transaction_data(PreEip1898BlockSpec::Number(block_number))
@@ -374,7 +374,6 @@ pub async fn run_full_block<
 /// impl_full_block_tests! {
 ///     mainnet_byzantium => L1ChainSpec {
 ///         block_number: 4_370_001,
-///         chain_id: 1,
 ///         url: get_alchemy_url(),
 ///     },
 /// }
@@ -384,7 +383,6 @@ macro_rules! impl_full_block_tests {
     ($(
         $name:ident => $chain_spec:ident {
             block_number: $block_number:expr,
-            chain_id: $chain_id:expr,
             url: $url:expr,
         },
     )+) => {
@@ -395,7 +393,7 @@ macro_rules! impl_full_block_tests {
                 async fn [<full_block_ $name>]() -> anyhow::Result<()> {
                     let url = $url;
 
-                    $crate::test_utils::run_full_block::<$chain_spec>(url, $block_number, $chain_id).await
+                    $crate::test_utils::run_full_block::<$chain_spec>(url, $block_number).await
                 }
             }
         )+

--- a/crates/edr_evm/src/test_utils.rs
+++ b/crates/edr_evm/src/test_utils.rs
@@ -162,9 +162,7 @@ pub async fn run_full_block<
     ChainSpecT: Debug
         + SyncChainSpec<
             Block: Default,
-            Hardfork: Debug + Send + Sync,
-            RpcBlockConversionError: Send + Sync,
-            RpcReceiptConversionError: Send + Sync,
+            Hardfork: Debug,
             ExecutionReceipt<FilterLog>: PartialEq,
             Transaction: Default
                              + TransactionValidation<

--- a/crates/edr_optimism/tests/full_block.rs
+++ b/crates/edr_optimism/tests/full_block.rs
@@ -7,22 +7,18 @@ use edr_test_utils::env::get_alchemy_url;
 impl_full_block_tests! {
     mainnet_regolith => OptimismChainSpec {
         block_number: 105_235_064,
-        chain_id: 10,
         url: get_alchemy_url().replace("eth-", "opt-"),
     },
     mainnet_canyon => OptimismChainSpec {
         block_number: 115_235_064,
-        chain_id: 10,
         url: get_alchemy_url().replace("eth-", "opt-"),
     },
     mainnet_ecotone => OptimismChainSpec {
         block_number: 121_874_088,
-        chain_id: 10,
         url: get_alchemy_url().replace("eth-", "opt-"),
     },
     mainnet_fjord => OptimismChainSpec {
         block_number: 122_514_212,
-        chain_id: 10,
         url: get_alchemy_url().replace("eth-", "opt-"),
     },
 }

--- a/crates/edr_provider/src/data.rs
+++ b/crates/edr_provider/src/data.rs
@@ -4092,58 +4092,48 @@ mod tests {
         impl_full_block_tests! {
             mainnet_byzantium => L1ChainSpec {
                 block_number: 4_370_001,
-                chain_id: 1,
                 url: get_alchemy_url(),
             },
             mainnet_constantinople => L1ChainSpec {
                 block_number: 7_280_001,
-                chain_id: 1,
                 url: get_alchemy_url(),
             },
             mainnet_istanbul => L1ChainSpec {
                 block_number: 9_069_001,
-                chain_id: 1,
                 url: get_alchemy_url(),
             },
             mainnet_muir_glacier => L1ChainSpec {
                 block_number: 9_300_077,
-                chain_id: 1,
                 url: get_alchemy_url(),
             },
             mainnet_shanghai => L1ChainSpec {
                 block_number: 17_050_001,
-                chain_id: 1,
                 url: get_alchemy_url(),
             },
             // This block contains a sequence of transaction that first raise
             // an empty account's balance and then decrease it
             mainnet_19318016 => L1ChainSpec {
                 block_number: 19_318_016,
-                chain_id: 1,
                 url: get_alchemy_url(),
             },
             // This block has both EIP-2930 and EIP-1559 transactions
             sepolia_eip_1559_2930 => L1ChainSpec {
                 block_number: 5_632_795,
-                chain_id: 11_155_111,
                 url: get_alchemy_url().replace("mainnet", "sepolia"),
             },
             sepolia_shanghai => L1ChainSpec {
                 block_number: 3_095_000,
-                chain_id: 11_155_111,
                 url: get_alchemy_url().replace("mainnet", "sepolia"),
             },
             // This block has an EIP-4844 transaction
             mainnet_cancun => L1ChainSpec {
                 block_number: 19_529_021,
-                chain_id: 1,
                 url: get_alchemy_url(),
             },
             // This block contains a transaction that uses the KZG point evaluation
             // precompile, introduced in Cancun
             mainnet_cancun2 => L1ChainSpec {
                 block_number: 19_562_047,
-                chain_id: 1,
                 url: get_alchemy_url(),
             },
         }

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -13,6 +13,7 @@ edr_defaults = { version = "0.3.5", path = "../edr_defaults" }
 edr_eth = { version = "0.3.5", path = "../edr_eth" }
 edr_evm = { version = "0.3.5", path = "../edr_evm", features = ["test-utils", "tracing"] }
 edr_napi_core = { path = "../edr_napi_core" }
+edr_optimism = { path = "../edr_optimism" }
 edr_provider = { version = "0.3.5", path = "../edr_provider" }
 edr_rpc_eth = { version = "0.3.5", path = "../edr_rpc_eth" }
 flate2 = "1.0.28"

--- a/crates/tools/src/main.rs
+++ b/crates/tools/src/main.rs
@@ -9,6 +9,7 @@ mod remote_block;
 mod scenario;
 mod update;
 
+use remote_block::SupportedChainTypes;
 use update::Mode;
 
 // Matches `edr_napi`. Important for scenarios.
@@ -45,6 +46,8 @@ enum Command {
     GenExecutionApi,
     /// Replays a block from a remote node and compares it to the mined block.
     ReplayBlock {
+        #[clap(long, value_enum)]
+        chain_type: SupportedChainTypes,
         /// The URL of the remote node
         #[clap(long, short)]
         url: String,
@@ -52,7 +55,7 @@ enum Command {
         #[clap(long, short)]
         block_number: Option<u64>,
         /// The chain ID
-        #[clap(long, short)]
+        #[clap(long)]
         chain_id: u64,
     },
     /// Execute a benchmark scenario and report statistics
@@ -80,10 +83,11 @@ async fn main() -> anyhow::Result<()> {
         } => benchmark::run(working_directory, &test_command, iterations),
         Command::GenExecutionApi => execution_api::generate(Mode::Overwrite),
         Command::ReplayBlock {
+            chain_type,
             url,
             block_number,
             chain_id,
-        } => remote_block::replay(url, block_number, chain_id).await,
+        } => remote_block::replay(chain_type, url, block_number, chain_id).await,
         Command::Scenario { path, count } => scenario::execute(&path, count).await,
     }
 }

--- a/crates/tools/src/main.rs
+++ b/crates/tools/src/main.rs
@@ -46,7 +46,7 @@ enum Command {
     GenExecutionApi,
     /// Replays a block from a remote node and compares it to the mined block.
     ReplayBlock {
-        #[clap(long, value_enum)]
+        #[clap(long, short, value_enum)]
         chain_type: SupportedChainTypes,
         /// The URL of the remote node
         #[clap(long, short)]
@@ -54,9 +54,6 @@ enum Command {
         /// The block number to replay
         #[clap(long, short)]
         block_number: Option<u64>,
-        /// The chain ID
-        #[clap(long)]
-        chain_id: u64,
     },
     /// Execute a benchmark scenario and report statistics
     Scenario {
@@ -86,8 +83,7 @@ async fn main() -> anyhow::Result<()> {
             chain_type,
             url,
             block_number,
-            chain_id,
-        } => remote_block::replay(chain_type, url, block_number, chain_id).await,
+        } => remote_block::replay(chain_type, url, block_number).await,
         Command::Scenario { path, count } => scenario::execute(&path, count).await,
     }
 }

--- a/crates/tools/src/remote_block.rs
+++ b/crates/tools/src/remote_block.rs
@@ -20,18 +20,16 @@ pub async fn replay(
     chain_type: SupportedChainTypes,
     url: String,
     block_number: Option<u64>,
-    chain_id: u64,
 ) -> anyhow::Result<()> {
     match chain_type {
         SupportedChainTypes::L1 => {
-            replay_chain_specific_block::<L1ChainSpec>("l1", url, block_number, chain_id).await
+            replay_chain_specific_block::<L1ChainSpec>("l1", url, block_number).await
         }
         SupportedChainTypes::Optimism => {
             replay_chain_specific_block::<OptimismChainSpec>(
                 "optimism",
                 url.replace("eth-", "opt-"),
                 block_number,
-                chain_id,
             )
             .await
         }
@@ -42,7 +40,6 @@ pub async fn replay_chain_specific_block<ChainSpecT>(
     chain_type: &str,
     url: String,
     block_number: Option<u64>,
-    chain_id: u64,
 ) -> anyhow::Result<()>
 where
     ChainSpecT: Debug
@@ -68,5 +65,5 @@ where
     };
 
     println!("Testing block {block_number} for chain type {chain_type}");
-    run_full_block::<ChainSpecT>(url, block_number, chain_id).await
+    run_full_block::<ChainSpecT>(url, block_number).await
 }


### PR DESCRIPTION
This PR adds support for replaying Optimism on-chain blocks to the CLI app and adds a GitHub workflow for nightly replays of the latest Optimism block.

This PR contains a breaking change to the CLI:
- `--chain-id` was removed as it can be retrieved from the remote
- `--chain-type` was added, replacing the meaning of `-c` from `--chain-id` to `--chain-type`

Once merged, this PR commit should be cherry-picked and applied to `main` to ensure that the `on.schedule` works.
> Scheduled workflows will only run on the default branch.
>
> https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule