### PR TITLE
fix: remove one way branching in bytecode trie

### DIFF
--- a/.changeset/strange-boxes-shout.md
+++ b/.changeset/strange-boxes-shout.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Improved stack trace generation performance by eliminating one-way branching in the bytecode trie

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,6 +296,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
 name = "anyhow"
 version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,12 +763,31 @@ dependencies = [
  "atty",
  "bitflags 1.3.2",
  "clap_derive",
- "clap_lex",
+ "clap_lex 0.2.4",
  "indexmap 1.9.3",
  "once_cell",
  "strsim",
  "termcolor",
  "textwrap",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+dependencies = [
+ "anstyle",
+ "clap_lex 0.7.4",
 ]
 
 [[package]]
@@ -786,6 +811,12 @@ checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "console"
@@ -878,13 +909,39 @@ dependencies = [
  "atty",
  "cast",
  "ciborium",
- "clap",
+ "clap 3.2.25",
  "criterion-plot",
  "itertools 0.10.5",
  "lazy_static",
  "num-traits",
  "oorandom",
  "plotters",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap 4.5.27",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
  "regex",
  "serde",
  "serde_derive",
@@ -1126,7 +1183,7 @@ dependencies = [
  "async-rwlock",
  "auto_impl",
  "cita_trie",
- "criterion",
+ "criterion 0.4.0",
  "dyn-clone",
  "edr_defaults",
  "edr_eth",
@@ -1286,6 +1343,7 @@ dependencies = [
  "alloy-json-abi",
  "alloy-sol-types 0.7.7",
  "anyhow",
+ "criterion 0.5.1",
  "edr_eth",
  "edr_evm",
  "indexmap 2.2.6",
@@ -1700,6 +1758,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1899,6 +1963,17 @@ name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
+dependencies = [
+ "hermit-abi 0.4.0",
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "itertools"
@@ -3795,7 +3870,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cfg-if",
- "clap",
+ "clap 3.2.25",
  "difference",
  "edr_defaults",
  "edr_eth",

--- a/crates/edr_solidity/Cargo.toml
+++ b/crates/edr_solidity/Cargo.toml
@@ -19,5 +19,12 @@ strum = { version = "0.26.0", features = ["derive"] }
 semver = "1.0.23"
 thiserror = "1.0.58"
 
+[dev-dependencies]
+criterion = "0.5"
+
+[[bench]]
+name = "contracts_identifier"
+harness = false
+
 [lints]
 workspace = true

--- a/crates/edr_solidity/benches/contracts_identifier.rs
+++ b/crates/edr_solidity/benches/contracts_identifier.rs
@@ -1,0 +1,71 @@
+//! Benchmark for construcing a contract identifier.
+//!
+//! Steps to run:
+//! 1. Check out https://github.com/NomicFoundation/forge-std/tree/js-benchmark-config
+//!    locally (note the branch).
+//! 2. In the `forge-std` repo root:
+//! 2.1. `npm i`
+//! 2.2. `npx hardhat compile`
+//! 3. In the `crates/edr_solidity` directory:
+//! 3.1. `export FORGE_STD_ARTIFACTS_DIR=/path/to/forge-std/artifacts`
+//! 3.2. `cargo bench contracts_identifier`
+use std::{fs, path::PathBuf, time::Duration};
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use edr_solidity::{
+    artifacts::BuildInfo,
+    contract_decoder::{BuildInfoConfig, ContractDecoder},
+};
+
+fn load_build_info_config() -> anyhow::Result<BuildInfoConfig> {
+    let artifacts_dir = std::env::var("FORGE_STD_ARTIFACTS_DIR")?;
+    let build_info_dir = PathBuf::from(&artifacts_dir).join("build-info");
+
+    let mut build_infos = Vec::new();
+    for entry in fs::read_dir(build_info_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+
+        if path.is_file() && path.extension().and_then(|ext| ext.to_str()) == Some("json") {
+            let contents = fs::read(&path)?;
+            let build_info = serde_json::from_slice::<BuildInfo>(&contents)?;
+            build_infos.push(build_info);
+        }
+    }
+
+    println!("build infos len: {}", build_infos.len());
+
+    Ok(BuildInfoConfig {
+        build_infos: Some(build_infos),
+        ignore_contracts: None,
+    })
+}
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    let build_info_config = load_build_info_config().expect("loads build info config");
+    let contracts = &build_info_config
+        .build_infos
+        .as_ref()
+        .expect("loaded build info")
+        .first()
+        .expect("there is at least one build info")
+        .output
+        .contracts;
+
+    // Sanity check
+    let total_contracts = contracts.iter().map(|(k, v)| v.len()).sum::<usize>();
+    let min_contracts = 70;
+    if total_contracts < min_contracts {
+        panic!(
+            "Expected at least {} contracts, instead it is {}",
+            min_contracts, total_contracts
+        );
+    }
+
+    c.bench_function("initialize_contracts_identifier", |b| {
+        b.iter(|| ContractDecoder::new(black_box(&build_info_config)).unwrap())
+    });
+}
+
+criterion_group!(name = benches; config = Criterion::default().measurement_time(Duration::from_secs(30)); targets = criterion_benchmark);
+criterion_main!(benches);

--- a/crates/edr_solidity/benches/contracts_identifier.rs
+++ b/crates/edr_solidity/benches/contracts_identifier.rs
@@ -1,13 +1,13 @@
 //! Benchmark for construcing a contract identifier.
 //!
 //! Steps to run:
-//! 1. Check out https://github.com/NomicFoundation/forge-std/tree/js-benchmark-config
+//! 1. Check out <https://github.com/NomicFoundation/forge-std/tree/js-benchmark-config>
 //!    locally (note the branch).
 //! 2. In the `forge-std` repo root:
 //! 2.1. `npm i`
 //! 2.2. `npx hardhat compile`
 //! 3. In the `crates/edr_solidity` directory:
-//! 3.1. `export FORGE_STD_ARTIFACTS_DIR=/path/to/forge-std/artifacts`
+//! 3.1. `export EDR_FORGE_STD_ARTIFACTS_DIR=/path/to/forge-std/artifacts`
 //! 3.2. `cargo bench contracts_identifier`
 use std::{fs, path::PathBuf, time::Duration};
 
@@ -17,8 +17,13 @@ use edr_solidity::{
     contract_decoder::{BuildInfoConfig, ContractDecoder},
 };
 
-fn load_build_info_config() -> anyhow::Result<BuildInfoConfig> {
-    let artifacts_dir = std::env::var("FORGE_STD_ARTIFACTS_DIR")?;
+const FORGE_STD_ARTIFACTS_DIR: &str = "EDR_FORGE_STD_ARTIFACTS_DIR";
+
+fn load_build_info_config() -> anyhow::Result<Option<BuildInfoConfig>> {
+    let Ok(artifacts_dir) = std::env::var(FORGE_STD_ARTIFACTS_DIR) else {
+        println!("Skipping contracts identifier benchmark as {FORGE_STD_ARTIFACTS_DIR} environment variable is not set");
+        return Ok(None);
+    };
     let build_info_dir = PathBuf::from(&artifacts_dir).join("build-info");
 
     let mut build_infos = Vec::new();
@@ -33,16 +38,17 @@ fn load_build_info_config() -> anyhow::Result<BuildInfoConfig> {
         }
     }
 
-    println!("build infos len: {}", build_infos.len());
-
-    Ok(BuildInfoConfig {
+    Ok(Some(BuildInfoConfig {
         build_infos: Some(build_infos),
         ignore_contracts: None,
-    })
+    }))
 }
 
 pub fn criterion_benchmark(c: &mut Criterion) {
-    let build_info_config = load_build_info_config().expect("loads build info config");
+    let Some(build_info_config) = load_build_info_config().expect("loads build info config") else {
+        return;
+    };
+
     let contracts = &build_info_config
         .build_infos
         .as_ref()
@@ -53,17 +59,15 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         .contracts;
 
     // Sanity check
-    let total_contracts = contracts.iter().map(|(k, v)| v.len()).sum::<usize>();
+    let total_contracts = contracts.iter().map(|(_k, v)| v.len()).sum::<usize>();
     let min_contracts = 70;
-    if total_contracts < min_contracts {
-        panic!(
-            "Expected at least {} contracts, instead it is {}",
-            min_contracts, total_contracts
-        );
-    }
+    assert!(
+        total_contracts >= min_contracts,
+        "Expected at least {min_contracts} contracts, instead it is {total_contracts}",
+    );
 
     c.bench_function("initialize_contracts_identifier", |b| {
-        b.iter(|| ContractDecoder::new(black_box(&build_info_config)).unwrap())
+        b.iter(|| ContractDecoder::new(black_box(&build_info_config)).unwrap());
     });
 }
 

--- a/crates/edr_solidity/src/bytecode_trie.rs
+++ b/crates/edr_solidity/src/bytecode_trie.rs
@@ -1,83 +1,417 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    cmp::Ordering,
+    collections::{hash_map::Entry, HashMap},
+    fmt::Debug,
+    sync::Arc,
+};
 
 use crate::build_model::ContractMetadata;
 
+/// The key for an item in the bytecode trie.
+pub trait TrieKeyTrait {
+    fn key(&self) -> &[u8];
+}
+
 /// The result of searching for a bytecode in a [`BytecodeTrie`].
-pub enum TrieSearch<'a> {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TrieSearch<'a, T> {
     /// An exact match was found.
-    ExactHit(Arc<ContractMetadata>),
+    ExactHit(T),
     /// No exact match found; a node with the longest prefix is returned.
-    LongestPrefixNode(&'a BytecodeTrie),
+    LongestPrefixNode {
+        node: &'a BytecodeTrie<T>,
+        match_: Option<T>,
+        diff_index: usize,
+    },
 }
 
-/// This class represent a somewhat special Trie of bytecodes.
+/// This class represent a somewhat special compressed Trie of bytecodes.
 ///
-/// What makes it special is that every node has a set of all of its descendants
-/// and its depth.
-#[derive(Debug, Clone)]
-pub struct BytecodeTrie {
-    pub descendants: Vec<Arc<ContractMetadata>>,
-    pub match_: Option<Arc<ContractMetadata>>,
-    pub depth: Option<u32>,
-    child_nodes: HashMap<u8, Box<BytecodeTrie>>,
+/// What makes it special is that every node has a set of all of its
+/// descendants.
+///
+/// Wrap the item type `T` in an `Arc` or `Rc` if it's expensive to clone.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BytecodeTrie<T> {
+    /// The purpose of this is to keep track of the order in which descendants
+    /// are added.
+    pub descendants: Vec<T>,
+    /// If set, there is an exact match at the end of the prefix for the node.
+    match_: Option<T>,
+    child_nodes: HashMap<u8, Box<BytecodeTrie<T>>>,
+    prefix: TriePrefix<T>,
 }
 
-impl BytecodeTrie {
-    pub fn new(depth: Option<u32>) -> BytecodeTrie {
-        BytecodeTrie {
+impl<T: Clone + TrieKeyTrait> BytecodeTrie<T> {
+    /// Create a new trie root.
+    pub fn new_root() -> BytecodeTrie<T> {
+        Self {
             child_nodes: HashMap::new(),
             descendants: Vec::new(),
             match_: None,
-            depth,
+            prefix: TriePrefix::new_root(),
         }
     }
-
-    pub fn add(&mut self, bytecode: Arc<ContractMetadata>) {
+    pub fn add(&mut self, new_item: T) {
         let mut cursor = self;
 
-        let bytecode_normalized_code = &bytecode.normalized_code;
-        for (index, byte) in bytecode_normalized_code.iter().enumerate() {
-            cursor.descendants.push(bytecode.clone());
+        for (index, new_key_byte) in new_item.key().iter().copied().enumerate() {
+            if index < cursor.prefix.range_end {
+                // If there is a mismatch with the prefix of the cursor, we have to add a split
+                // node
+                if new_key_byte != cursor.prefix.key.key()[index] {
+                    let split_node = Self::new_split_node(index, new_item.clone());
+                    let node_to_split = std::mem::replace(cursor, split_node);
+                    cursor.fill_split_node(node_to_split, new_item.clone());
 
-            let node = cursor
-                .child_nodes
-                .entry(*byte)
-                .or_insert_with(|| Box::new(BytecodeTrie::new(Some(index as u32))));
+                    // `Self::fill_split_node` adds the item as a child of the split node so we can
+                    // stop here.
+                    return;
+                }
+            } else {
+                cursor.descendants.push(new_item.clone());
 
-            cursor = node;
+                match cursor.child_nodes.entry(new_key_byte) {
+                    Entry::Occupied(entry) => {
+                        cursor = entry.into_mut();
+                    }
+                    Entry::Vacant(entry) => {
+                        entry.insert(Box::new(Self::new_leaf(new_item.clone())));
+                        return;
+                    }
+                }
+            }
         }
 
-        // If multiple contracts with the exact same bytecode are added we keep the last
-        // of them. Note that this includes the metadata hash, so the chances of
-        // happening are pretty remote, except in super artificial cases that we
-        // have in our test suite.
-        cursor.match_ = Some(bytecode.clone());
+        // If multiple contracts with the exact same bytecode are added we keep
+        // the last of them. Note that this includes the metadata hash,
+        // so the chances of happening are pretty remote, except in
+        // super artificial cases that we have in our test suite.
+        cursor.match_ = Some(new_item);
     }
 
     /// Searches for a bytecode. If it's an exact match, it is returned. If
     /// there's no match, but a prefix of the code is found in the trie, the
     /// node of the longest prefix is returned. If the entire code is
     /// covered by the trie, and there's no match, we return None.
-    pub fn search(&self, code: &[u8], current_code_byte: u32) -> Option<TrieSearch<'_>> {
-        if current_code_byte > code.len() as u32 {
+    pub fn search(&self, key: &[u8], current_code_byte: usize) -> Option<TrieSearch<'_, T>> {
+        if current_code_byte > key.len() {
             return None;
         }
 
         let mut cursor = self;
+        let mut index = current_code_byte;
 
-        for byte in code.iter().skip(current_code_byte as usize) {
-            let child_node = cursor.child_nodes.get(byte);
-
-            if let Some(node) = child_node {
+        while index < key.len() {
+            if index < cursor.prefix.range_end {
+                if key[index] != cursor.prefix.key.key()[index] {
+                    // Cursor cannot be root here, because the root's prefix ends at index 0.
+                    return Some(TrieSearch::LongestPrefixNode {
+                        node: cursor,
+                        diff_index: index,
+                        // We're not yet at the end of the range, so it cannot be a match.
+                        match_: None,
+                    });
+                }
+            } else if let Some(node) = cursor.child_nodes.get(&key[index]) {
                 cursor = node;
-            } else {
-                return Some(TrieSearch::LongestPrefixNode(cursor));
+            } else if !cursor.is_root() {
+                return Some(TrieSearch::LongestPrefixNode {
+                    node: cursor,
+                    diff_index: index,
+                    match_: cursor.match_.clone(),
+                });
             }
+
+            index += 1;
         }
 
-        cursor
-            .match_
-            .as_ref()
-            .map(|bytecode| TrieSearch::ExactHit(bytecode.clone()))
+        cursor.match_.as_ref().and_then(|item| {
+            if cursor.prefix.range_end == key.len() {
+                // If the cursor's range ends where the key ends, we have a hit.
+                Some(TrieSearch::ExactHit(item.clone()))
+            } else {
+                // Otherwise the cursor's range is greater than the key's length which means the
+                // key is a prefix of the match.
+                None
+            }
+        })
+    }
+
+    /// Whether the node is a root node.
+    pub fn is_root(&self) -> bool {
+        matches!(self.prefix.key, TrieKey::Root)
+    }
+
+    fn new_leaf(new_item: T) -> Self {
+        Self {
+            child_nodes: HashMap::default(),
+            // We have to include leaf nodes as descendants of themselves, because
+            // leaf nodes can be returned in `TrieSearch::LongestPrefixNode` results after
+            // eliminating one-way branching.
+            descendants: vec![new_item.clone()],
+            match_: Some(new_item.clone()),
+            prefix: TriePrefix {
+                range_end: new_item.key().len(),
+                key: TrieKey::Key(new_item),
+            },
+        }
+    }
+
+    /// Create a new split node with the split prefix.
+    /// Fill it by calling `Self::fill_split_node` on it after swapping it with
+    /// the node to split.
+    fn new_split_node(split_index: usize, new_item: T) -> Self {
+        BytecodeTrie {
+            prefix: TriePrefix {
+                range_end: split_index,
+                key: TrieKey::Key(new_item),
+            },
+
+            // These be filled in by calling `Self::fill_split_node`
+            child_nodes: HashMap::default(),
+            descendants: Vec::default(),
+            match_: None,
+        }
+    }
+
+    /// Fill the split node from the node with the node
+    /// and the new key as children. If the new key is shorter than the
+    /// node's prefix, the new split node will be a match for the new
+    /// key. Panics if `split_index > new_key.key().len()`
+    fn fill_split_node(&mut self, node_to_split: BytecodeTrie<T>, new_item: T) {
+        // We use the descendants to keep track of insertion order, so it's
+        // important to preserve that order here
+        let mut descendants = Vec::with_capacity(node_to_split.descendants.len() + 1);
+        descendants.extend(node_to_split.descendants.iter().cloned());
+        descendants.push(new_item.clone());
+
+        let split_index = self.prefix.range_end;
+
+        // Add occupied node as child
+        self.child_nodes.insert(
+            node_to_split.prefix.key.key()[split_index],
+            Box::new(node_to_split),
+        );
+
+        match split_index.cmp(&new_item.key().len()) {
+            Ordering::Less => {
+                // If the new key is longer than the end of split prefix, add it as a child node
+                self.child_nodes.insert(
+                    new_item.key()[split_index],
+                    Box::new(Self::new_leaf(new_item)),
+                );
+            }
+            Ordering::Equal => {
+                // Otherwise it's an exact match for the split node
+                self.match_ = Some(new_item);
+            }
+            Ordering::Greater => {
+                // If the split index is greater than the length of the key, this function was
+                // called with the wrong arguments due to a bug.
+                panic!("split index is greater than new key length")
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TriePrefix<T> {
+    /// `key[..range_end]` represents this prefix
+    range_end: usize,
+    key: TrieKey<T>,
+}
+
+impl<T: TrieKeyTrait> TriePrefix<T> {
+    fn new_root() -> Self {
+        Self {
+            // Root node never needs to be split
+            range_end: 0,
+            key: TrieKey::Root,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum TrieKey<T> {
+    Root,
+    Key(T),
+}
+
+impl<T: TrieKeyTrait> TrieKeyTrait for TrieKey<T> {
+    fn key(&self) -> &[u8] {
+        match self {
+            TrieKey::Root => &[],
+            TrieKey::Key(key) => key.key(),
+        }
+    }
+}
+
+impl TrieKeyTrait for Arc<ContractMetadata> {
+    fn key(&self) -> &[u8] {
+        &self.normalized_code
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::bytecode_trie::{BytecodeTrie, TrieKeyTrait, TrieSearch};
+
+    impl<T: TrieKeyTrait> BytecodeTrie<T> {
+        /// The number of nodes in this (sub)trie. Useful for testing.
+        fn node_count(&self) -> usize {
+            1 + self
+                .child_nodes
+                .values()
+                .map(|node| node.node_count())
+                .sum::<usize>()
+        }
+    }
+
+    impl TrieKeyTrait for &'static str {
+        fn key(&self) -> &[u8] {
+            self.as_bytes()
+        }
+    }
+
+    fn assert_prefix_node(
+        result: Option<TrieSearch<'_, &'static str>>,
+        expected_prefix: &str,
+        should_match: bool,
+    ) {
+        let Some(TrieSearch::LongestPrefixNode {
+            node,
+            diff_index: _,
+            match_,
+        }) = result
+        else {
+            assert!(result.is_some(), "received None");
+            panic!("received exact hit");
+        };
+        assert_eq!(should_match, match_.is_some());
+        assert_eq!(
+            &node.prefix.key.key()[..node.prefix.range_end],
+            expected_prefix.as_bytes()
+        );
+    }
+
+    #[test]
+    fn test_one_key_exact_match() {
+        let mut trie = BytecodeTrie::<&'static str>::new_root();
+        trie.add("hello");
+        assert_eq!(
+            trie.search(b"hello", 0),
+            Some(TrieSearch::ExactHit("hello"))
+        );
+        assert_eq!(trie.node_count(), 2);
+    }
+
+    #[test]
+    fn test_empty_trie() {
+        let trie = BytecodeTrie::<&'static str>::new_root();
+        assert_eq!(trie.search(b"hello", 0), None);
+        assert_eq!(trie.node_count(), 1);
+    }
+
+    #[test]
+    fn test_empty_trie_empty_key() {
+        let trie = BytecodeTrie::<&'static str>::new_root();
+        assert_eq!(trie.search(&[], 0), None);
+    }
+
+    #[test]
+    fn test_empty_some_trie_empty_key() {
+        let mut trie = BytecodeTrie::<&'static str>::new_root();
+        trie.add("hello");
+        assert_eq!(trie.search(&[], 0), None);
+    }
+
+    #[test]
+    fn test_one_key_prefix() {
+        let mut trie = BytecodeTrie::<&'static str>::new_root();
+        trie.add("hello");
+        assert_prefix_node(trie.search(b"hellos", 0), "hello", true);
+        assert_eq!(trie.search(b"hel", 0), None);
+        assert_eq!(trie.node_count(), 2);
+    }
+
+    #[test]
+    fn test_not_found() {
+        let mut trie = BytecodeTrie::<&'static str>::new_root();
+        trie.add("hello");
+        assert_eq!(trie.search(b"foo", 0), None);
+    }
+
+    #[test]
+    fn test_duplicate_key() {
+        let mut trie = BytecodeTrie::<&'static str>::new_root();
+        trie.add("hello");
+        trie.add("hello");
+        assert_eq!(
+            trie.search(b"hello", 0),
+            Some(TrieSearch::ExactHit("hello"))
+        );
+        assert_eq!(trie.node_count(), 2);
+    }
+
+    #[test]
+    fn test_two_keys_that_are_prefix() {
+        let mut trie = BytecodeTrie::<&'static str>::new_root();
+        trie.add("hello");
+        trie.add("hellos");
+        assert_eq!(
+            trie.search(b"hello", 0),
+            Some(TrieSearch::ExactHit("hello"))
+        );
+        assert_eq!(
+            trie.search(b"hellos", 0),
+            Some(TrieSearch::ExactHit("hellos"))
+        );
+        assert_eq!(trie.node_count(), 3);
+    }
+
+    #[test]
+    fn test_root_multiple_children() {
+        let mut trie = BytecodeTrie::<&'static str>::new_root();
+        trie.add("foo");
+        trie.add("bar");
+        assert_eq!(trie.search(b"foo", 0), Some(TrieSearch::ExactHit("foo")));
+        assert_eq!(trie.search(b"bar", 0), Some(TrieSearch::ExactHit("bar")));
+        assert_eq!(trie.node_count(), 3);
+    }
+
+    #[test]
+    fn test_non_trivial() {
+        // Based on Sedgewick, Algorithms
+        let mut trie = BytecodeTrie::<&'static str>::new_root();
+        let words = vec!["shell", "sheep", "shells", "shellfish", "ship"];
+
+        for word in &words {
+            trie.add(word);
+        }
+
+        // + 3 = root node + two split nodes ("sh" and "she")
+        assert_eq!(trie.node_count(), words.len() + 3);
+
+        for word in &words {
+            assert_eq!(
+                trie.search(word.as_bytes(), 0),
+                Some(TrieSearch::ExactHit(*word))
+            );
+        }
+
+        // Expected prefix is leaf
+        assert_prefix_node(trie.search(b"sheepherder", 0), "sheep", true);
+        // Expected prefix is split node with match
+        assert_prefix_node(trie.search(b"shelly", 0), "shell", true);
+        // Expected prefix is split node without match
+        assert_prefix_node(trie.search(b"sharp", 0), "sh", false);
+
+        // Split nodes without match shouldn't match
+        assert_eq!(trie.search(b"sh", 0), None);
+        assert_eq!(trie.search(b"she", 0), None);
+
+        // Prefix contained in trie without node shouldn't match
+        assert_eq!(trie.search(b"shee", 0), None);
     }
 }

--- a/crates/edr_solidity/src/bytecode_trie.rs
+++ b/crates/edr_solidity/src/bytecode_trie.rs
@@ -1,0 +1,83 @@
+use std::{collections::HashMap, sync::Arc};
+
+use crate::build_model::ContractMetadata;
+
+/// The result of searching for a bytecode in a [`BytecodeTrie`].
+pub enum TrieSearch<'a> {
+    /// An exact match was found.
+    ExactHit(Arc<ContractMetadata>),
+    /// No exact match found; a node with the longest prefix is returned.
+    LongestPrefixNode(&'a BytecodeTrie),
+}
+
+/// This class represent a somewhat special Trie of bytecodes.
+///
+/// What makes it special is that every node has a set of all of its descendants
+/// and its depth.
+#[derive(Debug, Clone)]
+pub struct BytecodeTrie {
+    pub descendants: Vec<Arc<ContractMetadata>>,
+    pub match_: Option<Arc<ContractMetadata>>,
+    pub depth: Option<u32>,
+    child_nodes: HashMap<u8, Box<BytecodeTrie>>,
+}
+
+impl BytecodeTrie {
+    pub fn new(depth: Option<u32>) -> BytecodeTrie {
+        BytecodeTrie {
+            child_nodes: HashMap::new(),
+            descendants: Vec::new(),
+            match_: None,
+            depth,
+        }
+    }
+
+    pub fn add(&mut self, bytecode: Arc<ContractMetadata>) {
+        let mut cursor = self;
+
+        let bytecode_normalized_code = &bytecode.normalized_code;
+        for (index, byte) in bytecode_normalized_code.iter().enumerate() {
+            cursor.descendants.push(bytecode.clone());
+
+            let node = cursor
+                .child_nodes
+                .entry(*byte)
+                .or_insert_with(|| Box::new(BytecodeTrie::new(Some(index as u32))));
+
+            cursor = node;
+        }
+
+        // If multiple contracts with the exact same bytecode are added we keep the last
+        // of them. Note that this includes the metadata hash, so the chances of
+        // happening are pretty remote, except in super artificial cases that we
+        // have in our test suite.
+        cursor.match_ = Some(bytecode.clone());
+    }
+
+    /// Searches for a bytecode. If it's an exact match, it is returned. If
+    /// there's no match, but a prefix of the code is found in the trie, the
+    /// node of the longest prefix is returned. If the entire code is
+    /// covered by the trie, and there's no match, we return None.
+    pub fn search(&self, code: &[u8], current_code_byte: u32) -> Option<TrieSearch<'_>> {
+        if current_code_byte > code.len() as u32 {
+            return None;
+        }
+
+        let mut cursor = self;
+
+        for byte in code.iter().skip(current_code_byte as usize) {
+            let child_node = cursor.child_nodes.get(byte);
+
+            if let Some(node) = child_node {
+                cursor = node;
+            } else {
+                return Some(TrieSearch::LongestPrefixNode(cursor));
+            }
+        }
+
+        cursor
+            .match_
+            .as_ref()
+            .map(|bytecode| TrieSearch::ExactHit(bytecode.clone()))
+    }
+}

--- a/crates/edr_solidity/src/contracts_identifier.rs
+++ b/crates/edr_solidity/src/contracts_identifier.rs
@@ -10,87 +10,10 @@ use std::{borrow::Cow, collections::HashMap, sync::Arc};
 use edr_eth::Address;
 use edr_evm::interpreter::OpCode;
 
-use crate::build_model::ContractMetadata;
-
-/// The result of searching for a bytecode in a [`BytecodeTrie`].
-enum TrieSearch<'a> {
-    /// An exact match was found.
-    ExactHit(Arc<ContractMetadata>),
-    /// No exact match found; a node with the longest prefix is returned.
-    LongestPrefixNode(&'a BytecodeTrie),
-}
-
-/// This class represent a somewhat special Trie of bytecodes.
-///
-/// What makes it special is that every node has a set of all of its descendants
-/// and its depth.
-#[derive(Debug, Clone)]
-struct BytecodeTrie {
-    child_nodes: HashMap<u8, Box<BytecodeTrie>>,
-    descendants: Vec<Arc<ContractMetadata>>,
-    match_: Option<Arc<ContractMetadata>>,
-    depth: Option<u32>,
-}
-
-impl BytecodeTrie {
-    fn new(depth: Option<u32>) -> BytecodeTrie {
-        BytecodeTrie {
-            child_nodes: HashMap::new(),
-            descendants: Vec::new(),
-            match_: None,
-            depth,
-        }
-    }
-
-    fn add(&mut self, bytecode: Arc<ContractMetadata>) {
-        let mut cursor = self;
-
-        let bytecode_normalized_code = &bytecode.normalized_code;
-        for (index, byte) in bytecode_normalized_code.iter().enumerate() {
-            cursor.descendants.push(bytecode.clone());
-
-            let node = cursor
-                .child_nodes
-                .entry(*byte)
-                .or_insert_with(|| Box::new(BytecodeTrie::new(Some(index as u32))));
-
-            cursor = node;
-        }
-
-        // If multiple contracts with the exact same bytecode are added we keep the last
-        // of them. Note that this includes the metadata hash, so the chances of
-        // happening are pretty remote, except in super artificial cases that we
-        // have in our test suite.
-        cursor.match_ = Some(bytecode.clone());
-    }
-
-    /// Searches for a bytecode. If it's an exact match, it is returned. If
-    /// there's no match, but a prefix of the code is found in the trie, the
-    /// node of the longest prefix is returned. If the entire code is
-    /// covered by the trie, and there's no match, we return None.
-    fn search(&self, code: &[u8], current_code_byte: u32) -> Option<TrieSearch<'_>> {
-        if current_code_byte > code.len() as u32 {
-            return None;
-        }
-
-        let mut cursor = self;
-
-        for byte in code.iter().skip(current_code_byte as usize) {
-            let child_node = cursor.child_nodes.get(byte);
-
-            if let Some(node) = child_node {
-                cursor = node;
-            } else {
-                return Some(TrieSearch::LongestPrefixNode(cursor));
-            }
-        }
-
-        cursor
-            .match_
-            .as_ref()
-            .map(|bytecode| TrieSearch::ExactHit(bytecode.clone()))
-    }
-}
+use crate::{
+    build_model::ContractMetadata,
+    bytecode_trie::{BytecodeTrie, TrieSearch},
+};
 
 /// Returns true if the `last_byte` is placed right when the metadata starts or
 /// after it.

--- a/crates/edr_solidity/src/lib.rs
+++ b/crates/edr_solidity/src/lib.rs
@@ -18,6 +18,7 @@ pub mod nested_tracer;
 pub mod solidity_stack_trace;
 pub mod solidity_tracer;
 
+mod bytecode_trie;
 mod error_inferrer;
 mod mapped_inline_internal_functions_heuristics;
 mod return_data;


### PR DESCRIPTION
This PR fixes stack overflow on drop in the `BytecodeTrie` by eliminating one-way branching which produces very deep tries for large contracts. Care has been taken to preserve the implementation details of the previous implementation which the stack trace heuristics rely on.

I moved the `BytecodeTrie` to a separate module in [7bcb871](https://github.com/NomicFoundation/edr/pull/775/commits/7bcb8712fb70428a6184292a13100daccce06e51). The changes to eliminate one-way branching can be reviewed by reviewing [76840d8](https://github.com/NomicFoundation/edr/pull/775/commits/76840d88c77e6688f616f430f6b50ced1e85bd66).

I also added a [benchmark](https://github.com/NomicFoundation/edr/pull/775/files#diff-f3f8c0e043dcf722c2eb7c98f6ce432856efd6464495c6f54051985243bcdb34) for constructing the `ContractDecoder`, but maybe it'd be better to put this in the `tools` crate, as running the benchmark requires some manual setup.

Eliminating one way branching resulted in a 5x speed up for constructing the `ContractDecoder` for the `forge-std` test suite. 

We are benchmarking the `ContractDecoder` construction instead of the `BytecodeTrie` construction as the former takes care of constructing the data that goes in the trie and I didn't want to spend time on recreating that logic separately. This does mean however that the benchmark also measures parsing and normalizing the contract metadata, I suspect which now takes the majority of the time.
