### PR TITLE
chore: upgrade soltest crates to Revm 9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ dependencies = [
 [[package]]
 name = "alloy-consensus"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=899fc51#899fc51af8b5f4de6df1605ca3ffe8d8d6fa8c69"
+source = "git+https://github.com/alloy-rs/alloy?rev=f415827#f41582792950a3bf4c334c588a5497468e1f8149"
 dependencies = [
  "alloy-eips 0.1.0",
  "alloy-primitives 0.7.7",
@@ -103,7 +103,7 @@ dependencies = [
 [[package]]
 name = "alloy-eips"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=899fc51#899fc51af8b5f4de6df1605ca3ffe8d8d6fa8c69"
+source = "git+https://github.com/alloy-rs/alloy?rev=f415827#f41582792950a3bf4c334c588a5497468e1f8149"
 dependencies = [
  "alloy-primitives 0.7.7",
  "alloy-rlp",
@@ -132,7 +132,7 @@ dependencies = [
 [[package]]
 name = "alloy-genesis"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=899fc51#899fc51af8b5f4de6df1605ca3ffe8d8d6fa8c69"
+source = "git+https://github.com/alloy-rs/alloy?rev=f415827#f41582792950a3bf4c334c588a5497468e1f8149"
 dependencies = [
  "alloy-primitives 0.7.7",
  "alloy-serde 0.1.0",
@@ -155,7 +155,7 @@ dependencies = [
 [[package]]
 name = "alloy-json-rpc"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=899fc51#899fc51af8b5f4de6df1605ca3ffe8d8d6fa8c69"
+source = "git+https://github.com/alloy-rs/alloy?rev=f415827#f41582792950a3bf4c334c588a5497468e1f8149"
 dependencies = [
  "alloy-primitives 0.7.7",
  "serde",
@@ -167,7 +167,7 @@ dependencies = [
 [[package]]
 name = "alloy-network"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=899fc51#899fc51af8b5f4de6df1605ca3ffe8d8d6fa8c69"
+source = "git+https://github.com/alloy-rs/alloy?rev=f415827#f41582792950a3bf4c334c588a5497468e1f8149"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 0.1.0",
@@ -232,7 +232,7 @@ dependencies = [
 [[package]]
 name = "alloy-provider"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=899fc51#899fc51af8b5f4de6df1605ca3ffe8d8d6fa8c69"
+source = "git+https://github.com/alloy-rs/alloy?rev=f415827#f41582792950a3bf4c334c588a5497468e1f8149"
 dependencies = [
  "alloy-eips 0.1.0",
  "alloy-json-rpc",
@@ -249,6 +249,7 @@ dependencies = [
  "futures",
  "futures-utils-wasm",
  "lru",
+ "pin-project",
  "serde_json",
  "tokio",
  "tracing",
@@ -257,7 +258,7 @@ dependencies = [
 [[package]]
 name = "alloy-pubsub"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=899fc51#899fc51af8b5f4de6df1605ca3ffe8d8d6fa8c69"
+source = "git+https://github.com/alloy-rs/alloy?rev=f415827#f41582792950a3bf4c334c588a5497468e1f8149"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives 0.7.7",
@@ -297,7 +298,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-client"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=899fc51#899fc51af8b5f4de6df1605ca3ffe8d8d6fa8c69"
+source = "git+https://github.com/alloy-rs/alloy?rev=f415827#f41582792950a3bf4c334c588a5497468e1f8149"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -315,7 +316,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=899fc51#899fc51af8b5f4de6df1605ca3ffe8d8d6fa8c69"
+source = "git+https://github.com/alloy-rs/alloy?rev=f415827#f41582792950a3bf4c334c588a5497468e1f8149"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 0.1.0",
@@ -333,7 +334,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-engine"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=899fc51#899fc51af8b5f4de6df1605ca3ffe8d8d6fa8c69"
+source = "git+https://github.com/alloy-rs/alloy?rev=f415827#f41582792950a3bf4c334c588a5497468e1f8149"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 0.1.0",
@@ -350,7 +351,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-trace"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=899fc51#899fc51af8b5f4de6df1605ca3ffe8d8d6fa8c69"
+source = "git+https://github.com/alloy-rs/alloy?rev=f415827#f41582792950a3bf4c334c588a5497468e1f8149"
 dependencies = [
  "alloy-primitives 0.7.7",
  "alloy-rpc-types",
@@ -362,7 +363,7 @@ dependencies = [
 [[package]]
 name = "alloy-serde"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=899fc51#899fc51af8b5f4de6df1605ca3ffe8d8d6fa8c69"
+source = "git+https://github.com/alloy-rs/alloy?rev=f415827#f41582792950a3bf4c334c588a5497468e1f8149"
 dependencies = [
  "alloy-primitives 0.7.7",
  "serde",
@@ -383,7 +384,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=899fc51#899fc51af8b5f4de6df1605ca3ffe8d8d6fa8c69"
+source = "git+https://github.com/alloy-rs/alloy?rev=f415827#f41582792950a3bf4c334c588a5497468e1f8149"
 dependencies = [
  "alloy-primitives 0.7.7",
  "async-trait",
@@ -396,7 +397,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer-wallet"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=899fc51#899fc51af8b5f4de6df1605ca3ffe8d8d6fa8c69"
+source = "git+https://github.com/alloy-rs/alloy?rev=f415827#f41582792950a3bf4c334c588a5497468e1f8149"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -518,7 +519,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=899fc51#899fc51af8b5f4de6df1605ca3ffe8d8d6fa8c69"
+source = "git+https://github.com/alloy-rs/alloy?rev=f415827#f41582792950a3bf4c334c588a5497468e1f8149"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.22.1",
@@ -536,7 +537,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-http"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=899fc51#899fc51af8b5f4de6df1605ca3ffe8d8d6fa8c69"
+source = "git+https://github.com/alloy-rs/alloy?rev=f415827#f41582792950a3bf4c334c588a5497468e1f8149"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -550,7 +551,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ipc"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=899fc51#899fc51af8b5f4de6df1605ca3ffe8d8d6fa8c69"
+source = "git+https://github.com/alloy-rs/alloy?rev=f415827#f41582792950a3bf4c334c588a5497468e1f8149"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -568,7 +569,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ws"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=899fc51#899fc51af8b5f4de6df1605ca3ffe8d8d6fa8c69"
+source = "git+https://github.com/alloy-rs/alloy?rev=f415827#f41582792950a3bf4c334c588a5497468e1f8149"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -2362,7 +2363,7 @@ dependencies = [
  "k256",
  "p256",
  "regex",
- "revm 8.0.0",
+ "revm 9.0.0",
  "rustc-hash 1.1.0",
  "semver 1.0.23",
  "serde_json",
@@ -2438,7 +2439,7 @@ dependencies = [
  "foundry-evm-traces",
  "parking_lot 0.12.3",
  "proptest",
- "revm 8.0.0",
+ "revm 9.0.0",
  "revm-inspectors",
  "thiserror",
  "tracing",
@@ -2480,7 +2481,7 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.3",
  "reqwest 0.12.7",
- "revm 8.0.0",
+ "revm 9.0.0",
  "revm-inspectors",
  "rustc-hash 1.1.0",
  "semver 1.0.23",
@@ -2504,7 +2505,7 @@ dependencies = [
  "eyre",
  "foundry-compilers",
  "foundry-evm-core",
- "revm 8.0.0",
+ "revm 9.0.0",
  "rustc-hash 1.1.0",
  "semver 1.0.23",
  "tracing",
@@ -2527,7 +2528,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "proptest",
  "rand",
- "revm 8.0.0",
+ "revm 9.0.0",
  "serde",
  "thiserror",
  "tracing",
@@ -4732,15 +4733,15 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a454c1c650b2b2e23f0c461af09e6c31e1d15e1cbebe905a701c46b8a50afc"
+checksum = "3a2c336f9921588e50871c00024feb51a521eca50ce6d01494bb9c50f837c8ed"
 dependencies = [
  "auto_impl",
  "cfg-if",
  "dyn-clone",
- "revm-interpreter 4.0.0",
- "revm-precompile 6.0.0",
+ "revm-interpreter 5.0.0",
+ "revm-precompile 7.0.0",
  "serde",
  "serde_json",
 ]
@@ -4763,7 +4764,7 @@ dependencies = [
 [[package]]
 name = "revm-inspectors"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/evm-inspectors?rev=c1b5dd0#c1b5dd0d85dd46ef5ec5258aebd24adc041d103a"
+source = "git+https://github.com/paradigmxyz/revm-inspectors?rev=098ab30#098ab30faf3254c8ba3159b1af006d71d3577d95"
 dependencies = [
  "alloy-primitives 0.7.7",
  "alloy-rpc-types",
@@ -4771,7 +4772,7 @@ dependencies = [
  "alloy-sol-types 0.7.7",
  "anstyle",
  "colorchoice",
- "revm 8.0.0",
+ "revm 9.0.0",
  "serde",
  "serde_json",
  "thiserror",
@@ -4779,11 +4780,11 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d322f2730cd300e99d271a1704a2dfb8973d832428f5aa282aaa40e2473b5eec"
+checksum = "a58182c7454179826f9dad2ca577661963092ce9d0fd0c9d682c1e9215a72e70"
 dependencies = [
- "revm-primitives 3.1.1",
+ "revm-primitives 4.0.0",
  "serde",
 ]
 
@@ -4799,17 +4800,17 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "6.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "931f692f3f4fc72ec39d5d270f8e9d208c4a6008de7590ee96cf948e3b6d3f8d"
+checksum = "dc8af9aa737eef0509a50d9f3cc1a631557a00ef2e70a3aa8a75d9ee0ed275bb"
 dependencies = [
  "aurora-engine-modexp",
  "c-kzg",
  "k256",
  "once_cell",
- "revm-primitives 3.1.1",
+ "revm-primitives 4.0.0",
  "ripemd",
- "secp256k1 0.28.2",
+ "secp256k1",
  "sha2",
  "substrate-bn",
 ]
@@ -4828,16 +4829,16 @@ dependencies = [
  "p256",
  "revm-primitives 7.1.0",
  "ripemd",
- "secp256k1 0.29.1",
+ "secp256k1",
  "sha2",
  "substrate-bn",
 ]
 
 [[package]]
 name = "revm-primitives"
-version = "3.1.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbbc9640790cebcb731289afb7a7d96d16ad94afeb64b5d0b66443bd151e79d6"
+checksum = "b9bf5d465e64b697da6a111cb19e798b5b2ebb18e5faf2ad48e9e8d47c64add2"
 dependencies = [
  "alloy-primitives 0.7.7",
  "auto_impl",
@@ -5233,31 +5234,12 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.28.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
-dependencies = [
- "rand",
- "secp256k1-sys 0.9.2",
-]
-
-[[package]]
-name = "secp256k1"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
  "rand",
- "secp256k1-sys 0.10.0",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d1746aae42c19d583c3c1a8c646bfad910498e2051c551a7f2e3c0c9fbb7eb"
-dependencies = [
- "cc",
+ "secp256k1-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,9 +180,9 @@ foundry-compilers = { version = "0.4.3", features = ["full"] }
 
 ## revm
 # no default features to avoid c-kzg
-revm = { version = "8", default-features = false }
-revm-primitives = { version = "3", default-features = false }
-revm-inspectors = { git = "https://github.com/paradigmxyz/evm-inspectors", rev = "c1b5dd0", features = [
+revm = { version = "9", default-features = false }
+revm-primitives = { version = "4", default-features = false }
+revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "098ab30", features = [
     "serde",
 ] }
 
@@ -190,29 +190,29 @@ revm-inspectors = { git = "https://github.com/paradigmxyz/evm-inspectors", rev =
 ethers-contract-abigen = { version = "2.0.14", default-features = false }
 
 ## alloy
-alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "899fc51", default-features = false }
-alloy-contract = { git = "https://github.com/alloy-rs/alloy", rev = "899fc51", default-features = false }
-alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "899fc51", default-features = false }
-alloy-genesis = { git = "https://github.com/alloy-rs/alloy", rev = "899fc51", default-features = false }
-alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", rev = "899fc51", default-features = false }
-alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "899fc51", default-features = false }
-alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy", rev = "899fc51", default-features = false }
-alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "899fc51", default-features = false }
-alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", rev = "899fc51", default-features = false }
-alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", rev = "899fc51", default-features = false }
-alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "899fc51", default-features = false }
-alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "899fc51", default-features = false }
-alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "899fc51", default-features = false }
-alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "899fc51", default-features = false }
-alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "899fc51", default-features = false }
-alloy-signer-wallet = { git = "https://github.com/alloy-rs/alloy", rev = "899fc51", default-features = false }
-alloy-signer-aws = { git = "https://github.com/alloy-rs/alloy", rev = "899fc51", default-features = false }
-alloy-signer-ledger = { git = "https://github.com/alloy-rs/alloy", rev = "899fc51", default-features = false }
-alloy-signer-trezor = { git = "https://github.com/alloy-rs/alloy", rev = "899fc51", default-features = false }
-alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "899fc51", default-features = false }
-alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", rev = "899fc51", default-features = false }
-alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", rev = "899fc51", default-features = false }
-alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", rev = "899fc51", default-features = false }
+alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "f415827", default-features = false }
+alloy-contract = { git = "https://github.com/alloy-rs/alloy", rev = "f415827", default-features = false }
+alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "f415827", default-features = false }
+alloy-genesis = { git = "https://github.com/alloy-rs/alloy", rev = "f415827", default-features = false }
+alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", rev = "f415827", default-features = false }
+alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "f415827", default-features = false }
+alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy", rev = "f415827", default-features = false }
+alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "f415827", default-features = false }
+alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", rev = "f415827", default-features = false }
+alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", rev = "f415827", default-features = false }
+alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "f415827", default-features = false }
+alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "f415827", default-features = false }
+alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "f415827", default-features = false }
+alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "f415827", default-features = false }
+alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "f415827", default-features = false }
+alloy-signer-wallet = { git = "https://github.com/alloy-rs/alloy", rev = "f415827", default-features = false }
+alloy-signer-aws = { git = "https://github.com/alloy-rs/alloy", rev = "f415827", default-features = false }
+alloy-signer-ledger = { git = "https://github.com/alloy-rs/alloy", rev = "f415827", default-features = false }
+alloy-signer-trezor = { git = "https://github.com/alloy-rs/alloy", rev = "f415827", default-features = false }
+alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "f415827", default-features = false }
+alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", rev = "f415827", default-features = false }
+alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", rev = "f415827", default-features = false }
+alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", rev = "f415827", default-features = false }
 alloy-primitives = { version = "0.7.1", features = ["getrandom"] }
 alloy-dyn-abi = "0.7.1"
 alloy-json-abi = "0.7.1"

--- a/crates/edr_solidity_tests/tests/it/fork.rs
+++ b/crates/edr_solidity_tests/tests/it/fork.rs
@@ -33,8 +33,12 @@ async fn test_cheats_fork() {
     let runner = TEST_DATA_DEFAULT
         .runner_with_fs_permissions(FsPermissions::new(vec![PathPermission::read("./fixtures")]))
         .await;
-    let filter = SolidityTestFilter::new(".*", ".*", &format!(".*cheats{RE_PATH_SEPARATOR}Fork"))
-        .exclude_tests(".*Revert");
+    let filter = SolidityTestFilter::new(
+        "testBlockNumbersMismatch()",
+        ".*",
+        &format!(".*cheats{RE_PATH_SEPARATOR}Fork"),
+    )
+    .exclude_tests(".*Revert");
     TestConfig::with_filter(runner, filter).run().await;
 }
 

--- a/crates/edr_solidity_tests/tests/it/helpers.rs
+++ b/crates/edr_solidity_tests/tests/it/helpers.rs
@@ -15,6 +15,7 @@ use alloy_primitives::U256;
 use edr_solidity_tests::{
     fuzz::FuzzDictionaryConfig,
     multi_runner::{TestContract, TestContracts},
+    revm::primitives::SpecId,
     MultiContractRunner, SolidityTestRunnerConfig,
 };
 use edr_test_utils::new_fd_lock;
@@ -91,6 +92,7 @@ impl ForgeTestProfile {
             initial_balance: U256::MAX,
             ffi: true,
             memory_limit: 1 << 26,
+            spec: SpecId::CANCUN,
             ..EvmOpts::default()
         }
     }

--- a/crates/edr_solidity_tests/tests/testdata/default/cheats/LastCallGas.t.sol
+++ b/crates/edr_solidity_tests/tests/testdata/default/cheats/LastCallGas.t.sol
@@ -53,10 +53,6 @@ abstract contract LastCallGasFixture is DSTest {
         (success,) = address(target).call("");
     }
 
-    function _performExpandMemory() internal view {
-        target.expandMemory(1000);
-    }
-
     function _performRefund() internal {
         target.setValue(1);
         target.resetValue();
@@ -84,12 +80,6 @@ contract LastCallGasIsolatedTest is LastCallGasFixture {
         _assertGas(vm.lastCallGas(), Gas({gasTotalUsed: 21064, gasMemoryUsed: 0, gasRefunded: 0}));
     }
 
-    function testRecordGasMemory() public {
-        _setup();
-        _performExpandMemory();
-        _assertGas(vm.lastCallGas(), Gas({gasTotalUsed: 186470, gasMemoryUsed: 4994, gasRefunded: 0}));
-    }
-
     function testRecordGasRefund() public {
         _setup();
         _performRefund();
@@ -102,24 +92,18 @@ contract LastCallGasDefaultTest is LastCallGasFixture {
     function testRecordLastCallGas() public {
         _setup();
         _performCall();
-        _assertGas(vm.lastCallGas(), Gas({gasTotalUsed: 64, gasMemoryUsed: 9, gasRefunded: 0}));
+        _assertGas(vm.lastCallGas(), Gas({gasTotalUsed: 64, gasMemoryUsed: 0, gasRefunded: 0}));
 
         _performCall();
-        _assertGas(vm.lastCallGas(), Gas({gasTotalUsed: 64, gasMemoryUsed: 9, gasRefunded: 0}));
+        _assertGas(vm.lastCallGas(), Gas({gasTotalUsed: 64, gasMemoryUsed: 0, gasRefunded: 0}));
 
         _performCall();
-        _assertGas(vm.lastCallGas(), Gas({gasTotalUsed: 64, gasMemoryUsed: 9, gasRefunded: 0}));
-    }
-
-    function testRecordGasMemory() public {
-        _setup();
-        _performExpandMemory();
-        _assertGas(vm.lastCallGas(), Gas({gasTotalUsed: 186470, gasMemoryUsed: 4994, gasRefunded: 0}));
+        _assertGas(vm.lastCallGas(), Gas({gasTotalUsed: 64, gasMemoryUsed: 0, gasRefunded: 0}));
     }
 
     function testRecordGasRefund() public {
         _setup();
         _performRefund();
-        _assertGas(vm.lastCallGas(), Gas({gasTotalUsed: 216, gasMemoryUsed: 9, gasRefunded: 19900}));
+        _assertGas(vm.lastCallGas(), Gas({gasTotalUsed: 216, gasMemoryUsed: 0, gasRefunded: 19900}));
     }
 }

--- a/crates/foundry/cheatcodes/assets/cheatcodes.json
+++ b/crates/foundry/cheatcodes/assets/cheatcodes.json
@@ -459,7 +459,7 @@
         {
           "name": "gasMemoryUsed",
           "ty": "uint64",
-          "description": "The amount of gas used for memory expansion."
+          "description": "DEPRECATED: The amount of gas used for memory expansion. Ref: <https://github.com/foundry-rs/foundry/pull/7934#pullrequestreview-2069236939>"
         },
         {
           "name": "gasRefunded",

--- a/crates/foundry/cheatcodes/spec/src/vm.rs
+++ b/crates/foundry/cheatcodes/spec/src/vm.rs
@@ -98,7 +98,7 @@ interface Vm {
         uint64 gasLimit;
         /// The total gas used.
         uint64 gasTotalUsed;
-        /// The amount of gas used for memory expansion.
+        /// DEPRECATED: The amount of gas used for memory expansion. Ref: <https://github.com/foundry-rs/foundry/pull/7934#pullrequestreview-2069236939>
         uint64 gasMemoryUsed;
         /// The amount of gas refunded.
         int64 gasRefunded;

--- a/crates/foundry/cheatcodes/src/evm.rs
+++ b/crates/foundry/cheatcodes/src/evm.rs
@@ -436,7 +436,7 @@ impl Cheatcode for etchCall {
         } = self;
         ensure_not_precompile!(target, ccx);
         ccx.ecx.load_account(*target)?;
-        let bytecode = Bytecode::new_raw(Bytes::copy_from_slice(newRuntimeBytecode)).to_checked();
+        let bytecode = Bytecode::new_raw(Bytes::copy_from_slice(newRuntimeBytecode));
         ccx.ecx.journaled_state.set_code(*target, bytecode);
         Ok(Vec::default())
     }

--- a/crates/foundry/cheatcodes/src/evm/mapping.rs
+++ b/crates/foundry/cheatcodes/src/evm/mapping.rs
@@ -136,7 +136,7 @@ pub(crate) fn step(mapping_slots: &mut HashMap<Address, MappingSlots>, interpret
     match interpreter.current_opcode() {
         opcode::KECCAK256 => {
             if interpreter.stack.peek(1) == Ok(U256::from(0x40)) {
-                let address = interpreter.contract.address;
+                let address = interpreter.contract.target_address;
                 let offset = interpreter
                     .stack
                     .peek(0)
@@ -155,7 +155,8 @@ pub(crate) fn step(mapping_slots: &mut HashMap<Address, MappingSlots>, interpret
             }
         }
         opcode::SSTORE => {
-            if let Some(mapping_slots) = mapping_slots.get_mut(&interpreter.contract.address) {
+            if let Some(mapping_slots) = mapping_slots.get_mut(&interpreter.contract.target_address)
+            {
                 if let Ok(slot) = interpreter.stack.peek(0) {
                     mapping_slots.insert(slot.into());
                 }

--- a/crates/foundry/cheatcodes/src/evm/mock.rs
+++ b/crates/foundry/cheatcodes/src/evm/mock.rs
@@ -74,7 +74,7 @@ impl Cheatcode for mockCall_0Call {
         // `extcodesize` check Solidity might perform.
         let empty_bytecode = acc.info.code.as_ref().map_or(true, Bytecode::is_empty);
         if empty_bytecode {
-            let code = Bytecode::new_raw(Bytes::from_static(&[0u8])).to_checked();
+            let code = Bytecode::new_raw(Bytes::from_static(&[0u8]));
             ccx.ecx.journaled_state.set_code(*callee, code);
         }
 

--- a/crates/foundry/cheatcodes/src/inspector.rs
+++ b/crates/foundry/cheatcodes/src/inspector.rs
@@ -238,7 +238,7 @@ impl Cheatcodes {
             }
             e
         })?;
-        let caller = call.context.caller;
+        let caller = call.caller;
 
         // ensure the caller is allowed to execute cheatcodes,
         // but only if the backend is in forking mode
@@ -396,7 +396,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
                     let key = try_or_continue!(interpreter.stack().peek(0));
                     storage_accesses
                         .reads
-                        .entry(interpreter.contract().address)
+                        .entry(interpreter.contract().target_address)
                         .or_default()
                         .push(key);
                 }
@@ -406,12 +406,12 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
                     // An SSTORE does an SLOAD internally
                     storage_accesses
                         .reads
-                        .entry(interpreter.contract().address)
+                        .entry(interpreter.contract().target_address)
                         .or_default()
                         .push(key);
                     storage_accesses
                         .writes
-                        .entry(interpreter.contract().address)
+                        .entry(interpreter.contract().target_address)
                         .or_default()
                         .push(key);
                 }
@@ -426,7 +426,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
                 let target = try_or_continue!(interpreter.stack().peek(0));
                 // load balance of this account
                 let value = ecx
-                    .balance(interpreter.contract().address)
+                    .balance(interpreter.contract().target_address)
                     .map(|(b, _)| b)
                     .unwrap_or(U256::ZERO);
                 let account = Address::from_word(B256::from(target));
@@ -445,7 +445,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
                         forkId: ecx.db.active_fork_id().unwrap_or_default(),
                         chainId: U256::from(ecx.env.cfg.chain_id),
                     },
-                    accessor: interpreter.contract().address,
+                    accessor: interpreter.contract().target_address,
                     account,
                     kind: crate::Vm::AccountAccessKind::SelfDestruct,
                     initialized,
@@ -471,7 +471,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
             match interpreter.current_opcode() {
                 opcode::SLOAD => {
                     let key = try_or_continue!(interpreter.stack().peek(0));
-                    let address = interpreter.contract().address;
+                    let address = interpreter.contract().target_address;
 
                     // Try to include present value for informational purposes, otherwise assume
                     // it's not set (zero value)
@@ -483,7 +483,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
                         }
                     }
                     let access = crate::Vm::StorageAccess {
-                        account: interpreter.contract().address,
+                        account: interpreter.contract().target_address,
                         slot: key.into(),
                         isWrite: false,
                         previousValue: present_value.into(),
@@ -499,7 +499,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
                 opcode::SSTORE => {
                     let key = try_or_continue!(interpreter.stack().peek(0));
                     let value = try_or_continue!(interpreter.stack().peek(1));
-                    let address = interpreter.contract().address;
+                    let address = interpreter.contract().target_address;
                     // Try to load the account and the slot's previous value, otherwise, assume it's
                     // not set (zero value)
                     let mut previous_value = U256::ZERO;
@@ -553,7 +553,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
                             forkId: ecx.db.active_fork_id().unwrap_or_default(),
                             chainId: U256::from(ecx.env.cfg.chain_id),
                         },
-                        accessor: interpreter.contract().address,
+                        accessor: interpreter.contract().target_address,
                         account: address,
                         kind,
                         initialized,
@@ -800,7 +800,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
             }
         }
 
-        if call.contract == CHEATCODE_ADDRESS {
+        if call.target_address == CHEATCODE_ADDRESS {
             return match self.apply_cheatcode(ecx, call) {
                 Ok(retdata) => Some(CallOutcome {
                     result: InterpreterResult {
@@ -823,14 +823,15 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
 
         let ecx = &mut ecx.inner;
 
-        if call.contract == HARDHAT_CONSOLE_ADDRESS {
+        if call.target_address == HARDHAT_CONSOLE_ADDRESS {
             return None;
         }
 
         // Handle expected calls
 
         // Grab the different calldatas expected.
-        if let Some(expected_calls_for_target) = self.expected_calls.get_mut(&(call.contract)) {
+        if let Some(expected_calls_for_target) = self.expected_calls.get_mut(&(call.target_address))
+        {
             // Match every partial/full calldata
             for (calldata, (expected, actual_count)) in expected_calls_for_target {
                 // Increment actual times seen if...
@@ -841,7 +842,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
                     // The value matches, if provided
                     expected
                         .value
-                        .map_or(true, |value| value == call.transfer.value) &&
+                        .map_or(true, |value| Some(value) == call.transfer_value()) &&
                     // The gas matches, if provided
                     expected.gas.map_or(true, |gas| gas == call.gas_limit) &&
                     // The minimum gas matches, if provided
@@ -853,10 +854,10 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
         }
 
         // Handle mocked calls
-        if let Some(mocks) = self.mocked_calls.get(&call.contract) {
+        if let Some(mocks) = self.mocked_calls.get(&call.target_address) {
             let ctx = MockCallDataContext {
                 calldata: call.input.clone(),
-                value: Some(call.transfer.value),
+                value: call.transfer_value(),
             };
             if let Some(return_data) = mocks.get(&ctx).or_else(|| {
                 mocks
@@ -865,7 +866,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
                         call.input.get(..mock.calldata.len()) == Some(&mock.calldata[..])
                             && mock
                                 .value
-                                .map_or(true, |value| value == call.transfer.value)
+                                .map_or(true, |value| Some(value) == call.transfer_value())
                     })
                     .map(|(_, v)| v)
             }) {
@@ -882,15 +883,12 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
 
         // Apply our prank
         if let Some(prank) = &self.prank {
-            if ecx.journaled_state.depth() >= prank.depth
-                && call.context.caller == prank.prank_caller
-            {
+            if ecx.journaled_state.depth() >= prank.depth && call.caller == prank.prank_caller {
                 let mut prank_applied = false;
 
                 // At the target depth we set `msg.sender`
                 if ecx.journaled_state.depth() == prank.depth {
-                    call.context.caller = prank.new_caller;
-                    call.transfer.source = prank.new_caller;
+                    call.caller = prank.new_caller;
                     prank_applied = true;
                 }
 
@@ -917,14 +915,17 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
             let initialized;
             let old_balance;
             // TODO: use ecx.load_account
-            if let Ok((acc, _)) = ecx.journaled_state.load_account(call.contract, &mut ecx.db) {
+            if let Ok((acc, _)) = ecx
+                .journaled_state
+                .load_account(call.target_address, &mut ecx.db)
+            {
                 initialized = acc.info.exists();
                 old_balance = acc.info.balance;
             } else {
                 initialized = false;
                 old_balance = U256::ZERO;
             }
-            let kind = match call.context.scheme {
+            let kind = match call.scheme {
                 CallScheme::Call => crate::Vm::AccountAccessKind::Call,
                 CallScheme::CallCode => crate::Vm::AccountAccessKind::CallCode,
                 CallScheme::DelegateCall => crate::Vm::AccountAccessKind::DelegateCall,
@@ -941,13 +942,13 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
                     forkId: ecx.db.active_fork_id().unwrap_or_default(),
                     chainId: U256::from(ecx.env.cfg.chain_id),
                 },
-                accessor: call.context.caller,
-                account: call.contract,
+                accessor: call.caller,
+                account: call.bytecode_address,
                 kind,
                 initialized,
                 oldBalance: old_balance,
                 newBalance: U256::ZERO, // updated on call_end
-                value: call.transfer.value,
+                value: call.call_value(),
                 data: call.input.clone(),
                 reverted: false,
                 deployedCode: Bytes::new(),
@@ -966,8 +967,8 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
         mut outcome: CallOutcome,
     ) -> CallOutcome {
         let ecx = &mut ecx.inner;
-        let cheatcode_call =
-            call.contract == CHEATCODE_ADDRESS || call.contract == HARDHAT_CONSOLE_ADDRESS;
+        let cheatcode_call = call.target_address == CHEATCODE_ADDRESS
+            || call.target_address == HARDHAT_CONSOLE_ADDRESS;
 
         // Clean up pranks/broadcasts if it's not a cheatcode call end. We shouldn't do
         // it for cheatcode calls because they are not appplied for cheatcodes in the
@@ -1043,15 +1044,10 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
         // retrieve the gas usage of the last call.
         let gas = outcome.result.gas;
         self.last_call_gas = Some(crate::Vm::Gas {
-            // The gas limit of the call.
             gasLimit: gas.limit(),
-            // The total gas used.
             gasTotalUsed: gas.spent(),
-            // The amount of gas used for memory expansion.
-            gasMemoryUsed: gas.memory(),
-            // The amount of gas refunded.
+            gasMemoryUsed: 0,
             gasRefunded: gas.refunded(),
-            // The amount of gas remaining.
             gasRemaining: gas.remaining(),
         });
 
@@ -1083,8 +1079,9 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
                 // percolated up to a higher depth.
                 if call_access.depth == ecx.journaled_state.depth() {
                     // TODO: use ecx.load_account
-                    if let Ok((acc, _)) =
-                        ecx.journaled_state.load_account(call.contract, &mut ecx.db)
+                    if let Ok((acc, _)) = ecx
+                        .journaled_state
+                        .load_account(call.target_address, &mut ecx.db)
                     {
                         debug_assert!(access_is_call(call_access.kind));
                         call_access.newBalance = acc.info.balance;
@@ -1155,10 +1152,11 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
             // active fork
             if ecx.db.is_forked_mode()
                 && outcome.result.result == InstructionResult::Stop
-                && call.contract != test_contract
+                && call.target_address != test_contract
             {
-                self.fork_revert_diagnostic =
-                    ecx.db.diagnose_revert(call.contract, &ecx.journaled_state);
+                self.fork_revert_diagnostic = ecx
+                    .db
+                    .diagnose_revert(call.target_address, &ecx.journaled_state);
             }
         }
 

--- a/crates/foundry/evm/core/src/backend/mod.rs
+++ b/crates/foundry/evm/core/src/backend/mod.rs
@@ -14,7 +14,7 @@ use revm::{
     inspectors::NoOpInspector,
     precompile::{PrecompileSpecId, Precompiles},
     primitives::{
-        Account, AccountInfo, Bytecode, CreateScheme, Env, EnvWithHandlerCfg, HashMap as Map, Log,
+        Account, AccountInfo, Bytecode, Env, EnvWithHandlerCfg, HashMap as Map, Log,
         ResultAndState, SpecId, State, StorageSlot, TransactTo, KECCAK_EMPTY,
     },
     Database, DatabaseCommit, JournaledState,
@@ -821,13 +821,7 @@ impl Backend {
 
         let test_contract = match env.tx.transact_to {
             TransactTo::Call(to) => to,
-            TransactTo::Create(CreateScheme::Create) => {
-                env.tx.caller.create(env.tx.nonce.unwrap_or_default())
-            }
-            TransactTo::Create(CreateScheme::Create2 { salt }) => {
-                let code_hash = B256::from_slice(keccak256(&env.tx.data).as_slice());
-                env.tx.caller.create2(B256::from(salt), code_hash)
-            }
+            TransactTo::Create => env.tx.caller.create(env.tx.nonce.unwrap_or_default()),
         };
         self.set_test_contract(test_contract);
     }

--- a/crates/foundry/evm/core/src/fork/cache.rs
+++ b/crates/foundry/evm/core/src/fork/cache.rs
@@ -523,12 +523,12 @@ mod tests {
     "meta": {
         "cfg_env": {
             "chain_id": 1337,
-            "spec_id": "LATEST",
-            "perf_all_precompiles_have_balance": false,
-            "disable_coinbase_tip": false,
             "perf_analyse_created_bytecodes": "Analyse",
             "limit_contract_code_size": 18446744073709551615,
-            "memory_limit": 4294967295
+            "memory_limit": 4294967295,
+            "disable_block_gas_limit": false,
+            "disable_eip3607": false,
+            "disable_base_fee": false
         },
         "block_env": {
             "number": "0xed3ddf",
@@ -536,7 +536,8 @@ mod tests {
             "timestamp": "0x6324bc3f",
             "difficulty": "0x0",
             "basefee": "0x2e5fda223",
-            "gas_limit": "0x1c9c380"
+            "gas_limit": "0x1c9c380",
+            "prevrandao": "0x0000000000000000000000000000000000000000000000000000000000000000"
         },
         "hosts": [
             "eth-mainnet.alchemyapi.io"
@@ -548,11 +549,17 @@ mod tests {
             "nonce": 10,
             "code_hash": "0x3ac64c95eedf82e5d821696a12daac0e1b22c8ee18a9fd688b00cfaf14550aad",
             "code": {
-                "bytecode": "0x60806040526004361061006c5763ffffffff7c01000000000000000000000000000000000000000000000000000000006000350416634555d5c9811461012b5780634558850c1461015257806348a0c8dd146101965780635c60da1b146101bf57806386070cfe146101d4575b6127107f665fd576fbbe6f247aff98f5c94a561e3f71ec2d3c988d56f12d342396c50cea6000825a10156100e15760003411361583541616156100dc576040513381523460208201527f15eeaa57c7bd188c1388020bcadc2c436ec60d647d36ef5b9eb3c742217ddee1604082a1005b600080fd5b6100e96101e9565b9050610126816000368080601f0160208091040260200160405190810160405280939291908181526020018383808284375061026c945050505050565b505050005b34801561013757600080fd5b506101406102ad565b60408051918252519081900360200190f35b34801561015e57600080fd5b5061016d6004356024356102b2565b6040805173ffffffffffffffffffffffffffffffffffffffff9092168252519081900360200190f35b3480156101a257600080fd5b506101ab6102e2565b604080519115158252519081900360200190f35b3480156101cb57600080fd5b5061016d6101e9565b3480156101e057600080fd5b50610140610312565b7f3b4bf6bf3ad5000ecf0f989d5befde585c6860fea3e574a4fab4c49d1c177d9c6000527fc67454ed56db7ff90a4bb32fc9a8de1ab3174b221e5fecea22b7503a3111791f6020527f8e2ed18767e9c33b25344c240cdf92034fae56be99e2c07f3d9946d949ffede45473ffffffffffffffffffffffffffffffffffffffff1690565b600061027783610318565b151561028257600080fd5b612710905060008083516020850186855a03f43d604051816000823e8280156102a9578282f35b8282fd5b600290565b600060208181529281526040808220909352908152205473ffffffffffffffffffffffffffffffffffffffff1681565b600061030d7f665fd576fbbe6f247aff98f5c94a561e3f71ec2d3c988d56f12d342396c50cea610352565b905090565b60015481565b60008073ffffffffffffffffffffffffffffffffffffffff83161515610341576000915061034c565b823b90506000811191505b50919050565b54905600a165627a7a72305820968d404e148c1ec7bb58c8df6cbdcaad4978b93a804e00a1f0e97a5e789eacd40029000000000000000000000000000000000000000000000000000000000000000000",
-                "hash": "0x3ac64c95eedf82e5d821696a12daac0e1b22c8ee18a9fd688b00cfaf14550aad",
-                "state": {
-                    "Checked": {
-                        "len": 898
+                "LegacyAnalyzed": {
+                    "bytecode": "0x00",
+                    "original_len": 0,
+                    "jump_table": {
+                      "order": "bitvec::order::Lsb0",
+                      "head": {
+                        "width": 8,
+                        "index": 0
+                      },
+                      "bits": 1,
+                      "data": [0]
                     }
                 }
             }
@@ -593,7 +600,7 @@ mod tests {
     "meta": {
         "cfg_env": {
             "chain_id": 1,
-            "spec_id": "LATEST",
+            "kzg_settings": "Default",
             "perf_analyse_created_bytecodes": "Analyse",
             "limit_contract_code_size": 18446744073709551615,
             "memory_limit": 134217728,
@@ -625,10 +632,17 @@ mod tests {
             "nonce": 128912,
             "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
             "code": {
-                "bytecode": "0x000000000000000000000000000000000000000000000000000000000000000000",
-                "state": {
-                    "Checked": {
-                        "len": 0
+                "LegacyAnalyzed": {
+                    "bytecode": "0x00",
+                    "original_len": 0,
+                    "jump_table": {
+                      "order": "bitvec::order::Lsb0",
+                      "head": {
+                        "width": 8,
+                        "index": 0
+                      },
+                      "bits": 1,
+                      "data": [0]
                     }
                 }
             }

--- a/crates/foundry/evm/core/src/utils.rs
+++ b/crates/foundry/evm/core/src/utils.rs
@@ -10,8 +10,8 @@ use revm::{
     db::WrapDatabaseRef,
     handler::register::EvmHandler,
     interpreter::{
-        return_ok, CallContext, CallInputs, CallOutcome, CallScheme, CreateInputs, CreateOutcome,
-        Gas, InstructionResult, InterpreterResult, Transfer,
+        return_ok, CallInputs, CallOutcome, CallScheme, CallValue, CreateInputs, CreateOutcome,
+        Gas, InstructionResult, InterpreterResult,
     },
     primitives::{CreateScheme, EVMError, SpecId, TransactTo, KECCAK_EMPTY},
     FrameOrResult, FrameResult,
@@ -117,23 +117,16 @@ pub fn gas_used(spec: SpecId, spent: u64, refunded: u64) -> u64 {
 fn get_create2_factory_call_inputs(salt: U256, inputs: CreateInputs) -> CallInputs {
     let calldata = [&salt.to_be_bytes::<32>()[..], &inputs.init_code[..]].concat();
     CallInputs {
-        contract: DEFAULT_CREATE2_DEPLOYER,
-        transfer: Transfer {
-            source: inputs.caller,
-            target: DEFAULT_CREATE2_DEPLOYER,
-            value: inputs.value,
-        },
+        caller: inputs.caller,
+        bytecode_address: DEFAULT_CREATE2_DEPLOYER,
+        target_address: DEFAULT_CREATE2_DEPLOYER,
+        scheme: CallScheme::Call,
+        value: CallValue::Transfer(inputs.value),
         input: calldata.into(),
         gas_limit: inputs.gas_limit,
-        context: CallContext {
-            caller: inputs.caller,
-            address: DEFAULT_CREATE2_DEPLOYER,
-            code_address: DEFAULT_CREATE2_DEPLOYER,
-            apparent_value: inputs.value,
-            scheme: CallScheme::Call,
-        },
         is_static: false,
         return_memory_offset: 0..0,
+        is_eof: false,
     }
 }
 

--- a/crates/foundry/evm/coverage/src/anchors.rs
+++ b/crates/foundry/evm/coverage/src/anchors.rs
@@ -4,8 +4,8 @@ use alloy_primitives::Bytes;
 use foundry_compilers::sourcemap::{SourceElement, SourceMap};
 use foundry_evm_core::utils::IcPcMap;
 use revm::{
-    interpreter::opcode::{self, spec_opcode_gas},
-    primitives::{HashSet, SpecId},
+    interpreter::opcode::{self, PUSH1, PUSH32},
+    primitives::HashSet,
 };
 
 use super::{CoverageItem, CoverageItemKind, ItemAnchor, SourceLocation};
@@ -118,10 +118,6 @@ pub fn find_anchor_branch(
     item_id: usize,
     loc: &SourceLocation,
 ) -> eyre::Result<(ItemAnchor, ItemAnchor)> {
-    // NOTE(onbjerg): We use `SpecId::LATEST` here since it does not matter; the
-    // only difference is the gas cost.
-    let opcode_infos = spec_opcode_gas(SpecId::LATEST);
-
     let mut anchors: Option<(ItemAnchor, ItemAnchor)> = None;
     let mut pc = 0;
     let mut cumulative_push_size = 0;
@@ -130,7 +126,9 @@ pub fn find_anchor_branch(
 
         // We found a push, so we do some PC -> IC translation accounting, but we also
         // check if this push is coupled with the JUMPI we are interested in.
-        if opcode_infos[op as usize].is_push() {
+
+        // Check if Opcode is PUSH
+        if (PUSH1..=PUSH32).contains(&op) {
             let element = if let Some(element) = source_map.get(pc - cumulative_push_size) {
                 element
             } else {

--- a/crates/foundry/evm/coverage/src/inspector.rs
+++ b/crates/foundry/evm/coverage/src/inspector.rs
@@ -11,15 +11,15 @@ pub struct CoverageCollector {
 impl<DB: Database> Inspector<DB> for CoverageCollector {
     #[inline]
     fn initialize_interp(&mut self, interp: &mut Interpreter, _context: &mut EvmContext<DB>) {
-        let hash = interp.contract.hash;
+        let hash = interp.contract.hash.expect("Contract hash is None");
         self.maps
             .entry(hash)
-            .or_insert_with(|| HitMap::new(interp.contract.bytecode.original_bytecode()));
+            .or_insert_with(|| HitMap::new(interp.contract.bytecode.original_bytes()));
     }
 
     #[inline]
     fn step(&mut self, interp: &mut Interpreter, _context: &mut EvmContext<DB>) {
-        let hash = interp.contract.hash;
+        let hash = interp.contract.hash.expect("Contract hash is None");
         self.maps
             .entry(hash)
             .and_modify(|map| map.hit(interp.program_counter()));

--- a/crates/foundry/evm/evm/src/executors/mod.rs
+++ b/crates/foundry/evm/evm/src/executors/mod.rs
@@ -25,7 +25,7 @@ use foundry_evm_coverage::HitMaps;
 use foundry_evm_traces::CallTraceArena;
 use revm::{
     db::{DatabaseCommit, DatabaseRef},
-    interpreter::{return_ok, CreateScheme, InstructionResult},
+    interpreter::{return_ok, InstructionResult},
     primitives::{
         BlockEnv, Bytecode, Env, EnvWithHandlerCfg, ExecutionResult, Output, ResultAndState,
         SpecId, TransactTo, TxEnv,
@@ -92,7 +92,7 @@ impl Executor {
         backend.insert_account_info(
             CHEATCODE_ADDRESS,
             revm::primitives::AccountInfo {
-                code: Some(Bytecode::new_raw(Bytes::from_static(&[0])).to_checked()),
+                code: Some(Bytecode::new_raw(Bytes::from_static(&[0]))),
                 ..Default::default()
             },
         );
@@ -404,7 +404,7 @@ impl Executor {
         rd: Option<&RevertDecoder>,
     ) -> Result<DeployResult, EvmError> {
         assert!(
-            matches!(env.tx.transact_to, TransactTo::Create(_)),
+            matches!(env.tx.transact_to, TransactTo::Create),
             "Expected create transaction, got {:?}",
             env.tx.transact_to
         );
@@ -440,7 +440,7 @@ impl Executor {
         value: U256,
         rd: Option<&RevertDecoder>,
     ) -> Result<DeployResult, EvmError> {
-        let env = self.build_test_env(from, TransactTo::Create(CreateScheme::Create), code, value);
+        let env = self.build_test_env(from, TransactTo::Create, code, value);
         self.deploy_with_env(env, rd)
     }
 

--- a/crates/foundry/evm/evm/src/inspectors/logs.rs
+++ b/crates/foundry/evm/evm/src/inspectors/logs.rs
@@ -53,7 +53,7 @@ impl<DB: Database> Inspector<DB> for LogCollector {
         _context: &mut EvmContext<DB>,
         inputs: &mut CallInputs,
     ) -> Option<CallOutcome> {
-        if inputs.contract == HARDHAT_CONSOLE_ADDRESS {
+        if inputs.target_address == HARDHAT_CONSOLE_ADDRESS {
             let (res, out) = self.hardhat_log(inputs.input.to_vec());
             if res != InstructionResult::Continue {
                 return Some(CallOutcome {

--- a/crates/foundry/evm/fuzz/src/inspector.rs
+++ b/crates/foundry/evm/fuzz/src/inspector.rs
@@ -31,7 +31,7 @@ impl<DB: Database> Inspector<DB> for Fuzzer {
     #[inline]
     fn call(&mut self, ecx: &mut EvmContext<DB>, inputs: &mut CallInputs) -> Option<CallOutcome> {
         // We don't want to override the very first call made to the test contract.
-        if self.call_generator.is_some() && ecx.env.tx.caller != inputs.context.caller {
+        if self.call_generator.is_some() && ecx.env.tx.caller != inputs.caller {
             self.override_call(inputs);
         }
 
@@ -81,20 +81,18 @@ impl Fuzzer {
     fn override_call(&mut self, call: &mut CallInputs) {
         if let Some(ref mut call_generator) = self.call_generator {
             // We only override external calls which are not coming from the test contract.
-            if call.context.caller != call_generator.test_address
-                && call.context.scheme == CallScheme::Call
+            if call.caller != call_generator.test_address
+                && call.scheme == CallScheme::Call
                 && !call_generator.used
             {
                 // There's only a 30% chance that an override happens.
-                if let Some(tx) = call_generator.next(call.context.caller, call.contract) {
+                if let Some(tx) = call_generator.next(call.caller, call.target_address) {
                     *call.input = tx.call_details.calldata.0;
-                    call.context.caller = tx.sender;
-                    call.contract = tx.call_details.target;
+                    call.caller = tx.sender;
+                    call.target_address = tx.call_details.target;
 
                     // TODO: in what scenarios can the following be problematic
-                    call.context.code_address = tx.call_details.target;
-                    call.context.address = tx.call_details.target;
-
+                    call.bytecode_address = tx.call_details.target;
                     call_generator.used = true;
                 }
             }

--- a/crates/foundry/evm/fuzz/src/strategies/state.rs
+++ b/crates/foundry/evm/fuzz/src/strategies/state.rs
@@ -15,8 +15,8 @@ use indexmap::IndexSet;
 use parking_lot::{lock_api::RwLockReadGuard, RawRwLock, RwLock};
 use revm::{
     db::{CacheDB, DatabaseRef, DbAccount},
-    interpreter::opcode::{self, spec_opcode_gas},
-    primitives::{AccountInfo, SpecId},
+    interpreter::opcode,
+    primitives::AccountInfo,
 };
 
 use crate::{
@@ -234,7 +234,7 @@ impl FuzzDictionary {
             // Insert push bytes
             if let Some(code) = account_info.code.clone() {
                 self.insert_address(*address, collected);
-                for push_byte in collect_push_bytes(code.bytes()) {
+                for push_byte in collect_push_bytes(&code.bytes()) {
                     self.insert_value(push_byte, collected);
                 }
             }
@@ -348,11 +348,10 @@ fn collect_push_bytes(code: &[u8]) -> Vec<[u8; 32]> {
     let mut bytes: Vec<[u8; 32]> = Vec::new();
     // We use [SpecId::LATEST] since we do not really care what spec it is - we are
     // not interested in gas costs.
-    let opcode_infos = spec_opcode_gas(SpecId::LATEST);
     let mut i = 0;
     while i < code.len().min(PUSH_BYTE_ANALYSIS_LIMIT) {
         let op = code[i];
-        if opcode_infos[op as usize].is_push() {
+        if (opcode::PUSH1..=opcode::PUSH32).contains(&op) {
             let push_size = (op - opcode::PUSH1 + 1) as usize;
             let push_start = i + 1;
             let push_end = push_start + push_size;


### PR DESCRIPTION
Bump the forked Foundry crates for the Solidity tests feature to use REVM 9. 

Based on https://github.com/foundry-rs/foundry/pull/7934. There was one additional change required: specifying the Cancun hardfork for the Rust integration tests, as they used the default version and in Revm 9 that is Prague which caused problems. (The JS interface specifies Cancun explicitly.)