### PR TITLE
fixup: Re-generate the index.d.ts file and bump @napi-rs/cli to 2.18.4

### DIFF
--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -636,12 +636,12 @@ export interface Withdrawal {
   /** The value contained in withdrawal */
   amount: bigint
 }
-export class EdrContext {
+export declare class EdrContext {
   /**Creates a new [`EdrContext`] instance. Should only be called once! */
   constructor()
 }
 /** A JSON-RPC provider for Ethereum. */
-export class Provider {
+export declare class Provider {
   /**Constructs a new provider with the provided configuration. */
   static withConfig(context: EdrContext, config: ProviderConfig, loggerConfig: LoggerConfig, subscriberCallback: (event: SubscriptionEvent) => void): Promise<Provider>
   /**Handles a JSON-RPC request and returns a JSON-RPC response. */
@@ -655,7 +655,7 @@ export class Provider {
    */
   setVerboseTracing(verboseTracing: boolean): void
 }
-export class Response {
+export declare class Response {
   /** Returns the response data as a JSON string or a JSON object. */
   get data(): string | any
   get solidityTrace(): RawTrace | null
@@ -665,13 +665,13 @@ export class Response {
  * Opaque handle to the `Bytecode` struct.
  * Only used on the JS side by the `VmTraceDecoder` class.
  */
-export class BytecodeWrapper { }
-export class Exit {
+export declare class BytecodeWrapper { }
+export declare class Exit {
   get kind(): ExitCode
   isError(): boolean
   getReason(): string
 }
-export class ReturnData {
+export declare class ReturnData {
   readonly value: Uint8Array
   constructor(value: Uint8Array)
   isEmpty(): boolean
@@ -680,12 +680,12 @@ export class ReturnData {
   decodeError(): string
   decodePanic(): bigint
 }
-export class SolidityTracer {
+export declare class SolidityTracer {
   
   constructor()
   getStackTrace(trace: PrecompileMessageTrace | CallMessageTrace | CreateMessageTrace): SolidityStackTrace
 }
-export class VmTraceDecoder {
+export declare class VmTraceDecoder {
   constructor()
   addBytecode(bytecode: BytecodeWrapper): void
   tryToDecodeMessageTrace(messageTrace: PrecompileMessageTrace | CallMessageTrace | CreateMessageTrace): PrecompileMessageTrace | CallMessageTrace | CreateMessageTrace
@@ -693,13 +693,13 @@ export class VmTraceDecoder {
 }
 export type VMTracer = VmTracer
 /** N-API bindings for the Rust port of `VMTracer` from Hardhat. */
-export class VmTracer {
+export declare class VmTracer {
   constructor()
   /** Observes a trace, collecting information about the execution of the EVM. */
   observe(trace: RawTrace): void
   getLastTopLevelMessageTrace(): PrecompileMessageTrace | CallMessageTrace | CreateMessageTrace | undefined
   getLastError(): Error | undefined
 }
-export class RawTrace {
+export declare class RawTrace {
   trace(): Array<TracingMessage | TracingStep | TracingMessageResult>
 }

--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -346,8 +346,8 @@ export interface SubscriptionEvent {
   filterId: bigint
   result: any
 }
-export function createModelsAndDecodeBytecodes(solcVersion: string, compilerInput: any, compilerOutput: any): Array<BytecodeWrapper>
-export function linkHexStringBytecode(code: string, address: string, position: number): string
+export declare function createModelsAndDecodeBytecodes(solcVersion: string, compilerInput: any, compilerOutput: any): Array<BytecodeWrapper>
+export declare function linkHexStringBytecode(code: string, address: string, position: number): string
 export const enum ContractFunctionType {
   CONSTRUCTOR = 0,
   FUNCTION = 1,
@@ -357,8 +357,8 @@ export const enum ContractFunctionType {
   MODIFIER = 5,
   FREE_FUNCTION = 6
 }
-export function printMessageTrace(trace: PrecompileMessageTrace | CallMessageTrace | CreateMessageTrace, depth?: number | undefined | null): void
-export function printStackTrace(trace: SolidityStackTrace): void
+export declare function printMessageTrace(trace: PrecompileMessageTrace | CallMessageTrace | CreateMessageTrace, depth?: number | undefined | null): void
+export declare function printStackTrace(trace: SolidityStackTrace): void
 /** Represents the exit code of the EVM. */
 export const enum ExitCode {
   /** Execution was successful. */
@@ -450,7 +450,7 @@ export const enum StackTraceEntryType {
   INTERNAL_FUNCTION_CALLSTACK_ENTRY = 22,
   CONTRACT_CALL_RUN_OUT_OF_GAS_ERROR = 23
 }
-export function stackTraceEntryTypeToString(val: StackTraceEntryType): string
+export declare function stackTraceEntryTypeToString(val: StackTraceEntryType): string
 export const FALLBACK_FUNCTION_NAME: string
 export const RECEIVE_FUNCTION_NAME: string
 export const CONSTRUCTOR_FUNCTION_NAME: string
@@ -582,7 +582,7 @@ export interface ContractAndFunctionName {
   contractName: string
   functionName: string | undefined
 }
-export function initializeVmTraceDecoder(vmTraceDecoder: VmTraceDecoder, tracingConfig: any): void
+export declare function initializeVmTraceDecoder(vmTraceDecoder: VmTraceDecoder, tracingConfig: any): void
 export interface TracingMessage {
   /** Sender address */
   readonly caller: Buffer

--- a/crates/edr_napi/package.json
+++ b/crates/edr_napi/package.json
@@ -2,7 +2,7 @@
   "name": "@nomicfoundation/edr",
   "version": "0.6.1",
   "devDependencies": {
-    "@napi-rs/cli": "^2.18.3",
+    "@napi-rs/cli": "^2.18.4",
     "@types/chai": "^4.2.0",
     "@types/chai-as-promised": "^7.1.8",
     "@types/mocha": ">=9.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
   crates/edr_napi:
     devDependencies:
       '@napi-rs/cli':
-        specifier: ^2.18.3
-        version: 2.18.3
+        specifier: ^2.18.4
+        version: 2.18.4
       '@types/chai':
         specifier: ^4.2.0
         version: 4.3.12
@@ -676,8 +676,8 @@ packages:
     resolution: {integrity: sha512-tghyZKLHZjcdlDqCA3gNZmLeR0XvOE9U1qoQO9ohyAZT6Pya+H9vkBPcsyXytmYLNgVoin7CKCmweo/R43V+tQ==}
     engines: {node: '>=12.0.0'}
 
-  '@napi-rs/cli@2.18.3':
-    resolution: {integrity: sha512-L0f4kP0dyG8W5Qtc7MtP73VvLLrOLyRcUEBzknIfu8Jk4Jfhrsx1ItMHgyalYqMSslWdY3ojEfAaU5sx1VyeQQ==}
+  '@napi-rs/cli@2.18.4':
+    resolution: {integrity: sha512-SgJeA4df9DE2iAEpr3M2H0OKl/yjtg1BnRI5/JyowS71tUWhrfSu2LT0V3vlHET+g1hBVlrO60PmEXwUEKp8Mg==}
     engines: {node: '>= 10'}
     hasBin: true
 
@@ -3760,7 +3760,7 @@ snapshots:
       tweetnacl: 1.0.3
       tweetnacl-util: 0.15.1
 
-  '@napi-rs/cli@2.18.3': {}
+  '@napi-rs/cli@2.18.4': {}
 
   '@noble/curves@1.2.0':
     dependencies:


### PR DESCRIPTION
This should make the CI green again and fixes an oversight from #673 (shouldn't merge queue be blocked on that?), where I forgot to re-generate the new index.d.ts file after bumping the napi typings.

Since the change now adds the `declare` to the top-level functions, I figured we can just go all the way and do the same for the classes, which is already done by bumping @napi-rs/cli to 2.18.4 (outstanding; closes #621).

