### PR TITLE
chore: get network config from foundry.toml

### DIFF
--- a/crates/tools/js/benchmark/package.json
+++ b/crates/tools/js/benchmark/package.json
@@ -24,6 +24,7 @@
     "mocha": "^10.0.0",
     "prettier": "^3.2.5",
     "simple-git": "^3.25.0",
+    "smol-toml": "^1.3.0",
     "tsx": "^4.7.1",
     "typescript": "~5.5.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,6 +148,9 @@ importers:
       simple-git:
         specifier: ^3.25.0
         version: 3.26.0
+      smol-toml:
+        specifier: ^1.3.0
+        version: 1.3.0
       tsx:
         specifier: ^4.7.1
         version: 4.7.1
@@ -1838,6 +1841,7 @@ packages:
   eslint@8.57.0:
     resolution: {integrity: sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
   espree@9.6.1:
@@ -2953,6 +2957,10 @@ packages:
     resolution: {integrity: sha512-vCsKNQxb7PnCNd2wY1WClWifAc2lwqsG8OaswpJkVJsvMGcnEntdTCDajZCkk93Ay1U3t/9puJmb525Rg5MZBA==}
     engines: {node: '>=6'}
     hasBin: true
+
+  smol-toml@1.3.0:
+    resolution: {integrity: sha512-tWpi2TsODPScmi48b/OQZGi2lgUmBCHy6SZrhi/FdnnHiU1GwebbCfuQuxsC3nHaLwtYeJGPrDZDIeodDOc4pA==}
+    engines: {node: '>= 18'}
 
   solc@0.8.26:
     resolution: {integrity: sha512-yiPQNVf5rBFHwN6SIf3TUUvVAFKcQqmSUFeq+fb6pNRCo0ZCgpYOZDi3BVoezCPIAcKrVYd/qXlBLUP9wVrZ9g==}
@@ -6343,6 +6351,8 @@ snapshots:
       strip-ansi: 6.0.1
       wcwidth: 1.0.1
       yargs: 15.4.1
+
+  smol-toml@1.3.0: {}
 
   solc@0.8.26(debug@4.3.7):
     dependencies:


### PR DESCRIPTION
 Get  network config from foundry.toml to replace hardcoded URLs.
 
Add [smol-toml](https://github.com/squirrelchat/smol-toml) package to parse the toml config

resolve #709 