### PR TITLE
refactor: adapt `isContext` cheatcode

### DIFF
--- a/crates/edr_napi/src/solidity_tests/config.rs
+++ b/crates/edr_napi/src/solidity_tests/config.rs
@@ -2,8 +2,10 @@ use std::{collections::HashMap, fmt::Debug, path::PathBuf};
 
 use alloy_primitives::hex;
 use edr_solidity_tests::{
-    executors::invariant::InvariantConfig, fuzz::FuzzConfig,
-    inspectors::cheatcodes::CheatsConfigOptions, SolidityTestRunnerConfig,
+    executors::invariant::InvariantConfig,
+    fuzz::FuzzConfig,
+    inspectors::cheatcodes::{CheatsConfigOptions, ExecutionContextConfig},
+    SolidityTestRunnerConfig,
 };
 use foundry_cheatcodes::{FsPermissions, RpcEndpoint, RpcEndpoints};
 use napi::{
@@ -190,6 +192,9 @@ impl TryFrom<SolidityTestRunnerConfigArgs> for SolidityTestRunnerConfig {
         let fuzz: FuzzConfig = fuzz.map(TryFrom::try_from).transpose()?.unwrap_or_default();
 
         let cheats_config_options = CheatsConfigOptions {
+            // TODO https://github.com/NomicFoundation/edr/issues/657
+            // If gas reporting or coverage is supported, take that into account here.
+            execution_context: ExecutionContextConfig::Test,
             rpc_endpoints: rpc_endpoints
                 .map(|endpoints| {
                     RpcEndpoints::new(

--- a/crates/edr_solidity_tests/tests/it/core.rs
+++ b/crates/edr_solidity_tests/tests/it/core.rs
@@ -82,6 +82,10 @@ async fn test_core() {
                     None,
                 )],
             ),
+            (
+                "default/core/ExecutionContext.t.sol:ExecutionContextTest",
+                vec![("testContext()", true, None, None, None)],
+            ),
         ]),
     );
 }

--- a/crates/edr_solidity_tests/tests/it/helpers.rs
+++ b/crates/edr_solidity_tests/tests/it/helpers.rs
@@ -18,7 +18,7 @@ use edr_solidity_tests::{
     MultiContractRunner, SolidityTestRunnerConfig,
 };
 use edr_test_utils::new_fd_lock;
-use foundry_cheatcodes::{FsPermissions, RpcEndpoint, RpcEndpoints};
+use foundry_cheatcodes::{ExecutionContextConfig, FsPermissions, RpcEndpoint, RpcEndpoints};
 use foundry_compilers::{
     artifacts::{CompactContractBytecode, Libraries},
     Artifact, EvmVersion, Project, ProjectCompileOutput,
@@ -100,7 +100,10 @@ impl ForgeTestProfile {
             trace: true,
             evm_opts: Self::evm_opts(),
             project_root: PROJECT_ROOT.clone(),
-            cheats_config_options: CheatsConfigOptions::default(),
+            cheats_config_options: CheatsConfigOptions {
+                execution_context: ExecutionContextConfig::Test,
+                ..CheatsConfigOptions::default()
+            },
             fuzz: TestFuzzConfig::default().into(),
             invariant: TestInvariantConfig::default().into(),
             coverage: false,

--- a/crates/edr_solidity_tests/tests/testdata/cheats/Vm.sol
+++ b/crates/edr_solidity_tests/tests/testdata/cheats/Vm.sol
@@ -8,7 +8,7 @@ pragma experimental ABIEncoderV2;
 interface Vm {
     enum CallerMode { None, Broadcast, RecurrentBroadcast, Prank, RecurrentPrank }
     enum AccountAccessKind { Call, DelegateCall, CallCode, StaticCall, Create, SelfDestruct, Resume, Balance, Extcodesize, Extcodehash, Extcodecopy }
-    enum ForgeContext { TestGroup, Test, Coverage, Snapshot, ScriptGroup, ScriptDryRun, ScriptBroadcast, ScriptResume, Unknown }
+    enum ExecutionContext { TestGroup, Test, Coverage, Snapshot, Unknown }
     struct Log { bytes32[] topics; bytes data; address emitter; }
     struct Rpc { string key; string url; }
     struct EthGetLogs { address emitter; bytes32[] topics; bytes data; bytes32 blockHash; uint64 blockNumber; bytes32 transactionHash; uint64 transactionIndex; uint256 logIndex; bool removed; }
@@ -233,7 +233,7 @@ interface Vm {
     function getNonce(address account) external view returns (uint64 nonce);
     function getRecordedLogs() external returns (Log[] memory logs);
     function indexOf(string calldata input, string calldata key) external pure returns (uint256);
-    function isContext(ForgeContext context) external view returns (bool result);
+    function isContext(ExecutionContext context) external view returns (bool result);
     function isDir(string calldata path) external returns (bool result);
     function isFile(string calldata path) external returns (bool result);
     function isPersistent(address account) external view returns (bool persistent);

--- a/crates/edr_solidity_tests/tests/testdata/default/core/ExecutionContext.t.sol
+++ b/crates/edr_solidity_tests/tests/testdata/default/core/ExecutionContext.t.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity 0.8.18;
+
+import "ds-test/test.sol";
+import "cheats/Vm.sol";
+
+contract ExecutionContextTest is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+
+    function testContext() public {
+        assertEq(vm.isContext(Vm.ExecutionContext.Test), true);
+        assertEq(vm.isContext(Vm.ExecutionContext.TestGroup), true);
+        assertEq(vm.isContext(Vm.ExecutionContext.Coverage), false);
+        assertEq(vm.isContext(Vm.ExecutionContext.Snapshot), false);
+        assertEq(vm.isContext(Vm.ExecutionContext.Unknown), false);
+    }
+}

--- a/crates/foundry/cheatcodes/assets/cheatcodes.json
+++ b/crates/foundry/cheatcodes/assets/cheatcodes.json
@@ -85,44 +85,28 @@
       ]
     },
     {
-      "name": "ForgeContext",
-      "description": "Forge execution contexts.",
+      "name": "ExecutionContext",
+      "description": "Solidity test execution contexts.",
       "variants": [
         {
           "name": "TestGroup",
-          "description": "Test group execution context (test, coverage or snapshot)."
+          "description": "Test group execution context: any of test, coverage or snapshot."
         },
         {
           "name": "Test",
-          "description": "`forge test` execution context."
+          "description": "Test execution context."
         },
         {
           "name": "Coverage",
-          "description": "`forge coverage` execution context."
+          "description": "Code coverage execution context."
         },
         {
           "name": "Snapshot",
-          "description": "`forge snapshot` execution context."
-        },
-        {
-          "name": "ScriptGroup",
-          "description": "Script group execution context (dry run, broadcast or resume)."
-        },
-        {
-          "name": "ScriptDryRun",
-          "description": "`forge script` execution context."
-        },
-        {
-          "name": "ScriptBroadcast",
-          "description": "`forge script --broadcast` execution context."
-        },
-        {
-          "name": "ScriptResume",
-          "description": "`forge script --resume` execution context."
+          "description": "Gas snapshot execution context."
         },
         {
           "name": "Unknown",
-          "description": "Unknown `forge` execution context."
+          "description": "Unknown execution context."
         }
       ]
     }
@@ -4755,7 +4739,7 @@
       "func": {
         "id": "isContext",
         "description": "Returns true if `forge` command was executed in given context.",
-        "declaration": "function isContext(ForgeContext context) external view returns (bool result);",
+        "declaration": "function isContext(ExecutionContext context) external view returns (bool result);",
         "visibility": "external",
         "mutability": "view",
         "signature": "isContext(uint8)",

--- a/crates/foundry/cheatcodes/spec/src/lib.rs
+++ b/crates/foundry/cheatcodes/spec/src/lib.rs
@@ -94,7 +94,7 @@ impl Cheatcodes<'static> {
             enums: Cow::Owned(vec![
                 Vm::CallerMode::ENUM.clone(),
                 Vm::AccountAccessKind::ENUM.clone(),
-                Vm::ForgeContext::ENUM.clone(),
+                Vm::ExecutionContext::ENUM.clone(),
             ]),
             errors: Vm::VM_ERRORS.iter().map(|&x| x.clone()).collect(),
             events: Cow::Borrowed(&[]),

--- a/crates/foundry/cheatcodes/spec/src/vm.rs
+++ b/crates/foundry/cheatcodes/spec/src/vm.rs
@@ -10,7 +10,6 @@ use super::{
     Cheatcode, CheatcodeDef, Cow, Enum, EnumVariant, Error, Function, Group, Mutability, Safety,
     Status, Struct, StructField, Visibility,
 };
-use crate::Vm::ForgeContext;
 
 sol! {
 // Cheatcodes are marked as view/pure/none using the following rules:
@@ -69,26 +68,18 @@ interface Vm {
         Extcodecopy,
     }
 
-    /// Forge execution contexts.
-    enum ForgeContext {
-        /// Test group execution context (test, coverage or snapshot).
+    /// Solidity test execution contexts.
+    enum ExecutionContext {
+        /// Test group execution context: any of test, coverage or snapshot.
         TestGroup,
-        /// `forge test` execution context.
+        /// Test execution context.
         Test,
-        /// `forge coverage` execution context.
+        /// Code coverage execution context.
         Coverage,
-        /// `forge snapshot` execution context.
+        /// Gas snapshot execution context.
         Snapshot,
-        /// Script group execution context (dry run, broadcast or resume).
-        ScriptGroup,
-        /// `forge script` execution context.
-        ScriptDryRun,
-        /// `forge script --broadcast` execution context.
-        ScriptBroadcast,
-        /// `forge script --resume` execution context.
-        ScriptResume,
-        /// Unknown `forge` execution context.
-        Unknown,
+        /// Unknown execution context.
+        Unknown
     }
 
     /// An Ethereum log. Returned by `getRecordedLogs`.
@@ -1644,7 +1635,7 @@ interface Vm {
 
     /// Returns true if `forge` command was executed in given context.
     #[cheatcode(group = Environment)]
-    function isContext(ForgeContext context) external view returns (bool result);
+    function isContext(ExecutionContext context) external view returns (bool result);
 
     // ======== Utilities ========
 
@@ -2023,31 +2014,4 @@ interface Vm {
     #[cheatcode(group = Utilities)]
     function ensNamehash(string calldata name) external pure returns (bytes32);
 }
-}
-
-impl PartialEq for ForgeContext {
-    // Handles test group case (any of test, coverage or snapshot)
-    // and script group case (any of dry run, broadcast or resume).
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (_, &ForgeContext::TestGroup) => {
-                self == &ForgeContext::Test
-                    || self == &ForgeContext::Snapshot
-                    || self == &ForgeContext::Coverage
-            }
-            (_, &ForgeContext::ScriptGroup) => {
-                self == &ForgeContext::ScriptDryRun
-                    || self == &ForgeContext::ScriptBroadcast
-                    || self == &ForgeContext::ScriptResume
-            }
-            (&ForgeContext::Test, &ForgeContext::Test)
-            | (&ForgeContext::Snapshot, &ForgeContext::Snapshot)
-            | (&ForgeContext::Coverage, &ForgeContext::Coverage)
-            | (&ForgeContext::ScriptDryRun, &ForgeContext::ScriptDryRun)
-            | (&ForgeContext::ScriptBroadcast, &ForgeContext::ScriptBroadcast)
-            | (&ForgeContext::ScriptResume, &ForgeContext::ScriptResume)
-            | (&ForgeContext::Unknown, &ForgeContext::Unknown) => true,
-            _ => false,
-        }
-    }
 }

--- a/crates/foundry/cheatcodes/src/config.rs
+++ b/crates/foundry/cheatcodes/src/config.rs
@@ -20,6 +20,9 @@ use crate::{cache::StorageCachingConfig, Vm::Rpc};
 /// to know.
 #[derive(Clone, Debug)]
 pub struct CheatsConfig {
+    /// Whether the execution is in the context of a test run, gas snapshot or
+    /// code coverage.
+    pub execution_context: ExecutionContextConfig,
     /// Whether the FFI cheatcode is enabled.
     pub ffi: bool,
     /// Use the create 2 factory in all cases including tests and
@@ -51,9 +54,25 @@ pub struct CheatsConfig {
     pub running_version: Option<Version>,
 }
 
+/// Solidity test execution contexts.
+#[derive(Clone, Debug, Default)]
+pub enum ExecutionContextConfig {
+    /// Test execution context.
+    Test,
+    /// Code coverage execution context.
+    Coverage,
+    /// Gas snapshot execution context.
+    Snapshot,
+    /// Unknown execution context.
+    #[default]
+    Unknown,
+}
+
 /// Configuration options specific to cheat codes.
 #[derive(Clone, Debug, Default)]
 pub struct CheatsConfigOptions {
+    /// Solidity test execution contexts.
+    pub execution_context: ExecutionContextConfig,
     /// Multiple rpc endpoints and their aliases
     pub rpc_endpoints: RpcEndpoints,
     /// Optional RPC cache path. If this is none, then no RPC calls will be
@@ -84,6 +103,7 @@ impl CheatsConfig {
         running_version: Option<Version>,
     ) -> Self {
         let CheatsConfigOptions {
+            execution_context,
             rpc_endpoints,
             rpc_cache_path,
             prompt_timeout,
@@ -95,6 +115,7 @@ impl CheatsConfig {
         let fs_permissions = fs_permissions.joined(&project_root);
 
         Self {
+            execution_context,
             ffi: evm_opts.ffi,
             always_use_create_2_factory: evm_opts.always_use_create_2_factory,
             prompt_timeout: Duration::from_secs(prompt_timeout),
@@ -239,6 +260,7 @@ impl CheatsConfig {
 impl Default for CheatsConfig {
     fn default() -> Self {
         Self {
+            execution_context: ExecutionContextConfig::default(),
             ffi: false,
             always_use_create_2_factory: false,
             prompt_timeout: Duration::from_secs(120),
@@ -262,6 +284,7 @@ mod tests {
 
     fn config(root: &str, fs_permissions: FsPermissions) -> CheatsConfig {
         let cheats_config_options = CheatsConfigOptions {
+            execution_context: ExecutionContextConfig::default(),
             rpc_endpoints: RpcEndpoints::default(),
             rpc_cache_path: None,
             rpc_storage_caching: StorageCachingConfig::default(),

--- a/crates/foundry/cheatcodes/src/lib.rs
+++ b/crates/foundry/cheatcodes/src/lib.rs
@@ -16,7 +16,7 @@ pub extern crate foundry_cheatcodes_spec as spec;
 extern crate tracing;
 
 use alloy_primitives::Address;
-pub use config::{CheatsConfig, CheatsConfigOptions};
+pub use config::{CheatsConfig, CheatsConfigOptions, ExecutionContextConfig};
 pub use endpoints::{RpcEndpoint, RpcEndpoints};
 pub use error::{Error, ErrorKind, Result};
 use foundry_evm_core::backend::DatabaseExt;
@@ -44,9 +44,8 @@ mod toml;
 mod utils;
 
 pub use cache::{CachedChains, CachedEndpoints, StorageCachingConfig};
-pub use env::set_execution_context;
 pub use test::expect::ExpectedCallTracker;
-pub use Vm::ForgeContext;
+pub use Vm::ExecutionContext;
 
 /// Cheatcode implementation.
 pub(crate) trait Cheatcode: CheatcodeDef + DynCheatcode {

--- a/js/integration-tests/solidity-tests/contracts/ContractEnvironment.t.sol
+++ b/js/integration-tests/solidity-tests/contracts/ContractEnvironment.t.sol
@@ -2,9 +2,12 @@
 pragma solidity ^0.8.24;
 
 import "./test.sol";
+import "./Vm.sol";
 
 // Test that the contract environment related config values are passed on correctly
 contract ContractEnvironmentTest is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+    
     function chainId() internal view returns (uint256 id) {
         assembly {
             id := chainid()
@@ -16,5 +19,9 @@ contract ContractEnvironmentTest is DSTest {
         assertEq(chainId(), 12, "chain id is incorrect");
         assertEq(block.number, 23, "block number is incorrect");
         assertEq(block.timestamp, 45, "timestamp is incorrect");
+    }
+    
+    function testContextIsTest() public {
+        assertEq(vm.isContext(Vm.ExecutionContext.Test), true);
     }
 }

--- a/js/integration-tests/solidity-tests/contracts/FuzzFixture.t.sol
+++ b/js/integration-tests/solidity-tests/contracts/FuzzFixture.t.sol
@@ -6,7 +6,7 @@ import "./Vm.sol";
 
 // Contract to be tested with overflow vulnerability
 contract IdentityContract {
-    function identity(uint256 amount) view public returns(uint256) {
+    function identity(uint256 amount) pure public returns(uint256) {
         require(amount != 7191815684697958081204101901807852913954269296144377099693178655035380638910, "Got value from fixture");
         return amount;
     }

--- a/js/integration-tests/solidity-tests/test/unit.ts
+++ b/js/integration-tests/solidity-tests/test/unit.ts
@@ -29,7 +29,7 @@ describe("Unit tests", () => {
     );
 
     assert.equal(failedTests, 0);
-    assert.equal(totalTests, 1);
+    assert.equal(totalTests, 2);
   });
 
   describe("IsolateMode", function () {


### PR DESCRIPTION
Foundry has an `isContext` [cheatcode](https://github.com/foundry-rs/foundry/pull/7377) that tells you which `forge` command was used to execute the Solidity code (e.g. `forge test` or `forge coverage` or `forge script`). 

I adapted the `isContext` cheatcode for EDR by renaming the context enum from `ForgeContext` to `ExecutionContext` and removed the scripting related variants.

The Foundry code assumes that Solidity code is ran via the `forge` CLI and that the execution context is set based on the subcommand once per process. This doesn't make sense for us, since EDR provides Solidity tests as a library, so I changed this to getting the execution context as a config value in the cheatcode implementation.

I changed the representation of the execution context in the Rust code. I split the previous `ForgeContext` enum into two enums as it was previously used as both as an argument from Solidity where it can have five variants and as a config value where it can only have four variants (`TestGroup` doesn't make sense as a config value).

I also removed the `PartialEq` implementation for the previous `ForgeContext` and inlined its logic in the cheatcode as the `PartialEq` implementation wasn't symmetric (`Test == TestGroup`, but `TestGroup != Test`) which can be a source of subtle bugs.