### PR TITLE
test: switch to `forge-std` for JS integration tests

### DIFF
--- a/js/integration-tests/solidity-tests/contracts/ContractEnvironment.t.sol
+++ b/js/integration-tests/solidity-tests/contracts/ContractEnvironment.t.sol
@@ -1,13 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import "./test.sol";
-import "./Vm.sol";
+import {Test} from "forge-std/src/Test.sol";
 
 // Test that the contract environment related config values are passed on correctly
-contract ContractEnvironmentTest is DSTest {
-    Vm constant vm = Vm(HEVM_ADDRESS);
-    
+contract ContractEnvironmentTest is Test {
     function chainId() internal view returns (uint256 id) {
         assembly {
             id := chainid()
@@ -19,9 +16,5 @@ contract ContractEnvironmentTest is DSTest {
         assertEq(chainId(), 12, "chain id is incorrect");
         assertEq(block.number, 23, "block number is incorrect");
         assertEq(block.timestamp, 45, "timestamp is incorrect");
-    }
-    
-    function testContextIsTest() public {
-        assertEq(vm.isContext(Vm.ExecutionContext.Test), true);
     }
 }

--- a/js/integration-tests/solidity-tests/contracts/EnvVar.t.sol
+++ b/js/integration-tests/solidity-tests/contracts/EnvVar.t.sol
@@ -1,12 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import "./test.sol";
-import "./Vm.sol";
+import {Test} from "forge-std/src/Test.sol";
 
-contract EnvVarTest is DSTest {
-    Vm constant vm = Vm(HEVM_ADDRESS);
-
+contract EnvVarTest is Test {
     function testGetEnv() public {
         string memory key = "_EDR_SOLIDITY_TESTS_GET_ENV_TEST_KEY";
         string memory val = "_edrSolidityTestsGetEnvTestVal";

--- a/js/integration-tests/solidity-tests/contracts/ForkCheatcode.t.sol
+++ b/js/integration-tests/solidity-tests/contracts/ForkCheatcode.t.sol
@@ -1,18 +1,16 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import "./test.sol";
-import "./Vm.sol";
+import {Test} from "forge-std/src/Test.sol";
 
 // Test that the fork cheatcode works correctly
-contract ForkCheatcodeTest is DSTest {
-    Vm constant vm = Vm(HEVM_ADDRESS);
+contract ForkCheatcodeTest is Test {
     uint256 fork;
-    
+
     function setUp() public {
         fork = vm.createSelectFork("alchemyMainnet", 20_000_000);
     }
-    
+
     function testBlockNumber() public {
         assertEq(fork, vm.activeFork());
         assertEq(block.number, 20_000_000);

--- a/js/integration-tests/solidity-tests/contracts/FuzzFixture.t.sol
+++ b/js/integration-tests/solidity-tests/contracts/FuzzFixture.t.sol
@@ -1,26 +1,23 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import "./test.sol";
-import "./Vm.sol";
+import {Test} from "forge-std/src/Test.sol";
 
 // Contract to be tested with overflow vulnerability
 contract IdentityContract {
-    function identity(uint256 amount) pure public returns(uint256) {
+    function identity(uint256 amount) pure public returns (uint256) {
         require(amount != 7191815684697958081204101901807852913954269296144377099693178655035380638910, "Got value from fixture");
         return amount;
     }
 }
 
 // Test that fuzz fixtures specified in Solidity are not supported.
-contract FuzzFixtureTest is DSTest {
-    Vm constant vm = Vm(HEVM_ADDRESS);
-    
+contract FuzzFixtureTest is Test {
     IdentityContract testDummy;
 
     uint256[] public fixtureAmount = [
-        // This is a random value
-        7191815684697958081204101901807852913954269296144377099693178655035380638910
+    // This is a random value
+    7191815684697958081204101901807852913954269296144377099693178655035380638910
     ];
 
     function setUp() public {

--- a/js/integration-tests/solidity-tests/contracts/Invariant.t.sol
+++ b/js/integration-tests/solidity-tests/contracts/Invariant.t.sol
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import "./test.sol";
-import "./Vm.sol";
+import {Test} from "forge-std/src/Test.sol";
 
 contract StochasticWrongContract {
     uint256 public a;
@@ -25,7 +24,7 @@ contract StochasticWrongContract {
 }
 
 // Test that the invariant testing works correctly by catching a bug in the contract.
-contract FailingInvariantTest is DSTest {
+contract FailingInvariantTest is Test {
     StochasticWrongContract wrongContract;
 
     function setUp() external {

--- a/js/integration-tests/solidity-tests/contracts/IsolateTest.sol
+++ b/js/integration-tests/solidity-tests/contracts/IsolateTest.sol
@@ -1,32 +1,31 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity ^0.8.24;
 
-import "./test.sol";
-import "./Vm.sol";
+import {Test} from "forge-std/src/Test.sol";
 
 contract TransientStorageStore {
-  uint value;
+    uint value;
 
-  function tstore(uint key, uint val) public {
-    assembly {
-      tstore(key, val)
+    function tstore(uint key, uint val) public {
+        assembly {
+            tstore(key, val)
+        }
     }
-  }
 
-  function tload(uint key) public view returns (uint) {
-    uint val;
-    assembly {
-      val := tload(key)
+    function tload(uint key) public view returns (uint) {
+        uint val;
+        assembly {
+            val := tload(key)
+        }
+        return val;
     }
-    return val;
-  }
 }
 
-contract IsolateTest is DSTest {
+contract IsolateTest is Test {
     TransientStorageStore transientStorageStore;
 
     function setUp() public {
-      transientStorageStore = new TransientStorageStore();
+        transientStorageStore = new TransientStorageStore();
     }
 
     function testIsolateTest() public {

--- a/js/integration-tests/solidity-tests/contracts/Overflow.t.sol
+++ b/js/integration-tests/solidity-tests/contracts/Overflow.t.sol
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import "./test.sol";
-import "./Vm.sol";
+import {Test} from "forge-std/src/Test.sol";
 
 // Contract to be tested with overflow vulnerability
 contract MyContract {
@@ -12,9 +11,7 @@ contract MyContract {
 }
 
 // Test that the fuzzing catches overflows
-contract OverflowTest is DSTest {
-    Vm constant vm = Vm(HEVM_ADDRESS);
-
+contract OverflowTest is Test {
     MyContract public myContract;
 
     function setUp() public {

--- a/js/integration-tests/solidity-tests/hardhat.config.ts
+++ b/js/integration-tests/solidity-tests/hardhat.config.ts
@@ -1,35 +1,6 @@
-import { task } from "hardhat/config";
-import fs from "node:fs";
-import path from "node:path";
-
-const RUST_INTEGRATION_TEST_DATA_PATH =
-  "../../../crates/edr_solidity_tests/tests/testdata";
-
-// HACK: copy the libraries Rust integration tests into the Hardhat project source
-task("copyLibraries", "Run pre-test script", async (taskArgs, hre) => {
-  await fs.promises.copyFile(
-    path.join(RUST_INTEGRATION_TEST_DATA_PATH, "lib/ds-test/src/test.sol"),
-    path.join(hre.config.paths.sources, "test.sol")
-  );
-  await fs.promises.copyFile(
-    path.join(RUST_INTEGRATION_TEST_DATA_PATH, "cheats/Vm.sol"),
-    path.join(hre.config.paths.sources, "Vm.sol")
-  );
-});
-
-task("test").setAction(async (taskArgs, hre, runSuper) => {
-  // Run the pretest task before tests
-  await hre.run("copyLibraries");
-  // Run the actual tests
-  await runSuper();
-});
-
 export default {
   solidity: {
     version: "0.8.24",
     settings: { evmVersion: "cancun" },
-  },
-  compilerOptions: {
-    paths: { "forge-std": ["node_modules/forge-std/src/"] },
   },
 };

--- a/js/integration-tests/solidity-tests/hardhat.config.ts
+++ b/js/integration-tests/solidity-tests/hardhat.config.ts
@@ -25,5 +25,11 @@ task("test").setAction(async (taskArgs, hre, runSuper) => {
 });
 
 export default {
-  solidity: { version: "0.8.24", settings: { evmVersion: "cancun" } },
+  solidity: {
+    version: "0.8.24",
+    settings: { evmVersion: "cancun" },
+  },
+  compilerOptions: {
+    paths: { "forge-std": ["node_modules/forge-std/src/"] },
+  },
 };

--- a/js/integration-tests/solidity-tests/package.json
+++ b/js/integration-tests/solidity-tests/package.json
@@ -11,6 +11,7 @@
     "@types/mocha": ">=9.1.0",
     "@types/node": "^20.0.0",
     "chai": "^4.3.6",
+    "forge-std": "github:foundry-rs/forge-std#v1.9.5",
     "hardhat": "2.22.17",
     "prettier": "^3.2.5",
     "ts-node": "^10.8.0",

--- a/js/integration-tests/solidity-tests/test/unit.ts
+++ b/js/integration-tests/solidity-tests/test/unit.ts
@@ -38,7 +38,7 @@ describe("Unit tests", () => {
     );
 
     assert.equal(failedTests, 0);
-    assert.equal(totalTests, 2);
+    assert.equal(totalTests, 1);
   });
 
   describe("IsolateMode", function () {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -441,6 +441,9 @@ importers:
       chai:
         specifier: ^4.3.6
         version: 4.4.1
+      forge-std:
+        specifier: github:foundry-rs/forge-std#v1.9.5
+        version: https://codeload.github.com/foundry-rs/forge-std/tar.gz/b93cf4bc34ff214c099dc970b153f85ade8c9f66
       hardhat:
         specifier: 2.22.17
         version: 2.22.17(patch_hash=b56mb3giqnesjnxlhj4zd6oicm)(ts-node@10.9.2(@types/node@20.16.1)(typescript@5.5.4))(typescript@5.5.4)
@@ -1977,6 +1980,10 @@ packages:
 
   for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
+
+  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/b93cf4bc34ff214c099dc970b153f85ade8c9f66:
+    resolution: {tarball: https://codeload.github.com/foundry-rs/forge-std/tar.gz/b93cf4bc34ff214c099dc970b153f85ade8c9f66}
+    version: 1.9.5
 
   fp-ts@1.19.3:
     resolution: {integrity: sha512-H5KQDspykdHuztLTg+ajGN0Z2qUjcEf3Ybxc6hLt0k7/zPkn29XnKnxlBPyW2XIddWrGaJBzBl4VLYOtk39yZg==}
@@ -5319,6 +5326,8 @@ snapshots:
   for-each@0.3.3:
     dependencies:
       is-callable: 1.2.7
+
+  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/b93cf4bc34ff214c099dc970b153f85ade8c9f66: {}
 
   fp-ts@1.19.3: {}
 


### PR DESCRIPTION
Switch to `forge-std` for Solidity test JS integration tests.