### PR TITLE
fix: Allow block time offset to be negative

### DIFF
--- a/.changeset/hungry-cats-enjoy.md
+++ b/.changeset/hungry-cats-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Allow forked block time offset to be negative

--- a/crates/edr_provider/src/data.rs
+++ b/crates/edr_provider/src/data.rs
@@ -2692,8 +2692,8 @@ fn create_blockchain_and_state(
                 );
 
             let elapsed = match timer.since(fork_block_timestamp) {
-                Ok(elapsed) => i128::from(elapsed),
-                Err(forward_drift) => -i128::from(forward_drift.duration().as_secs()),
+                Ok(elapsed) => -i128::from(elapsed),
+                Err(forward_drift) => i128::from(forward_drift.duration().as_secs()),
             };
 
             elapsed

--- a/crates/edr_provider/src/data.rs
+++ b/crates/edr_provider/src/data.rs
@@ -2691,11 +2691,13 @@ fn create_blockchain_and_state(
                         .timestamp,
                 );
 
-            let elapsed_time = timer
-                .since(fork_block_timestamp)
-                .expect("current time must be after fork block");
+            let elapsed = match timer.since(fork_block_timestamp) {
+                Ok(elapsed) => i128::from(elapsed),
+                Err(forward_drift) => -i128::from(forward_drift.duration().as_secs()),
+            };
 
-            -i64::try_from(elapsed_time)
+            elapsed
+                .try_into()
                 .expect("Elapsed time since fork block must be representable as i64")
         };
 

--- a/crates/edr_provider/src/time.rs
+++ b/crates/edr_provider/src/time.rs
@@ -42,7 +42,7 @@ mod test_utils {
 
     use super::{CurrentTime, TimeSinceEpoch};
 
-    /// An internally mutable mock implementation of `TimeSinceEpoch`.
+    /// An internally mutable mock implementation of [`TimeSinceEpoch`].
     #[derive(Debug)]
     pub struct MockTime(AtomicU64);
 

--- a/crates/edr_provider/tests/issues/issue_588.rs
+++ b/crates/edr_provider/tests/issues/issue_588.rs
@@ -1,0 +1,36 @@
+//! Allow forking blocks with future timestamps.
+//!
+//! See <https://github.com/NomicFoundation/edr/issues/588>
+
+use std::sync::Arc;
+
+use edr_provider::{
+    hardhat_rpc_types::ForkConfig, test_utils::create_test_config_with_fork, time::MockTime,
+    NoopLogger, Provider,
+};
+use edr_test_utils::env::get_alchemy_url;
+use tokio::runtime;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn issue_588() -> anyhow::Result<()> {
+    let logger = Box::new(NoopLogger);
+    let subscriber = Box::new(|_event| {});
+
+    let early_mainnet_fork = create_test_config_with_fork(Some(ForkConfig {
+        json_rpc_url: get_alchemy_url(),
+        block_number: Some(2_675_000),
+        http_headers: None,
+    }));
+
+    let current_time_is_1970 = Arc::new(MockTime::with_seconds(0));
+
+    let _forking_succeeds = Provider::new(
+        runtime::Handle::current(),
+        logger,
+        subscriber,
+        early_mainnet_fork,
+        current_time_is_1970,
+    )?;
+
+    Ok(())
+}

--- a/crates/edr_provider/tests/issues/mod.rs
+++ b/crates/edr_provider/tests/issues/mod.rs
@@ -11,3 +11,4 @@ mod issue_407;
 mod issue_503;
 mod issue_533;
 mod issue_570;
+mod issue_588;


### PR DESCRIPTION
Closes #588

This uses a simple approach of first converting to `i128`, which we know will be lossless, to only then fallibly convert it to a smaller type of `i64`.

We do that for simplicity: one could convert a tuple of (sign, value) to shave some bytes and cycles but we would have to explicitly handle the case of `i64::MIN` (its absolute value is greater by 1 than i64::MAX), which would be a bit noisy, whereas not handling it and naively using a `if sign { -1 } else { 1 } * i64::try_from(value)...` would not fully handle that edge case.

I tested locally the reproduction steps from #588 and can both confirm that the error happens using the steps and the problem disappears after applying the fix here. Let me know if you feel that we should add a regression test and if so, how would you prefer to proceed with testing this.