### PR TITLE
refactor: rename json_rpc_url to url in ForkConfig of edr_napi and edr_provider.

### DIFF
--- a/crates/edr_napi/src/provider/config.rs
+++ b/crates/edr_napi/src/provider/config.rs
@@ -27,7 +27,7 @@ pub struct ChainConfig {
 #[napi(object)]
 pub struct ForkConfig {
     /// The URL of the JSON-RPC endpoint to fork from
-    pub json_rpc_url: String,
+    pub url: String,
     /// The block number to fork from. If not provided, the latest safe block is
     /// used.
     pub block_number: Option<BigInt>,
@@ -140,7 +140,7 @@ impl TryFrom<ForkConfig> for edr_provider::hardhat_rpc_types::ForkConfig {
         });
 
         Ok(Self {
-            json_rpc_url: value.json_rpc_url,
+            url: value.url,
             block_number,
             http_headers,
         })

--- a/crates/edr_provider/src/data.rs
+++ b/crates/edr_provider/src/data.rs
@@ -2609,7 +2609,7 @@ fn create_blockchain_and_state(
             .transpose()?;
 
         let rpc_client = Arc::new(EthRpcClient::<L1ChainSpec>::new(
-            &fork_config.json_rpc_url,
+            &fork_config.url,
             config.cache_dir.clone(),
             http_headers.clone(),
         )?);
@@ -2837,9 +2837,9 @@ pub(crate) mod test_utils {
         }
 
         fn with_fork(fork: Option<String>) -> anyhow::Result<Self> {
-            let fork = fork.map(|json_rpc_url| {
+            let fork = fork.map(|url| {
                 ForkConfig {
-                    json_rpc_url,
+                    url,
                     // Random recent block for better cache consistency
                     block_number: Some(FORK_BLOCK_NUMBER),
                     http_headers: None,
@@ -3948,7 +3948,7 @@ mod tests {
             let mut fixture = ProviderTestFixture::new_local()?;
 
             let fork_config = Some(ForkConfig {
-                json_rpc_url: get_alchemy_url(),
+                url: get_alchemy_url(),
                 // Random recent block for better cache consistency
                 block_number: Some(FORK_BLOCK_NUMBER),
                 http_headers: None,
@@ -4040,7 +4040,7 @@ mod tests {
                 .build()?;
 
             let default_config = create_test_config_with_fork(Some(ForkConfig {
-                json_rpc_url: get_alchemy_url(),
+                url: get_alchemy_url(),
                 block_number: Some(EIP_1559_ACTIVATION_BLOCK),
                 http_headers: None,
             }));

--- a/crates/edr_provider/src/requests/hardhat/rpc_types/config.rs
+++ b/crates/edr_provider/src/requests/hardhat/rpc_types/config.rs
@@ -9,7 +9,7 @@ pub struct ResetProviderConfig {
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ForkConfig {
-    pub json_rpc_url: String,
+    pub url: String,
     pub block_number: Option<u64>,
     pub http_headers: Option<HashMap<String, String>>,
 }

--- a/crates/edr_provider/src/test_utils.rs
+++ b/crates/edr_provider/src/test_utils.rs
@@ -135,7 +135,7 @@ where
 pub async fn run_full_block(url: String, block_number: u64, chain_id: u64) -> anyhow::Result<()> {
     let runtime = tokio::runtime::Handle::current();
     let default_config = create_test_config_with_fork(Some(ForkConfig {
-        json_rpc_url: url.clone(),
+        url: url.clone(),
         block_number: Some(block_number - 1),
         http_headers: None,
     }));

--- a/crates/edr_provider/tests/hardhat_request_serialization.rs
+++ b/crates/edr_provider/tests/hardhat_request_serialization.rs
@@ -93,7 +93,7 @@ fn serde_hardhat_mine() {
 fn serde_hardhat_reset() {
     help_test_method_invocation_serde(MethodInvocation::Reset(Some(ResetProviderConfig {
         forking: Some(ForkConfig {
-            json_rpc_url: String::from("http://whatever.com/whatever"),
+            url: String::from("http://whatever.com/whatever"),
             block_number: Some(123456),
             http_headers: None,
         }),

--- a/crates/edr_provider/tests/issues/issue_324.rs
+++ b/crates/edr_provider/tests/issues/issue_324.rs
@@ -24,7 +24,7 @@ async fn issue_324() -> anyhow::Result<()> {
     let subscriber = Box::new(|_event| {});
 
     let mut config = create_test_config_with_fork(Some(ForkConfig {
-        json_rpc_url: get_alchemy_url().replace("mainnet", "sepolia"),
+        url: get_alchemy_url().replace("mainnet", "sepolia"),
         block_number: Some(DEPLOYMENT_BLOCK_NUMBER),
         http_headers: None,
     }));

--- a/crates/edr_provider/tests/issues/issue_356.rs
+++ b/crates/edr_provider/tests/issues/issue_356.rs
@@ -25,7 +25,7 @@ async fn issue_356() -> anyhow::Result<()> {
     let subscriber = Box::new(|_event| {});
 
     let mut config = create_test_config_with_fork(Some(ForkConfig {
-        json_rpc_url: get_alchemy_url().replace("mainnet", "sepolia"),
+        url: get_alchemy_url().replace("mainnet", "sepolia"),
         // Pre-cancun Sepolia block
         block_number: Some(4243456),
         http_headers: None,

--- a/crates/edr_provider/tests/issues/issue_384.rs
+++ b/crates/edr_provider/tests/issues/issue_384.rs
@@ -13,7 +13,7 @@ async fn avalanche_chain_mine_local_block() -> anyhow::Result<()> {
     let subscriber = Box::new(|_event| {});
 
     let config = create_test_config_with_fork(Some(ForkConfig {
-        json_rpc_url: get_infura_url().replace("mainnet", "avalanche-mainnet"),
+        url: get_infura_url().replace("mainnet", "avalanche-mainnet"),
         block_number: Some(BLOCK_NUMBER),
         http_headers: None,
     }));

--- a/crates/edr_provider/tests/issues/issue_503.rs
+++ b/crates/edr_provider/tests/issues/issue_503.rs
@@ -15,7 +15,7 @@ async fn issue_503() -> anyhow::Result<()> {
     let subscriber = Box::new(|_event| {});
 
     let mut config = create_test_config_with_fork(Some(ForkConfig {
-        json_rpc_url: get_alchemy_url(),
+        url: get_alchemy_url(),
         block_number: Some(19_909_475),
         http_headers: None,
     }));

--- a/crates/edr_provider/tests/issues/issue_533.rs
+++ b/crates/edr_provider/tests/issues/issue_533.rs
@@ -15,7 +15,7 @@ async fn issue_533() -> anyhow::Result<()> {
     let subscriber = Box::new(|_event| {});
 
     let mut config = create_test_config_with_fork(Some(ForkConfig {
-        json_rpc_url: get_alchemy_url(),
+        url: get_alchemy_url(),
         block_number: Some(20_384_300),
         http_headers: None,
     }));

--- a/crates/edr_provider/tests/issues/issue_570.rs
+++ b/crates/edr_provider/tests/issues/issue_570.rs
@@ -20,7 +20,7 @@ fn get_provider() -> anyhow::Result<Provider<Infallible>> {
     let subscriber = Box::new(|_event| {});
 
     let mut config = create_test_config_with_fork(Some(ForkConfig {
-        json_rpc_url: get_alchemy_url().replace("eth-mainnet", "base-sepolia"),
+        url: get_alchemy_url().replace("eth-mainnet", "base-sepolia"),
         block_number: Some(BLOCK_NUMBER),
         http_headers: None,
     }));

--- a/crates/edr_provider/tests/issues/issue_588.rs
+++ b/crates/edr_provider/tests/issues/issue_588.rs
@@ -17,7 +17,7 @@ async fn issue_588() -> anyhow::Result<()> {
     let subscriber = Box::new(|_event| {});
 
     let early_mainnet_fork = create_test_config_with_fork(Some(ForkConfig {
-        json_rpc_url: get_alchemy_url(),
+        url: get_alchemy_url(),
         block_number: Some(2_675_000),
         http_headers: None,
     }));


### PR DESCRIPTION
Renames json_rpc_url to url in the ForkConfig of edr_napi and edr_provider.

Fixes #745 