### PR TITLE
fix: Handle nullptr JS TypedArrays by bumping napi to 2.6.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1172,6 +1172,7 @@ dependencies = [
  "mimalloc",
  "napi",
  "napi-build",
+ "napi-derive",
  "openssl-sys",
  "parking_lot 0.12.1",
  "rand",
@@ -2182,6 +2183,8 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
+ "regex",
+ "semver 1.0.22",
  "syn 2.0.58",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2138,9 +2138,9 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "2.16.1"
+version = "2.16.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4ca998356d8ff9fba7a070dae4508a2298439c98c9f3bc9c07669538b999e8f"
+checksum = "53575dfa17f208dd1ce3a2da2da4659aae393b256a472f2738a8586a6c4107fd"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -2161,9 +2161,9 @@ checksum = "2f9130fccc5f763cf2069b34a089a18f0d0883c66aceb81f2fad541a3d823c43"
 
 [[package]]
 name = "napi-derive"
-version = "2.16.1"
+version = "2.16.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b138cecf1141ae0ff5d62f4aa0e2f269aec339f66070f346ba6fb4279f1fc178"
+checksum = "150d87c4440b9f4815cb454918db498b5aae9a57aa743d20783fe75381181d01"
 dependencies = [
  "cfg-if",
  "convert_case 0.6.0",
@@ -2175,9 +2175,9 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "1.0.63"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce5126b64f6ad9e28e30e6d15213dd378626b38f556454afebc42f7f02a90902"
+checksum = "967c485e00f0bf3b1bdbe510a38a4606919cf1d34d9a37ad41f25a81aa077abe"
 dependencies = [
  "convert_case 0.6.0",
  "once_cell",
@@ -2190,9 +2190,9 @@ dependencies = [
 
 [[package]]
 name = "napi-sys"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2503fa6af34dc83fb74888df8b22afe933b58d37daf7d80424b1c60c68196b8b"
+checksum = "427802e8ec3a734331fec1035594a210ce1ff4dc5bc1950530920ab717964ea3"
 dependencies = [
  "libloading",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1172,7 +1172,6 @@ dependencies = [
  "mimalloc",
  "napi",
  "napi-build",
- "napi-derive",
  "openssl-sys",
  "parking_lot 0.12.1",
  "rand",
@@ -2183,8 +2182,6 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "regex",
- "semver 1.0.22",
  "syn 2.0.58",
 ]
 

--- a/crates/edr_napi/Cargo.toml
+++ b/crates/edr_napi/Cargo.toml
@@ -18,8 +18,8 @@ k256 = { version = "0.13.1", default-features = false, features = ["arithmetic",
 log = { version = "0.4.20", default-features = false }
 # when napi is pinned, be sure to pin napi-derive to the same version
 # The `async` feature ensures that a tokio runtime is available
-napi = { version = "2.16.0", default-features = false, features = ["async", "error_anyhow", "napi8", "serde-json"] }
-napi-derive = "2.16.0"
+napi = { version = "2.16.11", default-features = false, features = ["async", "error_anyhow", "napi8", "serde-json"] }
+napi-derive = "2.16.11"
 edr_defaults = { version = "0.3.5", path = "../edr_defaults" }
 edr_evm = { version = "0.3.5", path = "../edr_evm", features = ["tracing"]}
 edr_eth = { version = "0.3.5", path = "../edr_eth" }

--- a/crates/edr_napi/Cargo.toml
+++ b/crates/edr_napi/Cargo.toml
@@ -18,6 +18,7 @@ k256 = { version = "0.13.1", default-features = false, features = ["arithmetic",
 log = { version = "0.4.20", default-features = false }
 # The `async` feature ensures that a tokio runtime is available
 napi = { version = "2.16.11", default-features = false, features = ["async", "error_anyhow", "napi8", "serde-json"] }
+napi-derive = "2.16.11"
 edr_defaults = { version = "0.3.5", path = "../edr_defaults" }
 edr_evm = { version = "0.3.5", path = "../edr_evm", features = ["tracing"]}
 edr_eth = { version = "0.3.5", path = "../edr_eth" }

--- a/crates/edr_napi/Cargo.toml
+++ b/crates/edr_napi/Cargo.toml
@@ -16,10 +16,8 @@ itertools = { version = "0.12.0", default-features = false }
 indexmap = { version = "2" }
 k256 = { version = "0.13.1", default-features = false, features = ["arithmetic", "ecdsa", "pkcs8", "precomputed-tables", "std"] }
 log = { version = "0.4.20", default-features = false }
-# when napi is pinned, be sure to pin napi-derive to the same version
 # The `async` feature ensures that a tokio runtime is available
 napi = { version = "2.16.11", default-features = false, features = ["async", "error_anyhow", "napi8", "serde-json"] }
-napi-derive = "2.16.11"
 edr_defaults = { version = "0.3.5", path = "../edr_defaults" }
 edr_evm = { version = "0.3.5", path = "../edr_evm", features = ["tracing"]}
 edr_eth = { version = "0.3.5", path = "../edr_eth" }


### PR DESCRIPTION
This fixes an instance where we roundtrip a zero-length `Uint8Array` in JS code and violate the `slice::from_raw_parts` contract (checked in debug builds at run-time since Rust 1.78) because internally napi calls it with a null pointer, see https://github.com/napi-rs/napi-rs/pull/2258.

Found while running the test suite of https://github.com/ProjectOpenSea/seaport with local, most recent Hardhat+EDR.

This should unblock further testing and releasing a Hardhat version that uses the EDR-powered stack tracing.