### PR TITLE
chore: fix setting tracing subscriber

### DIFF
--- a/crates/edr_napi/src/context.rs
+++ b/crates/edr_napi/src/context.rs
@@ -1,5 +1,7 @@
 use std::{ops::Deref, sync::Arc};
 
+#[cfg(feature = "tracing")]
+use napi::Status;
 use napi_derive::napi;
 use tracing_subscriber::{prelude::*, EnvFilter, Registry};
 

--- a/crates/edr_napi/src/context.rs
+++ b/crates/edr_napi/src/context.rs
@@ -1,6 +1,5 @@
 use std::{ops::Deref, sync::Arc};
 
-use napi::Status;
 use napi_derive::napi;
 use tracing_subscriber::{prelude::*, EnvFilter, Registry};
 
@@ -67,12 +66,12 @@ impl Context {
         #[cfg(feature = "tracing")]
         let subscriber = subscriber.with(flame_layer);
 
-        tracing::subscriber::set_global_default(subscriber).map_err(|err| {
-            napi::Error::new(
-                Status::GenericFailure,
-                format!("Failed to set global tracing subscriber with error: {err:?}"),
-            )
-        })?;
+        if let Err(error) = tracing::subscriber::set_global_default(subscriber) {
+            println!(
+                "Failed to set global tracing subscriber with error: {error}\n\
+                Please only initialize EdrContext once per process to avoid this error."
+            );
+        }
 
         Ok(Self {
             #[cfg(feature = "tracing")]

--- a/crates/edr_napi/src/context.rs
+++ b/crates/edr_napi/src/context.rs
@@ -1,4 +1,4 @@
-use std::{io, ops::Deref, sync::Arc};
+use std::{ops::Deref, sync::Arc};
 
 use napi::Status;
 use napi_derive::napi;
@@ -23,8 +23,7 @@ impl EdrContext {
     #[doc = "Creates a new [`EdrContext`] instance. Should only be called once!"]
     #[napi(constructor)]
     pub fn new() -> napi::Result<Self> {
-        let context =
-            Context::new().map_err(|e| napi::Error::new(Status::GenericFailure, e.to_string()))?;
+        let context = Context::new()?;
 
         Ok(Self {
             inner: Arc::new(context),
@@ -34,14 +33,13 @@ impl EdrContext {
 
 #[derive(Debug)]
 pub struct Context {
-    _subscriber_guard: tracing::subscriber::DefaultGuard,
     #[cfg(feature = "tracing")]
     _tracing_write_guard: tracing_flame::FlushGuard<std::io::BufWriter<std::fs::File>>,
 }
 
 impl Context {
     /// Creates a new [`Context`] instance. Should only be called once!
-    pub fn new() -> io::Result<Self> {
+    pub fn new() -> napi::Result<Self> {
         let fmt_layer = tracing_subscriber::fmt::layer()
             .with_file(true)
             .with_line_number(true)
@@ -54,8 +52,13 @@ impl Context {
 
         #[cfg(feature = "tracing")]
         let (flame_layer, guard) = {
-            let (flame_layer, guard) =
-                tracing_flame::FlameLayer::with_file("tracing.folded").unwrap();
+            let (flame_layer, guard) = tracing_flame::FlameLayer::with_file("tracing.folded")
+                .map_err(|err| {
+                    napi::Error::new(
+                        Status::GenericFailure,
+                        format!("Failed to create tracing.folded file with error: {err:?}"),
+                    )
+                })?;
 
             let flame_layer = flame_layer.with_empty_samples(false);
             (flame_layer, guard)
@@ -64,10 +67,14 @@ impl Context {
         #[cfg(feature = "tracing")]
         let subscriber = subscriber.with(flame_layer);
 
-        let subscriber_guard = tracing::subscriber::set_default(subscriber);
+        tracing::subscriber::set_global_default(subscriber).map_err(|err| {
+            napi::Error::new(
+                Status::GenericFailure,
+                format!("Failed to set global tracing subscriber with error: {err:?}"),
+            )
+        })?;
 
         Ok(Self {
-            _subscriber_guard: subscriber_guard,
             #[cfg(feature = "tracing")]
             _tracing_write_guard: guard,
         })

--- a/crates/edr_napi/test/context.ts
+++ b/crates/edr_napi/test/context.ts
@@ -1,0 +1,8 @@
+import { EdrContext } from "../index";
+
+describe("EdrContext", () => {
+  it("EdrContext doesn't throw if initialized twice", () => {
+    new EdrContext();
+    new EdrContext();
+  });
+});

--- a/crates/edr_napi/test/helpers.ts
+++ b/crates/edr_napi/test/helpers.ts
@@ -1,4 +1,9 @@
-import { TracingMessage, TracingMessageResult, TracingStep } from "..";
+import {
+  EdrContext,
+  TracingMessage,
+  TracingMessageResult,
+  TracingStep,
+} from "..";
 
 function getEnv(key: string): string | undefined {
   const variable = process.env[key];
@@ -15,6 +20,15 @@ export const ALCHEMY_URL = getEnv("ALCHEMY_URL");
 
 export function isCI(): boolean {
   return getEnv("CI") === "true";
+}
+
+let context: EdrContext | undefined;
+
+export function getContext(): EdrContext {
+  if (context === undefined) {
+    context = new EdrContext();
+  }
+  return context;
 }
 
 /**

--- a/crates/edr_napi/test/issues.ts
+++ b/crates/edr_napi/test/issues.ts
@@ -2,16 +2,15 @@ import { JsonStreamStringify } from "json-stream-stringify";
 
 import {
   ContractAndFunctionName,
-  EdrContext,
   MineOrdering,
   Provider,
   SpecId,
   SubscriptionEvent,
 } from "..";
-import { ALCHEMY_URL, isCI } from "./helpers";
+import { ALCHEMY_URL, getContext, isCI } from "./helpers";
 
 describe("Provider", () => {
-  const context = new EdrContext();
+  const context = getContext();
   const providerConfig = {
     allowBlocksWithSameTimestamp: false,
     allowUnlimitedContractSize: true,

--- a/crates/edr_napi/test/provider.ts
+++ b/crates/edr_napi/test/provider.ts
@@ -3,7 +3,6 @@ import chaiAsPromised from "chai-as-promised";
 
 import {
   ContractAndFunctionName,
-  EdrContext,
   MineOrdering,
   Provider,
   SpecId,

--- a/crates/edr_napi/test/provider.ts
+++ b/crates/edr_napi/test/provider.ts
@@ -9,12 +9,17 @@ import {
   SpecId,
   SubscriptionEvent,
 } from "..";
-import { collectMessages, collectSteps, ALCHEMY_URL } from "./helpers";
+import {
+  collectMessages,
+  collectSteps,
+  ALCHEMY_URL,
+  getContext,
+} from "./helpers";
 
 chai.use(chaiAsPromised);
 
 describe("Provider", () => {
-  const context = new EdrContext();
+  const context = getContext();
   const providerConfig = {
     allowBlocksWithSameTimestamp: false,
     allowUnlimitedContractSize: true,


### PR DESCRIPTION
Previously we were only setting a default tracing subscriber for the current thread in `edr_napi` which precluded logs from other threads being collected.

With this change, the subscriber is set globally for all threads so that we can get tracing output when running JS tests, e.g. from `hardhat-tests`: `RUST_LOG=debug pnpm test`.