### PR TITLE
[multi-chain]: Drive-by clarify the required traits in `ChainSpec` and decouple them a bit

### DIFF
--- a/crates/edr_evm/src/block.rs
+++ b/crates/edr_evm/src/block.rs
@@ -135,8 +135,8 @@ impl<ChainSpecT: ChainSpec> TryFrom<edr_rpc_eth::Block<ChainSpecT::RpcTransactio
         let transactions = value
             .transactions
             .into_iter()
-            .map(ChainSpecT::Transaction::try_from)
-            .collect::<Result<Vec<_>, _>>()
+            .map(TryInto::try_into)
+            .collect::<Result<Vec<ChainSpecT::Transaction>, _>>()
             .map_err(RemoteBlockConversionError::TransactionConversionError)?;
 
         let hash = value.hash.ok_or(RemoteBlockConversionError::MissingHash)?;

--- a/crates/edr_evm/src/chain_spec.rs
+++ b/crates/edr_evm/src/chain_spec.rs
@@ -31,35 +31,29 @@ pub trait ChainSpec:
     + EvmWiring<
         Block: BlockEnvConstructor<Self, block::Header> + BlockEnvConstructor<Self, PartialHeader>,
         Transaction: alloy_rlp::Encodable
-                         + Clone
-                         + Debug
-                         + PartialEq
-                         + Eq
-                         + ExecutableTransaction
-                         + Transaction
-                         + TransactionType,
+          + Clone
+          + Debug
+          + PartialEq
+          + Eq
+          + ExecutableTransaction
+          + Transaction
+          + TransactionType,
     >
-    // Defines an RPC spec and a conversion between RPC <-> EVM types
-    + RpcSpec<RpcTransaction: TryInto<<Self as revm::primitives::EvmWiring>::Transaction, Error = Self::RpcTransactionConversionError>>
+    // Defines an RPC spec and conversion between RPC <-> EVM types
     + RpcSpec<
-        ExecutionReceipt<FilterLog>: Debug,
         RpcBlock<<Self as RpcSpec>::RpcTransaction>: EthRpcBlock
-                                                         + TryInto<
-            EthBlockData<Self>,
-            Error = Self::RpcBlockConversionError,
-        >,
-        RpcReceipt: Debug
-                        + RpcTypeFrom<BlockReceipt<Self>, Hardfork = Self::Hardfork>
-                        + TryInto<BlockReceipt<Self>, Error = Self::RpcReceiptConversionError>,
+          + TryInto<EthBlockData<Self>, Error = Self::RpcBlockConversionError>,
         RpcTransaction: EthRpcTransaction
-                            + RpcTypeFrom<TransactionAndBlock<Self>, Hardfork = Self::Hardfork>,
-    > + RpcSpec<
+          + RpcTypeFrom<TransactionAndBlock<Self>, Hardfork = Self::Hardfork>
+          + TryInto<<Self as revm::primitives::EvmWiring>::Transaction, Error = Self::RpcTransactionConversionError>,
+        RpcReceipt: Debug
+          + RpcTypeFrom<BlockReceipt<Self>, Hardfork = Self::Hardfork>
+          + TryInto<BlockReceipt<Self>, Error = Self::RpcReceiptConversionError>,
+    >
+    + RpcSpec<ExecutionReceipt<FilterLog>: Debug>
+    + RpcSpec<
         ExecutionReceipt<ExecutionLog>: alloy_rlp::Encodable
-                                            + MapReceiptLogs<
-            ExecutionLog,
-            FilterLog,
-            Self::ExecutionReceipt<FilterLog>,
-        >,
+          + MapReceiptLogs<ExecutionLog, FilterLog, Self::ExecutionReceipt<FilterLog>>,
         RpcBlock<B256>: EthRpcBlock,
     >
 {

--- a/crates/edr_evm/src/chain_spec.rs
+++ b/crates/edr_evm/src/chain_spec.rs
@@ -43,12 +43,12 @@ pub trait ChainSpec:
     + RpcSpec<
         RpcBlock<<Self as RpcSpec>::RpcTransaction>: EthRpcBlock
           + TryInto<EthBlockData<Self>, Error = Self::RpcBlockConversionError>,
-        RpcTransaction: EthRpcTransaction
-          + RpcTypeFrom<TransactionAndBlock<Self>, Hardfork = Self::Hardfork>
-          + TryInto<<Self as revm::primitives::EvmWiring>::Transaction, Error = Self::RpcTransactionConversionError>,
         RpcReceipt: Debug
           + RpcTypeFrom<BlockReceipt<Self>, Hardfork = Self::Hardfork>
           + TryInto<BlockReceipt<Self>, Error = Self::RpcReceiptConversionError>,
+        RpcTransaction: EthRpcTransaction
+          + RpcTypeFrom<TransactionAndBlock<Self>, Hardfork = Self::Hardfork>
+          + TryInto<<Self as revm::primitives::EvmWiring>::Transaction, Error = Self::RpcTransactionConversionError>,
     >
     + RpcSpec<ExecutionReceipt<FilterLog>: Debug>
     + RpcSpec<


### PR DESCRIPTION
When I started implementing the `ChainSpec` trait I found it difficult to navigate all of the required traits, their associated types and how they all relate to each other.

Since the [book chapter](https://github.com/NomicFoundation/edr/blob/feat/multichain/book/src/04_multichain/01_chain_spec.md) reads like the traits should be increasing in scope depending on the impls, I tried to decouple them a bit to make them more additive and to clarify which trait is responsible for what.

Firstly, instead of requiring the `EvmWiring::Transaction` to be convertible to its RPC counterpart directly in the trait bound, I moved the fallible conversion down to the RpcSpec. While strictly less powerful (does not impl TryFrom anymore but also was not used) I feel that it makes it clear that the `RpcSpec` add strictly more logic, and decouples the traits, based on the core EVM (wiring) types above.

Secondly, while also changing the semantics a bit, I extracted and grouped the conversions between the RPC types and the internal/EVM ones. I hope that makes sense as I don't know the code well enough but it made sense to always require these conversions despite which logs (execution/filter) we further require and this also groups the relevant errors together and provides some more symmetry with the core (wiring) Block/Transaction types.

I don't feel so strongly about formatting but not indenting so much makes it a bit easier for me to follow but I'm happy to bring the old back.