### PR TITLE
fix: Use correct bytecode in proxy error propagation check

### DIFF
--- a/.changeset/famous-eggs-buy.md
+++ b/.changeset/famous-eggs-buy.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+fix(tracing): Use correct subtrace when detecting error error propagation across delegatecall

--- a/crates/edr_napi/src/trace/error_inferrer.rs
+++ b/crates/edr_napi/src/trace/error_inferrer.rs
@@ -1173,7 +1173,7 @@ impl ErrorInferrer {
                 _ => return Ok(false),
             };
 
-            let inst = subtrace_bytecode.get_instruction(step.pc)?;
+            let inst = bytecode.get_instruction(step.pc)?;
 
             // All the remaining locations should be valid, as they are part of the inline
             // asm


### PR DESCRIPTION
This was a mistake done when porting; the original code is correct: https://github.com/NomicFoundation/hardhat/blob/f93c4478dbe366ecbe13c793e630ec761e98ee6e/packages/hardhat-core/src/internal/hardhat-network/stack-traces/error-inferrer.ts#L1700

I've tried to scan the both ports and couldn't find any more obvious bugs; hopefully I didn't miss anything.

@fvictorio this fixes the latest OpenZeppelin issue that we caught.