### PR TITLE
ci: solidity test benchmarks

### DIFF
--- a/.github/workflows/edr-benchmark-feat-solidity-tests.yml
+++ b/.github/workflows/edr-benchmark-feat-solidity-tests.yml
@@ -29,13 +29,13 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-node
       - uses: ./.github/actions/setup-rust
-        
+
       - name: Install packages
         run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Run benchmark tests
         run: pnpm test
-  
+
   js-scenario-benchmark:
     name: Run JS scenario runner benchmark for Hardhat Node style workload
     environment: github-action-benchmark
@@ -61,7 +61,7 @@ jobs:
 
       - name: Install packages
         run: pnpm install --frozen-lockfile --prefer-offline
-        
+
       - name: Run benchmark
         run: pnpm run benchmark
 

--- a/.github/workflows/edr-benchmark-feat-solidity-tests.yml
+++ b/.github/workflows/edr-benchmark-feat-solidity-tests.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: ./.github/actions/setup-rust
 
       - name: Rust cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry/index/
@@ -55,7 +55,9 @@ jobs:
             ~/.cargo/git/db/
             .cargo-cache
             target/
-          key: benchmark-rs-cache-v1
+          save-always: true
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
 
       - name: Install packages
         run: pnpm install --frozen-lockfile --prefer-offline

--- a/.github/workflows/edr-benchmark-feat-solidity-tests.yml
+++ b/.github/workflows/edr-benchmark-feat-solidity-tests.yml
@@ -24,7 +24,7 @@ jobs:
     environment: github-action-benchmark
     runs-on: self-hosted
     # Only run for trusted collaborators since third-parties could run malicious code on the self-hosted benchmark runner.
-    if: github.ref == 'refs/heads/main' || github.repository == github.event.pull_request.head.repo.full_name
+    if: github.ref == 'refs/heads/feat/solidity-tests' || github.repository == github.event.pull_request.head.repo.full_name
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-node

--- a/.github/workflows/edr-benchmark-feat-solidity-tests.yml
+++ b/.github/workflows/edr-benchmark-feat-solidity-tests.yml
@@ -1,4 +1,4 @@
-name: EDR Benchmark for feat/solidity-tests
+name: EDR Benchmarks for feat/solidity-tests
 
 on:
   push:
@@ -19,36 +19,47 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/feat/solidity-tests' }}
 
 jobs:
-  js-benchmark:
-    name: Run JS scenario runner benchmark
+  benchmarks-test:
+    name: Benchmarks test
     environment: github-action-benchmark
     runs-on: self-hosted
     # Only run for trusted collaborators since third-parties could run malicious code on the self-hosted benchmark runner.
-    if: github.ref == 'refs/heads/feat/solidity-tests' || (github.event.pull_request.author_association == 'OWNER' || github.event.pull_request.author_association == 'MEMBER' || github.event.pull_request.author_association == 'COLLABORATOR')
+    if: github.ref == 'refs/heads/main' || github.repository == github.event.pull_request.head.repo.full_name
     steps:
       - uses: actions/checkout@v3
-
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9
-      - name: Install Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 20
-          cache: pnpm
-
-      - name: Install Rust (stable)
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          override: true
-
-      - name: Install package
+      - uses: ./.github/actions/setup-node
+      - uses: ./.github/actions/setup-rust
+        
+      - name: Install packages
         run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Run benchmark tests
         run: pnpm test
+  
+  js-scenario-benchmark:
+    name: Run JS scenario runner benchmark for Hardhat Node style workload
+    environment: github-action-benchmark
+    runs-on: self-hosted
+    needs: benchmarks-test
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup-node
+      - uses: ./.github/actions/setup-rust
 
+      - name: Rust cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            .cargo-cache
+            target/
+          key: benchmark-rs-cache-v1
+
+      - name: Install packages
+        run: pnpm install --frozen-lockfile --prefer-offline
+        
       - name: Run benchmark
         run: pnpm run benchmark
 
@@ -56,13 +67,13 @@ jobs:
         run: pnpm run verify
 
       - name: Generate report for github-action-benchmark
-        run: pnpm run --silent report | tee report.json
+        run: pnpm run --silent report | tee scenario-report.json
 
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:
           tool: customSmallerIsBetter
-          output-file-path: crates/tools/js/benchmark/report.json
+          output-file-path: crates/tools/js/benchmark/scenario-report.json
           gh-repository: github.com/nomic-foundation-automation/edr-benchmark-results
           gh-pages-branch: feat/solidity-tests
           benchmark-data-dir-path: bench

--- a/.github/workflows/edr-benchmark.yml
+++ b/.github/workflows/edr-benchmark.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: ./.github/actions/setup-rust
         
       - name: Rust cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry/index/
@@ -59,7 +59,9 @@ jobs:
             ~/.cargo/git/db/
             .cargo-cache
             target/
-          key: benchmark-rs-cache-v1
+          save-always: true
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
 
       - name: Install packages
         run: pnpm install --frozen-lockfile --prefer-offline
@@ -102,14 +104,14 @@ jobs:
       - uses: ./.github/actions/setup-rust
 
       - name: Cache EDR RPC cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             **/edr-cache
           key: edr-rs-rpc-cache-v1
 
       - name: Rust cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry/index/
@@ -117,7 +119,9 @@ jobs:
             ~/.cargo/git/db/
             .cargo-cache
             target/
-          key: benchmark-rs-cache-v1
+          save-always: true
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
       
       - name: Install packages
         run: pnpm install --frozen-lockfile --prefer-offline

--- a/.github/workflows/edr-benchmark.yml
+++ b/.github/workflows/edr-benchmark.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Run benchmark tests
         run: pnpm test
-  
+
   js-scenario-benchmark:
     name: Run JS scenario runner benchmark for Hardhat Node style workload
     environment: github-action-benchmark
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-node
       - uses: ./.github/actions/setup-rust
-        
+
       - name: Rust cache
         uses: actions/cache@v4
         with:
@@ -65,7 +65,7 @@ jobs:
 
       - name: Install packages
         run: pnpm install --frozen-lockfile --prefer-offline
-      
+
       - name: Run benchmark
         run: pnpm run benchmark
 
@@ -92,7 +92,7 @@ jobs:
           # Enable Job Summary for PRs
           summary-always: true
           max-items-in-chart: 1000
-  
+
   js-soltests-benchmark:
     name: Run JS Solidity test runner benchmark
     environment: github-action-benchmark
@@ -122,7 +122,7 @@ jobs:
           save-always: true
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
-      
+
       - name: Install packages
         run: pnpm install --frozen-lockfile --prefer-offline
 

--- a/.github/workflows/edr-benchmark.yml
+++ b/.github/workflows/edr-benchmark.yml
@@ -1,9 +1,11 @@
-name: EDR Benchmark
+name: EDR Benchmarks
 
 on:
   push:
     branches:
-      - main
+      # TODO: change to `main` when we merging to main
+      # https://github.com/NomicFoundation/edr/issues/685
+      - "feat/solidity-tests"
   pull_request:
     branches:
       - "**"
@@ -16,11 +18,13 @@ defaults:
 concurrency:
   group: ${{github.workflow}}-${{github.ref}}
   # Don't cancel in progress jobs in main
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  # TODO: change to `main` when we merging to main
+  # https://github.com/NomicFoundation/edr/issues/685
+  cancel-in-progress: ${{ github.ref != 'refs/heads/feat/solidity-tests' }}
 
 jobs:
-  js-benchmark:
-    name: Run JS scenario runner benchmark
+  benchmarks-test:
+    name: Benchmarks test
     environment: github-action-benchmark
     runs-on: self-hosted
     # Only run for trusted collaborators since third-parties could run malicious code on the self-hosted benchmark runner.
@@ -30,12 +34,36 @@ jobs:
       - uses: ./.github/actions/setup-node
       - uses: ./.github/actions/setup-rust
 
-      - name: Install package
+      - name: Install packages
         run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Run benchmark tests
         run: pnpm test
+  
+  js-scenario-benchmark:
+    name: Run JS scenario runner benchmark for Hardhat Node style workload
+    environment: github-action-benchmark
+    runs-on: self-hosted
+    needs: benchmarks-test
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup-node
+      - uses: ./.github/actions/setup-rust
+        
+      - name: Rust cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            .cargo-cache
+            target/
+          key: benchmark-rs-cache-v1
 
+      - name: Install packages
+        run: pnpm install --frozen-lockfile --prefer-offline
+      
       - name: Run benchmark
         run: pnpm run benchmark
 
@@ -43,19 +71,73 @@ jobs:
         run: pnpm run verify
 
       - name: Generate report for github-action-benchmark
-        run: pnpm run --silent report | tee report.json
+        run: pnpm run --silent report | tee scenario-report.json
 
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:
           tool: customSmallerIsBetter
-          output-file-path: crates/tools/js/benchmark/report.json
+          output-file-path: crates/tools/js/benchmark/scenario-report.json
           gh-repository: github.com/nomic-foundation-automation/edr-benchmark-results
           gh-pages-branch: main
           benchmark-data-dir-path: bench
           github-token: ${{ secrets.BENCHMARK_GITHUB_TOKEN }}
           # Only save the data for main branch pushes. For PRs we only compare
           auto-push: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' }}
+          alert-threshold: "110%"
+          # Only fail on pull requests, don't break CI in main
+          fail-on-alert: ${{ github.event_name == 'pull_request' }}
+          # Enable Job Summary for PRs
+          summary-always: true
+          max-items-in-chart: 1000
+  
+  js-soltests-benchmark:
+    name: Run JS Solidity test runner benchmark
+    environment: github-action-benchmark
+    runs-on: self-hosted
+    needs: benchmarks-test
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup-node
+      - uses: ./.github/actions/setup-rust
+
+      - name: Cache EDR RPC cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            **/edr-cache
+          key: edr-rs-rpc-cache-v1
+
+      - name: Rust cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            .cargo-cache
+            target/
+          key: benchmark-rs-cache-v1
+      
+      - name: Install packages
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Run benchmark and generate report for github-action-benchmark
+        run: pnpm run --silent soltests | tee soltest-report.json
+
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          tool: customSmallerIsBetter
+          output-file-path: crates/tools/js/benchmark/soltest-report.json
+          gh-repository: github.com/nomic-foundation-automation/edr-benchmark-results
+          gh-pages-branch: main
+          benchmark-data-dir-path: soltests
+          github-token: ${{ secrets.BENCHMARK_GITHUB_TOKEN }}
+          # Only save the data for main branch pushes. For PRs we only compare
+          # TODO: change to `main` when we merging to main
+          # https://github.com/NomicFoundation/edr/issues/685
+          auto-push: ${{ github.ref == 'refs/heads/feat/solidity-tests' && github.event_name != 'pull_request' }}
           alert-threshold: "110%"
           # Only fail on pull requests, don't break CI in main
           fail-on-alert: ${{ github.event_name == 'pull_request' }}

--- a/crates/tools/js/benchmark/src/solidity-tests.ts
+++ b/crates/tools/js/benchmark/src/solidity-tests.ts
@@ -117,12 +117,12 @@ export async function runForgeStdTests(forgeStdRepoPath: string) {
     allResults.push(results);
   }
 
-  const results = getResults(runs);
+  const measurements = getMeasurements(runs);
 
   // Log info to stderr so that it doesn't pollute stdout where we write the results
-  console.error("median total elapsed (s)", displaySec(results[0].value));
+  console.error("median total elapsed (s)", displaySec(measurements[0].value));
 
-  console.log(JSON.stringify(results));
+  console.log(JSON.stringify(measurements));
 }
 
 function getConfig(forgeStdRepoPath: string): SolidityTestRunnerConfigArgs {
@@ -146,8 +146,8 @@ function getConfig(forgeStdRepoPath: string): SolidityTestRunnerConfigArgs {
   };
 }
 
-function getResults(runs: Map<string, number[]>) {
-  const results: { name: string; unit: string; value: number }[] = [];
+function getMeasurements(runs: Map<string, number[]>) {
+  const results: Array<{ name: string; unit: string; value: number }> = [];
 
   const total = runs.get(TOTAL_NAME)!;
   results.push({ name: TOTAL_NAME, unit: "ms", value: medianMs(total) });

--- a/crates/tools/js/benchmark/src/solidity-tests.ts
+++ b/crates/tools/js/benchmark/src/solidity-tests.ts
@@ -1,24 +1,26 @@
 // Baseline
 // foundryup --commit 0a5b22f07
-// forge test --no-match-contract 'StdChainsTest|StdCheatsTest|MockERC721Test|MockERC20Test|StdCheatsForkTest|StdJsonTest|StdUtilsForkTest|StdTomlTest'
+// forge test --no-match-test "test_ChainBubbleUp()|test_DeriveRememberKey()"
 
 import fs from "fs";
 import { execSync } from "child_process";
 import path from "path";
 import simpleGit from "simple-git";
 import { runAllSolidityTests } from "@nomicfoundation/edr-helpers";
+import {
+  SolidityTestRunnerConfigArgs,
+  FsAccessPermission,
+} from "@nomicfoundation/edr";
 
-const EXCLUDED_TEST_SUITES = new Set([
-  "StdChainsTest",
-  "StdCheatsTest",
-  "MockERC721Test",
-  "MockERC20Test",
-  "StdCheatsForkTest",
-  "StdJsonTest",
-  "StdUtilsForkTest",
-  "StdTomlTest",
+const EXPECTED_RESULTS = 15;
+
+// Hack: since EDR currently doesn't support filtering certain tests in test suites, we run them, but ignore their failures.
+const EXCLUDED_TESTS = new Set([
+  // This relies on environment variable interpolation in the `rpcEndpoints` config which is not supported by EDR.
+  "test_ChainBubbleUp()",
+  // This relies on the `deriveKey` and `rememberKey` cheatcodes which are not supported by EDR.
+  "test_DeriveRememberKey()",
 ]);
-const EXPECTED_RESULTS = 7;
 
 const REPO_DIR = "forge-std";
 const REPO_URL = "https://github.com/NomicFoundation/forge-std.git";
@@ -53,29 +55,53 @@ export async function runForgeStdTests(forgeStdRepoPath: string) {
     path.join(forgeStdRepoPath, "hardhat.config.js")
   );
 
-  const artifacts = listFilesRecursively(artifactsDir)
+  let artifacts = listFilesRecursively(artifactsDir)
     .filter((p) => !p.endsWith(".dbg.json") && !p.includes("build-info"))
-    .map((artifactPath) => loadArtifact(hardhatConfig, artifactPath));
+    .map((artifactPath) => loadArtifact(hardhatConfig, artifactPath))
+    .filter((a) => a !== undefined);
 
   const testSuiteIds = artifacts
     .filter(
       (a) =>
-        a.id.source.includes(".t.sol") && !EXCLUDED_TEST_SUITES.has(a.id.name)
+        a.contract !== undefined &&
+        a.contract.abi !== undefined &&
+        a.contract.abi.some(
+          (item: { type: string; name: string }) =>
+            item.type === "function" && item.name.startsWith("test")
+        )
     )
     .map((a) => a.id);
 
-  const configs = {
+  artifacts = artifacts.map((a) => {
+    a.contract.abi = JSON.stringify(a.contract.abi);
+    return a;
+  });
+
+  const configs: SolidityTestRunnerConfigArgs = {
     projectRoot: forgeStdRepoPath,
+    // TODO cache this in CI
+    rpcCachePath: "./forge-std-rpc-cache",
+    fsPermissions: [
+      { path: forgeStdRepoPath, access: FsAccessPermission.ReadWrite },
+    ],
+    testFail: true,
+    rpcEndpoints: {
+      // These are hardcoded in the `forge-std` foundry.toml
+      mainnet:
+        "https://eth-mainnet.alchemyapi.io/v2/WV407BEiBmjNJfKo9Uo_55u0z0ITyCOX",
+      optimism_sepolia: "https://sepolia.optimism.io/",
+      arbitrum_one_sepolia: "https://sepolia-rollup.arbitrum.io/rpc/",
+    },
     fuzz: {
-      failurePersistDir: path.join(forgeStdRepoPath, "failures"),
+      seed: "0x1234567890123456789012345678901234567890",
     },
   };
+
   const results = await runAllSolidityTests(artifacts, testSuiteIds, configs);
 
   console.error("elapsed (s)", computeElapsedSec(start));
 
   if (results.length !== EXPECTED_RESULTS) {
-    console.log(results.map((r: any) => r.name));
     throw new Error(
       `Expected ${EXPECTED_RESULTS} results, got ${results.length}`
     );
@@ -84,8 +110,8 @@ export async function runForgeStdTests(forgeStdRepoPath: string) {
   const failed = new Set();
   for (const res of results) {
     for (const r of res.testResults) {
-      if (r.status !== "Success") {
-        failed.add(`${res.id.name} ${r.name} ${r.status}`);
+      if (r.status !== "Success" && !EXCLUDED_TESTS.has(r.name)) {
+        failed.add(`${res.id.name} ${r.name} ${r.status} reason:\n${r.reason}`);
       }
     }
   }
@@ -117,7 +143,13 @@ function listFilesRecursively(dir: string, fileList: string[] = []): string[] {
 
 // Load a contract built with Hardhat
 function loadArtifact(hardhatConfig: any, artifactPath: string) {
-  const compiledContract = require(artifactPath);
+  let compiledContract;
+  try {
+    compiledContract = require(artifactPath);
+  } catch (e) {
+    console.error("Failed to load artifact", artifactPath);
+    return undefined;
+  }
 
   const artifactId = {
     name: compiledContract.contractName,
@@ -125,14 +157,14 @@ function loadArtifact(hardhatConfig: any, artifactPath: string) {
     source: compiledContract.sourceName,
   } as { name: string; solcVersion: string; source: string };
 
-  const testContract = {
-    abi: JSON.stringify(compiledContract.abi),
+  const contract = {
+    abi: compiledContract.abi,
     bytecode: compiledContract.bytecode,
     deployedBytecode: compiledContract.deployedBytecode,
   };
 
   return {
     id: artifactId,
-    contract: testContract,
+    contract: contract,
   };
 }

--- a/crates/tools/js/benchmark/src/solidity-tests.ts
+++ b/crates/tools/js/benchmark/src/solidity-tests.ts
@@ -15,7 +15,7 @@ import {
   ContractData,
 } from "@ignored/edr";
 
-const EXPECTED_RESULTS = 15;
+const EXPECTED_RESULTS = 14;
 // This is automatically cached in CI
 const RPC_CACHE_PATH = "./edr-cache";
 const SAMPLES = 9;
@@ -28,6 +28,9 @@ const EXCLUDED_TESTS = new Set([
   // This relies on the `deriveKey` and `rememberKey` cheatcodes which are not supported by EDR.
   "test_DeriveRememberKey()",
 ]);
+
+// This just has one test to check against accidental modifications in the `forge-std` repo.
+const EXCLUDED_TEST_SUITES = new Set(["VmTest"]);
 
 const REPO_DIR = "forge-std";
 const REPO_URL = "https://github.com/NomicFoundation/forge-std.git";
@@ -214,7 +217,7 @@ function loadArtifacts(
       source: compiledContract.sourceName,
     };
 
-    if (isTestSuite(compiledContract)) {
+    if (isTestSuite(compiledContract) && !EXCLUDED_TEST_SUITES.has(id.name)) {
       testSuiteIds.push(id);
     }
 

--- a/crates/tools/js/benchmark/src/solidity-tests.ts
+++ b/crates/tools/js/benchmark/src/solidity-tests.ts
@@ -13,7 +13,7 @@ import {
   Artifact,
   ArtifactId,
   ContractData,
-} from "@nomicfoundation/edr";
+} from "@ignored/edr";
 
 const EXPECTED_RESULTS = 15;
 // This is automatically cached in CI

--- a/crates/tools/js/benchmark/src/solidity-tests.ts
+++ b/crates/tools/js/benchmark/src/solidity-tests.ts
@@ -110,7 +110,7 @@ export async function runForgeStdTests(forgeStdRepoPath: string) {
       const results = await runAllSolidityTests(artifacts, ids, config);
       const elapsed = performance.now() - start;
 
-      let expectedResults = name === TOTAL_NAME ? TOTAL_EXPECTED_RESULTS : 1;
+      const expectedResults = name === TOTAL_NAME ? TOTAL_EXPECTED_RESULTS : 1;
       if (results.length !== expectedResults) {
         throw new Error(
           `Expected ${expectedResults} results for ${name}, got ${results.length}`

--- a/crates/tools/js/benchmark/src/solidity-tests.ts
+++ b/crates/tools/js/benchmark/src/solidity-tests.ts
@@ -177,6 +177,7 @@ function getConfig(forgeStdRepoPath: string): SolidityTestRunnerConfigArgs {
       arbitrum_one_sepolia: "https://sepolia-rollup.arbitrum.io/rpc/",
     },
     fuzz: {
+      // Used to ensure deterministic fuzz execution
       seed: "0x1234567890123456789012345678901234567890",
     },
   };


### PR DESCRIPTION
This PR adds automated regression checks for the JS Solidity test runner. The setup is similar to how the RPC benchmark that benchmarks Hardhat Node-style workloads works.

## Benchmark Suite

The benchmark runs the test harness of `forge-std`. This has two advantages:
- Largest coverage of cheatcodes in a single test harness which is helpful to catch regressions in all features.
- Makes sure our implementation works with `forge-std` which we intend to use.
 
The disadvantage is that `forge-std` is not representative of how users are writing Solidity tests. But this is not a concern as long as we’re not using the benchmark to guide optimizations, only to catch regressions.

There are multiple benchmark scenarios. The first one is called `Total` which measures the entire test harness execution of the `forge-std` test harness. The purpose of this scenario is to make sure that there are no regressions in the parallel test suite executor.

In addition to test suites, individual tests within test suites are also parallelized. This means that if we want to catch regressions in features covered by a certain test suite, we have to execute that test suite in isolation. For this reason, in addition to the `Total` scenario, we execute the following test suites as well:

- `StdCheatsTest`: [environment](https://book.getfoundry.sh/cheatcodes/environment)-related cheatcode coverage + fuzzing.
- `StdStorageTest`: storage-related cheatcode coverage + fuzzing.
- `StdMathTest`: math-related utilities + it's very quick (~15ms on my machine), so regressions from FFI overhead should show up on this.
- `StdUtilsForkTest`: read-type programmatic fork tests.
- `StdCheatsForkTest`: write + fuzz tests for programmatic forking.

The rest of the test suites in `forge-std` test things implemented in Solidity or test file-system utilities, so they're less interesting for us.

## Benchmark Metric

The metric for all scenarios is the wall clock time measured from JS in milliseconds. The measurement excludes loading files from disk as that's out of scope for EDR. If there is a 10% regression on any of the scenarios above, the benchmark job fails (same as the RPC benchmark).

## Baseline 

The baseline is executing the same tests with `forge test`. Instructions to run the baseline are in the [crates/tools/js/benchmark/src/solidity-tests.ts](https://github.com/NomicFoundation/edr/blob/e5eb6201ff6fede9373e08fc87c7e90ffb77878b/crates/tools/js/benchmark/src/solidity-tests.ts) file. 

I tested manually that performance is identical to `forge test` on my machine, so we don't have to keep running the baseline.

## Benchmark Jobs

There are two benchmark workflows in the `feat/solidity-tests` branch and three benchmark jobs:

- `EDR Benchmarks`:
  - `Run JS scenario runner benchmark for Hardhat Node style workload`
    - Stores results for `main` and compares PRs against against those results
    - Dashboard: https://nomic-foundation-automation.github.io/edr-benchmark-results/bench/
  - `Run JS Solidity test runner benchmark`
    - This is the new job
    - Stores results for `feat/solidity-tests` and compares PRs targeting `feat/solidity-tests` against those results
      - Once `feat/solidity-tests` is merged to `main`, we'll switch to storing results for `main`
    - Dashboard will be live here once this PR is merged: https://nomic-foundation-automation.github.io/edr-benchmark-results/soltests/

- `EDR Benchmarks for feat/solidity-tests`
  - `Run JS scenario runner benchmark for Hardhat Node style workload`
    - Stores results for `feat/solidity-tests` and compares PRs against against those results
    - Once `feat/solidity-tests` is merged to `main`, we'll remove this

I reorganized the workflow files a bit to share Rust compilation cache + start caching the RPC cache for the Solidity test runner benchmarks.

