### PR TITLE
fix: ignore unknown opcodes in source maps

### DIFF
--- a/crates/edr_solidity/src/source_map.rs
+++ b/crates/edr_solidity/src/source_map.rs
@@ -159,7 +159,10 @@ pub fn decode_instructions(
         let source_map = &source_maps[instructions.len()];
 
         let pc = bytes_index;
-        let opcode = OpCode::new(bytecode[pc]).expect("Invalid opcode");
+        let opcode = match OpCode::new(bytecode[pc]) {
+            Some(opcode) => opcode,
+            None => continue,
+        };
 
         let push_data = if opcode.is_push() {
             let push_data = &bytecode[bytes_index..][..1 + opcode.info().immediate_size() as usize];


### PR DESCRIPTION
Closes #763.

As far as I can tell, this can only happens when solc produces source maps that have an error, so I think just ignoring this is fine. I'm not adding a test for this because it seems to only happen in very special circumstances, with older versions of solc.