### PR TITLE
fix: return empty result for empty test suite

### DIFF
--- a/crates/edr_solidity_tests/src/multi_runner.rs
+++ b/crates/edr_solidity_tests/src/multi_runner.rs
@@ -2,12 +2,11 @@
 
 use std::{collections::BTreeMap, fmt::Debug, path::PathBuf, sync::Arc, time::Instant};
 
-use alloy_json_abi::{Function, JsonAbi};
+use alloy_json_abi::JsonAbi;
 use alloy_primitives::Bytes;
 use eyre::Result;
 use foundry_compilers::artifacts::Libraries;
 use foundry_evm::{
-    abi::TestFunctionExt,
     backend::Backend,
     contracts::{get_contract_name, ArtifactId, ContractsByArtifact},
     decode::RevertDecoder,
@@ -229,7 +228,7 @@ impl MultiContractRunner {
     ) -> impl Iterator<Item = (&ArtifactId, &TestContract)> {
         self.test_contracts
             .iter()
-            .filter(|&(id, TestContract { abi, .. })| matches_contract(id, abi, filter))
+            .filter(|&(id, _)| matches_contract(id, filter))
     }
 
     fn run_tests(
@@ -295,13 +294,6 @@ impl MultiContractRunner {
     }
 }
 
-fn matches_contract(id: &ArtifactId, abi: &JsonAbi, filter: &dyn TestFilter) -> bool {
-    (filter.matches_path(&id.source) && filter.matches_contract(&id.name))
-        && abi.functions().any(|func| is_matching_test(func, filter))
-}
-
-/// Returns `true` if the function is a test function that matches the given
-/// filter.
-pub(crate) fn is_matching_test(func: &Function, filter: &dyn TestFilter) -> bool {
-    (func.is_test() || func.is_invariant_test()) && filter.matches_test(&func.signature())
+fn matches_contract(id: &ArtifactId, filter: &dyn TestFilter) -> bool {
+    filter.matches_path(&id.source) && filter.matches_contract(&id.name)
 }

--- a/crates/edr_solidity_tests/src/runner.rs
+++ b/crates/edr_solidity_tests/src/runner.rs
@@ -38,7 +38,7 @@ use rayon::prelude::*;
 
 use crate::{
     fuzz::{invariant::BasicTxDetails, BaseCounterExample, FuzzConfig},
-    multi_runner::{is_matching_test, TestContract},
+    multi_runner::TestContract,
     result::{SuiteResult, TestKind, TestResult, TestSetup, TestStatus},
     traces::Traces,
     TestFilter, TestOptions,
@@ -1016,4 +1016,10 @@ fn merge_coverages(mut coverage: Option<HitMaps>, other: Option<HitMaps>) -> Opt
         (Some(old_coverage), None) => Some(old_coverage),
         (None, None) => None,
     }
+}
+
+/// Returns `true` if the function is a test function that matches the given
+/// filter.
+fn is_matching_test(func: &Function, filter: &dyn TestFilter) -> bool {
+    (func.is_test() || func.is_invariant_test()) && filter.matches_test(&func.signature())
 }

--- a/crates/edr_solidity_tests/tests/it/fork.rs
+++ b/crates/edr_solidity_tests/tests/it/fork.rs
@@ -11,7 +11,7 @@ async fn test_cheats_fork_revert() {
     let filter = SolidityTestFilter::new(
         "testNonExistingContractRevert",
         ".*",
-        &format!(".*cheats{RE_PATH_SEPARATOR}Fork"),
+        &format!(".*cheats{RE_PATH_SEPARATOR}Fork2"),
     );
     let runner = TEST_DATA_DEFAULT.runner().await;
     let suite_result = runner.test_collect(filter).await;

--- a/js/integration-tests/solidity-tests/contracts/Empty.t.sol
+++ b/js/integration-tests/solidity-tests/contracts/Empty.t.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+// Contract without any test methods
+contract EmptyTest {
+}

--- a/js/integration-tests/solidity-tests/test/unit.ts
+++ b/js/integration-tests/solidity-tests/test/unit.ts
@@ -8,6 +8,15 @@ describe("Unit tests", () => {
     testContext = await TestContext.setup();
   });
 
+  // Empty test suite should still return a result.
+  it("Empty", async function () {
+    const { totalTests, failedTests } =
+      await testContext.runTestsWithStats("EmptyTest");
+
+    assert.equal(failedTests, 0);
+    assert.equal(totalTests, 0);
+  });
+
   it("SuccessAndFailure", async function () {
     const { totalTests, failedTests } = await testContext.runTestsWithStats(
       "SuccessAndFailureTest"


### PR DESCRIPTION
Make sure we return an empty test suite result for empty test suites. 

The fix changes the semantics of the `TestFilter` slightly, hence the need for the change to `crates/edr_solidity_tests/tests/it/fork.rs`, but since the `TestFilter` isn't exposed (it's only used in integration tests), I think this is ok. 

The change in semantics is that previously we only returned results for a test suite if the test name filter also matched at least one test name in the test suite. Now we return an empty result instead if the path filter and suite name filter match, but the test name filter doesn't match.

Fixes https://github.com/NomicFoundation/edr/issues/702