### PR TITLE
edr-0.6.4

### DIFF
--- a/.changeset/mighty-turtles-wait.md
+++ b/.changeset/mighty-turtles-wait.md
@@ -1,5 +1,0 @@
----
-"@nomicfoundation/edr": patch
----
-
-Fix panic due to remote nodes not returning total difficulty

--- a/crates/edr_napi/CHANGELOG.md
+++ b/crates/edr_napi/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @nomicfoundation/edr
 
+## 0.6.4
+
+### Patch Changes
+
+- 14620c9: Fix panic due to remote nodes not returning total difficulty by adding fallback value
+
 ## 0.6.3
 
 ### Patch Changes

--- a/crates/edr_napi/package.json
+++ b/crates/edr_napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomicfoundation/edr",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "devDependencies": {
     "@napi-rs/cli": "^2.18.4",
     "@types/chai": "^4.2.0",


### PR DESCRIPTION
Trigger release for https://github.com/NomicFoundation/edr/commit/fcb943a8142b621c9c58b5a9db1f1863943fd536 as that got merged with the wrong commit message.