### PR TITLE
fix: statically link Windows C runtime

### DIFF
--- a/.changeset/popular-singers-sit.md
+++ b/.changeset/popular-singers-sit.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Fixed crash when loading EDR on Windows without a C Runtime library installed

--- a/crates/edr_napi/.cargo/config.toml
+++ b/crates/edr_napi/.cargo/config.toml
@@ -6,3 +6,6 @@ target-dir = "./target"
 [target.aarch64-unknown-linux-musl]
 linker = "aarch64-linux-musl-gcc"
 rustflags = ["-C", "target-feature=-crt-static"]
+
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION
Fixes https://github.com/NomicFoundation/edr/issues/781

Tested locally on a fresh Windows install.