### PR TITLE
fix: Make sure to uniformly 0x-prefix hex strings in custom error message

### DIFF
--- a/crates/edr_napi/src/trace/error_inferrer.rs
+++ b/crates/edr_napi/src/trace/error_inferrer.rs
@@ -2206,14 +2206,44 @@ fn format_dyn_sol_value(val: &DynSolValue) -> String {
         // surround string values with quotes
         DynSolValue::String(s) => format!("\"{s}\""),
 
-        DynSolValue::Address(address) => format!("\"0x{address}\""),
-        DynSolValue::Bytes(bytes) => format!("\"0x{}\"", hex::encode(bytes)),
+        DynSolValue::Address(address) => format!("\"{address}\""),
+        DynSolValue::Bytes(bytes) => format!("\"{}\"", hex::encode_prefixed(bytes)),
         DynSolValue::FixedBytes(word, size) => {
-            format!("\"0x{}\"", hex::encode(&word.0.as_slice()[..*size]))
+            format!("\"{}\"", hex::encode_prefixed(&word.0.as_slice()[..*size]))
         }
         DynSolValue::Bool(b) => b.to_string(),
         DynSolValue::Function(_) => "<function>".to_string(),
         DynSolValue::Int(int, _bits) => int.to_string(),
         DynSolValue::Uint(uint, _bits) => uint.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sol_value_to_string() {
+        assert_eq!(
+            format_dyn_sol_value(&DynSolValue::String("hello".to_string())),
+            "\"hello\""
+        );
+        // Uniform, 0-prefixed hex strings
+        assert_eq!(
+            format_dyn_sol_value(&DynSolValue::Address([0u8; 20].into())),
+            format!(r#""0x{}""#, "0".repeat(2 * 20))
+        );
+        assert_eq!(
+            format_dyn_sol_value(&DynSolValue::Bytes(vec![0u8; 32])),
+            format!(r#""0x{}""#, "0".repeat(2 * 32))
+        );
+        assert_eq!(
+            format_dyn_sol_value(&DynSolValue::FixedBytes([0u8; 32].into(), 10)),
+            format!(r#""0x{}""#, "0".repeat(2 * 10))
+        );
+        assert_eq!(
+            format_dyn_sol_value(&DynSolValue::FixedBytes([0u8; 32].into(), 32)),
+            format!(r#""0x{}""#, "0".repeat(2 * 32))
+        );
     }
 }

--- a/hardhat-tests/test/internal/hardhat-network/stack-traces/test-files/0_8/custom-errors/complex-custom-error/c.sol
+++ b/hardhat-tests/test/internal/hardhat-network/stack-traces/test-files/0_8/custom-errors/complex-custom-error/c.sol
@@ -6,7 +6,7 @@ contract C {
     uint y;
   }
 
-  error MyError(uint x, uint[] xs, bytes4 b, Point p, Point[] ps);
+  error MyError(uint x, uint[] xs, address a, bytes4 b, Point p, Point[] ps);
 
   function test() public {
     uint x = 0;
@@ -18,12 +18,14 @@ contract C {
 
     bytes4 b = 0x12345678;
 
+    address a = address(0xDEADBEEF);
+
     Point memory p = Point(4, 5);
 
     Point[] memory ps = new Point[](2);
     ps[0] = Point(6,7);
     ps[1] = Point(8,9);
 
-    revert MyError(x, xs, b, p, ps);
+    revert MyError(x, xs, a, b, p, ps);
   }
 }

--- a/hardhat-tests/test/internal/hardhat-network/stack-traces/test-files/0_8/custom-errors/complex-custom-error/test.json
+++ b/hardhat-tests/test/internal/hardhat-network/stack-traces/test-files/0_8/custom-errors/complex-custom-error/test.json
@@ -11,12 +11,12 @@
       "stackTrace": [
         {
           "type": "CUSTOM_ERROR",
-          "message": "reverted with custom error 'MyError(0, [1, 2, 3], \"0x12345678\", [4, 5], [[6, 7], [8, 9]])'",
+          "message": "reverted with custom error 'MyError(0, [1, 2, 3], \"0x00000000000000000000000000000000DeaDBeef\", \"0x12345678\", [4, 5], [[6, 7], [8, 9]])'",
           "sourceReference": {
             "contract": "C",
             "file": "c.sol",
             "function": "test",
-            "line": 27
+            "line": 29
           }
         }
       ]


### PR DESCRIPTION
Fixes https://github.com/NomicFoundation/hardhat/issues/5793

The address case slipped through the cracks - I adapted the stack trace test and added a unit test for that.

cc @fvictorio 