### PR TITLE
fix: Correctly handle optional solc output in the tracing engine

### DIFF
--- a/.changeset/seven-dogs-decide.md
+++ b/.changeset/seven-dogs-decide.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Handle optional solc settings better in the tracing engine

--- a/crates/edr_napi/src/trace/error_inferrer.rs
+++ b/crates/edr_napi/src/trace/error_inferrer.rs
@@ -955,8 +955,14 @@ impl ErrorInferrer {
             return Ok(entry);
         }
 
+        // This function is only called after we jumped into the initial function in
+        // call traces, so there should always be at least a function jumpdest.
         let trace = match trace {
-            Either::A(_call) => unreachable!("This shouldn't happen: a call trace has no functionJumpdest but has already jumped into a function"),
+            Either::A(_call) => return Err(
+              napi::Error::new(
+                napi::Status::GenericFailure,
+                "This shouldn't happen: a call trace has no functionJumpdest but has already jumped into a function"
+              )),
             Either::B(create) => create,
         };
 

--- a/crates/edr_solidity/src/artifacts.rs
+++ b/crates/edr_solidity/src/artifacts.rs
@@ -1,5 +1,7 @@
 //! Represents artifacts of the Solidity compiler input and output in the
 //! Standard JSON format.
+//!
+//! See <https://docs.soliditylang.org/en/latest/using-the-compiler.html#compiler-input-and-output-json-description>.
 #![allow(missing_docs)]
 
 use std::collections::HashMap;
@@ -37,7 +39,7 @@ pub struct Source {
 pub struct CompilerInput {
     pub language: String,
     pub sources: HashMap<String, Source>,
-    pub settings: CompilerSettings,
+    pub settings: Option<CompilerSettings>,
 }
 
 /// Additional settings like the optimizer, metadata, etc.
@@ -46,7 +48,7 @@ pub struct CompilerInput {
 pub struct CompilerSettings {
     #[serde(rename = "viaIR")]
     via_ir: Option<bool>,
-    optimizer: OptimizerSettings,
+    optimizer: Option<OptimizerSettings>,
     metadata: Option<MetadataSettings>,
     output_selection: HashMap<String, HashMap<String, Vec<String>>>,
     evm_version: Option<String>,
@@ -66,21 +68,21 @@ pub struct OptimizerSettings {
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct OptimizerDetails {
-    yul_details: YulDetails,
+    yul_details: Option<YulDetails>,
 }
 
 /// Yul-specific optimizer details.
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct YulDetails {
-    optimizer_steps: String,
+    optimizer_steps: Option<String>,
 }
 
 /// Specifies the metadata settings.
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MetadataSettings {
-    use_literal_content: bool,
+    use_literal_content: Option<bool>,
 }
 
 /// The main output of the Solidity compiler.


### PR DESCRIPTION
...and mimick what Hardhat does, i.e. catch an internal error (rather than unconditionally print a panic message) when we analyze a call trace with no jump destination.

@fvictorio this fixes the issues we caught when testing the Seaport repository.