### PR TITLE
feat: stack trace support for setup/deployment and invariant tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1802,12 +1802,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aac81fa3e28d21450aa4d2ac065992ba96a1d7303efbce51a95f4fd175b67562"
 
 [[package]]
-name = "downcast"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
-
-[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2093,9 +2087,7 @@ dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
  "alloy-primitives 0.7.7",
- "anyhow",
  "comfy-table",
- "criterion 0.5.1",
  "dunce",
  "edr_common",
  "edr_defaults",
@@ -2108,27 +2100,18 @@ dependencies = [
  "foundry-compilers",
  "foundry-evm",
  "futures",
- "globset",
  "humantime-serde",
  "itertools 0.12.1",
  "log",
- "mockall",
  "num_cpus",
  "once_cell",
  "paste",
- "path-slash",
  "proptest",
  "rayon",
  "regex",
- "revm 12.1.0",
- "revm 13.0.0",
- "revm-primitives 7.1.0",
- "revm-primitives 8.0.0",
  "semver 1.0.23",
  "serde",
  "serial_test",
- "similar-asserts",
- "svm-rs",
  "tempfile",
  "thiserror",
  "tokio",
@@ -2513,6 +2496,7 @@ dependencies = [
  "alloy-primitives 0.7.7",
  "alloy-sol-types 0.7.7",
  "const-hex",
+ "edr_solidity",
  "eyre",
  "foundry-cheatcodes",
  "foundry-evm-core",
@@ -2521,6 +2505,7 @@ dependencies = [
  "foundry-evm-traces",
  "parking_lot 0.12.3",
  "proptest",
+ "revm 12.1.0",
  "revm 13.0.0",
  "revm-inspectors",
  "thiserror",
@@ -2666,12 +2651,6 @@ dependencies = [
  "tracing",
  "url",
 ]
-
-[[package]]
-name = "fragile"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "fs4"
@@ -2825,19 +2804,6 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
-
-[[package]]
-name = "globset"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f1ce686646e7f1e19bf7d5533fe443a45dbfb990e00629110797578b42fb19"
-dependencies = [
- "aho-corasick",
- "bstr",
- "log",
- "regex-automata 0.4.8",
- "regex-syntax 0.8.5",
-]
 
 [[package]]
 name = "group"
@@ -3692,33 +3658,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mockall"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43766c2b5203b10de348ffe19f7e54564b64f3d6018ff7648d1e2d6d3a0f0a48"
-dependencies = [
- "cfg-if",
- "downcast",
- "fragile",
- "lazy_static",
- "mockall_derive",
- "predicates",
- "predicates-tree",
-]
-
-[[package]]
-name = "mockall_derive"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
-dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "syn 2.0.85",
-]
-
-[[package]]
 name = "mockito"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4379,32 +4318,6 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
-
-[[package]]
-name = "predicates"
-version = "3.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
-dependencies = [
- "anstyle",
- "predicates-core",
-]
-
-[[package]]
-name = "predicates-core"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931"
-
-[[package]]
-name = "predicates-tree"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13"
-dependencies = [
- "predicates-core",
- "termtree",
-]
 
 [[package]]
 name = "primeorder"
@@ -5907,12 +5820,6 @@ checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "termtree"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "textwrap"

--- a/crates/edr_solidity/src/solidity_stack_trace.rs
+++ b/crates/edr_solidity/src/solidity_stack_trace.rs
@@ -190,4 +190,16 @@ impl StackTraceEntry {
             | StackTraceEntry::UnrecognizedContractError { .. } => None,
         }
     }
+
+    /// Whether the stack trace entry is an unrecognized contract call to the
+    /// specified address.
+    pub fn is_unrecognized_contract_call_error(&self, contract_address: &Address) -> bool {
+        match self {
+            StackTraceEntry::UnrecognizedContractCallstackEntry { address }
+            | StackTraceEntry::UnrecognizedContractError { address, .. } => {
+                address == contract_address
+            }
+            _ => false,
+        }
+    }
 }

--- a/crates/edr_solidity_tests/Cargo.toml
+++ b/crates/edr_solidity_tests/Cargo.toml
@@ -30,33 +30,21 @@ alloy-dyn-abi.workspace = true
 alloy-json-abi.workspace = true
 alloy-primitives = { workspace = true, features = ["serde"] }
 
-revm_foundry = { version = "=13.0.0", package = "revm" }
-revm_primitives_foundry = { version = "=8.0.0", package = "revm-primitives" }
-revm_edr = { version = "=12.1.0", package = "revm" }
-revm_primitives_edr = { version = "=7.1.0", package = "revm-primitives" }
-
 tokio = { workspace = true, features = ["time"] }
 evm-disassembler.workspace = true
 thiserror = "1.0.61"
 log = "0.4.22"
-anyhow = "1.0.91"
 
 [dev-dependencies]
 edr_test_utils.workspace = true
 
-mockall = "0.12"
-criterion = "0.5"
 futures = "0.3"
-globset = "0.4"
 itertools.workspace = true
 once_cell = "1"
 paste = "1.0"
-path-slash = "0.2"
 regex = "1"
-similar-asserts.workspace = true
 semver = "1"
 serial_test = "2.0.0"
-svm = { package = "svm-rs", version = "0.5", default-features = false, features = ["rustls"] }
 tempfile.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 

--- a/crates/edr_solidity_tests/src/lib.rs
+++ b/crates/edr_solidity_tests/src/lib.rs
@@ -26,8 +26,7 @@ pub use config::{SolidityTestRunnerConfig, SolidityTestRunnerConfigError};
 
 pub mod result;
 
-mod stack_trace;
-pub use stack_trace::StackTraceError;
+pub use foundry_evm::executors::stack_trace::StackTraceError;
 
 mod test_filter;
 

--- a/crates/edr_solidity_tests/src/runner.rs
+++ b/crates/edr_solidity_tests/src/runner.rs
@@ -866,16 +866,16 @@ impl<'a, NestedTraceDecoderT: SyncNestedTraceDecoder> ContractRunner<'a, NestedT
                                 }
                                 counterexample =
                                     Some(CounterExample::Sequence(counterexample_sequence));
+                            }
 
-                                // If we can't get a revert reason for the second time, we couldn't
-                                // replay the failure, so keep the original revert reason
-                                // and discard the stack trace as it may be misleading.
-                                if reason.is_some() && revert_reason.is_none() {
-                                    tracing::warn!(?invariant_contract.invariant_function, "Failed to compute stack trace");
-                                } else {
-                                    stack_trace = stack_trace_result;
-                                    reason = revert_reason;
-                                }
+                            // If we can't get a revert reason for the second time, we couldn't
+                            // replay the failure, so keep the original revert reason
+                            // and discard the stack trace as it may be misleading.
+                            if reason.is_some() && revert_reason.is_none() {
+                                tracing::warn!(?invariant_contract.invariant_function, "Failed to compute stack trace");
+                            } else {
+                                stack_trace = stack_trace_result;
+                                reason = revert_reason;
                             }
                         }
                         Err(err) => {

--- a/crates/edr_solidity_tests/src/runner.rs
+++ b/crates/edr_solidity_tests/src/runner.rs
@@ -12,7 +12,8 @@ use alloy_dyn_abi::DynSolValue;
 use alloy_json_abi::Function;
 use alloy_primitives::{Address, Log, U256};
 use edr_solidity::{
-    contract_decoder::SyncNestedTraceDecoder, solidity_stack_trace::StackTraceEntry,
+    contract_decoder::{NestedTraceDecoder, SyncNestedTraceDecoder},
+    solidity_stack_trace::StackTraceEntry,
 };
 use eyre::Result;
 use foundry_evm::{
@@ -25,8 +26,10 @@ use foundry_evm::{
         fuzz::FuzzedExecutor,
         invariant::{
             check_sequence, replay_error, replay_run, InvariantConfig, InvariantExecutor,
-            InvariantFuzzError, InvariantFuzzTestResult,
+            InvariantFuzzError, InvariantFuzzTestResult, ReplayErrorArgs, ReplayResult,
+            ReplayRunArgs,
         },
+        stack_trace::{get_stack_trace, StackTraceError},
         CallResult, EvmError, ExecutionErr, Executor, ExecutorBuilder, RawCallResult,
     },
     fuzz::{
@@ -43,7 +46,6 @@ use crate::{
     fuzz::{invariant::BasicTxDetails, BaseCounterExample, FuzzConfig},
     multi_runner::TestContract,
     result::{SuiteResult, TestKind, TestResult, TestSetup, TestStatus},
-    stack_trace::{get_stack_trace, StackTraceError},
     traces::Traces,
     TestFilter, TestOptions,
 };
@@ -174,12 +176,17 @@ impl<'a, NestedTraceDecoderT: SyncNestedTraceDecoder> ContractRunner<'a, NestedT
             .any(foundry_evm::abi::TestFunctionExt::is_invariant_test);
 
         // Invariant testing requires tracing to figure out what contracts were created.
-        let tmp_tracing = executor.inspector.tracer.is_none() && has_invariants && needs_setup;
-        if tmp_tracing {
+        // This would be only strictly needed for invariant tests if there are contracts
+        // created in the `setUp()` method. We do it even if there is no `setUp` method,
+        // because stack trace generation needs setup traces as well to match addresses
+        // to contract code, and it simplifies re-execution for invariant tests
+        // if we don't need to redo the setup.
+        let setup_tracing = executor.inspector.tracer.is_none() && has_invariants;
+        if setup_tracing {
             executor.set_tracing(true);
         }
         let setup = self.setup(&mut executor, needs_setup);
-        if tmp_tracing {
+        if setup_tracing {
             executor.set_tracing(false);
         }
 
@@ -193,7 +200,7 @@ impl<'a, NestedTraceDecoderT: SyncNestedTraceDecoder> ContractRunner<'a, NestedT
             executor.inspector.enable_for_stack_traces();
             let setup_for_stack_traces = self.setup(&mut executor, needs_setup);
             let stack_trace_result =
-                get_stack_trace(&self.contract_decoder, &setup_for_stack_traces.traces)
+                get_stack_trace(&*self.contract_decoder, &setup_for_stack_traces.traces)
                     .transpose()
                     .expect("traces are not empty");
 
@@ -687,7 +694,7 @@ impl<'a, NestedTraceDecoderT: SyncNestedTraceDecoder> ContractRunner<'a, NestedT
         let mut traces = setup.traces;
         traces.push((TraceKind::Execution, new_traces));
 
-        get_stack_trace(&self.contract_decoder, &traces)
+        get_stack_trace(&*self.contract_decoder, &traces)
             .transpose()
             .expect("traces are not empty")
     }
@@ -765,20 +772,20 @@ impl<'a, NestedTraceDecoderT: SyncNestedTraceDecoder> ContractRunner<'a, NestedT
             .map(|failure_dir| failure_dir.join(&invariant_contract.invariant_function.name));
 
         if let Some(failure_file) = failure_file.as_ref() {
-            if let Some(result) = try_to_replay_recorded_failures(
-                executor.clone(),
-                ReplayArgs {
-                    failure_file,
-                    invariant_config: &invariant_config,
-                    known_contracts,
-                    identified_contracts,
-                    invariant_contract: &invariant_contract,
-                    logs: &mut logs,
-                    traces: &mut traces,
-                    coverage: &mut coverage,
-                    start: &start,
-                },
-            ) {
+            if let Some(result) = try_to_replay_recorded_failures(ReplayRecordedFailureArgs {
+                executor: executor.clone(),
+                contract_decoder: &*self.contract_decoder,
+                revert_decoder: self.revert_decoder,
+                failure_file,
+                invariant_config: &invariant_config,
+                known_contracts,
+                identified_contracts,
+                invariant_contract: &invariant_contract,
+                logs: &mut logs,
+                traces: &mut traces,
+                coverage: &mut coverage,
+                start: &start,
+            }) {
                 return result;
             }
         }
@@ -812,8 +819,9 @@ impl<'a, NestedTraceDecoderT: SyncNestedTraceDecoder> ContractRunner<'a, NestedT
         };
 
         let mut counterexample = None;
+        let mut stack_trace = None;
         let success = error.is_none();
-        let reason = error
+        let mut reason = error
             .as_ref()
             .and_then(foundry_evm::executors::invariant::InvariantFuzzError::revert_reason);
 
@@ -824,18 +832,25 @@ impl<'a, NestedTraceDecoderT: SyncNestedTraceDecoder> ContractRunner<'a, NestedT
                 | InvariantFuzzError::Revert(case_data) => {
                     // Replay error to create counterexample and to collect logs, traces and
                     // coverage.
-                    match replay_error(
-                        &case_data,
-                        &invariant_contract,
-                        executor.clone(),
+                    match replay_error::<NestedTraceDecoderT>(ReplayErrorArgs {
+                        executor: executor.clone(),
+                        failed_case: &case_data,
+                        invariant_contract: &invariant_contract,
                         known_contracts,
-                        identified_contracts.clone(),
-                        &mut logs,
-                        &mut traces,
-                        &mut coverage,
-                    ) {
-                        Ok(call_sequence) => {
-                            if !call_sequence.is_empty() {
+                        ided_contracts: identified_contracts.clone(),
+                        logs: &mut logs,
+                        traces: &mut traces,
+                        coverage: &mut coverage,
+                        generate_stack_trace: true,
+                        contract_decoder: Some(&*self.contract_decoder),
+                        revert_decoder: self.revert_decoder,
+                    }) {
+                        Ok(ReplayResult {
+                            counterexample_sequence,
+                            stack_trace_result,
+                            revert_reason,
+                        }) => {
+                            if !counterexample_sequence.is_empty() {
                                 // Persist error in invariant failure dir.
                                 if let Some(failure_dir) = failure_dir {
                                     let failure_file = failure_file
@@ -844,12 +859,15 @@ impl<'a, NestedTraceDecoderT: SyncNestedTraceDecoder> ContractRunner<'a, NestedT
                                         error!(%err, "Failed to create invariant failure dir");
                                     } else if let Err(err) = edr_common::fs::write_json_file(
                                         failure_file.as_path(),
-                                        &call_sequence,
+                                        &counterexample_sequence,
                                     ) {
                                         error!(%err, "Failed to record call sequence");
                                     }
                                 }
-                                counterexample = Some(CounterExample::Sequence(call_sequence));
+                                counterexample =
+                                    Some(CounterExample::Sequence(counterexample_sequence));
+                                stack_trace = stack_trace_result;
+                                reason = revert_reason;
                             }
                         }
                         Err(err) => {
@@ -863,16 +881,19 @@ impl<'a, NestedTraceDecoderT: SyncNestedTraceDecoder> ContractRunner<'a, NestedT
             // If invariants ran successfully, replay the last run to collect logs and
             // traces.
             _ => {
-                if let Err(err) = replay_run(
-                    &invariant_contract,
+                if let Err(err) = replay_run::<NestedTraceDecoderT>(ReplayRunArgs {
+                    invariant_contract: &invariant_contract,
                     executor,
                     known_contracts,
-                    identified_contracts.clone(),
-                    &mut logs,
-                    &mut traces,
-                    &mut coverage,
-                    last_run_inputs.clone(),
-                ) {
+                    ided_contracts: identified_contracts.clone(),
+                    logs: &mut logs,
+                    traces: &mut traces,
+                    coverage: &mut coverage,
+                    inputs: last_run_inputs.clone(),
+                    generate_stack_trace: false,
+                    contract_decoder: None,
+                    revert_decoder: self.revert_decoder,
+                }) {
                     error!(%err, "Failed to replay last invariant run");
                 }
             }
@@ -897,8 +918,7 @@ impl<'a, NestedTraceDecoderT: SyncNestedTraceDecoder> ContractRunner<'a, NestedT
             labeled_addresses: labeled_addresses.clone(),
             duration: start.elapsed(),
             gas_report_traces,
-            // TODO
-            stack_trace_result: None,
+            stack_trace_result: stack_trace,
         }
     }
 
@@ -1001,7 +1021,10 @@ impl<'a, NestedTraceDecoderT: SyncNestedTraceDecoder> ContractRunner<'a, NestedT
     }
 }
 
-struct ReplayArgs<'a> {
+struct ReplayRecordedFailureArgs<'a, NestedTraceDecoderT: NestedTraceDecoder> {
+    executor: Executor,
+    contract_decoder: &'a NestedTraceDecoderT,
+    revert_decoder: &'a RevertDecoder,
     failure_file: &'a Path,
     invariant_config: &'a InvariantConfig,
     known_contracts: &'a ContractsByArtifact,
@@ -1013,8 +1036,13 @@ struct ReplayArgs<'a> {
     start: &'a Instant,
 }
 
-fn try_to_replay_recorded_failures(executor: Executor, args: ReplayArgs<'_>) -> Option<TestResult> {
-    let ReplayArgs {
+fn try_to_replay_recorded_failures<NestedTraceDecoderT: NestedTraceDecoder>(
+    args: ReplayRecordedFailureArgs<'_, NestedTraceDecoderT>,
+) -> Option<TestResult> {
+    let ReplayRecordedFailureArgs {
+        executor,
+        contract_decoder,
+        revert_decoder,
         failure_file,
         invariant_config,
         known_contracts,
@@ -1056,31 +1084,41 @@ fn try_to_replay_recorded_failures(executor: Executor, args: ReplayArgs<'_>) -> 
             if !success {
                 // If sequence still fails then replay error to collect traces and
                 // exit without executing new runs.
-                let _ = replay_run(
+                let (reason, stack_trace_result) = replay_run(ReplayRunArgs {
                     invariant_contract,
                     executor,
                     known_contracts,
-                    identified_contracts.clone(),
+                    ided_contracts: identified_contracts.clone(),
                     logs,
                     traces,
                     coverage,
-                    txes,
+                    inputs: txes,
+                    generate_stack_trace: true,
+                    contract_decoder: Some(contract_decoder),
+                    revert_decoder,
+                })
+                .ok()
+                .map_or_else(
+                    || (None, None),
+                    |result| {
+                        let reason = result.revert_reason.unwrap_or_else(|| {
+                            if replayed_entirely {
+                                "replay failure"
+                            } else {
+                                "persisted failure revert"
+                            }
+                            .to_string()
+                        });
+                        (Some(reason), result.stack_trace_result)
+                    },
                 );
+
                 return Some(TestResult {
                     status: TestStatus::Failure,
-                    reason: if replayed_entirely {
-                        Some(format!(
-                            "{} replay failure",
-                            invariant_contract.invariant_function.name
-                        ))
-                    } else {
-                        Some(format!(
-                            "{} persisted failure revert",
-                            invariant_contract.invariant_function.name
-                        ))
-                    },
+                    reason,
                     decoded_logs: decode_console_logs(logs),
                     traces: traces.clone(),
+                    gas_report_traces: vec![],
                     coverage: coverage.clone(),
                     counterexample: Some(CounterExample::Sequence(call_sequence)),
                     kind: TestKind::Invariant {
@@ -1089,7 +1127,9 @@ fn try_to_replay_recorded_failures(executor: Executor, args: ReplayArgs<'_>) -> 
                         reverts: 1,
                     },
                     duration: start.elapsed(),
-                    ..Default::default()
+                    logs: vec![],
+                    labeled_addresses: HashMap::default(),
+                    stack_trace_result,
                 });
             }
         }

--- a/crates/edr_solidity_tests/src/stack_trace.rs
+++ b/crates/edr_solidity_tests/src/stack_trace.rs
@@ -73,13 +73,7 @@ pub(crate) fn get_stack_trace<NestedTraceDecoderT: NestedTraceDecoder>(
         let stack_trace = stack_trace
             .into_iter()
             .filter(|stack_trace| {
-                if let StackTraceEntry::UnrecognizedContractCallstackEntry { address, .. } =
-                    stack_trace
-                {
-                    *address != CHEATCODE_ADDRESS
-                } else {
-                    true
-                }
+                !stack_trace.is_unrecognized_contract_call_error(&CHEATCODE_ADDRESS)
             })
             .collect();
         Ok(Some(stack_trace))

--- a/crates/edr_solidity_tests/tests/it/core.rs
+++ b/crates/edr_solidity_tests/tests/it/core.rs
@@ -21,7 +21,7 @@ async fn test_core() {
                 vec![(
                     "setUp()",
                     false,
-                    Some("setup failed: revert: setup failed predictably".to_string()),
+                    Some("revert: setup failed predictably".to_string()),
                     None,
                     None,
                 )],
@@ -77,7 +77,7 @@ async fn test_core() {
                 vec![(
                     "setUp()",
                     false,
-                    Some("setup failed: execution error".to_string()),
+                    Some("execution error".to_string()),
                     None,
                     None,
                 )],

--- a/crates/edr_solidity_tests/tests/it/invariant.rs
+++ b/crates/edr_solidity_tests/tests/it/invariant.rs
@@ -475,7 +475,7 @@ async fn test_shrink_big_sequence() {
             vec![(
                 "invariant_shrink_big_sequence()",
                 false,
-                Some("invariant_shrink_big_sequence replay failure".into()),
+                Some("revert: condition met".into()),
                 None,
                 None,
             )],

--- a/crates/foundry/evm/evm/Cargo.toml
+++ b/crates/foundry/evm/evm/Cargo.toml
@@ -6,6 +6,7 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
+edr_solidity.workspace = true
 foundry-cheatcodes.workspace = true
 foundry-evm-core.workspace = true
 foundry-evm-coverage.workspace = true
@@ -27,6 +28,8 @@ revm = { workspace = true, default-features = false, features = [
     "c-kzg",
 ] }
 revm-inspectors.workspace = true
+
+revm_edr = { version = "=12.1.0", package = "revm" }
 
 eyre = "0.6"
 hex.workspace = true

--- a/crates/foundry/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/foundry/evm/evm/src/executors/invariant/mod.rs
@@ -36,7 +36,7 @@ pub use error::{InvariantFailures, InvariantFuzzError};
 use foundry_evm_core::contracts::{ContractsByAddress, ContractsByArtifact};
 
 mod replay;
-pub use replay::{replay_error, replay_run};
+pub use replay::{replay_error, replay_run, ReplayErrorArgs, ReplayResult, ReplayRunArgs};
 
 mod result;
 pub use result::InvariantFuzzTestResult;

--- a/crates/foundry/evm/evm/src/executors/invariant/replay.rs
+++ b/crates/foundry/evm/evm/src/executors/invariant/replay.rs
@@ -2,10 +2,12 @@ use std::sync::Arc;
 
 use alloy_dyn_abi::JsonAbiExt;
 use alloy_primitives::Log;
+use edr_solidity::{contract_decoder::NestedTraceDecoder, solidity_stack_trace::StackTraceEntry};
 use eyre::Result;
 use foundry_evm_core::{
     constants::CALLER,
     contracts::{ContractsByAddress, ContractsByArtifact},
+    decode::RevertDecoder,
 };
 use foundry_evm_coverage::HitMaps;
 use foundry_evm_fuzz::{
@@ -18,22 +20,56 @@ use proptest::test_runner::TestError;
 use revm::primitives::U256;
 
 use super::{error::FailedInvariantCaseData, shrink_sequence};
-use crate::executors::Executor;
+use crate::executors::{
+    stack_trace::{get_stack_trace, StackTraceError},
+    EvmError, Executor,
+};
+
+/// Arguments to `replay_run`.
+pub struct ReplayRunArgs<'a, NestedTraceDecoderT> {
+    pub executor: Executor,
+    pub invariant_contract: &'a InvariantContract<'a>,
+    pub known_contracts: &'a ContractsByArtifact,
+    pub ided_contracts: ContractsByAddress,
+    pub logs: &'a mut Vec<Log>,
+    pub traces: &'a mut Traces,
+    pub coverage: &'a mut Option<HitMaps>,
+    pub inputs: Vec<BasicTxDetails>,
+    pub generate_stack_trace: bool,
+    /// Must be provided if `generate_stack_trace` is true
+    pub contract_decoder: Option<&'a NestedTraceDecoderT>,
+    pub revert_decoder: &'a RevertDecoder,
+}
+
+/// Results of a replay
+#[derive(Debug, Default)]
+pub struct ReplayResult {
+    pub counterexample_sequence: Vec<BaseCounterExample>,
+    pub stack_trace_result: Option<Result<Vec<StackTraceEntry>, StackTraceError>>,
+    /// Revert reason
+    pub revert_reason: Option<String>,
+}
 
 /// Replays a call sequence for collecting logs and traces.
 /// Returns counterexample to be used when the call sequence is a failed
 /// scenario.
-#[allow(clippy::too_many_arguments)]
-pub fn replay_run(
-    invariant_contract: &InvariantContract<'_>,
-    mut executor: Executor,
-    known_contracts: &ContractsByArtifact,
-    mut ided_contracts: ContractsByAddress,
-    logs: &mut Vec<Log>,
-    traces: &mut Traces,
-    coverage: &mut Option<HitMaps>,
-    inputs: Vec<BasicTxDetails>,
-) -> Result<Vec<BaseCounterExample>> {
+pub fn replay_run<NestedTraceDecoderT: NestedTraceDecoder>(
+    args: ReplayRunArgs<'_, NestedTraceDecoderT>,
+) -> Result<ReplayResult> {
+    let ReplayRunArgs {
+        mut executor,
+        invariant_contract,
+        known_contracts,
+        mut ided_contracts,
+        logs,
+        traces,
+        coverage,
+        inputs,
+        generate_stack_trace,
+        contract_decoder,
+        revert_decoder,
+    } = args;
+
     // We want traces for a failed case.
     executor.set_tracing(true);
 
@@ -79,6 +115,9 @@ pub fn replay_run(
     // Checking after each call doesn't add valuable info for passing scenario
     // (invariant call result is always success) nor for failed scenarios
     // (invariant call result is always success until the last call that breaks it).
+    if generate_stack_trace {
+        executor.inspector.enable_for_stack_traces();
+    }
     let invariant_result = executor.call_raw(
         CALLER,
         invariant_contract.address,
@@ -93,27 +132,63 @@ pub fn replay_run(
         TraceKind::Execution,
         invariant_result.traces.clone().unwrap(),
     ));
-    logs.extend(invariant_result.logs);
+    logs.extend(invariant_result.logs.clone());
 
-    Ok(counterexample_sequence)
+    let stack_trace_result =
+        contract_decoder.and_then(|decoder| get_stack_trace(decoder, traces).transpose());
+    let reason = invariant_result
+        .into_decoded_result(invariant_contract.invariant_function, Some(revert_decoder))
+        .err()
+        .and_then(|err| match err {
+            EvmError::Execution(err) => Some(err.reason),
+            _ => None,
+        });
+
+    Ok(ReplayResult {
+        counterexample_sequence,
+        stack_trace_result,
+        revert_reason: reason,
+    })
+}
+
+/// Arguments to `replay_run`.
+pub struct ReplayErrorArgs<'a, NestedTraceDecoderT> {
+    pub executor: Executor,
+    pub failed_case: &'a FailedInvariantCaseData,
+    pub invariant_contract: &'a InvariantContract<'a>,
+    pub known_contracts: &'a ContractsByArtifact,
+    pub ided_contracts: ContractsByAddress,
+    pub logs: &'a mut Vec<Log>,
+    pub traces: &'a mut Traces,
+    pub coverage: &'a mut Option<HitMaps>,
+    pub generate_stack_trace: bool,
+    /// Must be provided if `generate_stack_trace` is true
+    pub contract_decoder: Option<&'a NestedTraceDecoderT>,
+    pub revert_decoder: &'a RevertDecoder,
 }
 
 /// Replays the error case, shrinks the failing sequence and collects all
 /// necessary traces.
-#[allow(clippy::too_many_arguments)]
-pub fn replay_error(
-    failed_case: &FailedInvariantCaseData,
-    invariant_contract: &InvariantContract<'_>,
-    mut executor: Executor,
-    known_contracts: &ContractsByArtifact,
-    ided_contracts: ContractsByAddress,
-    logs: &mut Vec<Log>,
-    traces: &mut Traces,
-    coverage: &mut Option<HitMaps>,
-) -> Result<Vec<BaseCounterExample>> {
+pub fn replay_error<NestedTraceDecoderT: NestedTraceDecoder>(
+    args: ReplayErrorArgs<'_, NestedTraceDecoderT>,
+) -> Result<ReplayResult> {
+    let ReplayErrorArgs {
+        mut executor,
+        failed_case,
+        invariant_contract,
+        known_contracts,
+        ided_contracts,
+        logs,
+        traces,
+        coverage,
+        generate_stack_trace,
+        contract_decoder,
+        revert_decoder,
+    } = args;
+
     match failed_case.test_error {
         // Don't use at the moment.
-        TestError::Abort(_) => Ok(vec![]),
+        TestError::Abort(_) => Ok(ReplayResult::default()),
         TestError::Fail(_, ref calls) => {
             // Shrink sequence of failed calls.
             let calls = shrink_sequence(failed_case, calls, &executor)?;
@@ -122,7 +197,7 @@ pub fn replay_error(
 
             // Replay calls to get the counterexample and to collect logs, traces and
             // coverage.
-            replay_run(
+            replay_run::<NestedTraceDecoderT>(ReplayRunArgs {
                 invariant_contract,
                 executor,
                 known_contracts,
@@ -130,8 +205,11 @@ pub fn replay_error(
                 logs,
                 traces,
                 coverage,
-                calls,
-            )
+                inputs: calls,
+                generate_stack_trace,
+                contract_decoder,
+                revert_decoder,
+            })
         }
     }
 }

--- a/crates/foundry/evm/evm/src/executors/mod.rs
+++ b/crates/foundry/evm/evm/src/executors/mod.rs
@@ -41,6 +41,8 @@ pub mod fuzz;
 pub use fuzz::FuzzedExecutor;
 
 pub mod invariant;
+pub mod stack_trace;
+
 pub use invariant::InvariantExecutor;
 
 sol! {

--- a/crates/foundry/evm/evm/src/executors/stack_trace.rs
+++ b/crates/foundry/evm/evm/src/executors/stack_trace.rs
@@ -39,8 +39,9 @@ impl From<EvmError> for StackTraceError {
 }
 
 /// Compute stack trace based on execution traces.
-/// Assumes last trace is the error one.
-/// Returns `None` if `traces` is empty.
+/// Assumes last trace is the error one. This is important for invariant tests
+/// where there might be multiple errors traces. Returns `None` if `traces` is
+/// empty.
 pub fn get_stack_trace<NestedTraceDecoderT: NestedTraceDecoder>(
     contract_decoder: &NestedTraceDecoderT,
     traces: &[(TraceKind, CallTraceArena)],

--- a/js/helpers/package.json
+++ b/js/helpers/package.json
@@ -31,7 +31,7 @@
   "private": true,
   "scripts": {
     "build": "pnpm run build:dev",
-    "build:dev": "tsc --build --incremental .",
+    "build:dev": "tsc --build .",
     "eslint": "eslint 'src/**/*.ts'",
     "lint": "pnpm prettier && pnpm eslint",
     "prettier": "prettier --check \"**/*.{js,ts,md,json}\""

--- a/js/integration-tests/solidity-tests/contracts/FailingDeploy.t.sol
+++ b/js/integration-tests/solidity-tests/contracts/FailingDeploy.t.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+contract FailingDeployTest {
+    uint immutable value;
+
+    constructor() {
+        revert("Deployment failed");
+        value = 1; // Unreachable but needed for immutable
+    }
+}

--- a/js/integration-tests/solidity-tests/contracts/Invariant.t.sol
+++ b/js/integration-tests/solidity-tests/contracts/Invariant.t.sol
@@ -36,3 +36,16 @@ contract FailingInvariantTest is Test {
     }
 }
 
+// Test where the invariant condition reverts on an empty sequence.
+contract BuggyInvariantTest is Test {
+    StochasticWrongContract wrongContract;
+
+    function setUp() external {
+        wrongContract = new StochasticWrongContract();
+    }
+
+    function invariant() external {
+        require(1 == 2, "one is not two");
+    }
+}
+

--- a/js/integration-tests/solidity-tests/test/fuzz.ts
+++ b/js/integration-tests/solidity-tests/test/fuzz.ts
@@ -155,4 +155,36 @@ describe("Fuzz and invariant testing", function () {
       expectedStackTraces
     );
   });
+
+  it("BuggyInvariant", async function () {
+    const expectedReason = "revert: one is not two";
+    const expectedStackTraces = [
+      { contract: "BuggyInvariantTest", function: "invariant" },
+    ];
+
+    const failureDir = testContext.invariantFailuresPersistDir;
+    const invariantConfig = {
+      runs: 256,
+      depth: 15,
+      // This is false by default, we just specify it here to make it obvious to the reader.
+      failOnRevert: false,
+    };
+
+    // Remove invariant config failure directory to make sure it's created fresh.
+    await fs.rm(failureDir, {
+      recursive: true,
+      force: true,
+    });
+
+    const result = await testContext.runTestsWithStats("BuggyInvariantTest", {
+      invariant: invariantConfig,
+    });
+    assert.equal(result.failedTests, 1);
+    assert.equal(result.totalTests, 1);
+    assertStackTraces(
+      result.stackTraces.get("invariant()"),
+      expectedReason,
+      expectedStackTraces
+    );
+  });
 });

--- a/js/integration-tests/solidity-tests/test/fuzz.ts
+++ b/js/integration-tests/solidity-tests/test/fuzz.ts
@@ -25,6 +25,15 @@ describe("Fuzz and invariant testing", function () {
     assert.equal(result1.failedTests, 1);
     assert.equal(result1.totalTests, 1);
 
+    assertStackTraces(
+      result1.stackTraces.get("testFuzzAddWithOverflow(uint256,uint256)"),
+      "arithmetic underflow or overflow",
+      [
+        { contract: "OverflowTest", function: "testFuzzAddWithOverflow" },
+        { contract: "MyContract", function: "addWithOverflow" },
+      ]
+    );
+
     // The fuzz failure directory should not be created if we don't set the directory
     assert.isFalse(existsSync(failureDir));
 

--- a/js/integration-tests/solidity-tests/test/testContext.ts
+++ b/js/integration-tests/solidity-tests/test/testContext.ts
@@ -125,7 +125,7 @@ export function assertStackTraces(
   if (actual === undefined) {
     throw new Error("stack trace is undefined");
   }
-  assert.equal(actual.reason, expectedReason);
+  assert.include(actual.reason, expectedReason);
   const stackTrace = actual.stackTrace;
   assert.equal(stackTrace.length, expectedEntries.length);
   for (let i = 0; i < stackTrace.length; i += 1) {

--- a/js/integration-tests/solidity-tests/test/testContext.ts
+++ b/js/integration-tests/solidity-tests/test/testContext.ts
@@ -69,7 +69,10 @@ export class TestContext {
       }
     );
 
-    const stackTraces = new Map<string, SolidityStackTrace>();
+    const stackTraces = new Map<
+      string,
+      { stackTrace: SolidityStackTrace; reason: string | undefined }
+    >();
     for (const suiteResult of suiteResults) {
       for (const testResult of suiteResult.testResults) {
         let failed = testResult.status === "Failure";
@@ -78,7 +81,10 @@ export class TestContext {
           failedTests++;
           const stackTrace = testResult.stackTrace();
           if (stackTrace !== null) {
-            stackTraces.set(testResult.name, stackTrace);
+            stackTraces.set(testResult.name, {
+              stackTrace: stackTrace,
+              reason: testResult.reason,
+            });
           }
         }
       }
@@ -100,19 +106,27 @@ export class TestContext {
 interface SolidityTestsRunResult {
   totalTests: number;
   failedTests: number;
-  stackTraces: Map<string, SolidityStackTrace>;
+  stackTraces: Map<
+    string,
+    { stackTrace: SolidityStackTrace; reason: string | undefined }
+  >;
 }
 
 export function assertStackTraces(
-  stackTrace: SolidityStackTrace | undefined,
+  actual:
+    | { stackTrace: SolidityStackTrace; reason: string | undefined }
+    | undefined,
+  expectedReason: string,
   expectedEntries: {
     function: string;
     contract: string;
   }[]
 ) {
-  if (stackTrace === undefined) {
+  if (actual === undefined) {
     throw new Error("stack trace is undefined");
   }
+  assert.equal(actual.reason, expectedReason);
+  const stackTrace = actual.stackTrace;
   assert.equal(stackTrace.length, expectedEntries.length);
   for (let i = 0; i < stackTrace.length; i += 1) {
     const expected = expectedEntries[i];

--- a/js/integration-tests/solidity-tests/test/unit.ts
+++ b/js/integration-tests/solidity-tests/test/unit.ts
@@ -21,9 +21,11 @@ describe("Unit tests", () => {
     const { totalTests, failedTests, stackTraces } =
       await testContext.runTestsWithStats("SuccessAndFailureTest");
 
-    assertStackTraces(stackTraces.get("testThatFails()"), [
-      { contract: "SuccessAndFailureTest", function: "testThatFails" },
-    ]);
+    assertStackTraces(
+      stackTraces.get("testThatFails()"),
+      "revert: 1 is not equal to 2",
+      [{ contract: "SuccessAndFailureTest", function: "testThatFails" }]
+    );
 
     assert.equal(failedTests, 1);
     assert.equal(totalTests, 2);
@@ -137,8 +139,14 @@ describe("Unit tests", () => {
   });
 
   it("FailingSetup", async function () {
-    const { totalTests, failedTests } =
+    const { totalTests, failedTests, stackTraces } =
       await testContext.runTestsWithStats("FailingSetupTest");
+
+    assertStackTraces(
+      stackTraces.get("setUp()"),
+      "invalid rpc url: nonExistentForkAlias",
+      [{ contract: "FailingSetupTest", function: "setUp" }]
+    );
 
     assert.equal(failedTests, 1);
     assert.equal(totalTests, 1);

--- a/js/integration-tests/solidity-tests/test/unit.ts
+++ b/js/integration-tests/solidity-tests/test/unit.ts
@@ -151,4 +151,16 @@ describe("Unit tests", () => {
     assert.equal(failedTests, 1);
     assert.equal(totalTests, 1);
   });
+
+  it("FailingDeploy", async function () {
+    const { totalTests, failedTests, stackTraces } =
+      await testContext.runTestsWithStats("FailingDeployTest");
+
+    assertStackTraces(stackTraces.get("setUp()"), "revert: Deployment failed", [
+      { contract: "FailingDeployTest", function: "constructor" },
+    ]);
+
+    assert.equal(failedTests, 1);
+    assert.equal(totalTests, 1);
+  });
 });


### PR DESCRIPTION
Adds stack trace support by re-executing failed calls for

- deployment and setup for all types of tests
- invariant tests

Re-execution on deployment and setup is rather forward, but for invariant tests there are two things to consider:

1. Previously, we only did tracing on setup and deployment if the invariant test had a `setUp` method. It greatly simplifies re-execution if we always do tracing on setup and deployment if there are invariant tests. The performance decrease should be negligible, because most invariant test have a `setUp` method and since they tend to take longer, the overhead is amortized.
2.  The way the revert reason is returned for invariant tests is a bit weird in Foundry. Sometimes it's not returned even if there is a revert and when replaying a recorded invariant failure, the rather obscure "replay failure" is [returned.](https://github.com/NomicFoundation/edr/compare/feat/solidity-tests...feat/stack-trace-replay?expand=1#diff-27fd00367d0897c3a5811c73b8615732cf5286feccc4fa83eec55fb234baff68L1062-L1072) I think the reason for this is that they're doing tracing by default on re-execution and display the revert reason from the traces instead of `TestResult::reason`. I opted to change this behavior so that the revert reason in the test result matches the stack trace which Hardhat relies on.  Note that there are some failing Foundry integration tests related to this which I'll fix if we agree on this point.

TODOS left for stack traces after this PR:

- Re-execution for fuzz tests
- Make sure re-execution is safe in fork mode based on whether the block spec is cacheable
- Detect if an impure cheatcode was used

No changeset as this gets released to @ignored/edr.