### PR TITLE
fix: Only add unmapped instructions at the opcode boundary

### DIFF
--- a/.changeset/dirty-phones-vanish.md
+++ b/.changeset/dirty-phones-vanish.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+fix(tracing): Decode unmapped instructions only at the opcode boundary

--- a/crates/edr_solidity/src/source_map.rs
+++ b/crates/edr_solidity/src/source_map.rs
@@ -209,3 +209,35 @@ pub fn decode_instructions(
 
     instructions
 }
+
+#[cfg(test)]
+mod tests {
+    use edr_evm::interpreter::opcode;
+
+    use super::*;
+
+    #[test]
+    fn unmapped_instruction_opcode_boundary() {
+        let bytecode = &[opcode::PUSH2, 0xde, 0xad, opcode::STOP, opcode::INVALID];
+
+        let mut instructions = vec![Instruction {
+            pc: 0,
+            opcode: OpCode::PUSH2,
+            jump_type: JumpType::NotJump,
+            push_data: Some(vec![0xde, 0xad]),
+            location: None,
+        }];
+
+        // Make sure we start decoding from opcode::STOP rather than from inside
+        // the push data.
+        add_unmapped_instructions(&mut instructions, bytecode);
+
+        assert!(matches!(
+            instructions.last(),
+            Some(Instruction {
+                opcode: OpCode::STOP,
+                ..
+            })
+        ));
+    }
+}


### PR DESCRIPTION
This fixes the adding unmapped instruction logic started from a misaligned opcode, i.e. in the middle of a PUSHx opcode. The bug was present in the original code but it did not verify the opcode for correctness, which is why we're only seeing it now.

@fvictorio this fixes the Chainlink's issue that's been reported lately.