### PR TITLE
fix: remove total difficulty from block

### DIFF
--- a/.changeset/tender-ties-retire.md
+++ b/.changeset/tender-ties-retire.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": minor
+---
+
+Removed total difficulty from RPC block responses following https://github.com/ethereum/execution-apis/pull/570

--- a/crates/edr_evm/src/block/remote.rs
+++ b/crates/edr_evm/src/block/remote.rs
@@ -5,7 +5,7 @@ use edr_eth::{
     receipt::BlockReceipt,
     transaction::{self, Transaction},
     withdrawal::Withdrawal,
-    B256, U256,
+    B256,
 };
 use edr_rpc_eth::{client::EthRpcClient, TransactionConversionError};
 use tokio::runtime;
@@ -126,24 +126,15 @@ where
     }
 }
 
-/// Trait that provides access to the state root and total difficulty of an
-/// Ethereum-based block.
+/// Trait that provides access to the state root of an Ethereum-based block.
 pub trait EthRpcBlock {
     /// Returns the root of the block's state trie.
     fn state_root(&self) -> &B256;
-
-    /// Returns the total difficulty of the chain until this block for finalised
-    /// blocks. For pending blocks, returns `None`.
-    fn total_difficulty(&self) -> Option<&U256>;
 }
 
 impl<TransactionT> EthRpcBlock for edr_rpc_eth::Block<TransactionT> {
     fn state_root(&self) -> &B256 {
         &self.state_root
-    }
-
-    fn total_difficulty(&self) -> Option<&U256> {
-        self.total_difficulty.as_ref()
     }
 }
 

--- a/crates/edr_evm/src/blockchain.rs
+++ b/crates/edr_evm/src/blockchain.rs
@@ -7,9 +7,7 @@ pub mod storage;
 use std::{collections::BTreeMap, fmt::Debug, ops::Bound::Included, sync::Arc};
 
 use auto_impl::auto_impl;
-use edr_eth::{
-    log::FilterLog, receipt::BlockReceipt, spec::HardforkActivations, Address, B256, U256,
-};
+use edr_eth::{log::FilterLog, receipt::BlockReceipt, spec::HardforkActivations, Address, B256};
 use revm::{
     db::BlockHashRef,
     primitives::{HashSet, SpecId},
@@ -24,7 +22,7 @@ pub use self::{
 use crate::{
     chain_spec::{ChainSpec, SyncChainSpec},
     state::{StateDiff, StateOverride, SyncState},
-    Block, BlockAndTotalDifficulty, LocalBlock, SyncBlock,
+    Block, LocalBlock, SyncBlock,
 };
 
 /// Combinatorial error for the blockchain API.
@@ -53,7 +51,8 @@ pub enum BlockchainError {
         expected: B256,
     },
     /// Missing hardfork activation history
-    #[error("No known hardfork for execution on historical block {block_number} (relative to fork block number {fork_block_number}) in chain with id {chain_id}. The node was not configured with a hardfork activation history.")]
+    #[error("No known hardfork for execution on historical block {block_number} (relative to fork block number {fork_block_number}) in chain with id {chain_id}. The node was not configured with a hardfork activation history."
+    )]
     MissingHardforkActivations {
         /// Block number
         block_number: u64,
@@ -69,7 +68,8 @@ pub enum BlockchainError {
     #[error("Unknown block number")]
     UnknownBlockNumber,
     /// No hardfork found for block
-    #[error("Could not find a hardfork to run for block {block_number}, after having looked for one in the hardfork activation history, which was: {hardfork_activations:?}.")]
+    #[error("Could not find a hardfork to run for block {block_number}, after having looked for one in the hardfork activation history, which was: {hardfork_activations:?}."
+    )]
     UnknownBlockSpec {
         /// Block number
         block_number: u64,
@@ -177,9 +177,6 @@ where
         // Block number -> state overrides
         state_overrides: &BTreeMap<u64, StateOverride>,
     ) -> Result<Box<dyn SyncState<Self::StateError>>, Self::BlockchainError>;
-
-    /// Retrieves the total difficulty at the block with the provided hash.
-    fn total_difficulty_by_hash(&self, hash: &B256) -> Result<Option<U256>, Self::BlockchainError>;
 }
 
 /// Trait for implementations of a mutable Ethereum blockchain
@@ -193,7 +190,7 @@ pub trait BlockchainMut<ChainSpecT: ChainSpec> {
         &mut self,
         block: LocalBlock<ChainSpecT>,
         state_diff: StateDiff,
-    ) -> Result<BlockAndTotalDifficulty<ChainSpecT, Self::Error>, Self::Error>;
+    ) -> Result<Arc<dyn SyncBlock<ChainSpecT, Error = Self::Error>>, Self::Error>;
 
     /// Reserves the provided number of blocks, starting from the next block
     /// number.

--- a/crates/edr_napi/src/subscribe.rs
+++ b/crates/edr_napi/src/subscribe.rs
@@ -28,7 +28,7 @@ impl SubscriberCallback {
                 let result = match ctx.value.result {
                     edr_provider::SubscriptionEventData::Logs(logs) => ctx.env.to_js_value(&logs),
                     edr_provider::SubscriptionEventData::NewHeads(block) => {
-                        let block = edr_rpc_eth::Block::<B256>::from(block);
+                        let block = edr_rpc_eth::Block::<B256>::from(block.as_ref());
                         ctx.env.to_js_value(&block)
                     }
                     edr_provider::SubscriptionEventData::NewPendingTransactions(tx_hash) => {

--- a/crates/edr_provider/src/subscribe.rs
+++ b/crates/edr_provider/src/subscribe.rs
@@ -1,6 +1,8 @@
+use std::sync::Arc;
+
 use dyn_clone::DynClone;
 use edr_eth::{filter::LogOutput, B256, U256};
-use edr_evm::{blockchain::BlockchainError, chain_spec::L1ChainSpec, BlockAndTotalDifficulty};
+use edr_evm::{blockchain::BlockchainError, chain_spec::L1ChainSpec, SyncBlock};
 
 /// Subscription event.
 #[derive(Clone, Debug)]
@@ -13,7 +15,7 @@ pub struct SubscriptionEvent {
 #[derive(Clone, Debug)]
 pub enum SubscriptionEventData {
     Logs(Vec<LogOutput>),
-    NewHeads(BlockAndTotalDifficulty<L1ChainSpec, BlockchainError>),
+    NewHeads(Arc<dyn SyncBlock<L1ChainSpec, Error = BlockchainError>>),
     NewPendingTransactions(B256),
 }
 

--- a/crates/edr_rpc_eth/src/block.rs
+++ b/crates/edr_rpc_eth/src/block.rs
@@ -39,8 +39,6 @@ pub struct Block<TransactionT> {
     pub timestamp: u64,
     /// integer of the difficulty for this blocket
     pub difficulty: U256,
-    /// integer of the total difficulty of the chain until this block
-    pub total_difficulty: Option<U256>,
     /// Array of uncle hashes
     #[serde(default)]
     pub uncles: Vec<B256>,

--- a/hardhat-tests/test/internal/hardhat-network/provider/modules/eth/methods/getBlockByNumber.ts
+++ b/hardhat-tests/test/internal/hardhat-network/provider/modules/eth/methods/getBlockByNumber.ts
@@ -1,7 +1,6 @@
 import { assert } from "chai";
 import {
   numberToRpcQuantity,
-  rpcQuantityToBigInt,
   rpcQuantityToNumber,
 } from "hardhat/internal/core/jsonrpc/types/base-types";
 import {
@@ -9,7 +8,6 @@ import {
   RpcTransactionOutput,
 } from "hardhat/internal/hardhat-network/provider/output";
 import { DEFAULT_COINBASE } from "hardhat/internal/hardhat-network/provider/provider";
-import { Context } from "mocha";
 
 import { workaroundWindowsCiFailures } from "../../../../../../utils/workaround-windows-ci-failures";
 import { assertQuantity } from "../../../../helpers/assertions";

--- a/hardhat-tests/test/internal/hardhat-network/provider/modules/eth/methods/getBlockByNumber.ts
+++ b/hardhat-tests/test/internal/hardhat-network/provider/modules/eth/methods/getBlockByNumber.ts
@@ -150,57 +150,6 @@ describe("Eth module", function () {
             await this.provider.send("eth_getTransactionByHash", [txHash])
           );
         });
-
-        it(
-          "should return the right block total difficulty",
-          isFork ? testTotalDifficultyFork : testTotalDifficulty
-        );
-
-        async function testTotalDifficultyFork(this: Context) {
-          const forkBlockNumber: number = rpcQuantityToNumber(
-            await this.provider.send("eth_blockNumber")
-          );
-
-          const forkBlock: RpcBlockOutput = await this.provider.send(
-            "eth_getBlockByNumber",
-            [numberToRpcQuantity(forkBlockNumber), false]
-          );
-
-          await sendTxToZeroAddress(this.provider);
-
-          const block: RpcBlockOutput = await this.provider.send(
-            "eth_getBlockByNumber",
-            [numberToRpcQuantity(forkBlockNumber + 1), false]
-          );
-
-          assertQuantity(
-            block.totalDifficulty,
-            rpcQuantityToBigInt(forkBlock.totalDifficulty) +
-              rpcQuantityToBigInt(block.difficulty)
-          );
-        }
-
-        async function testTotalDifficulty(this: Context) {
-          const genesisBlock: RpcBlockOutput = await this.provider.send(
-            "eth_getBlockByNumber",
-            [numberToRpcQuantity(0), false]
-          );
-
-          assertQuantity(genesisBlock.totalDifficulty, 1);
-          assertQuantity(genesisBlock.difficulty, 1);
-
-          await sendTxToZeroAddress(this.provider);
-
-          const block: RpcBlockOutput = await this.provider.send(
-            "eth_getBlockByNumber",
-            [numberToRpcQuantity(1), false]
-          );
-
-          assertQuantity(
-            block.totalDifficulty,
-            rpcQuantityToNumber(block.difficulty) + 1
-          );
-        }
       });
     });
   });

--- a/hardhat-tests/test/internal/hardhat-network/provider/modules/hardhat.ts
+++ b/hardhat-tests/test/internal/hardhat-network/provider/modules/hardhat.ts
@@ -1256,17 +1256,14 @@ describe("Hardhat module", function () {
           });
         });
 
-        describe("difficulty and totalDifficulty", function () {
+        describe("difficulty", function () {
           const getBlockDifficulty = async (blockNumber: number) => {
             const block = await this.ctx.provider.send("eth_getBlockByNumber", [
               numberToRpcQuantity(blockNumber),
               false,
             ]);
 
-            return {
-              difficulty: rpcQuantityToBigInt(block.difficulty),
-              totalDifficulty: rpcQuantityToBigInt(block.totalDifficulty),
-            };
+            return rpcQuantityToBigInt(block.difficulty);
           };
 
           it("reserved blocks should have a difficulty of 0", async function () {
@@ -1280,30 +1277,7 @@ describe("Hardhat module", function () {
               previousBlockNumber + 10
             );
 
-            assert.equal(middleBlockDifficulty.difficulty, 0n);
-          });
-
-          it("reserved blocks should have consistent difficulty values", async function () {
-            const previousBlockNumber = await getLatestBlockNumber();
-
-            await this.provider.send("hardhat_mine", [numberToRpcQuantity(20)]);
-
-            let previousBlockDifficulty =
-              await getBlockDifficulty(previousBlockNumber);
-
-            for (let i = 1; i <= 20; i++) {
-              const blockDifficulty = await getBlockDifficulty(
-                previousBlockNumber + i
-              );
-
-              assert.equal(
-                blockDifficulty.totalDifficulty,
-                previousBlockDifficulty.totalDifficulty +
-                  blockDifficulty.difficulty
-              );
-
-              previousBlockDifficulty = blockDifficulty;
-            }
+            assert.equal(middleBlockDifficulty, 0n);
           });
         });
       });


### PR DESCRIPTION
Removes `totalDifficulty` from `eth_getBlockByNumber` and `eth_getBlockByHash` responses following the [change](https://github.com/ethereum/execution-apis/pull/570) to the Ethereum execution API schema which Geth has implemented and it's causing problems for Hardhat in fork mode when EDR doesn't receive the `totalDifficulty` field from Geth nodes.

Relevant Hardhat issues: 
- https://github.com/NomicFoundation/hardhat/discussions/5814
- https://github.com/NomicFoundation/hardhat/issues/5816
