### PR TITLE
misc: make crate names explicit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,15 @@
 [workspace]
 members = [
-    "crates/*",
+    "crates/edr_defaults",
+    "crates/edr_eth",
+    "crates/edr_evm",
+    "crates/edr_napi",
+    "crates/edr_provider",
+    "crates/edr_rpc_client",
+    "crates/edr_rpc_eth",
+    "crates/edr_solidity",
+    "crates/edr_test_utils",
+    "crates/tools",
 ]
 resolver = "2"
 


### PR DESCRIPTION
I changed from `"crates/*"` in the workspace Cargo.toml to listing crates one-by-one, because I kept running into errors as I was switching back and forth between branches with different crates.