### PR TITLE
ci: upgrade upload/download artifacts to v4

### DIFF
--- a/.github/workflows/edr-npm-release.yml
+++ b/.github/workflows/edr-npm-release.yml
@@ -144,12 +144,13 @@ jobs:
         if: ${{ !matrix.settings.docker }}
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bindings-${{ matrix.settings.target }}
           # The upload artifact action doesn't respect the working directory setting. Unclear if this is a bug or not
           # https://github.com/actions/upload-artifact/issues/294
           path: ./crates/edr_napi/${{ env.APP_NAME }}.*.node
+          overwrite: true
           if-no-files-found: error
   test-macOS-windows-binding:
     name: Test bindings on ${{ matrix.settings.target }} - node@${{ matrix.node }}
@@ -178,7 +179,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: bindings-${{ matrix.settings.target }}
           path: ./crates/edr_napi/
@@ -204,7 +205,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: bindings-x86_64-unknown-linux-gnu
           path: ./crates/edr_napi/
@@ -236,7 +237,7 @@ jobs:
           pnpm config set supportedArchitectures.libc "musl"
           pnpm install --frozen-lockfile --prefer-offline
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: bindings-x86_64-unknown-linux-musl
           path: ./crates/edr_napi/
@@ -262,7 +263,7 @@ jobs:
         with:
           version: 9
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: bindings-aarch64-unknown-linux-gnu
           path: ./crates/edr_napi/
@@ -306,7 +307,7 @@ jobs:
         with:
           version: 9
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: bindings-aarch64-unknown-linux-musl
           path: ./crates/edr_napi/
@@ -377,7 +378,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
       - name: Download all artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: ./crates/edr_napi/artifacts
       - name: Check number of artifacts


### PR DESCRIPTION
Due to deprecation of v3: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/