### PR TITLE
Update macos-12 to macos-13 (latest macos to still support intel).

### DIFF
--- a/.github/workflows/edr-npm-release.yml
+++ b/.github/workflows/edr-npm-release.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          - host: macos-12
+          - host: macos-13
             target: x86_64-apple-darwin
             build: |
               pnpm build
@@ -53,7 +53,7 @@ jobs:
               set -e &&
               pnpm run build &&
               strip *.node
-          - host: macos-12
+          - host: macos-13
             target: aarch64-apple-darwin
             build: |
               pnpm build --target aarch64-apple-darwin
@@ -159,7 +159,7 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          - host: macos-12
+          - host: macos-13
             target: x86_64-apple-darwin
           - host: macos-14
             target: aarch64-apple-darwin


### PR DESCRIPTION
GitHub runner deprecated macos-12 (see https://github.com/actions/runner-images/issues/10721). macos-13 is the latest image to still support x86. 