### PR TITLE
fix: return EIP-7702 properties for transactions

### DIFF
--- a/crates/edr_eth/src/eips/eip7702.rs
+++ b/crates/edr_eth/src/eips/eip7702.rs
@@ -1,1 +1,1 @@
-pub use revm_primitives::eip7702::{Authorization, AuthorizationList, SignedAuthorization};
+pub use revm_primitives::eip7702::{Authorization, SignedAuthorization};

--- a/crates/edr_eth/src/transaction/signed.rs
+++ b/crates/edr_eth/src/transaction/signed.rs
@@ -6,7 +6,7 @@ mod eip7702;
 mod legacy;
 
 use alloy_rlp::{Buf, BufMut};
-use revm_primitives::{AccessListItem, AuthorizationList, TransactTo, TxEnv};
+use revm_primitives::{AccessListItem, TransactTo, TxEnv};
 
 pub use self::{
     eip155::Eip155,
@@ -19,7 +19,10 @@ pub use self::{
 use super::{
     Signed, SignedTransaction, Transaction, TransactionType, TxKind, INVALID_TX_TYPE_ERROR_MESSAGE,
 };
-use crate::{signature::Signature, utils::enveloped, Address, Bytes, B256, U256};
+use crate::{
+    eips::eip7702::SignedAuthorization, signature::Signature, utils::enveloped, Address, Bytes,
+    B256, U256,
+};
 
 /// Converts a `TxKind` to a `TransactTo`.
 fn kind_to_transact_to(kind: TxKind) -> TransactTo {
@@ -60,11 +63,14 @@ impl Signed {
         matches!(self, Signed::Eip7702(_))
     }
 
-    /// Retrieves the authorization list of the transaction for post-EIP-7702
-    /// transactions.
-    pub fn authorization_list(&self) -> Option<&AuthorizationList> {
-        // TODO: EIP-7702
-        None
+    /// Retrieves the list of signed authorizations of the transaction for
+    /// post-EIP-7702 transactions.
+    pub fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
+        if let Signed::Eip7702(tx) = self {
+            Some(tx.authorization_list.as_slice())
+        } else {
+            None
+        }
     }
 
     /// Retrieves the blob hashes of the transaction, if any.

--- a/crates/edr_evm/src/transaction.rs
+++ b/crates/edr_evm/src/transaction.rs
@@ -6,11 +6,11 @@ use std::fmt::Debug;
 
 // Re-export the transaction types from `edr_eth`.
 pub use edr_eth::transaction::*;
-use edr_eth::{transaction, SpecId, U256};
+use edr_eth::{eips::eip7702, transaction, SpecId, U256};
 use revm::{
     db::DatabaseComponentError,
     interpreter::gas::calculate_initial_tx_gas,
-    primitives::{AuthorizationList, EVMError, InvalidHeader, InvalidTransaction},
+    primitives::{EVMError, InvalidHeader, InvalidTransaction},
 };
 
 pub use self::detailed::*;
@@ -101,7 +101,7 @@ pub fn validate(
 pub fn initial_cost(transaction: &transaction::Signed, spec_id: SpecId) -> u64 {
     let authorization_list_num = transaction
         .authorization_list()
-        .map(AuthorizationList::len)
+        .map(<[eip7702::SignedAuthorization]>::len)
         // usize is guaranteed to fit into u64
         .unwrap_or_default() as u64;
 

--- a/crates/edr_provider/src/requests/eth/transactions.rs
+++ b/crates/edr_provider/src/requests/eth/transactions.rs
@@ -2,6 +2,7 @@ use core::fmt::Debug;
 use std::sync::Arc;
 
 use edr_eth::{
+    eips::eip7702,
     receipt::{BlockReceipt, TransactionReceipt},
     rlp::Decodable,
     transaction::{
@@ -257,6 +258,9 @@ pub fn transaction_to_rpc_result<LoggerErrorT: Debug>(
         max_priority_fee_per_gas: transaction.max_priority_fee_per_gas(),
         max_fee_per_blob_gas: transaction.max_fee_per_blob_gas(),
         blob_versioned_hashes: transaction.blob_hashes(),
+        authorization_list: transaction
+            .authorization_list()
+            .map(<[eip7702::SignedAuthorization]>::to_vec),
     })
 }
 

--- a/crates/edr_rpc_eth/src/transaction.rs
+++ b/crates/edr_rpc_eth/src/transaction.rs
@@ -1,6 +1,7 @@
 use std::sync::OnceLock;
 
 use edr_eth::{
+    eips::eip7702,
     signature::{self, SignatureWithYParity, SignatureWithYParityArgs},
     transaction::{self, TxKind},
     AccessListItem, Address, Bytes, B256, U256,
@@ -85,6 +86,11 @@ pub struct Transaction {
     /// data blobs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub blob_versioned_hashes: Option<Vec<B256>>,
+    /// Authorizations are used to temporarily set the code of its signer to
+    /// the code referenced by `address`. These also include a `chain_id` (which
+    /// can be set to zero and not evaluated) as well as an optional `nonce`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authorization_list: Option<Vec<eip7702::SignedAuthorization>>,
 }
 
 impl Transaction {
@@ -104,6 +110,7 @@ impl Transaction {
             Some(1) => RpcTransactionType::AccessList,
             Some(2) => RpcTransactionType::Eip1559,
             Some(3) => RpcTransactionType::Eip4844,
+            Some(4) => RpcTransactionType::Eip7702,
             Some(r#type) => RpcTransactionType::Unknown(r#type),
         }
     }
@@ -119,6 +126,8 @@ pub enum RpcTransactionType {
     Eip1559,
     /// EIP-4844 transaction
     Eip4844,
+    /// EIP-7702 transaction
+    Eip7702,
     /// Unknown transaction type
     Unknown(u64),
 }
@@ -268,6 +277,37 @@ impl TryFrom<Transaction> for transaction::Signed {
                     hash: OnceLock::from(value.hash),
                 })
             }
+            RpcTransactionType::Eip7702 => {
+                transaction::Signed::Eip7702(transaction::signed::Eip7702 {
+                    // SAFETY: The `from` field represents the caller address of the signed
+                    // transaction.
+                    signature: unsafe {
+                        signature::Fakeable::with_address_unchecked(
+                            SignatureWithYParity::new(SignatureWithYParityArgs {
+                                r: value.r,
+                                s: value.s,
+                                y_parity: value.odd_y_parity(),
+                            }),
+                            value.from,
+                        )
+                    },
+                    chain_id: value.chain_id.ok_or(ConversionError::ChainId)?,
+                    nonce: value.nonce,
+                    max_priority_fee_per_gas: value
+                        .max_priority_fee_per_gas
+                        .ok_or(ConversionError::MaxPriorityFeePerGas)?,
+                    max_fee_per_gas: value.max_fee_per_gas.ok_or(ConversionError::MaxFeePerGas)?,
+                    gas_limit: value.gas.to(),
+                    to: value.to.ok_or(ConversionError::ReceiverAddress)?,
+                    value: value.value,
+                    input: value.input,
+                    access_list: value.access_list.ok_or(ConversionError::AccessList)?.into(),
+                    authorization_list: value
+                        .authorization_list
+                        .ok_or(ConversionError::AuthorizationList)?,
+                    hash: OnceLock::from(value.hash),
+                })
+            }
             RpcTransactionType::Unknown(r#type) => {
                 log::warn!("Unsupported transaction type: {type}. Reverting to post-EIP 155 legacy transaction", );
 
@@ -305,6 +345,9 @@ pub enum ConversionError {
     /// Missing access list
     #[error("Missing access list")]
     AccessList,
+    /// Missing authorization list
+    #[error("Missing authorization list")]
+    AuthorizationList,
     /// EIP-4844 transaction is missing blob (versioned) hashes
     #[error("Missing blob hashes")]
     BlobHashes,
@@ -320,7 +363,7 @@ pub enum ConversionError {
     /// EIP-4844 transaction is missing the max fee per blob gas
     #[error("Missing max fee per blob gas")]
     MaxFeePerBlobGas,
-    /// EIP-4844 transaction is missing the receiver (to) address
+    /// EIP-4844 or EIP-7702 transaction is missing the receiver (to) address
     #[error("Missing receiver (to) address")]
     ReceiverAddress,
 }


### PR DESCRIPTION
This fixes two issues with EIP-7702 transactions:
- We were never parsing remote transactions to `transaction::Signed`, instead recognising them as EIP-155 transactions
- We weren't returning EIP-7702 properties from the JSON-RPC interface