### PR TITLE
ci: bump `seaport` and `uniswap` benchmark samples

### DIFF
--- a/crates/tools/js/benchmark/src/index.ts
+++ b/crates/tools/js/benchmark/src/index.ts
@@ -266,9 +266,12 @@ function numIterations(scenarioName: string): number {
     return 15;
   } else if (
     scenarioName.includes("seaport") ||
-    scenarioName.includes("openzeppelin") ||
-    scenarioName.includes("rocketpool") ||
     scenarioName.includes("uniswap")
+  ) {
+    return 11;
+  } else if (
+    scenarioName.includes("openzeppelin") ||
+    scenarioName.includes("rocketpool")
   ) {
     return 7;
   } else if (scenarioName.includes("neptune-mutual")) {


### PR DESCRIPTION
We've improved a lot on the `seaport` and `uniswap` benchmark scenarios which causes variability resulting in false positive regression alerts. The variability is observable visually at: https://nomic-foundation-automation.github.io/edr-benchmark-results/bench/

This is a quick fix for the variability by bumping the number of iterations for these scenarios. A proper fix would be using a more robust statistic for the results, but this takes some time to test.