### PR TITLE
chore: use @ignored npm namespace

### DIFF
--- a/.github/workflows/edr-npm-release.yml
+++ b/.github/workflows/edr-npm-release.yml
@@ -420,4 +420,4 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NOMICFOUNDATION_ORG_NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.IGNORED_ORG_NPM_TOKEN }}

--- a/.syncpackrc.js
+++ b/.syncpackrc.js
@@ -12,7 +12,7 @@ const config = {
     },
     {
       packages: ["**"],
-      dependencies: ["@nomicfoundation/edr", "@nomicfoundation/edr-helpers", "hardhat-solidity-tests"],
+      dependencies: ["@ignored/edr", "@nomicfoundation/edr-helpers", "hardhat-solidity-tests"],
       dependencyTypes: ["local"]
     },
   ],

--- a/crates/edr_napi/index.js
+++ b/crates/edr_napi/index.js
@@ -37,7 +37,7 @@ switch (platform) {
           if (localFileExisted) {
             nativeBinding = require('./edr.android-arm64.node')
           } else {
-            nativeBinding = require('@nomicfoundation/edr-android-arm64')
+            nativeBinding = require('@ignored/edr-android-arm64')
           }
         } catch (e) {
           loadError = e
@@ -49,7 +49,7 @@ switch (platform) {
           if (localFileExisted) {
             nativeBinding = require('./edr.android-arm-eabi.node')
           } else {
-            nativeBinding = require('@nomicfoundation/edr-android-arm-eabi')
+            nativeBinding = require('@ignored/edr-android-arm-eabi')
           }
         } catch (e) {
           loadError = e
@@ -69,7 +69,7 @@ switch (platform) {
           if (localFileExisted) {
             nativeBinding = require('./edr.win32-x64-msvc.node')
           } else {
-            nativeBinding = require('@nomicfoundation/edr-win32-x64-msvc')
+            nativeBinding = require('@ignored/edr-win32-x64-msvc')
           }
         } catch (e) {
           loadError = e
@@ -83,7 +83,7 @@ switch (platform) {
           if (localFileExisted) {
             nativeBinding = require('./edr.win32-ia32-msvc.node')
           } else {
-            nativeBinding = require('@nomicfoundation/edr-win32-ia32-msvc')
+            nativeBinding = require('@ignored/edr-win32-ia32-msvc')
           }
         } catch (e) {
           loadError = e
@@ -97,7 +97,7 @@ switch (platform) {
           if (localFileExisted) {
             nativeBinding = require('./edr.win32-arm64-msvc.node')
           } else {
-            nativeBinding = require('@nomicfoundation/edr-win32-arm64-msvc')
+            nativeBinding = require('@ignored/edr-win32-arm64-msvc')
           }
         } catch (e) {
           loadError = e
@@ -113,7 +113,7 @@ switch (platform) {
       if (localFileExisted) {
         nativeBinding = require('./edr.darwin-universal.node')
       } else {
-        nativeBinding = require('@nomicfoundation/edr-darwin-universal')
+        nativeBinding = require('@ignored/edr-darwin-universal')
       }
       break
     } catch {}
@@ -124,7 +124,7 @@ switch (platform) {
           if (localFileExisted) {
             nativeBinding = require('./edr.darwin-x64.node')
           } else {
-            nativeBinding = require('@nomicfoundation/edr-darwin-x64')
+            nativeBinding = require('@ignored/edr-darwin-x64')
           }
         } catch (e) {
           loadError = e
@@ -138,7 +138,7 @@ switch (platform) {
           if (localFileExisted) {
             nativeBinding = require('./edr.darwin-arm64.node')
           } else {
-            nativeBinding = require('@nomicfoundation/edr-darwin-arm64')
+            nativeBinding = require('@ignored/edr-darwin-arm64')
           }
         } catch (e) {
           loadError = e
@@ -157,7 +157,7 @@ switch (platform) {
       if (localFileExisted) {
         nativeBinding = require('./edr.freebsd-x64.node')
       } else {
-        nativeBinding = require('@nomicfoundation/edr-freebsd-x64')
+        nativeBinding = require('@ignored/edr-freebsd-x64')
       }
     } catch (e) {
       loadError = e
@@ -174,7 +174,7 @@ switch (platform) {
             if (localFileExisted) {
               nativeBinding = require('./edr.linux-x64-musl.node')
             } else {
-              nativeBinding = require('@nomicfoundation/edr-linux-x64-musl')
+              nativeBinding = require('@ignored/edr-linux-x64-musl')
             }
           } catch (e) {
             loadError = e
@@ -187,7 +187,7 @@ switch (platform) {
             if (localFileExisted) {
               nativeBinding = require('./edr.linux-x64-gnu.node')
             } else {
-              nativeBinding = require('@nomicfoundation/edr-linux-x64-gnu')
+              nativeBinding = require('@ignored/edr-linux-x64-gnu')
             }
           } catch (e) {
             loadError = e
@@ -203,7 +203,7 @@ switch (platform) {
             if (localFileExisted) {
               nativeBinding = require('./edr.linux-arm64-musl.node')
             } else {
-              nativeBinding = require('@nomicfoundation/edr-linux-arm64-musl')
+              nativeBinding = require('@ignored/edr-linux-arm64-musl')
             }
           } catch (e) {
             loadError = e
@@ -216,7 +216,7 @@ switch (platform) {
             if (localFileExisted) {
               nativeBinding = require('./edr.linux-arm64-gnu.node')
             } else {
-              nativeBinding = require('@nomicfoundation/edr-linux-arm64-gnu')
+              nativeBinding = require('@ignored/edr-linux-arm64-gnu')
             }
           } catch (e) {
             loadError = e
@@ -232,7 +232,7 @@ switch (platform) {
             if (localFileExisted) {
               nativeBinding = require('./edr.linux-arm-musleabihf.node')
             } else {
-              nativeBinding = require('@nomicfoundation/edr-linux-arm-musleabihf')
+              nativeBinding = require('@ignored/edr-linux-arm-musleabihf')
             }
           } catch (e) {
             loadError = e
@@ -245,7 +245,7 @@ switch (platform) {
             if (localFileExisted) {
               nativeBinding = require('./edr.linux-arm-gnueabihf.node')
             } else {
-              nativeBinding = require('@nomicfoundation/edr-linux-arm-gnueabihf')
+              nativeBinding = require('@ignored/edr-linux-arm-gnueabihf')
             }
           } catch (e) {
             loadError = e
@@ -261,7 +261,7 @@ switch (platform) {
             if (localFileExisted) {
               nativeBinding = require('./edr.linux-riscv64-musl.node')
             } else {
-              nativeBinding = require('@nomicfoundation/edr-linux-riscv64-musl')
+              nativeBinding = require('@ignored/edr-linux-riscv64-musl')
             }
           } catch (e) {
             loadError = e
@@ -274,7 +274,7 @@ switch (platform) {
             if (localFileExisted) {
               nativeBinding = require('./edr.linux-riscv64-gnu.node')
             } else {
-              nativeBinding = require('@nomicfoundation/edr-linux-riscv64-gnu')
+              nativeBinding = require('@ignored/edr-linux-riscv64-gnu')
             }
           } catch (e) {
             loadError = e
@@ -289,7 +289,7 @@ switch (platform) {
           if (localFileExisted) {
             nativeBinding = require('./edr.linux-s390x-gnu.node')
           } else {
-            nativeBinding = require('@nomicfoundation/edr-linux-s390x-gnu')
+            nativeBinding = require('@ignored/edr-linux-s390x-gnu')
           }
         } catch (e) {
           loadError = e

--- a/crates/edr_napi/npm/darwin-arm64/package.json
+++ b/crates/edr_napi/npm/darwin-arm64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nomicfoundation/edr-darwin-arm64",
+  "name": "@ignored/edr-darwin-arm64",
   "repository": {
     "url": "https://github.com/NomicFoundation/edr.git",
     "type": "git"

--- a/crates/edr_napi/npm/darwin-x64/package.json
+++ b/crates/edr_napi/npm/darwin-x64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nomicfoundation/edr-darwin-x64",
+  "name": "@ignored/edr-darwin-x64",
   "repository": {
     "url": "https://github.com/NomicFoundation/edr.git",
     "type": "git"

--- a/crates/edr_napi/npm/linux-arm64-gnu/package.json
+++ b/crates/edr_napi/npm/linux-arm64-gnu/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nomicfoundation/edr-linux-arm64-gnu",
+  "name": "@ignored/edr-linux-arm64-gnu",
   "repository": {
     "url": "https://github.com/NomicFoundation/edr.git",
     "type": "git"

--- a/crates/edr_napi/npm/linux-arm64-musl/package.json
+++ b/crates/edr_napi/npm/linux-arm64-musl/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nomicfoundation/edr-linux-arm64-musl",
+  "name": "@ignored/edr-linux-arm64-musl",
   "repository": {
     "url": "https://github.com/NomicFoundation/edr.git",
     "type": "git"

--- a/crates/edr_napi/npm/linux-x64-gnu/package.json
+++ b/crates/edr_napi/npm/linux-x64-gnu/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nomicfoundation/edr-linux-x64-gnu",
+  "name": "@ignored/edr-linux-x64-gnu",
   "repository": {
     "url": "https://github.com/NomicFoundation/edr.git",
     "type": "git"

--- a/crates/edr_napi/npm/linux-x64-musl/package.json
+++ b/crates/edr_napi/npm/linux-x64-musl/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nomicfoundation/edr-linux-x64-musl",
+  "name": "@ignored/edr-linux-x64-musl",
   "repository": {
     "url": "https://github.com/NomicFoundation/edr.git",
     "type": "git"

--- a/crates/edr_napi/npm/win32-x64-msvc/package.json
+++ b/crates/edr_napi/npm/win32-x64-msvc/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nomicfoundation/edr-win32-x64-msvc",
+  "name": "@ignored/edr-win32-x64-msvc",
   "repository": {
     "url": "https://github.com/NomicFoundation/edr.git",
     "type": "git"

--- a/crates/edr_napi/package.json
+++ b/crates/edr_napi/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nomicfoundation/edr",
+  "name": "@ignored/edr",
   "version": "0.6.1",
   "devDependencies": {
     "@napi-rs/cli": "^2.18.4",

--- a/crates/edr_napi/scripts/prepublish.sh
+++ b/crates/edr_napi/scripts/prepublish.sh
@@ -5,5 +5,6 @@ set -o pipefail
 
 pnpm napi prepublish -t npm --skip-gh-release
 
+# temporarily commented to be able to publish in the @ignored org locally with verdaccio
 # rename optionalDependencies key to dependencies
-jq 'with_entries(if .key == "optionalDependencies" then .key = "dependencies" else . end)' package.json | sponge package.json
+# jq 'with_entries(if .key == "optionalDependencies" then .key = "dependencies" else . end)' package.json | sponge package.json

--- a/crates/tools/js/benchmark/package.json
+++ b/crates/tools/js/benchmark/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "author": "",
   "devDependencies": {
-    "@nomicfoundation/edr": "workspace:*",
+    "@ignored/edr": "workspace:*",
     "@nomicfoundation/edr-helpers": "workspace:*",
     "@types/argparse": "^2.0.16",
     "@types/chai": "^4.2.0",

--- a/crates/tools/js/benchmark/test/test-local-edr.ts
+++ b/crates/tools/js/benchmark/test/test-local-edr.ts
@@ -7,7 +7,7 @@ import path from "path";
 it("uses the workspace version of EDR", async function () {
   const hardhatPath = require.resolve("hardhat");
 
-  const edrPath = require.resolve("@nomicfoundation/edr", {
+  const edrPath = require.resolve("@ignored/edr", {
     paths: [hardhatPath],
   });
 

--- a/hardhat-tests/package.json
+++ b/hardhat-tests/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "author": "Nomic Foundation",
   "devDependencies": {
+    "@ignored/edr": "workspace:*",
     "@metamask/eth-sig-util": "^4.0.0",
-    "@nomicfoundation/edr": "workspace:*",
     "@nomicfoundation/ethereumjs-block": "5.0.4",
     "@nomicfoundation/ethereumjs-common": "^4.0.4",
     "@nomicfoundation/ethereumjs-tx": "^5.0.4",

--- a/hardhat-tests/test/edr-override.ts
+++ b/hardhat-tests/test/edr-override.ts
@@ -7,7 +7,7 @@ import path from "path";
 it("uses the workspace version of EDR", async function () {
   const hardhatPath = require.resolve("hardhat");
 
-  const edrPath = require.resolve("@nomicfoundation/edr", {
+  const edrPath = require.resolve("@ignored/edr", {
     paths: [hardhatPath],
   });
 

--- a/js/helpers/package.json
+++ b/js/helpers/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "author": "",
   "dependencies": {
-    "@nomicfoundation/edr": "workspace:*"
+    "@ignored/edr": "workspace:*"
   },
   "devDependencies": {
     "@tsconfig/node20": "^20.1.4",

--- a/js/helpers/src/index.ts
+++ b/js/helpers/src/index.ts
@@ -7,7 +7,7 @@ import {
   Artifact,
   SolidityTestRunnerConfigArgs,
   TestResult,
-} from "@nomicfoundation/edr";
+} from "@ignored/edr";
 
 /**
  * Run all the given solidity tests and returns the whole results after finishing.

--- a/js/integration-tests/solidity-tests/package.json
+++ b/js/integration-tests/solidity-tests/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "author": "",
   "devDependencies": {
-    "@nomicfoundation/edr": "workspace:*",
+    "@ignored/edr": "workspace:*",
     "@nomicfoundation/edr-helpers": "workspace:*",
     "@tsconfig/node20": "^20.1.4",
     "@types/chai": "^4.2.0",

--- a/js/integration-tests/solidity-tests/test/fuzz.ts
+++ b/js/integration-tests/solidity-tests/test/fuzz.ts
@@ -2,7 +2,7 @@ import chai, { assert, expect } from "chai";
 import { TestContext } from "./testContext";
 import fs from "node:fs/promises";
 import { existsSync } from "node:fs";
-import { FuzzTestKind } from "@nomicfoundation/edr";
+import { FuzzTestKind } from "@ignored/edr";
 import { runAllSolidityTests } from "@nomicfoundation/edr-helpers";
 
 describe("Fuzz and invariant testing", function () {

--- a/js/integration-tests/solidity-tests/test/testContext.ts
+++ b/js/integration-tests/solidity-tests/test/testContext.ts
@@ -4,7 +4,7 @@ import {
   FuzzConfigArgs,
   InvariantConfigArgs,
   type SolidityTestRunnerConfigArgs,
-} from "@nomicfoundation/edr";
+} from "@ignored/edr";
 import {
   buildSolidityTestsInput,
   runAllSolidityTests,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "license": "SEE LICENSE IN EACH PACKAGE'S LICENSE FILE",
   "pnpm": {
     "overrides": {
-      "hardhat>@nomicfoundation/edr": "workspace:*"
+      "hardhat>@ignored/edr": "workspace:*"
     }
   },
   "private": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  hardhat>@nomicfoundation/edr: workspace:*
+  hardhat>@ignored/edr: workspace:*
 
 importers:
 
@@ -83,7 +83,7 @@ importers:
 
   crates/tools/js/benchmark:
     devDependencies:
-      '@nomicfoundation/edr':
+      '@ignored/edr':
         specifier: workspace:*
         version: link:../../../edr_napi
       '@nomicfoundation/edr-helpers':
@@ -207,12 +207,12 @@ importers:
 
   hardhat-tests:
     devDependencies:
+      '@ignored/edr':
+        specifier: workspace:*
+        version: link:../crates/edr_napi
       '@metamask/eth-sig-util':
         specifier: ^4.0.0
         version: 4.0.1
-      '@nomicfoundation/edr':
-        specifier: workspace:*
-        version: link:../crates/edr_napi
       '@nomicfoundation/ethereumjs-block':
         specifier: 5.0.4
         version: 5.0.4
@@ -369,7 +369,7 @@ importers:
 
   js/helpers:
     dependencies:
-      '@nomicfoundation/edr':
+      '@ignored/edr':
         specifier: workspace:*
         version: link:../../crates/edr_napi
     devDependencies:
@@ -412,7 +412,7 @@ importers:
 
   js/integration-tests/solidity-tests:
     devDependencies:
-      '@nomicfoundation/edr':
+      '@ignored/edr':
         specifier: workspace:*
         version: link:../../../crates/edr_napi
       '@nomicfoundation/edr-helpers':
@@ -860,6 +860,38 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@nomicfoundation/edr-darwin-arm64@0.5.2':
+    resolution: {integrity: sha512-Gm4wOPKhbDjGTIRyFA2QUAPfCXA1AHxYOKt3yLSGJkQkdy9a5WW+qtqKeEKHc/+4wpJSLtsGQfpzyIzggFfo/A==}
+    engines: {node: '>= 18'}
+
+  '@nomicfoundation/edr-darwin-x64@0.5.2':
+    resolution: {integrity: sha512-ClyABq2dFCsrYEED3/UIO0c7p4H1/4vvlswFlqUyBpOkJccr75qIYvahOSJRM62WgUFRhbSS0OJXFRwc/PwmVg==}
+    engines: {node: '>= 18'}
+
+  '@nomicfoundation/edr-linux-arm64-gnu@0.5.2':
+    resolution: {integrity: sha512-HWMTVk1iOabfvU2RvrKLDgtFjJZTC42CpHiw2h6rfpsgRqMahvIlx2jdjWYzFNy1jZKPTN1AStQ/91MRrg5KnA==}
+    engines: {node: '>= 18'}
+
+  '@nomicfoundation/edr-linux-arm64-musl@0.5.2':
+    resolution: {integrity: sha512-CwsQ10xFx/QAD5y3/g5alm9+jFVuhc7uYMhrZAu9UVF+KtVjeCvafj0PaVsZ8qyijjqVuVsJ8hD1x5ob7SMcGg==}
+    engines: {node: '>= 18'}
+
+  '@nomicfoundation/edr-linux-x64-gnu@0.5.2':
+    resolution: {integrity: sha512-CWVCEdhWJ3fmUpzWHCRnC0/VLBDbqtqTGTR6yyY1Ep3S3BOrHEAvt7h5gx85r2vLcztisu2vlDq51auie4IU1A==}
+    engines: {node: '>= 18'}
+
+  '@nomicfoundation/edr-linux-x64-musl@0.5.2':
+    resolution: {integrity: sha512-+aJDfwhkddy2pP5u1ISg3IZVAm0dO836tRlDTFWtvvSMQ5hRGqPcWwlsbobhDQsIxhPJyT7phL0orCg5W3WMeA==}
+    engines: {node: '>= 18'}
+
+  '@nomicfoundation/edr-win32-x64-msvc@0.5.2':
+    resolution: {integrity: sha512-CcvvuA3sAv7liFNPsIR/68YlH6rrybKzYttLlMr80d4GKJjwJ5OKb3YgE6FdZZnOfP19HEHhsLcE0DPLtY3r0w==}
+    engines: {node: '>= 18'}
+
+  '@nomicfoundation/edr@0.5.2':
+    resolution: {integrity: sha512-hW/iLvUQZNTVjFyX/I40rtKvvDOqUEyIi96T28YaLfmPL+3LW2lxmYLUXEJ6MI14HzqxDqrLyhf6IbjAa2r3Dw==}
+    engines: {node: '>= 18'}
 
   '@nomicfoundation/ethereumjs-block@5.0.4':
     resolution: {integrity: sha512-AcyacJ9eX/uPEvqsPiB+WO1ymE+kyH48qGGiGV+YTojdtas8itUTW5dehDSOXEEItWGbbzEJ4PRqnQZlWaPvDw==}
@@ -3962,6 +3994,30 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
 
+  '@nomicfoundation/edr-darwin-arm64@0.5.2': {}
+
+  '@nomicfoundation/edr-darwin-x64@0.5.2': {}
+
+  '@nomicfoundation/edr-linux-arm64-gnu@0.5.2': {}
+
+  '@nomicfoundation/edr-linux-arm64-musl@0.5.2': {}
+
+  '@nomicfoundation/edr-linux-x64-gnu@0.5.2': {}
+
+  '@nomicfoundation/edr-linux-x64-musl@0.5.2': {}
+
+  '@nomicfoundation/edr-win32-x64-msvc@0.5.2': {}
+
+  '@nomicfoundation/edr@0.5.2':
+    dependencies:
+      '@nomicfoundation/edr-darwin-arm64': 0.5.2
+      '@nomicfoundation/edr-darwin-x64': 0.5.2
+      '@nomicfoundation/edr-linux-arm64-gnu': 0.5.2
+      '@nomicfoundation/edr-linux-arm64-musl': 0.5.2
+      '@nomicfoundation/edr-linux-x64-gnu': 0.5.2
+      '@nomicfoundation/edr-linux-x64-musl': 0.5.2
+      '@nomicfoundation/edr-win32-x64-msvc': 0.5.2
+
   '@nomicfoundation/ethereumjs-block@5.0.4':
     dependencies:
       '@nomicfoundation/ethereumjs-common': 4.0.4
@@ -5382,7 +5438,7 @@ snapshots:
     dependencies:
       '@ethersproject/abi': 5.7.0
       '@metamask/eth-sig-util': 4.0.1
-      '@nomicfoundation/edr': link:crates/edr_napi
+      '@nomicfoundation/edr': 0.5.2
       '@nomicfoundation/ethereumjs-common': 4.0.4
       '@nomicfoundation/ethereumjs-tx': 5.0.4
       '@nomicfoundation/ethereumjs-util': 9.0.4


### PR DESCRIPTION
This PR mainly replaces `@nomicfoundation/edr` with `@ignored/edr` wherever it makes sense. Besides that:

- It uses the `IGNORED_ORG_NPM_TOKEN` secret for the release workflow.
- It uses optional dependencies to publish, like we used to do. This simplifies things locally, at least until we actually make a release in npm. Notice that the comment that explains this mentions `@ignored`; my hope here is that we'll remember to do this when we grep `@ignored` to remove all occurrences in the project.