### PR TITLE
misc: make EIP-7702 a breaking change

### DIFF
--- a/.changeset/sour-coats-look.md
+++ b/.changeset/sour-coats-look.md
@@ -1,5 +1,5 @@
 ---
-"@nomicfoundation/edr": patch
+"@nomicfoundation/edr": minor
 ---
 
 Adds EIP-7702 transactions to eth_call, eth_estimateGas, eth_sendTransaction, eth_sendRawTransaction, and debug_traceCall


### PR DESCRIPTION
After discussing, we decided that the changes to the JSON-RPC should be a breaking change.