### PR TITLE
fix: Optimism Sepolia hardfork

### DIFF
--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           files: codecov.json
           name: ${{ matrix.os }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Doctests

--- a/crates/edr_optimism/Cargo.toml
+++ b/crates/edr_optimism/Cargo.toml
@@ -22,6 +22,7 @@ tokio = { version = "1.21.2", default-features = false, features = ["macros", "r
 anyhow = "1.0.89"
 edr_defaults = { path = "../edr_defaults" }
 edr_evm = { path = "../edr_evm", features = ["test-utils"] }
+edr_provider = { path = "../edr_provider", features = ["test-utils"] }
 edr_rpc_eth = { path = "../edr_rpc_eth", features = ["test-utils"] }
 edr_test_utils = { path = "../edr_test_utils" }
 parking_lot = { version = "0.12.1", default-features = false }

--- a/crates/edr_optimism/src/hardfork.rs
+++ b/crates/edr_optimism/src/hardfork.rs
@@ -126,7 +126,7 @@ fn chain_configs() -> &'static HashMap<u64, &'static ChainConfig<OptimismChainSp
     CONFIGS.get_or_init(|| {
         let mut hardforks = HashMap::new();
         hardforks.insert(10, mainnet_config());
-        hardforks.insert(11_155_111, sepolia_config());
+        hardforks.insert(11_155_420, sepolia_config());
 
         hardforks
     })

--- a/crates/edr_optimism/src/hardfork.rs
+++ b/crates/edr_optimism/src/hardfork.rs
@@ -80,8 +80,6 @@ const SEPOLIA_HARDFORKS: &[(ForkCondition, OptimismSpecId)] = &[
     (ForkCondition::Block(0), OptimismSpecId::MERGE),
     (ForkCondition::Block(0), OptimismSpecId::BEDROCK),
     (ForkCondition::Block(0), OptimismSpecId::REGOLITH),
-    (ForkCondition::Block(0), OptimismSpecId::BEDROCK),
-    (ForkCondition::Block(0), OptimismSpecId::REGOLITH),
     (
         ForkCondition::Timestamp(1_699_981_200),
         OptimismSpecId::SHANGHAI,

--- a/crates/edr_optimism/tests/provider.rs
+++ b/crates/edr_optimism/tests/provider.rs
@@ -1,0 +1,28 @@
+use edr_eth::BlockSpec;
+use edr_optimism::{OptimismChainSpec, OptimismSpecId};
+use edr_provider::test_utils::ProviderTestFixture;
+use edr_test_utils::env::get_alchemy_url;
+
+#[test]
+fn sepolia_hardfork_activations() -> anyhow::Result<()> {
+    const CANYON_BLOCK_NUMBER: u64 = 4_089_330;
+    const SEPOLIA_CHAIN_ID: u64 = 11_155_420;
+
+    let url = get_alchemy_url()
+        .replace("eth-", "opt-")
+        .replace("mainnet", "sepolia");
+
+    let fixture = ProviderTestFixture::<OptimismChainSpec>::new_forked(Some(url))?;
+
+    let block_spec = BlockSpec::Number(CANYON_BLOCK_NUMBER);
+    let (_, hardfork) = fixture
+        .provider_data
+        .create_evm_config_at_block_spec(&block_spec)?;
+
+    assert_eq!(hardfork, OptimismSpecId::CANYON);
+
+    let chain_id = fixture.provider_data.chain_id_at_block_spec(&block_spec)?;
+    assert_eq!(chain_id, SEPOLIA_CHAIN_ID);
+
+    Ok(())
+}

--- a/crates/edr_provider/Cargo.toml
+++ b/crates/edr_provider/Cargo.toml
@@ -14,6 +14,7 @@ edr_defaults = { version = "0.3.5", path = "../edr_defaults" }
 edr_eth = { version = "0.3.5", path = "../edr_eth" }
 edr_evm = { version = "0.3.5", path = "../edr_evm", features = ["tracing"] }
 edr_rpc_eth = { version = "0.3.5", path = "../edr_rpc_eth" }
+edr_test_utils = { version = "0.3.5", path = "../edr_test_utils", optional = true }
 indexmap = { version = "2.0.0", default-features = false, features = ["std"] }
 itertools = { version = "0.12.0", default-features = false, features = ["use_alloc"] }
 k256 = { version = "0.13.1", default-features = false, features = ["arithmetic", "ecdsa", "pem", "pkcs8", "precomputed-tables", "std"] }
@@ -44,7 +45,7 @@ cargo_toml = { version = "0.15.3", default-features = false }
 toml = { version = "0.5.9", default-features = false }
 
 [features]
-test-utils = ["dep:anyhow"]
+test-utils = ["dep:anyhow", "dep:edr_test_utils"]
 tracing = ["dep:tracing", "edr_eth/tracing", "edr_evm/tracing"]
 test-remote = []
 

--- a/crates/edr_provider/src/data.rs
+++ b/crates/edr_provider/src/data.rs
@@ -2815,150 +2815,6 @@ fn create_blockchain_and_state<ChainSpecT: SyncRuntimeSpec<Hardfork: Debug>>(
     }
 }
 
-#[cfg(test)]
-pub(crate) mod test_utils {
-    use anyhow::anyhow;
-    use edr_eth::{
-        l1::L1ChainSpec,
-        transaction::{self, TxKind},
-    };
-
-    use super::*;
-    use crate::{
-        test_utils::{create_test_config_with_fork, one_ether, FORK_BLOCK_NUMBER},
-        NoopLogger, ProviderConfig,
-    };
-
-    pub(crate) struct ProviderTestFixture {
-        _runtime: runtime::Runtime,
-        pub config: ProviderConfig<L1ChainSpec>,
-        pub provider_data: ProviderData<L1ChainSpec>,
-        pub impersonated_account: Address,
-    }
-
-    impl ProviderTestFixture {
-        pub(crate) fn new_local() -> anyhow::Result<Self> {
-            Self::with_fork(None)
-        }
-
-        #[cfg(feature = "test-remote")]
-        pub(crate) fn new_forked(url: Option<String>) -> anyhow::Result<Self> {
-            use edr_test_utils::env::get_alchemy_url;
-
-            let fork_url = url.unwrap_or(get_alchemy_url());
-            Self::with_fork(Some(fork_url))
-        }
-
-        fn with_fork(fork: Option<String>) -> anyhow::Result<Self> {
-            let fork = fork.map(|json_rpc_url| {
-                ForkConfig {
-                    json_rpc_url,
-                    // Random recent block for better cache consistency
-                    block_number: Some(FORK_BLOCK_NUMBER),
-                    http_headers: None,
-                }
-            });
-
-            let config = create_test_config_with_fork(fork);
-
-            let runtime = runtime::Builder::new_multi_thread()
-                .worker_threads(1)
-                .enable_all()
-                .thread_name("provider-data-test")
-                .build()?;
-
-            Self::new(runtime, config)
-        }
-
-        pub fn new(
-            runtime: tokio::runtime::Runtime,
-            mut config: ProviderConfig<L1ChainSpec>,
-        ) -> anyhow::Result<Self> {
-            let logger = Box::<NoopLogger<L1ChainSpec>>::default();
-            let subscription_callback_noop = Box::new(|_| ());
-
-            let impersonated_account = Address::random();
-            config.genesis_accounts.insert(
-                impersonated_account,
-                AccountInfo {
-                    balance: one_ether(),
-                    nonce: 0,
-                    code: None,
-                    code_hash: KECCAK_EMPTY,
-                },
-            );
-
-            let mut provider_data = ProviderData::new(
-                runtime.handle().clone(),
-                logger,
-                subscription_callback_noop,
-                None,
-                config.clone(),
-                CurrentTime,
-            )?;
-
-            provider_data.impersonate_account(impersonated_account);
-
-            Ok(Self {
-                _runtime: runtime,
-                config,
-                provider_data,
-                impersonated_account,
-            })
-        }
-
-        pub fn dummy_transaction_request(
-            &self,
-            local_account_index: usize,
-            gas_limit: u64,
-            nonce: Option<u64>,
-        ) -> anyhow::Result<TransactionRequestAndSender<transaction::Request>> {
-            let request = transaction::Request::Eip155(transaction::request::Eip155 {
-                kind: TxKind::Call(Address::ZERO),
-                gas_limit,
-                gas_price: U256::from(42_000_000_000_u64),
-                value: U256::from(1),
-                input: Bytes::default(),
-                nonce: nonce.unwrap_or(0),
-                chain_id: self.config.chain_id,
-            });
-
-            let sender = self.nth_local_account(local_account_index)?;
-            Ok(TransactionRequestAndSender { request, sender })
-        }
-
-        /// Retrieves the nth local account.
-        ///
-        /// # Panics
-        ///
-        /// Panics if there are not enough local accounts
-        pub fn nth_local_account(&self, index: usize) -> anyhow::Result<Address> {
-            self.provider_data
-                .local_accounts
-                .keys()
-                .nth(index)
-                .copied()
-                .ok_or(anyhow!("the requested local account does not exist"))
-        }
-
-        pub fn impersonated_dummy_transaction(&self) -> anyhow::Result<transaction::Signed> {
-            let mut transaction = self.dummy_transaction_request(0, 30_000, None)?;
-            transaction.sender = self.impersonated_account;
-
-            Ok(self.provider_data.sign_transaction_request(transaction)?)
-        }
-
-        pub fn signed_dummy_transaction(
-            &self,
-            local_account_index: usize,
-            nonce: Option<u64>,
-        ) -> anyhow::Result<transaction::Signed> {
-            let transaction = self.dummy_transaction_request(local_account_index, 30_000, nonce)?;
-            Ok(self.provider_data.sign_transaction_request(transaction)?)
-        }
-    }
-}
-
 fn get_skip_unsupported_transaction_types_from_env() -> bool {
     std::env::var(EDR_UNSAFE_SKIP_UNSUPPORTED_TRANSACTION_TYPES)
         .map_or(DEFAULT_SKIP_UNSUPPORTED_TRANSACTION_TYPES, |s| s == "true")
@@ -2987,10 +2843,10 @@ mod tests {
     use edr_evm::MineOrdering;
     use serde_json::json;
 
-    use super::{test_utils::ProviderTestFixture, *};
+    use super::*;
     use crate::{
         console_log::tests::{deploy_console_log_contract, ConsoleLogTransaction},
-        test_utils::{create_test_config, one_ether},
+        test_utils::{create_test_config, one_ether, ProviderTestFixture},
         MemPoolConfig, MiningConfig, ProviderConfig,
     };
 

--- a/crates/edr_provider/src/data.rs
+++ b/crates/edr_provider/src/data.rs
@@ -1233,7 +1233,7 @@ where
 
     /// Creates a configuration, taking into account the hardfork at the
     /// provided `BlockSpec`.
-    fn create_evm_config_at_block_spec(
+    pub fn create_evm_config_at_block_spec(
         &self,
         block_spec: &BlockSpec,
     ) -> Result<(CfgEnv, ChainSpecT::Hardfork), ProviderError<ChainSpecT>> {

--- a/crates/edr_provider/src/data.rs
+++ b/crates/edr_provider/src/data.rs
@@ -2852,7 +2852,7 @@ mod tests {
 
     #[test]
     fn test_local_account_balance() -> anyhow::Result<()> {
-        let mut fixture = ProviderTestFixture::new_local()?;
+        let mut fixture = ProviderTestFixture::<L1ChainSpec>::new_local()?;
 
         let account = *fixture
             .provider_data
@@ -2874,7 +2874,7 @@ mod tests {
     #[cfg(feature = "test-remote")]
     #[test]
     fn test_local_account_balance_forked() -> anyhow::Result<()> {
-        let mut fixture = ProviderTestFixture::new_forked(None)?;
+        let mut fixture = ProviderTestFixture::<L1ChainSpec>::new_forked(None)?;
 
         let account = *fixture
             .provider_data
@@ -2895,7 +2895,7 @@ mod tests {
 
     #[test]
     fn test_sign_transaction_request() -> anyhow::Result<()> {
-        let fixture = ProviderTestFixture::new_local()?;
+        let fixture = ProviderTestFixture::<L1ChainSpec>::new_local()?;
 
         let transaction = fixture.signed_dummy_transaction(0, None)?;
         let recovered_address = transaction.caller();
@@ -2910,7 +2910,7 @@ mod tests {
 
     #[test]
     fn test_sign_transaction_request_impersonated_account() -> anyhow::Result<()> {
-        let fixture = ProviderTestFixture::new_local()?;
+        let fixture = ProviderTestFixture::<L1ChainSpec>::new_local()?;
 
         let transaction = fixture.impersonated_dummy_transaction()?;
 
@@ -2920,7 +2920,7 @@ mod tests {
     }
 
     fn test_add_pending_transaction(
-        fixture: &mut ProviderTestFixture,
+        fixture: &mut ProviderTestFixture<L1ChainSpec>,
         transaction: transaction::Signed,
     ) -> anyhow::Result<()> {
         let filter_id = fixture
@@ -2953,7 +2953,7 @@ mod tests {
 
     #[test]
     fn add_pending_transaction() -> anyhow::Result<()> {
-        let mut fixture = ProviderTestFixture::new_local()?;
+        let mut fixture = ProviderTestFixture::<L1ChainSpec>::new_local()?;
         let transaction = fixture.signed_dummy_transaction(0, None)?;
 
         test_add_pending_transaction(&mut fixture, transaction)
@@ -2961,7 +2961,7 @@ mod tests {
 
     #[test]
     fn add_pending_transaction_from_impersonated_account() -> anyhow::Result<()> {
-        let mut fixture = ProviderTestFixture::new_local()?;
+        let mut fixture = ProviderTestFixture::<L1ChainSpec>::new_local()?;
         let transaction = fixture.impersonated_dummy_transaction()?;
 
         test_add_pending_transaction(&mut fixture, transaction)
@@ -2969,7 +2969,7 @@ mod tests {
 
     #[test]
     fn block_by_block_spec_earliest() -> anyhow::Result<()> {
-        let fixture = ProviderTestFixture::new_local()?;
+        let fixture = ProviderTestFixture::<L1ChainSpec>::new_local()?;
 
         let block_spec = BlockSpec::Tag(BlockTag::Earliest);
 
@@ -2985,7 +2985,7 @@ mod tests {
 
     #[test]
     fn block_by_block_spec_finalized_safe_latest() -> anyhow::Result<()> {
-        let mut fixture = ProviderTestFixture::new_local()?;
+        let mut fixture = ProviderTestFixture::<L1ChainSpec>::new_local()?;
 
         // Mine a block to make sure we're not getting the genesis block
         fixture
@@ -3012,7 +3012,7 @@ mod tests {
 
     #[test]
     fn block_by_block_spec_pending() -> anyhow::Result<()> {
-        let fixture = ProviderTestFixture::new_local()?;
+        let fixture = ProviderTestFixture::<L1ChainSpec>::new_local()?;
 
         let block_spec = BlockSpec::Tag(BlockTag::Pending);
 
@@ -3026,7 +3026,7 @@ mod tests {
     // Make sure executing a transaction in a pending block context doesn't panic.
     #[test]
     fn execute_in_block_context_pending() -> anyhow::Result<()> {
-        let mut fixture = ProviderTestFixture::new_local()?;
+        let mut fixture = ProviderTestFixture::<L1ChainSpec>::new_local()?;
 
         let block_spec = Some(BlockSpec::Tag(BlockTag::Pending));
 
@@ -3046,7 +3046,7 @@ mod tests {
 
     #[test]
     fn chain_id() -> anyhow::Result<()> {
-        let fixture = ProviderTestFixture::new_local()?;
+        let fixture = ProviderTestFixture::<L1ChainSpec>::new_local()?;
 
         let chain_id = fixture.provider_data.chain_id();
         assert_eq!(chain_id, fixture.config.chain_id);
@@ -3057,7 +3057,7 @@ mod tests {
     #[cfg(feature = "test-remote")]
     #[test]
     fn chain_id_fork_mode() -> anyhow::Result<()> {
-        let fixture = ProviderTestFixture::new_forked(None)?;
+        let fixture = ProviderTestFixture::<L1ChainSpec>::new_forked(None)?;
 
         let chain_id = fixture.provider_data.chain_id();
         assert_eq!(chain_id, fixture.config.chain_id);
@@ -3073,7 +3073,7 @@ mod tests {
     #[cfg(feature = "test-remote")]
     #[test]
     fn fork_metadata_fork_mode() -> anyhow::Result<()> {
-        let fixture = ProviderTestFixture::new_forked(None)?;
+        let fixture = ProviderTestFixture::<L1ChainSpec>::new_forked(None)?;
 
         let fork_metadata = fixture
             .provider_data
@@ -3086,7 +3086,7 @@ mod tests {
 
     #[test]
     fn console_log_mine_block() -> anyhow::Result<()> {
-        let mut fixture = ProviderTestFixture::new_local()?;
+        let mut fixture = ProviderTestFixture::<L1ChainSpec>::new_local()?;
         let ConsoleLogTransaction {
             transaction,
             expected_call_data,
@@ -3118,7 +3118,7 @@ mod tests {
 
     #[test]
     fn console_log_run_call() -> anyhow::Result<()> {
-        let mut fixture = ProviderTestFixture::new_local()?;
+        let mut fixture = ProviderTestFixture::<L1ChainSpec>::new_local()?;
         let ConsoleLogTransaction {
             transaction,
             expected_call_data,
@@ -3143,7 +3143,7 @@ mod tests {
 
     #[test]
     fn mine_and_commit_block_empty() -> anyhow::Result<()> {
-        let mut fixture = ProviderTestFixture::new_local()?;
+        let mut fixture = ProviderTestFixture::<L1ChainSpec>::new_local()?;
 
         let previous_block_number = fixture.provider_data.last_block_number();
 
@@ -3171,7 +3171,7 @@ mod tests {
 
     #[test]
     fn mine_and_commit_blocks_empty() -> anyhow::Result<()> {
-        let mut fixture = ProviderTestFixture::new_local()?;
+        let mut fixture = ProviderTestFixture::<L1ChainSpec>::new_local()?;
 
         fixture
             .provider_data
@@ -3193,7 +3193,7 @@ mod tests {
 
     #[test]
     fn mine_and_commit_block_single_transaction() -> anyhow::Result<()> {
-        let mut fixture = ProviderTestFixture::new_local()?;
+        let mut fixture = ProviderTestFixture::<L1ChainSpec>::new_local()?;
 
         let transaction = fixture.signed_dummy_transaction(0, None)?;
         let expected = *transaction.value();
@@ -3222,7 +3222,7 @@ mod tests {
 
     #[test]
     fn mine_and_commit_block_two_transactions_different_senders() -> anyhow::Result<()> {
-        let mut fixture = ProviderTestFixture::new_local()?;
+        let mut fixture = ProviderTestFixture::<L1ChainSpec>::new_local()?;
 
         let transaction1 = fixture.signed_dummy_transaction(0, None)?;
         let transaction2 = fixture.signed_dummy_transaction(1, None)?;
@@ -3259,7 +3259,7 @@ mod tests {
 
     #[test]
     fn mine_and_commit_block_two_transactions_same_sender() -> anyhow::Result<()> {
-        let mut fixture = ProviderTestFixture::new_local()?;
+        let mut fixture = ProviderTestFixture::<L1ChainSpec>::new_local()?;
 
         let transaction1 = fixture.signed_dummy_transaction(0, Some(0))?;
         let transaction2 = fixture.signed_dummy_transaction(0, Some(1))?;
@@ -3296,7 +3296,7 @@ mod tests {
 
     #[test]
     fn mine_and_commit_block_removes_mined_transactions() -> anyhow::Result<()> {
-        let mut fixture = ProviderTestFixture::new_local()?;
+        let mut fixture = ProviderTestFixture::<L1ChainSpec>::new_local()?;
 
         let transaction = fixture.signed_dummy_transaction(0, None)?;
 
@@ -3321,7 +3321,7 @@ mod tests {
 
     #[test]
     fn mine_and_commit_block_leaves_unmined_transactions() -> anyhow::Result<()> {
-        let mut fixture = ProviderTestFixture::new_local()?;
+        let mut fixture = ProviderTestFixture::<L1ChainSpec>::new_local()?;
 
         // SAFETY: literal is non-zero
         fixture
@@ -3404,7 +3404,7 @@ mod tests {
             .thread_name("provider-data-test")
             .build()?;
 
-        let mut fixture = ProviderTestFixture::new(runtime, config)?;
+        let mut fixture = ProviderTestFixture::<L1ChainSpec>::new(runtime, config)?;
 
         let transaction1 = fixture.signed_dummy_transaction(0, None)?;
         let transaction2 = fixture.signed_dummy_transaction(1, None)?;
@@ -3441,7 +3441,7 @@ mod tests {
 
     #[test]
     fn mine_and_commit_block_correct_gas_used() -> anyhow::Result<()> {
-        let mut fixture = ProviderTestFixture::new_local()?;
+        let mut fixture = ProviderTestFixture::<L1ChainSpec>::new_local()?;
 
         let transaction1 = fixture.signed_dummy_transaction(0, None)?;
         let transaction2 = fixture.signed_dummy_transaction(1, None)?;
@@ -3490,7 +3490,7 @@ mod tests {
             .thread_name("provider-data-test")
             .build()?;
 
-        let mut fixture = ProviderTestFixture::new(runtime, config)?;
+        let mut fixture = ProviderTestFixture::<L1ChainSpec>::new(runtime, config)?;
 
         let miner = fixture.provider_data.beneficiary;
         let previous_miner_balance = fixture
@@ -3519,7 +3519,7 @@ mod tests {
     fn mine_and_commit_blocks_increases_block_number() -> anyhow::Result<()> {
         const NUM_MINED_BLOCKS: u64 = 10;
 
-        let mut fixture = ProviderTestFixture::new_local()?;
+        let mut fixture = ProviderTestFixture::<L1ChainSpec>::new_local()?;
 
         let previous_block_number = fixture.provider_data.last_block_number();
 
@@ -3543,7 +3543,7 @@ mod tests {
     fn mine_and_commit_blocks_works_with_snapshots() -> anyhow::Result<()> {
         const NUM_MINED_BLOCKS: u64 = 10;
 
-        let mut fixture = ProviderTestFixture::new_local()?;
+        let mut fixture = ProviderTestFixture::<L1ChainSpec>::new_local()?;
 
         let transaction1 = fixture.signed_dummy_transaction(0, None)?;
         let transaction2 = fixture.signed_dummy_transaction(1, None)?;
@@ -3606,7 +3606,7 @@ mod tests {
 
     #[test]
     fn next_filter_id() -> anyhow::Result<()> {
-        let mut fixture = ProviderTestFixture::new_local()?;
+        let mut fixture = ProviderTestFixture::<L1ChainSpec>::new_local()?;
 
         let mut prev_filter_id = fixture.provider_data.last_filter_id;
         for _ in 0..10 {
@@ -3620,7 +3620,7 @@ mod tests {
 
     #[test]
     fn pending_transactions_returns_pending_and_queued() -> anyhow::Result<()> {
-        let mut fixture = ProviderTestFixture::new_local().unwrap();
+        let mut fixture = ProviderTestFixture::<L1ChainSpec>::new_local().unwrap();
 
         let transaction1 = fixture.signed_dummy_transaction(0, Some(0))?;
         fixture
@@ -3653,7 +3653,7 @@ mod tests {
 
     #[test]
     fn set_balance_updates_mem_pool() -> anyhow::Result<()> {
-        let mut fixture = ProviderTestFixture::new_local()?;
+        let mut fixture = ProviderTestFixture::<L1ChainSpec>::new_local()?;
 
         let transaction = fixture.impersonated_dummy_transaction()?;
         let transaction_hash = fixture.provider_data.add_pending_transaction(transaction)?;
@@ -3679,7 +3679,7 @@ mod tests {
 
     #[test]
     fn transaction_by_invalid_hash() -> anyhow::Result<()> {
-        let fixture = ProviderTestFixture::new_local()?;
+        let fixture = ProviderTestFixture::<L1ChainSpec>::new_local()?;
 
         let non_existing_tx = fixture.provider_data.transaction_by_hash(&B256::ZERO)?;
 
@@ -3690,7 +3690,7 @@ mod tests {
 
     #[test]
     fn pending_transaction_by_hash() -> anyhow::Result<()> {
-        let mut fixture = ProviderTestFixture::new_local()?;
+        let mut fixture = ProviderTestFixture::<L1ChainSpec>::new_local()?;
 
         let transaction_request = fixture.signed_dummy_transaction(0, None)?;
         let transaction_hash = fixture
@@ -3712,7 +3712,7 @@ mod tests {
 
     #[test]
     fn transaction_by_hash() -> anyhow::Result<()> {
-        let mut fixture = ProviderTestFixture::new_local()?;
+        let mut fixture = ProviderTestFixture::<L1ChainSpec>::new_local()?;
 
         let transaction_request = fixture.signed_dummy_transaction(0, None)?;
         let transaction_hash = fixture
@@ -3747,7 +3747,7 @@ mod tests {
 
     #[test]
     fn sign_typed_data_v4() -> anyhow::Result<()> {
-        let fixture = ProviderTestFixture::new_local()?;
+        let fixture = ProviderTestFixture::<L1ChainSpec>::new_local()?;
 
         // This test was taken from the `eth_signTypedData` example from the
         // EIP-712 specification via Hardhat.
@@ -3815,7 +3815,7 @@ mod tests {
 
         #[test]
         fn reset_local_to_forking() -> anyhow::Result<()> {
-            let mut fixture = ProviderTestFixture::new_local()?;
+            let mut fixture = ProviderTestFixture::<L1ChainSpec>::new_local()?;
 
             let fork_config = Some(ForkConfig {
                 json_rpc_url: get_alchemy_url(),
@@ -3843,7 +3843,7 @@ mod tests {
 
         #[test]
         fn reset_forking_to_local() -> anyhow::Result<()> {
-            let mut fixture = ProviderTestFixture::new_forked(None)?;
+            let mut fixture = ProviderTestFixture::<L1ChainSpec>::new_forked(None)?;
 
             // We're fetching a specific block instead of the last block number for the
             // forked blockchain, because the last block number query cannot be
@@ -3925,7 +3925,7 @@ mod tests {
                 ..default_config
             };
 
-            let mut fixture = ProviderTestFixture::new(runtime, config)?;
+            let mut fixture = ProviderTestFixture::<L1ChainSpec>::new(runtime, config)?;
 
             let default_call = CallRequest {
                 from: Some(fixture.nth_local_account(0)?),

--- a/crates/edr_provider/src/requests/eth/gas.rs
+++ b/crates/edr_provider/src/requests/eth/gas.rs
@@ -191,13 +191,14 @@ fn resolve_estimate_gas_request<
 mod tests {
     use edr_eth::{transaction::Transaction as _, BlockTag};
     use edr_rpc_eth::CallRequest;
+    use l1::L1ChainSpec;
 
     use super::*;
     use crate::test_utils::{pending_base_fee, ProviderTestFixture};
 
     #[test]
     fn resolve_estimate_gas_request_with_default_max_priority_fee() -> anyhow::Result<()> {
-        let mut fixture = ProviderTestFixture::new_local()?;
+        let mut fixture = ProviderTestFixture::<L1ChainSpec>::new_local()?;
 
         let max_fee_per_gas =
             pending_base_fee(&mut fixture.provider_data)?.max(U256::from(10_000_000_000u64));
@@ -231,7 +232,7 @@ mod tests {
         let base_fee = U256::from(10);
         let max_priority_fee_per_gas = U256::from(1);
 
-        let mut fixture = ProviderTestFixture::new_local()?;
+        let mut fixture = ProviderTestFixture::<L1ChainSpec>::new_local()?;
         fixture
             .provider_data
             .set_next_block_base_fee_per_gas(base_fee)?;
@@ -265,7 +266,7 @@ mod tests {
     #[test]
     fn resolve_estimate_gas_request_with_default_max_fee_when_historic_block() -> anyhow::Result<()>
     {
-        let mut fixture = ProviderTestFixture::new_local()?;
+        let mut fixture = ProviderTestFixture::<L1ChainSpec>::new_local()?;
         fixture
             .provider_data
             .set_next_block_base_fee_per_gas(U256::from(10))?;
@@ -308,7 +309,7 @@ mod tests {
 
     #[test]
     fn resolve_estimate_gas_request_with_capped_max_priority_fee() -> anyhow::Result<()> {
-        let mut fixture = ProviderTestFixture::new_local()?;
+        let mut fixture = ProviderTestFixture::<L1ChainSpec>::new_local()?;
         fixture
             .provider_data
             .set_next_block_base_fee_per_gas(U256::ZERO)?;

--- a/crates/edr_provider/src/requests/eth/gas.rs
+++ b/crates/edr_provider/src/requests/eth/gas.rs
@@ -193,7 +193,7 @@ mod tests {
     use edr_rpc_eth::CallRequest;
 
     use super::*;
-    use crate::{data::test_utils::ProviderTestFixture, test_utils::pending_base_fee};
+    use crate::test_utils::{pending_base_fee, ProviderTestFixture};
 
     #[test]
     fn resolve_estimate_gas_request_with_default_max_priority_fee() -> anyhow::Result<()> {

--- a/crates/edr_provider/src/requests/eth/transactions.rs
+++ b/crates/edr_provider/src/requests/eth/transactions.rs
@@ -313,7 +313,7 @@ You can use them by running Hardhat Network with 'hardfork' {minimum_hardfork:?}
 #[cfg(test)]
 mod tests {
     use anyhow::Context;
-    use edr_eth::{Address, Bytes, U256};
+    use edr_eth::{l1::L1ChainSpec, Address, Bytes, U256};
     use transaction::{signed::FakeSign as _, TxKind};
 
     use super::*;
@@ -321,7 +321,7 @@ mod tests {
 
     #[test]
     fn transaction_by_hash_for_impersonated_account() -> anyhow::Result<()> {
-        let mut fixture = ProviderTestFixture::new_local()?;
+        let mut fixture = ProviderTestFixture::<L1ChainSpec>::new_local()?;
 
         let impersonated_account: Address = "0x20620fa0ad46516e915029c94e3c87c9cd7861ff".parse()?;
         fixture

--- a/crates/edr_provider/src/requests/eth/transactions.rs
+++ b/crates/edr_provider/src/requests/eth/transactions.rs
@@ -317,7 +317,7 @@ mod tests {
     use transaction::{signed::FakeSign as _, TxKind};
 
     use super::*;
-    use crate::{data::test_utils::ProviderTestFixture, test_utils::one_ether};
+    use crate::test_utils::{one_ether, ProviderTestFixture};
 
     #[test]
     fn transaction_by_hash_for_impersonated_account() -> anyhow::Result<()> {

--- a/crates/edr_provider/src/requests/resolve.rs
+++ b/crates/edr_provider/src/requests/resolve.rs
@@ -235,7 +235,7 @@ mod tests {
     use edr_rpc_eth::CallRequest;
 
     use super::*;
-    use crate::{data::test_utils::ProviderTestFixture, test_utils::pending_base_fee};
+    use crate::test_utils::{pending_base_fee, ProviderTestFixture};
 
     #[test]
     fn resolve_call_request_with_gas_price() -> anyhow::Result<()> {

--- a/crates/edr_provider/src/test_utils.rs
+++ b/crates/edr_provider/src/test_utils.rs
@@ -156,7 +156,6 @@ impl<ChainSpecT: Debug + SyncProviderSpec<CurrentTime>> ProviderTestFixture<Chai
     }
 
     /// Creates a new `ProviderTestFixture` with a forked provider.
-    #[cfg(feature = "test-remote")]
     pub fn new_forked(url: Option<String>) -> anyhow::Result<Self> {
         use edr_test_utils::env::get_alchemy_url;
 

--- a/crates/edr_provider/src/test_utils.rs
+++ b/crates/edr_provider/src/test_utils.rs
@@ -1,17 +1,26 @@
 use std::{num::NonZeroU64, time::SystemTime};
 
+use anyhow::anyhow;
 use edr_eth::{
-    block::BlobGas, l1::L1ChainSpec, result::InvalidTransaction, signature::secret_key_from_str,
-    transaction::TransactionValidation, trie::KECCAK_NULL_RLP, Address, Bytes, HashMap, B256, U160,
-    U256,
+    account::AccountInfo,
+    block::BlobGas,
+    l1::L1ChainSpec,
+    result::InvalidTransaction,
+    signature::secret_key_from_str,
+    transaction::{self, request::TransactionRequestAndSender, TransactionValidation, TxKind},
+    trie::KECCAK_NULL_RLP,
+    Address, Bytes, HashMap, B256, KECCAK_EMPTY, U160, U256,
 };
 use edr_evm::{spec::RuntimeSpec, Block};
 use edr_rpc_eth::TransactionRequest;
+use tokio::runtime;
 
 use crate::{
-    config::MiningConfig, requests::hardhat::rpc_types::ForkConfig, time::TimeSinceEpoch,
-    AccountConfig, MethodInvocation, Provider, ProviderConfig, ProviderData, ProviderError,
-    ProviderRequest, SyncProviderSpec,
+    config::MiningConfig,
+    requests::hardhat::rpc_types::ForkConfig,
+    time::{CurrentTime, TimeSinceEpoch},
+    AccountConfig, MethodInvocation, NoopLogger, Provider, ProviderConfig, ProviderData,
+    ProviderError, ProviderRequest, SyncProviderSpec,
 };
 
 pub const TEST_SECRET_KEY: &str =
@@ -129,4 +138,135 @@ where
     let contract_address = receipt.contract_address.expect("Call must create contract");
 
     Ok(contract_address)
+}
+
+/// Fixture for testing `ProviderData`.
+pub struct ProviderTestFixture {
+    _runtime: runtime::Runtime,
+    pub config: ProviderConfig<L1ChainSpec>,
+    pub provider_data: ProviderData<L1ChainSpec>,
+    pub impersonated_account: Address,
+}
+
+impl ProviderTestFixture {
+    /// Creates a new `ProviderTestFixture` with a local provider.
+    pub fn new_local() -> anyhow::Result<Self> {
+        Self::with_fork(None)
+    }
+
+    /// Creates a new `ProviderTestFixture` with a forked provider.
+    #[cfg(feature = "test-remote")]
+    pub fn new_forked(url: Option<String>) -> anyhow::Result<Self> {
+        use edr_test_utils::env::get_alchemy_url;
+
+        let fork_url = url.unwrap_or(get_alchemy_url());
+        Self::with_fork(Some(fork_url))
+    }
+
+    fn with_fork(fork: Option<String>) -> anyhow::Result<Self> {
+        let fork = fork.map(|json_rpc_url| {
+            ForkConfig {
+                json_rpc_url,
+                // Random recent block for better cache consistency
+                block_number: Some(FORK_BLOCK_NUMBER),
+                http_headers: None,
+            }
+        });
+
+        let config = create_test_config_with_fork(fork);
+
+        let runtime = runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .thread_name("provider-data-test")
+            .build()?;
+
+        Self::new(runtime, config)
+    }
+
+    pub fn new(
+        runtime: tokio::runtime::Runtime,
+        mut config: ProviderConfig<L1ChainSpec>,
+    ) -> anyhow::Result<Self> {
+        let logger = Box::<NoopLogger<L1ChainSpec>>::default();
+        let subscription_callback_noop = Box::new(|_| ());
+
+        let impersonated_account = Address::random();
+        config.genesis_accounts.insert(
+            impersonated_account,
+            AccountInfo {
+                balance: one_ether(),
+                nonce: 0,
+                code: None,
+                code_hash: KECCAK_EMPTY,
+            },
+        );
+
+        let mut provider_data = ProviderData::new(
+            runtime.handle().clone(),
+            logger,
+            subscription_callback_noop,
+            None,
+            config.clone(),
+            CurrentTime,
+        )?;
+
+        provider_data.impersonate_account(impersonated_account);
+
+        Ok(Self {
+            _runtime: runtime,
+            config,
+            provider_data,
+            impersonated_account,
+        })
+    }
+
+    pub fn dummy_transaction_request(
+        &self,
+        local_account_index: usize,
+        gas_limit: u64,
+        nonce: Option<u64>,
+    ) -> anyhow::Result<TransactionRequestAndSender<transaction::Request>> {
+        let request = transaction::Request::Eip155(transaction::request::Eip155 {
+            kind: TxKind::Call(Address::ZERO),
+            gas_limit,
+            gas_price: U256::from(42_000_000_000_u64),
+            value: U256::from(1),
+            input: Bytes::default(),
+            nonce: nonce.unwrap_or(0),
+            chain_id: self.config.chain_id,
+        });
+
+        let sender = self.nth_local_account(local_account_index)?;
+        Ok(TransactionRequestAndSender { request, sender })
+    }
+
+    /// Retrieves the nth local account.
+    ///
+    /// # Panics
+    ///
+    /// Panics if there are not enough local accounts
+    pub fn nth_local_account(&self, index: usize) -> anyhow::Result<Address> {
+        self.provider_data
+            .accounts()
+            .nth(index)
+            .copied()
+            .ok_or(anyhow!("the requested local account does not exist"))
+    }
+
+    pub fn impersonated_dummy_transaction(&self) -> anyhow::Result<transaction::Signed> {
+        let mut transaction = self.dummy_transaction_request(0, 30_000, None)?;
+        transaction.sender = self.impersonated_account;
+
+        Ok(self.provider_data.sign_transaction_request(transaction)?)
+    }
+
+    pub fn signed_dummy_transaction(
+        &self,
+        local_account_index: usize,
+        nonce: Option<u64>,
+    ) -> anyhow::Result<transaction::Signed> {
+        let transaction = self.dummy_transaction_request(local_account_index, 30_000, nonce)?;
+        Ok(self.provider_data.sign_transaction_request(transaction)?)
+    }
 }


### PR DESCRIPTION
This fixes an incorrect chain ID for the OP Sepolia testnet.

It also adds a test. To support this test, I needed to perform a small refactor to expose the `ProviderTestFixture` and make it chain-specific.