### PR TITLE
fix: deterministic re-execution for stack traces

### DIFF
--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -669,6 +669,52 @@ export interface AddressLabel {
   /** The label to assign to the address */
   label: string
 }
+/** The stack trace result */
+export interface StackTrace {
+  /** Enum tag for JS. */
+  kind: "StackTrace"
+  /** The stack trace entries */
+  entries: Array<SolidityStackTraceEntry>
+}
+/** We couldn't generate stack traces, because an unexpected error occurred. */
+export interface UnexpectedError {
+  /** Enum tag for JS. */
+  kind: "UnexpectedError"
+  /** The error message from the unexpected error. */
+  errorMessage: string
+}
+/**
+ * We couldn't generate stack traces, because the stack trace generation
+ * heuristics failed due to an unknown reason.
+ */
+export interface HeuristicFailed {
+  /** Enum tag for JS. */
+  kind: "HeuristicFailed"
+}
+/**
+ * We couldn't generate stack traces, because the test execution is unsafe to
+ * replay due to indeterminism. This can be caused by either specifying a fork
+ * url without a fork block number in the test runner config or using impure
+ * cheatcodes.
+ */
+export interface UnsafeToReplay {
+  /** Enum tag for JS. */
+  kind: "UnsafeToReplay"
+  /**
+   * Indeterminism due to specifying a fork url without a fork block number
+   * in the test runner config
+   */
+  globalForkLatest: boolean
+  /**
+   * The list of executed impure cheatcode signatures. We collect function
+   * signatures instead of function names as whether a cheatcode is impure
+   * can depend on the arguments it takes (e.g. `createFork` without a second
+   * argument means implicitly fork from “latest”). Example signature:
+   * `function createSelectFork(string calldata urlOrAlias) external returns
+   * (uint256 forkId);`.
+   */
+  impureCheatcodes: Array<string>
+}
 /**The result of a test execution. */
 export const enum TestStatus {
   /**Test success */
@@ -1041,11 +1087,12 @@ export declare class TestResult {
   readonly durationMs: bigint
   /**
    * Compute the error stack trace.
-   * If the heuristic failed, returns an empty array.
+   * The result is either the stack trace or the reason why we couldn't
+   * generate the stack trace.
    * Returns null if the test status is succeeded or skipped.
-   * Throws if there was an error computing the stack trace.
+   * Cannot throw.
    */
-  stackTrace(): Array<SolidityStackTraceEntry> | null
+  stackTrace(): StackTrace | UnexpectedError | HeuristicFailed | UnsafeToReplay | null
 }
 export declare class Exit {
   get kind(): ExitCode

--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -702,7 +702,7 @@ export interface UnsafeToReplay {
   kind: "UnsafeToReplay"
   /**
    * Indeterminism due to specifying a fork url without a fork block number
-   * in the test runner config
+   * in the test runner config.
    */
   globalForkLatest: boolean
   /**

--- a/crates/edr_napi/src/trace/solidity_stack_trace.rs
+++ b/crates/edr_napi/src/trace/solidity_stack_trace.rs
@@ -1,6 +1,8 @@
 //! Naive rewrite of `hardhat-network/stack-traces/solidity-stack-traces.ts`
 //! from Hardhat.
 
+use std::convert::Infallible;
+
 use edr_eth::U256;
 use edr_evm::hex;
 use napi::bindgen_prelude::{BigInt, Either24, FromNapiValue, ToNapiValue, Uint8Array, Undefined};
@@ -605,7 +607,7 @@ pub type SolidityStackTraceEntry = Either24<
 >;
 
 impl TryCast<SolidityStackTraceEntry> for edr_solidity::solidity_stack_trace::StackTraceEntry {
-    type Error = napi::Error;
+    type Error = Infallible;
 
     fn try_cast(self) -> Result<SolidityStackTraceEntry, Self::Error> {
         use edr_solidity::solidity_stack_trace::StackTraceEntry;

--- a/crates/edr_solidity_tests/src/result.rs
+++ b/crates/edr_solidity_tests/src/result.rs
@@ -7,19 +7,18 @@ use std::{
 };
 
 use alloy_primitives::{Address, Log};
-use edr_solidity::solidity_stack_trace::StackTraceEntry;
 use foundry_compilers::artifacts::Libraries;
 use foundry_evm::{
     contracts::{get_contract_name, get_file_name},
     coverage::HitMaps,
-    executors::EvmError,
+    executors::{stack_trace::StackTraceResult, EvmError},
     fuzz::{CounterExample, FuzzFixtures},
     traces::{CallTraceArena, CallTraceDecoder, TraceKind, Traces},
 };
 use serde::{Deserialize, Serialize};
 use yansi::Paint;
 
-use crate::{gas_report::GasReport, StackTraceError};
+use crate::gas_report::GasReport;
 
 /// The aggregated result of a test run.
 #[derive(Clone, Debug)]
@@ -389,7 +388,7 @@ pub struct TestResult {
     /// If the heuristic failed the vec is set but emtpy.
     /// Error if there was an error computing the stack trace.
     #[serde(skip)]
-    pub stack_trace_result: Option<Result<Vec<StackTraceEntry>, StackTraceError>>,
+    pub stack_trace_result: Option<StackTraceResult>,
 }
 
 impl fmt::Display for TestResult {

--- a/crates/edr_solidity_tests/src/runner.rs
+++ b/crates/edr_solidity_tests/src/runner.rs
@@ -1086,7 +1086,7 @@ impl<'a, NestedTraceDecoderT: SyncNestedTraceDecoder> ContractRunner<'a, NestedT
         executor.inspector.enable_for_stack_traces();
 
         // Run counterexample test
-        let (call, _indeterminism_reasons) = executor
+        let (call, _cow_backend) = executor
             .call_raw(
                 self.sender,
                 address,

--- a/crates/edr_solidity_tests/src/runner.rs
+++ b/crates/edr_solidity_tests/src/runner.rs
@@ -630,7 +630,7 @@ impl<'a, NestedTraceDecoderT: SyncNestedTraceDecoder> ContractRunner<'a, NestedT
 
         // Exclude stack trace generation from test execution time for accurate
         // reporting
-        let stack_trace_result = if !success {
+        let stack_trace_result = if !success && executor.safe_to_re_execute() {
             Some(self.re_run_test_for_stack_traces(func, setup.has_setup_method))
         } else {
             None
@@ -1009,11 +1009,15 @@ impl<'a, NestedTraceDecoderT: SyncNestedTraceDecoder> ContractRunner<'a, NestedT
 
         let stack_trace_result =
             if let Some(CounterExample::Single(counter_example)) = result.counterexample.as_ref() {
-                Some(self.re_run_fuzz_counterexample_for_stack_traces(
-                    address,
-                    counter_example,
-                    has_setup_method,
-                ))
+                if counter_example.safe_to_re_execute {
+                    Some(self.re_run_fuzz_counterexample_for_stack_traces(
+                        address,
+                        counter_example,
+                        has_setup_method,
+                    ))
+                } else {
+                    None
+                }
             } else {
                 None
             };

--- a/crates/foundry/cheatcodes/src/base64.rs
+++ b/crates/foundry/cheatcodes/src/base64.rs
@@ -2,10 +2,11 @@ use alloy_sol_types::SolValue;
 use base64::prelude::*;
 
 use crate::{
-    Cheatcode, Cheatcodes, Result,
+    impl_is_pure_true, Cheatcode, Cheatcodes, Result,
     Vm::{toBase64URL_0Call, toBase64URL_1Call, toBase64_0Call, toBase64_1Call},
 };
 
+impl_is_pure_true!(toBase64_0Call);
 impl Cheatcode for toBase64_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { data } = self;
@@ -13,6 +14,7 @@ impl Cheatcode for toBase64_0Call {
     }
 }
 
+impl_is_pure_true!(toBase64_1Call);
 impl Cheatcode for toBase64_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { data } = self;
@@ -20,6 +22,7 @@ impl Cheatcode for toBase64_1Call {
     }
 }
 
+impl_is_pure_true!(toBase64URL_0Call);
 impl Cheatcode for toBase64URL_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { data } = self;
@@ -27,6 +30,7 @@ impl Cheatcode for toBase64URL_0Call {
     }
 }
 
+impl_is_pure_true!(toBase64URL_1Call);
 impl Cheatcode for toBase64URL_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { data } = self;

--- a/crates/foundry/cheatcodes/src/env.rs
+++ b/crates/foundry/cheatcodes/src/env.rs
@@ -7,7 +7,7 @@ use alloy_sol_types::SolValue;
 
 use crate::{
     config::ExecutionContextConfig,
-    string, Cheatcode, Cheatcodes, Error, Result,
+    impl_is_pure_false, string, Cheatcode, Cheatcodes, Error, Result,
     Vm::{
         envAddress_0Call, envAddress_1Call, envBool_0Call, envBool_1Call, envBytes32_0Call,
         envBytes32_1Call, envBytes_0Call, envBytes_1Call, envExistsCall, envInt_0Call,
@@ -18,6 +18,7 @@ use crate::{
     },
 };
 
+impl_is_pure_false!(setEnvCall);
 impl Cheatcode for setEnvCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name: key, value } = self;
@@ -42,6 +43,7 @@ impl Cheatcode for setEnvCall {
     }
 }
 
+impl_is_pure_false!(envExistsCall);
 impl Cheatcode for envExistsCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name } = self;
@@ -49,6 +51,7 @@ impl Cheatcode for envExistsCall {
     }
 }
 
+impl_is_pure_false!(envBool_0Call);
 impl Cheatcode for envBool_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name } = self;
@@ -56,6 +59,7 @@ impl Cheatcode for envBool_0Call {
     }
 }
 
+impl_is_pure_false!(envUint_0Call);
 impl Cheatcode for envUint_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name } = self;
@@ -63,6 +67,7 @@ impl Cheatcode for envUint_0Call {
     }
 }
 
+impl_is_pure_false!(envInt_0Call);
 impl Cheatcode for envInt_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name } = self;
@@ -70,6 +75,7 @@ impl Cheatcode for envInt_0Call {
     }
 }
 
+impl_is_pure_false!(envAddress_0Call);
 impl Cheatcode for envAddress_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name } = self;
@@ -77,6 +83,7 @@ impl Cheatcode for envAddress_0Call {
     }
 }
 
+impl_is_pure_false!(envBytes32_0Call);
 impl Cheatcode for envBytes32_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name } = self;
@@ -84,6 +91,7 @@ impl Cheatcode for envBytes32_0Call {
     }
 }
 
+impl_is_pure_false!(envString_0Call);
 impl Cheatcode for envString_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name } = self;
@@ -91,6 +99,7 @@ impl Cheatcode for envString_0Call {
     }
 }
 
+impl_is_pure_false!(envBytes_0Call);
 impl Cheatcode for envBytes_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name } = self;
@@ -98,6 +107,7 @@ impl Cheatcode for envBytes_0Call {
     }
 }
 
+impl_is_pure_false!(envBool_1Call);
 impl Cheatcode for envBool_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, delim } = self;
@@ -105,6 +115,7 @@ impl Cheatcode for envBool_1Call {
     }
 }
 
+impl_is_pure_false!(envUint_1Call);
 impl Cheatcode for envUint_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, delim } = self;
@@ -112,6 +123,7 @@ impl Cheatcode for envUint_1Call {
     }
 }
 
+impl_is_pure_false!(envInt_1Call);
 impl Cheatcode for envInt_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, delim } = self;
@@ -119,6 +131,7 @@ impl Cheatcode for envInt_1Call {
     }
 }
 
+impl_is_pure_false!(envAddress_1Call);
 impl Cheatcode for envAddress_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, delim } = self;
@@ -126,6 +139,7 @@ impl Cheatcode for envAddress_1Call {
     }
 }
 
+impl_is_pure_false!(envBytes32_1Call);
 impl Cheatcode for envBytes32_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, delim } = self;
@@ -133,6 +147,7 @@ impl Cheatcode for envBytes32_1Call {
     }
 }
 
+impl_is_pure_false!(envString_1Call);
 impl Cheatcode for envString_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, delim } = self;
@@ -140,6 +155,7 @@ impl Cheatcode for envString_1Call {
     }
 }
 
+impl_is_pure_false!(envBytes_1Call);
 impl Cheatcode for envBytes_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, delim } = self;
@@ -148,6 +164,7 @@ impl Cheatcode for envBytes_1Call {
 }
 
 // bool
+impl_is_pure_false!(envOr_0Call);
 impl Cheatcode for envOr_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, defaultValue } = self;
@@ -156,6 +173,7 @@ impl Cheatcode for envOr_0Call {
 }
 
 // uint256
+impl_is_pure_false!(envOr_1Call);
 impl Cheatcode for envOr_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, defaultValue } = self;
@@ -164,6 +182,7 @@ impl Cheatcode for envOr_1Call {
 }
 
 // int256
+impl_is_pure_false!(envOr_2Call);
 impl Cheatcode for envOr_2Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, defaultValue } = self;
@@ -172,6 +191,7 @@ impl Cheatcode for envOr_2Call {
 }
 
 // address
+impl_is_pure_false!(envOr_3Call);
 impl Cheatcode for envOr_3Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, defaultValue } = self;
@@ -180,6 +200,7 @@ impl Cheatcode for envOr_3Call {
 }
 
 // bytes32
+impl_is_pure_false!(envOr_4Call);
 impl Cheatcode for envOr_4Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, defaultValue } = self;
@@ -188,6 +209,7 @@ impl Cheatcode for envOr_4Call {
 }
 
 // string
+impl_is_pure_false!(envOr_5Call);
 impl Cheatcode for envOr_5Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, defaultValue } = self;
@@ -196,6 +218,7 @@ impl Cheatcode for envOr_5Call {
 }
 
 // bytes
+impl_is_pure_false!(envOr_6Call);
 impl Cheatcode for envOr_6Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, defaultValue } = self;
@@ -204,6 +227,7 @@ impl Cheatcode for envOr_6Call {
 }
 
 // bool[]
+impl_is_pure_false!(envOr_7Call);
 impl Cheatcode for envOr_7Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self {
@@ -216,6 +240,7 @@ impl Cheatcode for envOr_7Call {
 }
 
 // uint256[]
+impl_is_pure_false!(envOr_8Call);
 impl Cheatcode for envOr_8Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self {
@@ -228,6 +253,7 @@ impl Cheatcode for envOr_8Call {
 }
 
 // int256[]
+impl_is_pure_false!(envOr_9Call);
 impl Cheatcode for envOr_9Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self {
@@ -240,6 +266,7 @@ impl Cheatcode for envOr_9Call {
 }
 
 // address[]
+impl_is_pure_false!(envOr_10Call);
 impl Cheatcode for envOr_10Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self {
@@ -252,6 +279,7 @@ impl Cheatcode for envOr_10Call {
 }
 
 // bytes32[]
+impl_is_pure_false!(envOr_11Call);
 impl Cheatcode for envOr_11Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self {
@@ -264,6 +292,7 @@ impl Cheatcode for envOr_11Call {
 }
 
 // string[]
+impl_is_pure_false!(envOr_12Call);
 impl Cheatcode for envOr_12Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self {
@@ -276,6 +305,7 @@ impl Cheatcode for envOr_12Call {
 }
 
 // bytes[]
+impl_is_pure_false!(envOr_13Call);
 impl Cheatcode for envOr_13Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self {
@@ -288,6 +318,7 @@ impl Cheatcode for envOr_13Call {
     }
 }
 
+impl_is_pure_false!(isContextCall);
 impl Cheatcode for isContextCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {

--- a/crates/foundry/cheatcodes/src/evm.rs
+++ b/crates/foundry/cheatcodes/src/evm.rs
@@ -20,7 +20,7 @@ use revm::{
 use spec::Vm::signCall;
 
 use crate::{
-    Cheatcode, Cheatcodes, CheatsCtxt, Result,
+    impl_is_pure_false, impl_is_pure_true, Cheatcode, Cheatcodes, CheatsCtxt, Result,
     Vm::{
         accessesCall, addrCall, blobBaseFeeCall, blobhashesCall, chainIdCall, coinbaseCall,
         coolCall, dealCall, deleteSnapshotCall, deleteSnapshotsCall, difficultyCall, dumpStateCall,
@@ -59,6 +59,7 @@ pub struct DealRecord {
     pub new_balance: U256,
 }
 
+impl_is_pure_true!(addrCall);
 impl Cheatcode for addrCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { privateKey } = self;
@@ -67,6 +68,7 @@ impl Cheatcode for addrCall {
     }
 }
 
+impl_is_pure_true!(getNonceCall);
 impl Cheatcode for getNonceCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { account } = self;
@@ -74,6 +76,7 @@ impl Cheatcode for getNonceCall {
     }
 }
 
+impl_is_pure_true!(loadCall);
 impl Cheatcode for loadCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { target, slot } = *self;
@@ -84,6 +87,7 @@ impl Cheatcode for loadCall {
     }
 }
 
+impl_is_pure_false!(loadAllocsCall);
 impl Cheatcode for loadAllocsCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { pathToAllocsJson } = self;
@@ -113,6 +117,7 @@ impl Cheatcode for loadAllocsCall {
     }
 }
 
+impl_is_pure_false!(dumpStateCall);
 impl Cheatcode for dumpStateCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { pathToStateJson } = self;
@@ -159,6 +164,7 @@ impl Cheatcode for dumpStateCall {
     }
 }
 
+impl_is_pure_true!(signCall);
 impl Cheatcode for signCall {
     fn apply_full<DB: DatabaseExt>(&self, _: &mut CheatsCtxt<DB>) -> Result {
         let Self { privateKey, digest } = self;
@@ -166,6 +172,7 @@ impl Cheatcode for signCall {
     }
 }
 
+impl_is_pure_true!(signP256Call);
 impl Cheatcode for signP256Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { privateKey, digest } = self;
@@ -173,6 +180,7 @@ impl Cheatcode for signP256Call {
     }
 }
 
+impl_is_pure_true!(recordCall);
 impl Cheatcode for recordCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {} = self;
@@ -181,6 +189,7 @@ impl Cheatcode for recordCall {
     }
 }
 
+impl_is_pure_true!(accessesCall);
 impl Cheatcode for accessesCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { target } = *self;
@@ -198,6 +207,7 @@ impl Cheatcode for accessesCall {
     }
 }
 
+impl_is_pure_true!(recordLogsCall);
 impl Cheatcode for recordLogsCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {} = self;
@@ -206,6 +216,7 @@ impl Cheatcode for recordLogsCall {
     }
 }
 
+impl_is_pure_true!(getRecordedLogsCall);
 impl Cheatcode for getRecordedLogsCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {} = self;
@@ -217,6 +228,7 @@ impl Cheatcode for getRecordedLogsCall {
     }
 }
 
+impl_is_pure_true!(pauseGasMeteringCall);
 impl Cheatcode for pauseGasMeteringCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {} = self;
@@ -227,6 +239,7 @@ impl Cheatcode for pauseGasMeteringCall {
     }
 }
 
+impl_is_pure_true!(resumeGasMeteringCall);
 impl Cheatcode for resumeGasMeteringCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {} = self;
@@ -235,6 +248,7 @@ impl Cheatcode for resumeGasMeteringCall {
     }
 }
 
+impl_is_pure_true!(lastCallGasCall);
 impl Cheatcode for lastCallGasCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {} = self;
@@ -251,6 +265,7 @@ impl Cheatcode for lastCallGasCall {
     }
 }
 
+impl_is_pure_true!(chainIdCall);
 impl Cheatcode for chainIdCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { newChainId } = self;
@@ -263,6 +278,7 @@ impl Cheatcode for chainIdCall {
     }
 }
 
+impl_is_pure_true!(coinbaseCall);
 impl Cheatcode for coinbaseCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { newCoinbase } = self;
@@ -271,6 +287,7 @@ impl Cheatcode for coinbaseCall {
     }
 }
 
+impl_is_pure_true!(difficultyCall);
 impl Cheatcode for difficultyCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { newDifficulty } = self;
@@ -284,6 +301,7 @@ impl Cheatcode for difficultyCall {
     }
 }
 
+impl_is_pure_true!(feeCall);
 impl Cheatcode for feeCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { newBasefee } = self;
@@ -292,6 +310,7 @@ impl Cheatcode for feeCall {
     }
 }
 
+impl_is_pure_true!(prevrandao_0Call);
 impl Cheatcode for prevrandao_0Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { newPrevrandao } = self;
@@ -305,6 +324,7 @@ impl Cheatcode for prevrandao_0Call {
     }
 }
 
+impl_is_pure_true!(prevrandao_1Call);
 impl Cheatcode for prevrandao_1Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { newPrevrandao } = self;
@@ -318,6 +338,7 @@ impl Cheatcode for prevrandao_1Call {
     }
 }
 
+impl_is_pure_true!(blobhashesCall);
 impl Cheatcode for blobhashesCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { hashes } = self;
@@ -331,6 +352,7 @@ impl Cheatcode for blobhashesCall {
     }
 }
 
+impl_is_pure_true!(getBlobhashesCall);
 impl Cheatcode for getBlobhashesCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self {} = self;
@@ -343,6 +365,7 @@ impl Cheatcode for getBlobhashesCall {
     }
 }
 
+impl_is_pure_true!(rollCall);
 impl Cheatcode for rollCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { newHeight } = self;
@@ -351,6 +374,7 @@ impl Cheatcode for rollCall {
     }
 }
 
+impl_is_pure_true!(getBlockNumberCall);
 impl Cheatcode for getBlockNumberCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self {} = self;
@@ -358,6 +382,7 @@ impl Cheatcode for getBlockNumberCall {
     }
 }
 
+impl_is_pure_true!(txGasPriceCall);
 impl Cheatcode for txGasPriceCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { newGasPrice } = self;
@@ -366,6 +391,7 @@ impl Cheatcode for txGasPriceCall {
     }
 }
 
+impl_is_pure_true!(warpCall);
 impl Cheatcode for warpCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { newTimestamp } = self;
@@ -374,6 +400,7 @@ impl Cheatcode for warpCall {
     }
 }
 
+impl_is_pure_true!(getBlockTimestampCall);
 impl Cheatcode for getBlockTimestampCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self {} = self;
@@ -381,6 +408,7 @@ impl Cheatcode for getBlockTimestampCall {
     }
 }
 
+impl_is_pure_true!(blobBaseFeeCall);
 impl Cheatcode for blobBaseFeeCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { newBlobBaseFee } = self;
@@ -397,6 +425,7 @@ impl Cheatcode for blobBaseFeeCall {
     }
 }
 
+impl_is_pure_true!(getBlobBaseFeeCall);
 impl Cheatcode for getBlobBaseFeeCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self {} = self;
@@ -410,6 +439,7 @@ impl Cheatcode for getBlobBaseFeeCall {
     }
 }
 
+impl_is_pure_true!(dealCall);
 impl Cheatcode for dealCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self {
@@ -428,6 +458,7 @@ impl Cheatcode for dealCall {
     }
 }
 
+impl_is_pure_true!(etchCall);
 impl Cheatcode for etchCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self {
@@ -442,6 +473,7 @@ impl Cheatcode for etchCall {
     }
 }
 
+impl_is_pure_true!(resetNonceCall);
 impl Cheatcode for resetNonceCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { account } = self;
@@ -457,6 +489,7 @@ impl Cheatcode for resetNonceCall {
     }
 }
 
+impl_is_pure_true!(setNonceCall);
 impl Cheatcode for setNonceCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { account, newNonce } = *self;
@@ -473,6 +506,7 @@ impl Cheatcode for setNonceCall {
     }
 }
 
+impl_is_pure_true!(setNonceUnsafeCall);
 impl Cheatcode for setNonceUnsafeCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { account, newNonce } = *self;
@@ -482,6 +516,7 @@ impl Cheatcode for setNonceUnsafeCall {
     }
 }
 
+impl_is_pure_true!(storeCall);
 impl Cheatcode for storeCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self {
@@ -497,6 +532,7 @@ impl Cheatcode for storeCall {
     }
 }
 
+impl_is_pure_true!(coolCall);
 impl Cheatcode for coolCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { target } = self;
@@ -508,6 +544,7 @@ impl Cheatcode for coolCall {
     }
 }
 
+impl_is_pure_true!(readCallersCall);
 impl Cheatcode for readCallersCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self {} = self;
@@ -515,6 +552,7 @@ impl Cheatcode for readCallersCall {
     }
 }
 
+impl_is_pure_true!(snapshotCall);
 impl Cheatcode for snapshotCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self {} = self;
@@ -526,6 +564,7 @@ impl Cheatcode for snapshotCall {
     }
 }
 
+impl_is_pure_true!(revertToCall);
 impl Cheatcode for revertToCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { snapshotId } = self;
@@ -546,6 +585,7 @@ impl Cheatcode for revertToCall {
     }
 }
 
+impl_is_pure_true!(revertToAndDeleteCall);
 impl Cheatcode for revertToAndDeleteCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { snapshotId } = self;
@@ -566,6 +606,7 @@ impl Cheatcode for revertToAndDeleteCall {
     }
 }
 
+impl_is_pure_true!(deleteSnapshotCall);
 impl Cheatcode for deleteSnapshotCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { snapshotId } = self;
@@ -573,6 +614,8 @@ impl Cheatcode for deleteSnapshotCall {
         Ok(result.abi_encode())
     }
 }
+
+impl_is_pure_true!(deleteSnapshotsCall);
 impl Cheatcode for deleteSnapshotsCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self {} = self;
@@ -581,6 +624,7 @@ impl Cheatcode for deleteSnapshotsCall {
     }
 }
 
+impl_is_pure_true!(startStateDiffRecordingCall);
 impl Cheatcode for startStateDiffRecordingCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {} = self;
@@ -589,6 +633,7 @@ impl Cheatcode for startStateDiffRecordingCall {
     }
 }
 
+impl_is_pure_true!(stopAndReturnStateDiffCall);
 impl Cheatcode for stopAndReturnStateDiffCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {} = self;

--- a/crates/foundry/cheatcodes/src/evm/fork.rs
+++ b/crates/foundry/cheatcodes/src/evm/fork.rs
@@ -5,7 +5,7 @@ use alloy_sol_types::SolValue;
 use foundry_evm_core::fork::{provider::ProviderBuilder, CreateFork};
 
 use crate::{
-    Cheatcode, CheatsCtxt, DatabaseExt, Result,
+    impl_is_pure_false, impl_is_pure_true, Cheatcode, CheatsCtxt, DatabaseExt, Result,
     Vm::{
         activeForkCall, allowCheatcodesCall, createFork_0Call, createFork_1Call, createFork_2Call,
         createSelectFork_0Call, createSelectFork_1Call, createSelectFork_2Call, eth_getLogsCall,
@@ -16,6 +16,7 @@ use crate::{
     },
 };
 
+impl_is_pure_true!(activeForkCall);
 impl Cheatcode for activeForkCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self {} = self;
@@ -27,6 +28,7 @@ impl Cheatcode for activeForkCall {
     }
 }
 
+impl_is_pure_false!(createFork_0Call);
 impl Cheatcode for createFork_0Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { urlOrAlias } = self;
@@ -34,6 +36,7 @@ impl Cheatcode for createFork_0Call {
     }
 }
 
+impl_is_pure_true!(createFork_1Call);
 impl Cheatcode for createFork_1Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self {
@@ -44,6 +47,7 @@ impl Cheatcode for createFork_1Call {
     }
 }
 
+impl_is_pure_true!(createFork_2Call);
 impl Cheatcode for createFork_2Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { urlOrAlias, txHash } = self;
@@ -51,6 +55,7 @@ impl Cheatcode for createFork_2Call {
     }
 }
 
+impl_is_pure_false!(createSelectFork_0Call);
 impl Cheatcode for createSelectFork_0Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { urlOrAlias } = self;
@@ -58,6 +63,7 @@ impl Cheatcode for createSelectFork_0Call {
     }
 }
 
+impl_is_pure_true!(createSelectFork_1Call);
 impl Cheatcode for createSelectFork_1Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self {
@@ -68,6 +74,7 @@ impl Cheatcode for createSelectFork_1Call {
     }
 }
 
+impl_is_pure_true!(createSelectFork_2Call);
 impl Cheatcode for createSelectFork_2Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { urlOrAlias, txHash } = self;
@@ -75,6 +82,7 @@ impl Cheatcode for createSelectFork_2Call {
     }
 }
 
+impl_is_pure_true!(rollFork_0Call);
 impl Cheatcode for rollFork_0Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { blockNumber } = self;
@@ -88,6 +96,7 @@ impl Cheatcode for rollFork_0Call {
     }
 }
 
+impl_is_pure_true!(rollFork_1Call);
 impl Cheatcode for rollFork_1Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { txHash } = self;
@@ -101,6 +110,7 @@ impl Cheatcode for rollFork_1Call {
     }
 }
 
+impl_is_pure_true!(rollFork_2Call);
 impl Cheatcode for rollFork_2Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self {
@@ -117,6 +127,7 @@ impl Cheatcode for rollFork_2Call {
     }
 }
 
+impl_is_pure_true!(rollFork_3Call);
 impl Cheatcode for rollFork_3Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { forkId, txHash } = self;
@@ -130,6 +141,7 @@ impl Cheatcode for rollFork_3Call {
     }
 }
 
+impl_is_pure_true!(selectForkCall);
 impl Cheatcode for selectForkCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { forkId } = self;
@@ -141,6 +153,7 @@ impl Cheatcode for selectForkCall {
     }
 }
 
+impl_is_pure_true!(transact_0Call);
 impl Cheatcode for transact_0Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { txHash } = *self;
@@ -155,6 +168,7 @@ impl Cheatcode for transact_0Call {
     }
 }
 
+impl_is_pure_true!(transact_1Call);
 impl Cheatcode for transact_1Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { forkId, txHash } = *self;
@@ -169,6 +183,7 @@ impl Cheatcode for transact_1Call {
     }
 }
 
+impl_is_pure_true!(allowCheatcodesCall);
 impl Cheatcode for allowCheatcodesCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { account } = self;
@@ -177,6 +192,7 @@ impl Cheatcode for allowCheatcodesCall {
     }
 }
 
+impl_is_pure_true!(makePersistent_0Call);
 impl Cheatcode for makePersistent_0Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { account } = self;
@@ -185,6 +201,7 @@ impl Cheatcode for makePersistent_0Call {
     }
 }
 
+impl_is_pure_true!(makePersistent_1Call);
 impl Cheatcode for makePersistent_1Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { account0, account1 } = self;
@@ -194,6 +211,7 @@ impl Cheatcode for makePersistent_1Call {
     }
 }
 
+impl_is_pure_true!(makePersistent_2Call);
 impl Cheatcode for makePersistent_2Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self {
@@ -208,6 +226,7 @@ impl Cheatcode for makePersistent_2Call {
     }
 }
 
+impl_is_pure_true!(makePersistent_3Call);
 impl Cheatcode for makePersistent_3Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { accounts } = self;
@@ -218,6 +237,7 @@ impl Cheatcode for makePersistent_3Call {
     }
 }
 
+impl_is_pure_true!(revokePersistent_0Call);
 impl Cheatcode for revokePersistent_0Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { account } = self;
@@ -226,6 +246,7 @@ impl Cheatcode for revokePersistent_0Call {
     }
 }
 
+impl_is_pure_true!(revokePersistent_1Call);
 impl Cheatcode for revokePersistent_1Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { accounts } = self;
@@ -236,6 +257,7 @@ impl Cheatcode for revokePersistent_1Call {
     }
 }
 
+impl_is_pure_true!(isPersistentCall);
 impl Cheatcode for isPersistentCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { account } = self;
@@ -243,6 +265,8 @@ impl Cheatcode for isPersistentCall {
     }
 }
 
+// Calls like `eth_getBlockByNumber` are impure
+impl_is_pure_false!(rpcCall);
 impl Cheatcode for rpcCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { method, params } = self;
@@ -263,6 +287,7 @@ impl Cheatcode for rpcCall {
     }
 }
 
+impl_is_pure_true!(eth_getLogsCall);
 impl Cheatcode for eth_getLogsCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self {

--- a/crates/foundry/cheatcodes/src/evm/mapping.rs
+++ b/crates/foundry/cheatcodes/src/evm/mapping.rs
@@ -5,7 +5,7 @@ use alloy_sol_types::SolValue;
 use revm::interpreter::{opcode, Interpreter};
 
 use crate::{
-    Cheatcode, Cheatcodes, Result,
+    impl_is_pure_true, Cheatcode, Cheatcodes, Result,
     Vm::{
         getMappingKeyAndParentOfCall, getMappingLengthCall, getMappingSlotAtCall,
         startMappingRecordingCall, stopMappingRecordingCall,
@@ -51,6 +51,7 @@ impl MappingSlots {
     }
 }
 
+impl_is_pure_true!(startMappingRecordingCall);
 impl Cheatcode for startMappingRecordingCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {} = self;
@@ -61,6 +62,7 @@ impl Cheatcode for startMappingRecordingCall {
     }
 }
 
+impl_is_pure_true!(stopMappingRecordingCall);
 impl Cheatcode for stopMappingRecordingCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {} = self;
@@ -69,6 +71,7 @@ impl Cheatcode for stopMappingRecordingCall {
     }
 }
 
+impl_is_pure_true!(getMappingLengthCall);
 impl Cheatcode for getMappingLengthCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {
@@ -80,6 +83,7 @@ impl Cheatcode for getMappingLengthCall {
     }
 }
 
+impl_is_pure_true!(getMappingSlotAtCall);
 impl Cheatcode for getMappingSlotAtCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {
@@ -95,6 +99,7 @@ impl Cheatcode for getMappingSlotAtCall {
     }
 }
 
+impl_is_pure_true!(getMappingKeyAndParentOfCall);
 impl Cheatcode for getMappingKeyAndParentOfCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {

--- a/crates/foundry/cheatcodes/src/evm/mock.rs
+++ b/crates/foundry/cheatcodes/src/evm/mock.rs
@@ -4,7 +4,7 @@ use alloy_primitives::{Address, Bytes, U256};
 use revm::{interpreter::InstructionResult, primitives::Bytecode};
 
 use crate::{
-    Cheatcode, Cheatcodes, CheatsCtxt, DatabaseExt, Result,
+    impl_is_pure_true, Cheatcode, Cheatcodes, CheatsCtxt, DatabaseExt, Result,
     Vm::{
         clearMockedCallsCall, mockCallRevert_0Call, mockCallRevert_1Call, mockCall_0Call,
         mockCall_1Call,
@@ -49,6 +49,7 @@ impl Ord for MockCallDataContext {
     }
 }
 
+impl_is_pure_true!(clearMockedCallsCall);
 impl Cheatcode for clearMockedCallsCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {} = self;
@@ -57,6 +58,7 @@ impl Cheatcode for clearMockedCallsCall {
     }
 }
 
+impl_is_pure_true!(mockCall_0Call);
 impl Cheatcode for mockCall_0Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self {
@@ -90,6 +92,7 @@ impl Cheatcode for mockCall_0Call {
     }
 }
 
+impl_is_pure_true!(mockCall_1Call);
 impl Cheatcode for mockCall_1Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self {
@@ -111,6 +114,7 @@ impl Cheatcode for mockCall_1Call {
     }
 }
 
+impl_is_pure_true!(mockCallRevert_0Call);
 impl Cheatcode for mockCallRevert_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {
@@ -130,6 +134,7 @@ impl Cheatcode for mockCallRevert_0Call {
     }
 }
 
+impl_is_pure_true!(mockCallRevert_1Call);
 impl Cheatcode for mockCallRevert_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {

--- a/crates/foundry/cheatcodes/src/evm/prank.rs
+++ b/crates/foundry/cheatcodes/src/evm/prank.rs
@@ -1,7 +1,7 @@
 use alloy_primitives::Address;
 
 use crate::{
-    Cheatcode, Cheatcodes, CheatsCtxt, DatabaseExt, Result,
+    impl_is_pure_true, Cheatcode, Cheatcodes, CheatsCtxt, DatabaseExt, Result,
     Vm::{prank_0Call, prank_1Call, startPrank_0Call, startPrank_1Call, stopPrankCall},
 };
 
@@ -59,6 +59,7 @@ impl Prank {
     }
 }
 
+impl_is_pure_true!(prank_0Call);
 impl Cheatcode for prank_0Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { msgSender } = self;
@@ -66,6 +67,7 @@ impl Cheatcode for prank_0Call {
     }
 }
 
+impl_is_pure_true!(startPrank_0Call);
 impl Cheatcode for startPrank_0Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { msgSender } = self;
@@ -73,6 +75,7 @@ impl Cheatcode for startPrank_0Call {
     }
 }
 
+impl_is_pure_true!(prank_1Call);
 impl Cheatcode for prank_1Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self {
@@ -83,6 +86,7 @@ impl Cheatcode for prank_1Call {
     }
 }
 
+impl_is_pure_true!(startPrank_1Call);
 impl Cheatcode for startPrank_1Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self {
@@ -93,6 +97,7 @@ impl Cheatcode for startPrank_1Call {
     }
 }
 
+impl_is_pure_true!(stopPrankCall);
 impl Cheatcode for stopPrankCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {} = self;

--- a/crates/foundry/cheatcodes/src/fs.rs
+++ b/crates/foundry/cheatcodes/src/fs.rs
@@ -20,7 +20,7 @@ use walkdir::WalkDir;
 
 use super::string::parse;
 use crate::{
-    Cheatcode, Cheatcodes, FsAccessKind, Result,
+    impl_is_pure_false, Cheatcode, Cheatcodes, FsAccessKind, Result,
     Vm::{
         closeFileCall, copyFileCall, createDirCall, existsCall, ffiCall, fsMetadataCall,
         getCodeCall, getDeployedCodeCall, isDirCall, isFileCall, projectRootCall,
@@ -31,6 +31,7 @@ use crate::{
     },
 };
 
+impl_is_pure_false!(existsCall);
 impl Cheatcode for existsCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { path } = self;
@@ -39,6 +40,7 @@ impl Cheatcode for existsCall {
     }
 }
 
+impl_is_pure_false!(fsMetadataCall);
 impl Cheatcode for fsMetadataCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { path } = self;
@@ -68,6 +70,7 @@ impl Cheatcode for fsMetadataCall {
     }
 }
 
+impl_is_pure_false!(isDirCall);
 impl Cheatcode for isDirCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { path } = self;
@@ -76,6 +79,7 @@ impl Cheatcode for isDirCall {
     }
 }
 
+impl_is_pure_false!(isFileCall);
 impl Cheatcode for isFileCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { path } = self;
@@ -84,6 +88,7 @@ impl Cheatcode for isFileCall {
     }
 }
 
+impl_is_pure_false!(projectRootCall);
 impl Cheatcode for projectRootCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {} = self;
@@ -91,6 +96,7 @@ impl Cheatcode for projectRootCall {
     }
 }
 
+impl_is_pure_false!(unixTimeCall);
 impl Cheatcode for unixTimeCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self {} = self;
@@ -101,6 +107,7 @@ impl Cheatcode for unixTimeCall {
     }
 }
 
+impl_is_pure_false!(closeFileCall);
 impl Cheatcode for closeFileCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { path } = self;
@@ -112,6 +119,7 @@ impl Cheatcode for closeFileCall {
     }
 }
 
+impl_is_pure_false!(copyFileCall);
 impl Cheatcode for copyFileCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { from, to } = self;
@@ -124,6 +132,7 @@ impl Cheatcode for copyFileCall {
     }
 }
 
+impl_is_pure_false!(createDirCall);
 impl Cheatcode for createDirCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { path, recursive } = self;
@@ -139,6 +148,7 @@ impl Cheatcode for createDirCall {
     }
 }
 
+impl_is_pure_false!(readDir_0Call);
 impl Cheatcode for readDir_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { path } = self;
@@ -146,6 +156,7 @@ impl Cheatcode for readDir_0Call {
     }
 }
 
+impl_is_pure_false!(readDir_1Call);
 impl Cheatcode for readDir_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { path, maxDepth } = self;
@@ -153,6 +164,7 @@ impl Cheatcode for readDir_1Call {
     }
 }
 
+impl_is_pure_false!(readDir_2Call);
 impl Cheatcode for readDir_2Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {
@@ -164,6 +176,7 @@ impl Cheatcode for readDir_2Call {
     }
 }
 
+impl_is_pure_false!(readFileCall);
 impl Cheatcode for readFileCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { path } = self;
@@ -172,6 +185,7 @@ impl Cheatcode for readFileCall {
     }
 }
 
+impl_is_pure_false!(readFileBinaryCall);
 impl Cheatcode for readFileBinaryCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { path } = self;
@@ -180,6 +194,7 @@ impl Cheatcode for readFileBinaryCall {
     }
 }
 
+impl_is_pure_false!(readLineCall);
 impl Cheatcode for readLineCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { path } = self;
@@ -208,6 +223,7 @@ impl Cheatcode for readLineCall {
     }
 }
 
+impl_is_pure_false!(readLinkCall);
 impl Cheatcode for readLinkCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { linkPath: path } = self;
@@ -217,6 +233,7 @@ impl Cheatcode for readLinkCall {
     }
 }
 
+impl_is_pure_false!(removeDirCall);
 impl Cheatcode for removeDirCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { path, recursive } = self;
@@ -232,6 +249,7 @@ impl Cheatcode for removeDirCall {
     }
 }
 
+impl_is_pure_false!(removeFileCall);
 impl Cheatcode for removeFileCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { path } = self;
@@ -251,6 +269,7 @@ impl Cheatcode for removeFileCall {
     }
 }
 
+impl_is_pure_false!(writeFileCall);
 impl Cheatcode for writeFileCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { path, data } = self;
@@ -258,6 +277,7 @@ impl Cheatcode for writeFileCall {
     }
 }
 
+impl_is_pure_false!(writeFileBinaryCall);
 impl Cheatcode for writeFileBinaryCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { path, data } = self;
@@ -265,6 +285,7 @@ impl Cheatcode for writeFileBinaryCall {
     }
 }
 
+impl_is_pure_false!(writeLineCall);
 impl Cheatcode for writeLineCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { path, data: line } = self;
@@ -286,6 +307,7 @@ impl Cheatcode for writeLineCall {
     }
 }
 
+impl_is_pure_false!(getCodeCall);
 impl Cheatcode for getCodeCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { artifactPath: path } = self;
@@ -293,6 +315,7 @@ impl Cheatcode for getCodeCall {
     }
 }
 
+impl_is_pure_false!(getDeployedCodeCall);
 impl Cheatcode for getDeployedCodeCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { artifactPath: path } = self;
@@ -401,6 +424,7 @@ fn get_artifact_code(state: &Cheatcodes, path: &str, deployed: bool) -> Result<B
     maybe_bytecode.ok_or_else(|| fmt_err!("No bytecode for contract. Is it abstract or unlinked?"))
 }
 
+impl_is_pure_false!(ffiCall);
 impl Cheatcode for ffiCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {
@@ -418,6 +442,7 @@ impl Cheatcode for ffiCall {
     }
 }
 
+impl_is_pure_false!(tryFfiCall);
 impl Cheatcode for tryFfiCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {
@@ -427,6 +452,7 @@ impl Cheatcode for tryFfiCall {
     }
 }
 
+impl_is_pure_false!(promptCall);
 impl Cheatcode for promptCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { promptText: text } = self;
@@ -434,6 +460,7 @@ impl Cheatcode for promptCall {
     }
 }
 
+impl_is_pure_false!(promptSecretCall);
 impl Cheatcode for promptSecretCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { promptText: text } = self;
@@ -441,6 +468,7 @@ impl Cheatcode for promptSecretCall {
     }
 }
 
+impl_is_pure_false!(promptAddressCall);
 impl Cheatcode for promptAddressCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { promptText: text } = self;
@@ -448,6 +476,7 @@ impl Cheatcode for promptAddressCall {
     }
 }
 
+impl_is_pure_false!(promptUintCall);
 impl Cheatcode for promptUintCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { promptText: text } = self;

--- a/crates/foundry/cheatcodes/src/json.rs
+++ b/crates/foundry/cheatcodes/src/json.rs
@@ -9,7 +9,7 @@ use edr_common::fs;
 use serde_json::Value;
 
 use crate::{
-    string, Cheatcode, Cheatcodes, FsAccessKind, Result,
+    impl_is_pure_false, impl_is_pure_true, string, Cheatcode, Cheatcodes, FsAccessKind, Result,
     Vm::{
         keyExistsCall, keyExistsJsonCall, parseJsonAddressArrayCall, parseJsonAddressCall,
         parseJsonBoolArrayCall, parseJsonBoolCall, parseJsonBytes32ArrayCall, parseJsonBytes32Call,
@@ -24,6 +24,7 @@ use crate::{
     },
 };
 
+impl_is_pure_true!(keyExistsCall);
 impl Cheatcode for keyExistsCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
@@ -31,6 +32,7 @@ impl Cheatcode for keyExistsCall {
     }
 }
 
+impl_is_pure_true!(keyExistsJsonCall);
 impl Cheatcode for keyExistsJsonCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
@@ -38,6 +40,7 @@ impl Cheatcode for keyExistsJsonCall {
     }
 }
 
+impl_is_pure_true!(parseJson_0Call);
 impl Cheatcode for parseJson_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json } = self;
@@ -45,6 +48,7 @@ impl Cheatcode for parseJson_0Call {
     }
 }
 
+impl_is_pure_true!(parseJson_1Call);
 impl Cheatcode for parseJson_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
@@ -52,6 +56,7 @@ impl Cheatcode for parseJson_1Call {
     }
 }
 
+impl_is_pure_true!(parseJsonUintCall);
 impl Cheatcode for parseJsonUintCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
@@ -59,6 +64,7 @@ impl Cheatcode for parseJsonUintCall {
     }
 }
 
+impl_is_pure_true!(parseJsonUintArrayCall);
 impl Cheatcode for parseJsonUintArrayCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
@@ -66,6 +72,7 @@ impl Cheatcode for parseJsonUintArrayCall {
     }
 }
 
+impl_is_pure_true!(parseJsonIntCall);
 impl Cheatcode for parseJsonIntCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
@@ -73,6 +80,7 @@ impl Cheatcode for parseJsonIntCall {
     }
 }
 
+impl_is_pure_true!(parseJsonIntArrayCall);
 impl Cheatcode for parseJsonIntArrayCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
@@ -80,6 +88,7 @@ impl Cheatcode for parseJsonIntArrayCall {
     }
 }
 
+impl_is_pure_true!(parseJsonBoolCall);
 impl Cheatcode for parseJsonBoolCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
@@ -87,6 +96,7 @@ impl Cheatcode for parseJsonBoolCall {
     }
 }
 
+impl_is_pure_true!(parseJsonBoolArrayCall);
 impl Cheatcode for parseJsonBoolArrayCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
@@ -94,6 +104,7 @@ impl Cheatcode for parseJsonBoolArrayCall {
     }
 }
 
+impl_is_pure_true!(parseJsonAddressCall);
 impl Cheatcode for parseJsonAddressCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
@@ -101,6 +112,7 @@ impl Cheatcode for parseJsonAddressCall {
     }
 }
 
+impl_is_pure_true!(parseJsonAddressArrayCall);
 impl Cheatcode for parseJsonAddressArrayCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
@@ -108,6 +120,7 @@ impl Cheatcode for parseJsonAddressArrayCall {
     }
 }
 
+impl_is_pure_true!(parseJsonStringCall);
 impl Cheatcode for parseJsonStringCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
@@ -115,6 +128,7 @@ impl Cheatcode for parseJsonStringCall {
     }
 }
 
+impl_is_pure_true!(parseJsonStringArrayCall);
 impl Cheatcode for parseJsonStringArrayCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
@@ -122,6 +136,7 @@ impl Cheatcode for parseJsonStringArrayCall {
     }
 }
 
+impl_is_pure_true!(parseJsonBytesCall);
 impl Cheatcode for parseJsonBytesCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
@@ -129,6 +144,7 @@ impl Cheatcode for parseJsonBytesCall {
     }
 }
 
+impl_is_pure_true!(parseJsonBytesArrayCall);
 impl Cheatcode for parseJsonBytesArrayCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
@@ -136,6 +152,7 @@ impl Cheatcode for parseJsonBytesArrayCall {
     }
 }
 
+impl_is_pure_true!(parseJsonBytes32Call);
 impl Cheatcode for parseJsonBytes32Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
@@ -143,6 +160,7 @@ impl Cheatcode for parseJsonBytes32Call {
     }
 }
 
+impl_is_pure_true!(parseJsonBytes32ArrayCall);
 impl Cheatcode for parseJsonBytes32ArrayCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
@@ -150,6 +168,7 @@ impl Cheatcode for parseJsonBytes32ArrayCall {
     }
 }
 
+impl_is_pure_true!(parseJsonKeysCall);
 impl Cheatcode for parseJsonKeysCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
@@ -157,6 +176,7 @@ impl Cheatcode for parseJsonKeysCall {
     }
 }
 
+impl_is_pure_true!(serializeJsonCall);
 impl Cheatcode for serializeJsonCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { objectKey, value } = self;
@@ -164,6 +184,7 @@ impl Cheatcode for serializeJsonCall {
     }
 }
 
+impl_is_pure_true!(serializeBool_0Call);
 impl Cheatcode for serializeBool_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {
@@ -175,6 +196,7 @@ impl Cheatcode for serializeBool_0Call {
     }
 }
 
+impl_is_pure_true!(serializeUint_0Call);
 impl Cheatcode for serializeUint_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {
@@ -186,6 +208,7 @@ impl Cheatcode for serializeUint_0Call {
     }
 }
 
+impl_is_pure_true!(serializeInt_0Call);
 impl Cheatcode for serializeInt_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {
@@ -197,6 +220,7 @@ impl Cheatcode for serializeInt_0Call {
     }
 }
 
+impl_is_pure_true!(serializeAddress_0Call);
 impl Cheatcode for serializeAddress_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {
@@ -208,6 +232,7 @@ impl Cheatcode for serializeAddress_0Call {
     }
 }
 
+impl_is_pure_true!(serializeBytes32_0Call);
 impl Cheatcode for serializeBytes32_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {
@@ -219,6 +244,7 @@ impl Cheatcode for serializeBytes32_0Call {
     }
 }
 
+impl_is_pure_true!(serializeString_0Call);
 impl Cheatcode for serializeString_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {
@@ -230,6 +256,7 @@ impl Cheatcode for serializeString_0Call {
     }
 }
 
+impl_is_pure_true!(serializeBytes_0Call);
 impl Cheatcode for serializeBytes_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {
@@ -246,6 +273,7 @@ impl Cheatcode for serializeBytes_0Call {
     }
 }
 
+impl_is_pure_true!(serializeBool_1Call);
 impl Cheatcode for serializeBool_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {
@@ -257,6 +285,7 @@ impl Cheatcode for serializeBool_1Call {
     }
 }
 
+impl_is_pure_true!(serializeUint_1Call);
 impl Cheatcode for serializeUint_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {
@@ -268,6 +297,7 @@ impl Cheatcode for serializeUint_1Call {
     }
 }
 
+impl_is_pure_true!(serializeInt_1Call);
 impl Cheatcode for serializeInt_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {
@@ -279,6 +309,7 @@ impl Cheatcode for serializeInt_1Call {
     }
 }
 
+impl_is_pure_true!(serializeAddress_1Call);
 impl Cheatcode for serializeAddress_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {
@@ -290,6 +321,7 @@ impl Cheatcode for serializeAddress_1Call {
     }
 }
 
+impl_is_pure_true!(serializeBytes32_1Call);
 impl Cheatcode for serializeBytes32_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {
@@ -301,6 +333,7 @@ impl Cheatcode for serializeBytes32_1Call {
     }
 }
 
+impl_is_pure_true!(serializeString_1Call);
 impl Cheatcode for serializeString_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {
@@ -312,6 +345,7 @@ impl Cheatcode for serializeString_1Call {
     }
 }
 
+impl_is_pure_true!(serializeBytes_1Call);
 impl Cheatcode for serializeBytes_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {
@@ -324,6 +358,7 @@ impl Cheatcode for serializeBytes_1Call {
     }
 }
 
+impl_is_pure_true!(serializeUintToHexCall);
 impl Cheatcode for serializeUintToHexCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {
@@ -336,6 +371,7 @@ impl Cheatcode for serializeUintToHexCall {
     }
 }
 
+impl_is_pure_false!(writeJson_0Call);
 impl Cheatcode for writeJson_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { json, path } = self;
@@ -345,6 +381,7 @@ impl Cheatcode for writeJson_0Call {
     }
 }
 
+impl_is_pure_false!(writeJson_1Call);
 impl Cheatcode for writeJson_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {

--- a/crates/foundry/cheatcodes/src/string.rs
+++ b/crates/foundry/cheatcodes/src/string.rs
@@ -5,7 +5,7 @@ use alloy_primitives::U256;
 use alloy_sol_types::SolValue;
 
 use crate::{
-    Cheatcode, Cheatcodes, Result,
+    impl_is_pure_true, Cheatcode, Cheatcodes, Result,
     Vm::{
         indexOfCall, parseAddressCall, parseBoolCall, parseBytes32Call, parseBytesCall,
         parseIntCall, parseUintCall, replaceCall, splitCall, toLowercaseCall, toString_0Call,
@@ -13,8 +13,8 @@ use crate::{
         toUppercaseCall, trimCall,
     },
 };
-
 // address
+impl_is_pure_true!(toString_0Call);
 impl Cheatcode for toString_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { value } = self;
@@ -23,6 +23,7 @@ impl Cheatcode for toString_0Call {
 }
 
 // bytes
+impl_is_pure_true!(toString_1Call);
 impl Cheatcode for toString_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { value } = self;
@@ -31,6 +32,7 @@ impl Cheatcode for toString_1Call {
 }
 
 // bytes32
+impl_is_pure_true!(toString_2Call);
 impl Cheatcode for toString_2Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { value } = self;
@@ -39,6 +41,7 @@ impl Cheatcode for toString_2Call {
 }
 
 // bool
+impl_is_pure_true!(toString_3Call);
 impl Cheatcode for toString_3Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { value } = self;
@@ -47,6 +50,7 @@ impl Cheatcode for toString_3Call {
 }
 
 // uint256
+impl_is_pure_true!(toString_4Call);
 impl Cheatcode for toString_4Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { value } = self;
@@ -55,6 +59,7 @@ impl Cheatcode for toString_4Call {
 }
 
 // int256
+impl_is_pure_true!(toString_5Call);
 impl Cheatcode for toString_5Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { value } = self;
@@ -62,6 +67,7 @@ impl Cheatcode for toString_5Call {
     }
 }
 
+impl_is_pure_true!(parseBytesCall);
 impl Cheatcode for parseBytesCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { stringifiedValue } = self;
@@ -69,6 +75,7 @@ impl Cheatcode for parseBytesCall {
     }
 }
 
+impl_is_pure_true!(parseAddressCall);
 impl Cheatcode for parseAddressCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { stringifiedValue } = self;
@@ -76,6 +83,7 @@ impl Cheatcode for parseAddressCall {
     }
 }
 
+impl_is_pure_true!(parseUintCall);
 impl Cheatcode for parseUintCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { stringifiedValue } = self;
@@ -83,6 +91,7 @@ impl Cheatcode for parseUintCall {
     }
 }
 
+impl_is_pure_true!(parseIntCall);
 impl Cheatcode for parseIntCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { stringifiedValue } = self;
@@ -90,6 +99,7 @@ impl Cheatcode for parseIntCall {
     }
 }
 
+impl_is_pure_true!(parseBytes32Call);
 impl Cheatcode for parseBytes32Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { stringifiedValue } = self;
@@ -97,6 +107,7 @@ impl Cheatcode for parseBytes32Call {
     }
 }
 
+impl_is_pure_true!(parseBoolCall);
 impl Cheatcode for parseBoolCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { stringifiedValue } = self;
@@ -105,6 +116,7 @@ impl Cheatcode for parseBoolCall {
 }
 
 // toLowercase
+impl_is_pure_true!(toLowercaseCall);
 impl Cheatcode for toLowercaseCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { input } = self;
@@ -113,6 +125,7 @@ impl Cheatcode for toLowercaseCall {
 }
 
 // toUppercase
+impl_is_pure_true!(toUppercaseCall);
 impl Cheatcode for toUppercaseCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { input } = self;
@@ -121,6 +134,7 @@ impl Cheatcode for toUppercaseCall {
 }
 
 // trim
+impl_is_pure_true!(trimCall);
 impl Cheatcode for trimCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { input } = self;
@@ -129,6 +143,7 @@ impl Cheatcode for trimCall {
 }
 
 // Replace
+impl_is_pure_true!(replaceCall);
 impl Cheatcode for replaceCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { input, from, to } = self;
@@ -137,6 +152,7 @@ impl Cheatcode for replaceCall {
 }
 
 // Split
+impl_is_pure_true!(splitCall);
 impl Cheatcode for splitCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { input, delimiter } = self;
@@ -146,6 +162,7 @@ impl Cheatcode for splitCall {
 }
 
 // indexOf
+impl_is_pure_true!(indexOfCall);
 impl Cheatcode for indexOfCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { input, key } = self;

--- a/crates/foundry/cheatcodes/src/test.rs
+++ b/crates/foundry/cheatcodes/src/test.rs
@@ -11,6 +11,9 @@ use crate::{
 pub(crate) mod assert;
 pub(crate) mod expect;
 
+use crate::impl_is_pure_true;
+
+impl_is_pure_true!(assumeCall);
 impl Cheatcode for assumeCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { condition } = self;
@@ -22,6 +25,7 @@ impl Cheatcode for assumeCall {
     }
 }
 
+impl_is_pure_true!(rpcUrlCall);
 impl Cheatcode for rpcUrlCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { rpcAlias } = self;
@@ -29,6 +33,7 @@ impl Cheatcode for rpcUrlCall {
     }
 }
 
+impl_is_pure_true!(rpcUrlsCall);
 impl Cheatcode for rpcUrlsCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {} = self;
@@ -36,6 +41,7 @@ impl Cheatcode for rpcUrlsCall {
     }
 }
 
+impl_is_pure_true!(rpcUrlStructsCall);
 impl Cheatcode for rpcUrlStructsCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {} = self;
@@ -43,6 +49,7 @@ impl Cheatcode for rpcUrlStructsCall {
     }
 }
 
+impl_is_pure_true!(sleepCall);
 impl Cheatcode for sleepCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { duration } = self;
@@ -52,6 +59,7 @@ impl Cheatcode for sleepCall {
     }
 }
 
+impl_is_pure_true!(skipCall);
 impl Cheatcode for skipCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { skipTest } = *self;

--- a/crates/foundry/cheatcodes/src/test/assert.rs
+++ b/crates/foundry/cheatcodes/src/test/assert.rs
@@ -5,7 +5,7 @@ use foundry_evm_core::abi::{format_units_int, format_units_uint};
 use itertools::Itertools;
 
 use crate::{
-    Cheatcode, Cheatcodes, Result,
+    impl_is_pure_true, Cheatcode, Cheatcodes, Result,
     Vm::{
         assertApproxEqAbsDecimal_0Call, assertApproxEqAbsDecimal_1Call,
         assertApproxEqAbsDecimal_2Call, assertApproxEqAbsDecimal_3Call, assertApproxEqAbs_0Call,
@@ -204,30 +204,35 @@ impl EqRelAssertionError<I256> {
 
 type ComparisonResult<'a, T> = Result<Vec<u8>, ComparisonAssertionError<'a, T>>;
 
+impl_is_pure_true!(assertTrue_0Call);
 impl Cheatcode for assertTrue_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(assert_true(self.condition).map_err(|e| e.to_string())?)
     }
 }
 
+impl_is_pure_true!(assertTrue_1Call);
 impl Cheatcode for assertTrue_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(assert_true(self.condition).map_err(|_err| self.error.clone())?)
     }
 }
 
+impl_is_pure_true!(assertFalse_0Call);
 impl Cheatcode for assertFalse_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(assert_false(self.condition).map_err(|e| e.to_string())?)
     }
 }
 
+impl_is_pure_true!(assertFalse_1Call);
 impl Cheatcode for assertFalse_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(assert_false(self.condition).map_err(|_err| self.error.clone())?)
     }
 }
 
+impl_is_pure_true!(assertEq_0Call);
 impl Cheatcode for assertEq_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right } = self;
@@ -236,6 +241,7 @@ impl Cheatcode for assertEq_0Call {
     }
 }
 
+impl_is_pure_true!(assertEq_1Call);
 impl Cheatcode for assertEq_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right, error } = self;
@@ -243,6 +249,7 @@ impl Cheatcode for assertEq_1Call {
     }
 }
 
+impl_is_pure_true!(assertEq_2Call);
 impl Cheatcode for assertEq_2Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right } = self;
@@ -251,6 +258,7 @@ impl Cheatcode for assertEq_2Call {
     }
 }
 
+impl_is_pure_true!(assertEq_3Call);
 impl Cheatcode for assertEq_3Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right, error } = self;
@@ -258,6 +266,7 @@ impl Cheatcode for assertEq_3Call {
     }
 }
 
+impl_is_pure_true!(assertEq_4Call);
 impl Cheatcode for assertEq_4Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right } = self;
@@ -266,6 +275,7 @@ impl Cheatcode for assertEq_4Call {
     }
 }
 
+impl_is_pure_true!(assertEq_5Call);
 impl Cheatcode for assertEq_5Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right, error } = self;
@@ -273,6 +283,7 @@ impl Cheatcode for assertEq_5Call {
     }
 }
 
+impl_is_pure_true!(assertEq_6Call);
 impl Cheatcode for assertEq_6Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right } = self;
@@ -281,6 +292,7 @@ impl Cheatcode for assertEq_6Call {
     }
 }
 
+impl_is_pure_true!(assertEq_7Call);
 impl Cheatcode for assertEq_7Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right, error } = self;
@@ -288,6 +300,7 @@ impl Cheatcode for assertEq_7Call {
     }
 }
 
+impl_is_pure_true!(assertEq_8Call);
 impl Cheatcode for assertEq_8Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right } = self;
@@ -296,6 +309,7 @@ impl Cheatcode for assertEq_8Call {
     }
 }
 
+impl_is_pure_true!(assertEq_9Call);
 impl Cheatcode for assertEq_9Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right, error } = self;
@@ -303,6 +317,7 @@ impl Cheatcode for assertEq_9Call {
     }
 }
 
+impl_is_pure_true!(assertEq_10Call);
 impl Cheatcode for assertEq_10Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right } = self;
@@ -311,6 +326,7 @@ impl Cheatcode for assertEq_10Call {
     }
 }
 
+impl_is_pure_true!(assertEq_11Call);
 impl Cheatcode for assertEq_11Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right, error } = self;
@@ -318,6 +334,7 @@ impl Cheatcode for assertEq_11Call {
     }
 }
 
+impl_is_pure_true!(assertEq_12Call);
 impl Cheatcode for assertEq_12Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right } = self;
@@ -328,6 +345,7 @@ impl Cheatcode for assertEq_12Call {
     }
 }
 
+impl_is_pure_true!(assertEq_13Call);
 impl Cheatcode for assertEq_13Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right, error } = self;
@@ -338,6 +356,7 @@ impl Cheatcode for assertEq_13Call {
     }
 }
 
+impl_is_pure_true!(assertEq_14Call);
 impl Cheatcode for assertEq_14Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right } = self;
@@ -346,6 +365,7 @@ impl Cheatcode for assertEq_14Call {
     }
 }
 
+impl_is_pure_true!(assertEq_15Call);
 impl Cheatcode for assertEq_15Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right, error } = self;
@@ -353,6 +373,7 @@ impl Cheatcode for assertEq_15Call {
     }
 }
 
+impl_is_pure_true!(assertEq_16Call);
 impl Cheatcode for assertEq_16Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right } = self;
@@ -361,6 +382,7 @@ impl Cheatcode for assertEq_16Call {
     }
 }
 
+impl_is_pure_true!(assertEq_17Call);
 impl Cheatcode for assertEq_17Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right, error } = self;
@@ -368,6 +390,7 @@ impl Cheatcode for assertEq_17Call {
     }
 }
 
+impl_is_pure_true!(assertEq_18Call);
 impl Cheatcode for assertEq_18Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right } = self;
@@ -376,6 +399,7 @@ impl Cheatcode for assertEq_18Call {
     }
 }
 
+impl_is_pure_true!(assertEq_19Call);
 impl Cheatcode for assertEq_19Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right, error } = self;
@@ -383,6 +407,7 @@ impl Cheatcode for assertEq_19Call {
     }
 }
 
+impl_is_pure_true!(assertEq_20Call);
 impl Cheatcode for assertEq_20Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right } = self;
@@ -391,6 +416,7 @@ impl Cheatcode for assertEq_20Call {
     }
 }
 
+impl_is_pure_true!(assertEq_21Call);
 impl Cheatcode for assertEq_21Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right, error } = self;
@@ -398,6 +424,7 @@ impl Cheatcode for assertEq_21Call {
     }
 }
 
+impl_is_pure_true!(assertEq_22Call);
 impl Cheatcode for assertEq_22Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right } = self;
@@ -406,6 +433,7 @@ impl Cheatcode for assertEq_22Call {
     }
 }
 
+impl_is_pure_true!(assertEq_23Call);
 impl Cheatcode for assertEq_23Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right, error } = self;
@@ -413,6 +441,7 @@ impl Cheatcode for assertEq_23Call {
     }
 }
 
+impl_is_pure_true!(assertEq_24Call);
 impl Cheatcode for assertEq_24Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right } = self;
@@ -421,6 +450,7 @@ impl Cheatcode for assertEq_24Call {
     }
 }
 
+impl_is_pure_true!(assertEq_25Call);
 impl Cheatcode for assertEq_25Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right, error } = self;
@@ -428,6 +458,7 @@ impl Cheatcode for assertEq_25Call {
     }
 }
 
+impl_is_pure_true!(assertEq_26Call);
 impl Cheatcode for assertEq_26Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right } = self;
@@ -438,6 +469,7 @@ impl Cheatcode for assertEq_26Call {
     }
 }
 
+impl_is_pure_true!(assertEq_27Call);
 impl Cheatcode for assertEq_27Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right, error } = self;
@@ -450,6 +482,7 @@ impl Cheatcode for assertEq_27Call {
     }
 }
 
+impl_is_pure_true!(assertEqDecimal_0Call);
 impl Cheatcode for assertEqDecimal_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(assert_eq(&self.left, &self.right).map_err(|e| {
@@ -461,6 +494,7 @@ impl Cheatcode for assertEqDecimal_0Call {
     }
 }
 
+impl_is_pure_true!(assertEqDecimal_1Call);
 impl Cheatcode for assertEqDecimal_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(assert_eq(&self.left, &self.right)
@@ -468,6 +502,7 @@ impl Cheatcode for assertEqDecimal_1Call {
     }
 }
 
+impl_is_pure_true!(assertEqDecimal_2Call);
 impl Cheatcode for assertEqDecimal_2Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(assert_eq(&self.left, &self.right).map_err(|e| {
@@ -479,6 +514,7 @@ impl Cheatcode for assertEqDecimal_2Call {
     }
 }
 
+impl_is_pure_true!(assertEqDecimal_3Call);
 impl Cheatcode for assertEqDecimal_3Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(assert_eq(&self.left, &self.right)
@@ -486,6 +522,7 @@ impl Cheatcode for assertEqDecimal_3Call {
     }
 }
 
+impl_is_pure_true!(assertNotEq_0Call);
 impl Cheatcode for assertNotEq_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right } = self;
@@ -494,6 +531,7 @@ impl Cheatcode for assertNotEq_0Call {
     }
 }
 
+impl_is_pure_true!(assertNotEq_1Call);
 impl Cheatcode for assertNotEq_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right, error } = self;
@@ -502,6 +540,7 @@ impl Cheatcode for assertNotEq_1Call {
     }
 }
 
+impl_is_pure_true!(assertNotEq_2Call);
 impl Cheatcode for assertNotEq_2Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right } = self;
@@ -510,6 +549,7 @@ impl Cheatcode for assertNotEq_2Call {
     }
 }
 
+impl_is_pure_true!(assertNotEq_3Call);
 impl Cheatcode for assertNotEq_3Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right, error } = self;
@@ -518,6 +558,7 @@ impl Cheatcode for assertNotEq_3Call {
     }
 }
 
+impl_is_pure_true!(assertNotEq_4Call);
 impl Cheatcode for assertNotEq_4Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right } = self;
@@ -526,6 +567,7 @@ impl Cheatcode for assertNotEq_4Call {
     }
 }
 
+impl_is_pure_true!(assertNotEq_5Call);
 impl Cheatcode for assertNotEq_5Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right, error } = self;
@@ -534,6 +576,7 @@ impl Cheatcode for assertNotEq_5Call {
     }
 }
 
+impl_is_pure_true!(assertNotEq_6Call);
 impl Cheatcode for assertNotEq_6Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right } = self;
@@ -542,6 +585,7 @@ impl Cheatcode for assertNotEq_6Call {
     }
 }
 
+impl_is_pure_true!(assertNotEq_7Call);
 impl Cheatcode for assertNotEq_7Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right, error } = self;
@@ -550,6 +594,7 @@ impl Cheatcode for assertNotEq_7Call {
     }
 }
 
+impl_is_pure_true!(assertNotEq_8Call);
 impl Cheatcode for assertNotEq_8Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right } = self;
@@ -558,6 +603,7 @@ impl Cheatcode for assertNotEq_8Call {
     }
 }
 
+impl_is_pure_true!(assertNotEq_9Call);
 impl Cheatcode for assertNotEq_9Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right, error } = self;
@@ -566,6 +612,7 @@ impl Cheatcode for assertNotEq_9Call {
     }
 }
 
+impl_is_pure_true!(assertNotEq_10Call);
 impl Cheatcode for assertNotEq_10Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right } = self;
@@ -574,6 +621,7 @@ impl Cheatcode for assertNotEq_10Call {
     }
 }
 
+impl_is_pure_true!(assertNotEq_11Call);
 impl Cheatcode for assertNotEq_11Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right, error } = self;
@@ -582,6 +630,7 @@ impl Cheatcode for assertNotEq_11Call {
     }
 }
 
+impl_is_pure_true!(assertNotEq_12Call);
 impl Cheatcode for assertNotEq_12Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right } = self;
@@ -592,6 +641,7 @@ impl Cheatcode for assertNotEq_12Call {
     }
 }
 
+impl_is_pure_true!(assertNotEq_13Call);
 impl Cheatcode for assertNotEq_13Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right, error } = self;
@@ -602,6 +652,7 @@ impl Cheatcode for assertNotEq_13Call {
     }
 }
 
+impl_is_pure_true!(assertNotEq_14Call);
 impl Cheatcode for assertNotEq_14Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right } = self;
@@ -610,6 +661,7 @@ impl Cheatcode for assertNotEq_14Call {
     }
 }
 
+impl_is_pure_true!(assertNotEq_15Call);
 impl Cheatcode for assertNotEq_15Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right, error } = self;
@@ -618,6 +670,7 @@ impl Cheatcode for assertNotEq_15Call {
     }
 }
 
+impl_is_pure_true!(assertNotEq_16Call);
 impl Cheatcode for assertNotEq_16Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right } = self;
@@ -626,6 +679,7 @@ impl Cheatcode for assertNotEq_16Call {
     }
 }
 
+impl_is_pure_true!(assertNotEq_17Call);
 impl Cheatcode for assertNotEq_17Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right, error } = self;
@@ -634,6 +688,7 @@ impl Cheatcode for assertNotEq_17Call {
     }
 }
 
+impl_is_pure_true!(assertNotEq_18Call);
 impl Cheatcode for assertNotEq_18Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right } = self;
@@ -642,6 +697,7 @@ impl Cheatcode for assertNotEq_18Call {
     }
 }
 
+impl_is_pure_true!(assertNotEq_19Call);
 impl Cheatcode for assertNotEq_19Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right, error } = self;
@@ -650,6 +706,7 @@ impl Cheatcode for assertNotEq_19Call {
     }
 }
 
+impl_is_pure_true!(assertNotEq_20Call);
 impl Cheatcode for assertNotEq_20Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right } = self;
@@ -658,6 +715,7 @@ impl Cheatcode for assertNotEq_20Call {
     }
 }
 
+impl_is_pure_true!(assertNotEq_21Call);
 impl Cheatcode for assertNotEq_21Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right, error } = self;
@@ -666,6 +724,7 @@ impl Cheatcode for assertNotEq_21Call {
     }
 }
 
+impl_is_pure_true!(assertNotEq_22Call);
 impl Cheatcode for assertNotEq_22Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right } = self;
@@ -674,6 +733,7 @@ impl Cheatcode for assertNotEq_22Call {
     }
 }
 
+impl_is_pure_true!(assertNotEq_23Call);
 impl Cheatcode for assertNotEq_23Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right, error } = self;
@@ -682,6 +742,7 @@ impl Cheatcode for assertNotEq_23Call {
     }
 }
 
+impl_is_pure_true!(assertNotEq_24Call);
 impl Cheatcode for assertNotEq_24Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right } = self;
@@ -690,6 +751,7 @@ impl Cheatcode for assertNotEq_24Call {
     }
 }
 
+impl_is_pure_true!(assertNotEq_25Call);
 impl Cheatcode for assertNotEq_25Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right, error } = self;
@@ -698,6 +760,7 @@ impl Cheatcode for assertNotEq_25Call {
     }
 }
 
+impl_is_pure_true!(assertNotEq_26Call);
 impl Cheatcode for assertNotEq_26Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right } = self;
@@ -708,6 +771,7 @@ impl Cheatcode for assertNotEq_26Call {
     }
 }
 
+impl_is_pure_true!(assertNotEq_27Call);
 impl Cheatcode for assertNotEq_27Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right, error } = self;
@@ -718,6 +782,7 @@ impl Cheatcode for assertNotEq_27Call {
     }
 }
 
+impl_is_pure_true!(assertNotEqDecimal_0Call);
 impl Cheatcode for assertNotEqDecimal_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(assert_not_eq(&self.left, &self.right).map_err(|e| {
@@ -729,6 +794,7 @@ impl Cheatcode for assertNotEqDecimal_0Call {
     }
 }
 
+impl_is_pure_true!(assertNotEqDecimal_1Call);
 impl Cheatcode for assertNotEqDecimal_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(assert_not_eq(&self.left, &self.right)
@@ -736,6 +802,7 @@ impl Cheatcode for assertNotEqDecimal_1Call {
     }
 }
 
+impl_is_pure_true!(assertNotEqDecimal_2Call);
 impl Cheatcode for assertNotEqDecimal_2Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(assert_not_eq(&self.left, &self.right).map_err(|e| {
@@ -747,6 +814,7 @@ impl Cheatcode for assertNotEqDecimal_2Call {
     }
 }
 
+impl_is_pure_true!(assertNotEqDecimal_3Call);
 impl Cheatcode for assertNotEqDecimal_3Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(assert_not_eq(&self.left, &self.right)
@@ -754,6 +822,7 @@ impl Cheatcode for assertNotEqDecimal_3Call {
     }
 }
 
+impl_is_pure_true!(assertGt_0Call);
 impl Cheatcode for assertGt_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right } = self;
@@ -762,6 +831,7 @@ impl Cheatcode for assertGt_0Call {
     }
 }
 
+impl_is_pure_true!(assertGt_1Call);
 impl Cheatcode for assertGt_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right, error } = self;
@@ -769,6 +839,7 @@ impl Cheatcode for assertGt_1Call {
     }
 }
 
+impl_is_pure_true!(assertGt_2Call);
 impl Cheatcode for assertGt_2Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right } = self;
@@ -777,6 +848,7 @@ impl Cheatcode for assertGt_2Call {
     }
 }
 
+impl_is_pure_true!(assertGt_3Call);
 impl Cheatcode for assertGt_3Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right, error } = self;
@@ -784,6 +856,7 @@ impl Cheatcode for assertGt_3Call {
     }
 }
 
+impl_is_pure_true!(assertGtDecimal_0Call);
 impl Cheatcode for assertGtDecimal_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(assert_gt(&self.left, &self.right).map_err(|e| {
@@ -795,6 +868,7 @@ impl Cheatcode for assertGtDecimal_0Call {
     }
 }
 
+impl_is_pure_true!(assertGtDecimal_1Call);
 impl Cheatcode for assertGtDecimal_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(assert_gt(&self.left, &self.right)
@@ -802,6 +876,7 @@ impl Cheatcode for assertGtDecimal_1Call {
     }
 }
 
+impl_is_pure_true!(assertGtDecimal_2Call);
 impl Cheatcode for assertGtDecimal_2Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(assert_gt(&self.left, &self.right).map_err(|e| {
@@ -813,6 +888,7 @@ impl Cheatcode for assertGtDecimal_2Call {
     }
 }
 
+impl_is_pure_true!(assertGtDecimal_3Call);
 impl Cheatcode for assertGtDecimal_3Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(assert_gt(&self.left, &self.right)
@@ -820,6 +896,7 @@ impl Cheatcode for assertGtDecimal_3Call {
     }
 }
 
+impl_is_pure_true!(assertGe_0Call);
 impl Cheatcode for assertGe_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right } = self;
@@ -828,6 +905,7 @@ impl Cheatcode for assertGe_0Call {
     }
 }
 
+impl_is_pure_true!(assertGe_1Call);
 impl Cheatcode for assertGe_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right, error } = self;
@@ -835,6 +913,7 @@ impl Cheatcode for assertGe_1Call {
     }
 }
 
+impl_is_pure_true!(assertGe_2Call);
 impl Cheatcode for assertGe_2Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right } = self;
@@ -843,6 +922,7 @@ impl Cheatcode for assertGe_2Call {
     }
 }
 
+impl_is_pure_true!(assertGe_3Call);
 impl Cheatcode for assertGe_3Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right, error } = self;
@@ -850,6 +930,7 @@ impl Cheatcode for assertGe_3Call {
     }
 }
 
+impl_is_pure_true!(assertGeDecimal_0Call);
 impl Cheatcode for assertGeDecimal_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(assert_ge(&self.left, &self.right).map_err(|e| {
@@ -861,6 +942,7 @@ impl Cheatcode for assertGeDecimal_0Call {
     }
 }
 
+impl_is_pure_true!(assertGeDecimal_1Call);
 impl Cheatcode for assertGeDecimal_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(assert_ge(&self.left, &self.right)
@@ -868,6 +950,7 @@ impl Cheatcode for assertGeDecimal_1Call {
     }
 }
 
+impl_is_pure_true!(assertGeDecimal_2Call);
 impl Cheatcode for assertGeDecimal_2Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(assert_ge(&self.left, &self.right).map_err(|e| {
@@ -879,6 +962,7 @@ impl Cheatcode for assertGeDecimal_2Call {
     }
 }
 
+impl_is_pure_true!(assertGeDecimal_3Call);
 impl Cheatcode for assertGeDecimal_3Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(assert_ge(&self.left, &self.right)
@@ -886,6 +970,7 @@ impl Cheatcode for assertGeDecimal_3Call {
     }
 }
 
+impl_is_pure_true!(assertLt_0Call);
 impl Cheatcode for assertLt_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right } = self;
@@ -894,6 +979,7 @@ impl Cheatcode for assertLt_0Call {
     }
 }
 
+impl_is_pure_true!(assertLt_1Call);
 impl Cheatcode for assertLt_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right, error } = self;
@@ -901,6 +987,7 @@ impl Cheatcode for assertLt_1Call {
     }
 }
 
+impl_is_pure_true!(assertLt_2Call);
 impl Cheatcode for assertLt_2Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right } = self;
@@ -909,6 +996,7 @@ impl Cheatcode for assertLt_2Call {
     }
 }
 
+impl_is_pure_true!(assertLt_3Call);
 impl Cheatcode for assertLt_3Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right, error } = self;
@@ -916,6 +1004,7 @@ impl Cheatcode for assertLt_3Call {
     }
 }
 
+impl_is_pure_true!(assertLtDecimal_0Call);
 impl Cheatcode for assertLtDecimal_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(assert_lt(&self.left, &self.right).map_err(|e| {
@@ -927,6 +1016,7 @@ impl Cheatcode for assertLtDecimal_0Call {
     }
 }
 
+impl_is_pure_true!(assertLtDecimal_1Call);
 impl Cheatcode for assertLtDecimal_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(assert_lt(&self.left, &self.right)
@@ -934,6 +1024,7 @@ impl Cheatcode for assertLtDecimal_1Call {
     }
 }
 
+impl_is_pure_true!(assertLtDecimal_2Call);
 impl Cheatcode for assertLtDecimal_2Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(assert_lt(&self.left, &self.right).map_err(|e| {
@@ -945,6 +1036,7 @@ impl Cheatcode for assertLtDecimal_2Call {
     }
 }
 
+impl_is_pure_true!(assertLtDecimal_3Call);
 impl Cheatcode for assertLtDecimal_3Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(assert_lt(&self.left, &self.right)
@@ -952,6 +1044,7 @@ impl Cheatcode for assertLtDecimal_3Call {
     }
 }
 
+impl_is_pure_true!(assertLe_0Call);
 impl Cheatcode for assertLe_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right } = self;
@@ -960,6 +1053,7 @@ impl Cheatcode for assertLe_0Call {
     }
 }
 
+impl_is_pure_true!(assertLe_1Call);
 impl Cheatcode for assertLe_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right, error } = self;
@@ -967,6 +1061,7 @@ impl Cheatcode for assertLe_1Call {
     }
 }
 
+impl_is_pure_true!(assertLe_2Call);
 impl Cheatcode for assertLe_2Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right } = self;
@@ -975,6 +1070,7 @@ impl Cheatcode for assertLe_2Call {
     }
 }
 
+impl_is_pure_true!(assertLe_3Call);
 impl Cheatcode for assertLe_3Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { left, right, error } = self;
@@ -982,6 +1078,7 @@ impl Cheatcode for assertLe_3Call {
     }
 }
 
+impl_is_pure_true!(assertLeDecimal_0Call);
 impl Cheatcode for assertLeDecimal_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(assert_le(&self.left, &self.right).map_err(|e| {
@@ -993,6 +1090,7 @@ impl Cheatcode for assertLeDecimal_0Call {
     }
 }
 
+impl_is_pure_true!(assertLeDecimal_1Call);
 impl Cheatcode for assertLeDecimal_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(assert_le(&self.left, &self.right)
@@ -1000,6 +1098,7 @@ impl Cheatcode for assertLeDecimal_1Call {
     }
 }
 
+impl_is_pure_true!(assertLeDecimal_2Call);
 impl Cheatcode for assertLeDecimal_2Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(assert_le(&self.left, &self.right).map_err(|e| {
@@ -1011,6 +1110,7 @@ impl Cheatcode for assertLeDecimal_2Call {
     }
 }
 
+impl_is_pure_true!(assertLeDecimal_3Call);
 impl Cheatcode for assertLeDecimal_3Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(assert_le(&self.left, &self.right)
@@ -1018,6 +1118,7 @@ impl Cheatcode for assertLeDecimal_3Call {
     }
 }
 
+impl_is_pure_true!(assertApproxEqAbs_0Call);
 impl Cheatcode for assertApproxEqAbs_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(
@@ -1027,6 +1128,7 @@ impl Cheatcode for assertApproxEqAbs_0Call {
     }
 }
 
+impl_is_pure_true!(assertApproxEqAbs_1Call);
 impl Cheatcode for assertApproxEqAbs_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(
@@ -1036,6 +1138,7 @@ impl Cheatcode for assertApproxEqAbs_1Call {
     }
 }
 
+impl_is_pure_true!(assertApproxEqAbs_2Call);
 impl Cheatcode for assertApproxEqAbs_2Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(
@@ -1045,6 +1148,7 @@ impl Cheatcode for assertApproxEqAbs_2Call {
     }
 }
 
+impl_is_pure_true!(assertApproxEqAbs_3Call);
 impl Cheatcode for assertApproxEqAbs_3Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(
@@ -1054,6 +1158,7 @@ impl Cheatcode for assertApproxEqAbs_3Call {
     }
 }
 
+impl_is_pure_true!(assertApproxEqAbsDecimal_0Call);
 impl Cheatcode for assertApproxEqAbsDecimal_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(
@@ -1067,6 +1172,7 @@ impl Cheatcode for assertApproxEqAbsDecimal_0Call {
     }
 }
 
+impl_is_pure_true!(assertApproxEqAbsDecimal_1Call);
 impl Cheatcode for assertApproxEqAbsDecimal_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(
@@ -1077,6 +1183,7 @@ impl Cheatcode for assertApproxEqAbsDecimal_1Call {
     }
 }
 
+impl_is_pure_true!(assertApproxEqAbsDecimal_2Call);
 impl Cheatcode for assertApproxEqAbsDecimal_2Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(
@@ -1090,6 +1197,7 @@ impl Cheatcode for assertApproxEqAbsDecimal_2Call {
     }
 }
 
+impl_is_pure_true!(assertApproxEqAbsDecimal_3Call);
 impl Cheatcode for assertApproxEqAbsDecimal_3Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(
@@ -1100,6 +1208,7 @@ impl Cheatcode for assertApproxEqAbsDecimal_3Call {
     }
 }
 
+impl_is_pure_true!(assertApproxEqRel_0Call);
 impl Cheatcode for assertApproxEqRel_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(
@@ -1109,6 +1218,7 @@ impl Cheatcode for assertApproxEqRel_0Call {
     }
 }
 
+impl_is_pure_true!(assertApproxEqRel_1Call);
 impl Cheatcode for assertApproxEqRel_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(
@@ -1118,6 +1228,7 @@ impl Cheatcode for assertApproxEqRel_1Call {
     }
 }
 
+impl_is_pure_true!(assertApproxEqRel_2Call);
 impl Cheatcode for assertApproxEqRel_2Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(
@@ -1127,6 +1238,7 @@ impl Cheatcode for assertApproxEqRel_2Call {
     }
 }
 
+impl_is_pure_true!(assertApproxEqRel_3Call);
 impl Cheatcode for assertApproxEqRel_3Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(
@@ -1136,6 +1248,7 @@ impl Cheatcode for assertApproxEqRel_3Call {
     }
 }
 
+impl_is_pure_true!(assertApproxEqRelDecimal_0Call);
 impl Cheatcode for assertApproxEqRelDecimal_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(
@@ -1151,6 +1264,7 @@ impl Cheatcode for assertApproxEqRelDecimal_0Call {
     }
 }
 
+impl_is_pure_true!(assertApproxEqRelDecimal_1Call);
 impl Cheatcode for assertApproxEqRelDecimal_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(
@@ -1161,6 +1275,7 @@ impl Cheatcode for assertApproxEqRelDecimal_1Call {
     }
 }
 
+impl_is_pure_true!(assertApproxEqRelDecimal_2Call);
 impl Cheatcode for assertApproxEqRelDecimal_2Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(
@@ -1174,6 +1289,7 @@ impl Cheatcode for assertApproxEqRelDecimal_2Call {
     }
 }
 
+impl_is_pure_true!(assertApproxEqRelDecimal_3Call);
 impl Cheatcode for assertApproxEqRelDecimal_3Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         Ok(

--- a/crates/foundry/cheatcodes/src/test/expect.rs
+++ b/crates/foundry/cheatcodes/src/test/expect.rs
@@ -6,7 +6,7 @@ use revm::interpreter::{return_ok, InstructionResult};
 use spec::Vm;
 
 use crate::{
-    Cheatcode, Cheatcodes, CheatsCtxt, DatabaseExt, Result,
+    impl_is_pure_true, Cheatcode, Cheatcodes, CheatsCtxt, DatabaseExt, Result,
     Vm::{
         _expectCheatcodeRevert_0Call, _expectCheatcodeRevert_1Call, _expectCheatcodeRevert_2Call,
         expectCallMinGas_0Call, expectCallMinGas_1Call, expectCall_0Call, expectCall_1Call,
@@ -111,6 +111,7 @@ pub struct ExpectedEmit {
     pub found: bool,
 }
 
+impl_is_pure_true!(expectCall_0Call);
 impl Cheatcode for expectCall_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { callee, data } = self;
@@ -127,6 +128,7 @@ impl Cheatcode for expectCall_0Call {
     }
 }
 
+impl_is_pure_true!(expectCall_1Call);
 impl Cheatcode for expectCall_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {
@@ -147,6 +149,7 @@ impl Cheatcode for expectCall_1Call {
     }
 }
 
+impl_is_pure_true!(expectCall_2Call);
 impl Cheatcode for expectCall_2Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {
@@ -167,6 +170,7 @@ impl Cheatcode for expectCall_2Call {
     }
 }
 
+impl_is_pure_true!(expectCall_3Call);
 impl Cheatcode for expectCall_3Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {
@@ -188,6 +192,7 @@ impl Cheatcode for expectCall_3Call {
     }
 }
 
+impl_is_pure_true!(expectCall_4Call);
 impl Cheatcode for expectCall_4Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {
@@ -209,6 +214,7 @@ impl Cheatcode for expectCall_4Call {
     }
 }
 
+impl_is_pure_true!(expectCall_5Call);
 impl Cheatcode for expectCall_5Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {
@@ -231,6 +237,7 @@ impl Cheatcode for expectCall_5Call {
     }
 }
 
+impl_is_pure_true!(expectCallMinGas_0Call);
 impl Cheatcode for expectCallMinGas_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {
@@ -252,6 +259,7 @@ impl Cheatcode for expectCallMinGas_0Call {
     }
 }
 
+impl_is_pure_true!(expectCallMinGas_1Call);
 impl Cheatcode for expectCallMinGas_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {
@@ -274,6 +282,7 @@ impl Cheatcode for expectCallMinGas_1Call {
     }
 }
 
+impl_is_pure_true!(expectEmit_0Call);
 impl Cheatcode for expectEmit_0Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self {
@@ -291,6 +300,7 @@ impl Cheatcode for expectEmit_0Call {
     }
 }
 
+impl_is_pure_true!(expectEmit_1Call);
 impl Cheatcode for expectEmit_1Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self {
@@ -309,6 +319,7 @@ impl Cheatcode for expectEmit_1Call {
     }
 }
 
+impl_is_pure_true!(expectEmit_2Call);
 impl Cheatcode for expectEmit_2Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self {} = self;
@@ -316,6 +327,7 @@ impl Cheatcode for expectEmit_2Call {
     }
 }
 
+impl_is_pure_true!(expectEmit_3Call);
 impl Cheatcode for expectEmit_3Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { emitter } = *self;
@@ -328,6 +340,7 @@ impl Cheatcode for expectEmit_3Call {
     }
 }
 
+impl_is_pure_true!(expectRevert_0Call);
 impl Cheatcode for expectRevert_0Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self {} = self;
@@ -335,6 +348,7 @@ impl Cheatcode for expectRevert_0Call {
     }
 }
 
+impl_is_pure_true!(expectRevert_1Call);
 impl Cheatcode for expectRevert_1Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { revertData } = self;
@@ -347,6 +361,7 @@ impl Cheatcode for expectRevert_1Call {
     }
 }
 
+impl_is_pure_true!(expectRevert_2Call);
 impl Cheatcode for expectRevert_2Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { revertData } = self;
@@ -359,12 +374,14 @@ impl Cheatcode for expectRevert_2Call {
     }
 }
 
+impl_is_pure_true!(_expectCheatcodeRevert_0Call);
 impl Cheatcode for _expectCheatcodeRevert_0Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         expect_revert(ccx.state, None, ccx.ecx.journaled_state.depth(), true)
     }
 }
 
+impl_is_pure_true!(_expectCheatcodeRevert_1Call);
 impl Cheatcode for _expectCheatcodeRevert_1Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { revertData } = self;
@@ -377,6 +394,7 @@ impl Cheatcode for _expectCheatcodeRevert_1Call {
     }
 }
 
+impl_is_pure_true!(_expectCheatcodeRevert_2Call);
 impl Cheatcode for _expectCheatcodeRevert_2Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { revertData } = self;
@@ -389,6 +407,7 @@ impl Cheatcode for _expectCheatcodeRevert_2Call {
     }
 }
 
+impl_is_pure_true!(expectSafeMemoryCall);
 impl Cheatcode for expectSafeMemoryCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { min, max } = *self;
@@ -396,6 +415,7 @@ impl Cheatcode for expectSafeMemoryCall {
     }
 }
 
+impl_is_pure_true!(stopExpectSafeMemoryCall);
 impl Cheatcode for stopExpectSafeMemoryCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self {} = self;
@@ -406,6 +426,7 @@ impl Cheatcode for stopExpectSafeMemoryCall {
     }
 }
 
+impl_is_pure_true!(expectSafeMemoryCallCall);
 impl Cheatcode for expectSafeMemoryCallCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { min, max } = *self;

--- a/crates/foundry/cheatcodes/src/toml.rs
+++ b/crates/foundry/cheatcodes/src/toml.rs
@@ -6,6 +6,7 @@ use serde_json::Value as JsonValue;
 use toml::Value as TomlValue;
 
 use crate::{
+    impl_is_pure_false, impl_is_pure_true,
     json::{
         canonicalize_json_path, check_json_key_exists, parse_json, parse_json_coerce,
         parse_json_keys,
@@ -20,6 +21,7 @@ use crate::{
     },
 };
 
+impl_is_pure_true!(keyExistsTomlCall);
 impl Cheatcode for keyExistsTomlCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { toml, key } = self;
@@ -27,6 +29,7 @@ impl Cheatcode for keyExistsTomlCall {
     }
 }
 
+impl_is_pure_true!(parseToml_0Call);
 impl Cheatcode for parseToml_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { toml } = self;
@@ -34,6 +37,7 @@ impl Cheatcode for parseToml_0Call {
     }
 }
 
+impl_is_pure_true!(parseToml_1Call);
 impl Cheatcode for parseToml_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { toml, key } = self;
@@ -41,6 +45,7 @@ impl Cheatcode for parseToml_1Call {
     }
 }
 
+impl_is_pure_true!(parseTomlUintCall);
 impl Cheatcode for parseTomlUintCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { toml, key } = self;
@@ -48,6 +53,7 @@ impl Cheatcode for parseTomlUintCall {
     }
 }
 
+impl_is_pure_true!(parseTomlUintArrayCall);
 impl Cheatcode for parseTomlUintArrayCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { toml, key } = self;
@@ -55,6 +61,7 @@ impl Cheatcode for parseTomlUintArrayCall {
     }
 }
 
+impl_is_pure_true!(parseTomlIntCall);
 impl Cheatcode for parseTomlIntCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { toml, key } = self;
@@ -62,6 +69,7 @@ impl Cheatcode for parseTomlIntCall {
     }
 }
 
+impl_is_pure_true!(parseTomlIntArrayCall);
 impl Cheatcode for parseTomlIntArrayCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { toml, key } = self;
@@ -69,6 +77,7 @@ impl Cheatcode for parseTomlIntArrayCall {
     }
 }
 
+impl_is_pure_true!(parseTomlBoolCall);
 impl Cheatcode for parseTomlBoolCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { toml, key } = self;
@@ -76,6 +85,7 @@ impl Cheatcode for parseTomlBoolCall {
     }
 }
 
+impl_is_pure_true!(parseTomlBoolArrayCall);
 impl Cheatcode for parseTomlBoolArrayCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { toml, key } = self;
@@ -83,6 +93,7 @@ impl Cheatcode for parseTomlBoolArrayCall {
     }
 }
 
+impl_is_pure_true!(parseTomlAddressCall);
 impl Cheatcode for parseTomlAddressCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { toml, key } = self;
@@ -90,6 +101,7 @@ impl Cheatcode for parseTomlAddressCall {
     }
 }
 
+impl_is_pure_true!(parseTomlAddressArrayCall);
 impl Cheatcode for parseTomlAddressArrayCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { toml, key } = self;
@@ -97,6 +109,7 @@ impl Cheatcode for parseTomlAddressArrayCall {
     }
 }
 
+impl_is_pure_true!(parseTomlStringCall);
 impl Cheatcode for parseTomlStringCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { toml, key } = self;
@@ -104,6 +117,7 @@ impl Cheatcode for parseTomlStringCall {
     }
 }
 
+impl_is_pure_true!(parseTomlStringArrayCall);
 impl Cheatcode for parseTomlStringArrayCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { toml, key } = self;
@@ -111,6 +125,7 @@ impl Cheatcode for parseTomlStringArrayCall {
     }
 }
 
+impl_is_pure_true!(parseTomlBytesCall);
 impl Cheatcode for parseTomlBytesCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { toml, key } = self;
@@ -118,6 +133,7 @@ impl Cheatcode for parseTomlBytesCall {
     }
 }
 
+impl_is_pure_true!(parseTomlBytesArrayCall);
 impl Cheatcode for parseTomlBytesArrayCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { toml, key } = self;
@@ -125,6 +141,7 @@ impl Cheatcode for parseTomlBytesArrayCall {
     }
 }
 
+impl_is_pure_true!(parseTomlBytes32Call);
 impl Cheatcode for parseTomlBytes32Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { toml, key } = self;
@@ -132,6 +149,7 @@ impl Cheatcode for parseTomlBytes32Call {
     }
 }
 
+impl_is_pure_true!(parseTomlBytes32ArrayCall);
 impl Cheatcode for parseTomlBytes32ArrayCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { toml, key } = self;
@@ -139,6 +157,7 @@ impl Cheatcode for parseTomlBytes32ArrayCall {
     }
 }
 
+impl_is_pure_true!(parseTomlKeysCall);
 impl Cheatcode for parseTomlKeysCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { toml, key } = self;
@@ -146,6 +165,7 @@ impl Cheatcode for parseTomlKeysCall {
     }
 }
 
+impl_is_pure_false!(writeToml_0Call);
 impl Cheatcode for writeToml_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { json, path } = self;
@@ -157,6 +177,7 @@ impl Cheatcode for writeToml_0Call {
     }
 }
 
+impl_is_pure_false!(writeToml_1Call);
 impl Cheatcode for writeToml_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {

--- a/crates/foundry/cheatcodes/src/utils.rs
+++ b/crates/foundry/cheatcodes/src/utils.rs
@@ -10,13 +10,13 @@ use p256::ecdsa::{signature::hazmat::PrehashSigner, Signature, SigningKey as P25
 
 use crate::{
     ens::namehash,
-    Cheatcode, Cheatcodes, Result,
+    impl_is_pure_true, Cheatcode, Cheatcodes, Result,
     Vm::{
         computeCreate2Address_0Call, computeCreate2Address_1Call, computeCreateAddressCall,
         ensNamehashCall, getLabelCall, labelCall,
     },
 };
-
+impl_is_pure_true!(labelCall);
 impl Cheatcode for labelCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { account, newLabel } = self;
@@ -25,6 +25,7 @@ impl Cheatcode for labelCall {
     }
 }
 
+impl_is_pure_true!(getLabelCall);
 impl Cheatcode for getLabelCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { account } = self;
@@ -35,6 +36,7 @@ impl Cheatcode for getLabelCall {
     }
 }
 
+impl_is_pure_true!(computeCreateAddressCall);
 impl Cheatcode for computeCreateAddressCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { nonce, deployer } = self;
@@ -46,6 +48,7 @@ impl Cheatcode for computeCreateAddressCall {
     }
 }
 
+impl_is_pure_true!(computeCreate2Address_0Call);
 impl Cheatcode for computeCreate2Address_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self {
@@ -57,6 +60,7 @@ impl Cheatcode for computeCreate2Address_0Call {
     }
 }
 
+impl_is_pure_true!(computeCreate2Address_1Call);
 impl Cheatcode for computeCreate2Address_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { salt, initCodeHash } = self;
@@ -66,6 +70,7 @@ impl Cheatcode for computeCreate2Address_1Call {
     }
 }
 
+impl_is_pure_true!(ensNamehashCall);
 impl Cheatcode for ensNamehashCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name } = self;

--- a/crates/foundry/evm/core/src/backend/cow.rs
+++ b/crates/foundry/evm/core/src/backend/cow.rs
@@ -265,6 +265,23 @@ impl<'a> DatabaseExt for CowBackend<'a> {
     fn has_cheatcode_access(&self, account: &Address) -> bool {
         self.backend.has_cheatcode_access(account)
     }
+
+    fn record_cheatcode_purity(&mut self, cheatcode_name: &'static str, is_pure: bool) {
+        // Only convert to mutable if we need to update.
+        if !is_pure
+            && !self
+                .backend
+                .inner
+                .impure_cheatcodes
+                .contains(cheatcode_name)
+        {
+            self.backend
+                .to_mut()
+                .inner
+                .impure_cheatcodes
+                .insert(cheatcode_name);
+        }
+    }
 }
 
 impl<'a> DatabaseRef for CowBackend<'a> {

--- a/crates/foundry/evm/core/src/backend/mod.rs
+++ b/crates/foundry/evm/core/src/backend/mod.rs
@@ -483,7 +483,8 @@ impl Backend {
         };
 
         if let Some(fork) = fork {
-            let (fork_id, fork, _, fork_block_number) = backend
+            let fork_block_number = fork.evm_opts.fork_block_number;
+            let (fork_id, fork, _) = backend
                 .forks
                 .create_fork(fork)
                 .expect("Unable to create fork");
@@ -1111,7 +1112,8 @@ impl DatabaseExt for Backend {
 
     fn create_fork(&mut self, create_fork: CreateFork) -> eyre::Result<LocalForkId> {
         trace!("create fork");
-        let (fork_id, fork, _, fork_block_number) = self.forks.create_fork(create_fork)?;
+        let fork_block_number = create_fork.evm_opts.fork_block_number;
+        let (fork_id, fork, _) = self.forks.create_fork(create_fork)?;
 
         let fork_db = ForkDB::new(fork);
         let (id, _) = self.inner.insert_new_fork(

--- a/crates/foundry/evm/core/src/backend/mod.rs
+++ b/crates/foundry/evm/core/src/backend/mod.rs
@@ -356,6 +356,10 @@ pub trait DatabaseExt: Database<Error = DatabaseError> {
         }
         Ok(())
     }
+
+    // Can't take generic cheatcode as argument as this trait needs to be
+    // object-safe.
+    fn record_cheatcode_purity(&mut self, cheatcode_name: &'static str, is_pure: bool);
 }
 
 struct _ObjectSafe(dyn DatabaseExt);
@@ -479,7 +483,7 @@ impl Backend {
         };
 
         if let Some(fork) = fork {
-            let (fork_id, fork, _) = backend
+            let (fork_id, fork, _, fork_block_number) = backend
                 .forks
                 .create_fork(fork)
                 .expect("Unable to create fork");
@@ -488,8 +492,14 @@ impl Backend {
                 fork_id.clone(),
                 fork_db,
                 backend.inner.new_journaled_state(),
+                fork_block_number,
             );
-            backend.inner.launched_with_fork = Some((fork_id, fork_ids.0, fork_ids.1));
+            backend.inner.launched_with_fork = Some(LaunchedWithFork {
+                fork_id,
+                local_fork_id: fork_ids.0,
+                fork_look_up_index: fork_ids.1,
+                fork_block_number,
+            });
             backend.active_fork_ids = Some(fork_ids);
         }
 
@@ -502,10 +512,17 @@ impl Backend {
     /// and sets the fork as active
     pub(crate) fn new_with_fork(id: &ForkId, fork: Fork, journaled_state: JournaledState) -> Self {
         let mut backend = Self::spawn(None);
-        let fork_ids = backend
-            .inner
-            .insert_new_fork(id.clone(), fork.db, journaled_state);
-        backend.inner.launched_with_fork = Some((id.clone(), fork_ids.0, fork_ids.1));
+        let fork_block_number = fork.fork_block_number;
+        let fork_ids =
+            backend
+                .inner
+                .insert_new_fork(id.clone(), fork.db, journaled_state, fork_block_number);
+        backend.inner.launched_with_fork = Some(LaunchedWithFork {
+            fork_id: id.clone(),
+            local_fork_id: fork_ids.0,
+            fork_look_up_index: fork_ids.1,
+            fork_block_number,
+        });
         backend.active_fork_ids = Some(fork_ids);
         backend
     }
@@ -694,6 +711,24 @@ impl Backend {
         }
 
         false
+    }
+
+    /// Whether the backend instance only executed pure cheatcodes.
+    /// Returns true if no cheatcodes were executed.
+    pub fn are_executed_cheatcodes_pure(&self) -> bool {
+        self.inner.impure_cheatcodes.is_empty()
+    }
+
+    /// Whether when re-executing the calls the same results are guaranteed.
+    pub fn safe_to_re_execute(&self) -> bool {
+        // Check that the global fork this backend was launched at isn't using the
+        // "latest" block tag.
+        let not_latest_block = self
+            .inner
+            .launched_with_fork
+            .as_ref()
+            .map_or(true, |lf| lf.fork_block_number.is_some());
+        not_latest_block && self.are_executed_cheatcodes_pure()
     }
 
     /// When creating or switching forks, we update the `AccountInfo` of the
@@ -1076,12 +1111,15 @@ impl DatabaseExt for Backend {
 
     fn create_fork(&mut self, create_fork: CreateFork) -> eyre::Result<LocalForkId> {
         trace!("create fork");
-        let (fork_id, fork, _) = self.forks.create_fork(create_fork)?;
+        let (fork_id, fork, _, fork_block_number) = self.forks.create_fork(create_fork)?;
 
         let fork_db = ForkDB::new(fork);
-        let (id, _) =
-            self.inner
-                .insert_new_fork(fork_id, fork_db, self.fork_init_journaled_state.clone());
+        let (id, _) = self.inner.insert_new_fork(
+            fork_id,
+            fork_db,
+            self.fork_init_journaled_state.clone(),
+            fork_block_number,
+        );
         Ok(id)
     }
 
@@ -1481,6 +1519,13 @@ impl DatabaseExt for Backend {
     fn has_cheatcode_access(&self, account: &Address) -> bool {
         self.inner.cheatcode_access_accounts.contains(account)
     }
+
+    #[inline(always)]
+    fn record_cheatcode_purity(&mut self, cheatcode_name: &'static str, is_pure: bool) {
+        if !is_pure {
+            self.inner.impure_cheatcodes.insert(cheatcode_name);
+        }
+    }
 }
 
 impl DatabaseRef for Backend {
@@ -1578,6 +1623,7 @@ pub enum BackendDatabaseSnapshot {
 pub struct Fork {
     db: ForkDB,
     journaled_state: JournaledState,
+    fork_block_number: Option<u64>,
 }
 
 // === impl Fork ===
@@ -1603,7 +1649,7 @@ pub struct BackendInner {
     /// In other words if [`Backend::spawn()`] was called with a `CreateFork`
     /// command, to launch directly in fork mode, this holds the
     /// corresponding fork identifier of this fork.
-    pub launched_with_fork: Option<(ForkId, LocalForkId, ForkLookupIndex)>,
+    pub launched_with_fork: Option<LaunchedWithFork>,
     /// This tracks numeric fork ids and the `ForkId` used by the handler.
     ///
     /// This is necessary, because there can be multiple `Backends` associated
@@ -1657,6 +1703,9 @@ pub struct BackendInner {
     pub spec_id: SpecId,
     /// All accounts that are allowed to execute cheatcodes
     pub cheatcode_access_accounts: HashSet<Address>,
+    /// The set of executed cheatcodes that are impure. The values are the
+    /// Solidity method declarations of the cheatcodes.
+    pub impure_cheatcodes: HashSet<&'static str>,
 }
 
 // === impl BackendInner ===
@@ -1742,27 +1791,6 @@ impl BackendInner {
         self.set_fork(idx, fork);
     }
 
-    /// Updates the fork and the local mapping and returns the new index for the
-    /// `fork_db`
-    pub fn update_fork_mapping(
-        &mut self,
-        id: LocalForkId,
-        fork_id: ForkId,
-        db: ForkDB,
-        journaled_state: JournaledState,
-    ) -> ForkLookupIndex {
-        let idx = self.forks.len();
-        self.issued_local_fork_ids.insert(id, fork_id.clone());
-        self.created_forks.insert(fork_id, idx);
-
-        let fork = Fork {
-            db,
-            journaled_state,
-        };
-        self.forks.push(Some(fork));
-        idx
-    }
-
     pub fn roll_fork(
         &mut self,
         id: LocalForkId,
@@ -1794,6 +1822,7 @@ impl BackendInner {
         fork_id: ForkId,
         db: ForkDB,
         journaled_state: JournaledState,
+        fork_block_number: Option<u64>,
     ) -> (LocalForkId, ForkLookupIndex) {
         let idx = self.forks.len();
         self.created_forks.insert(fork_id.clone(), idx);
@@ -1802,6 +1831,7 @@ impl BackendInner {
         let fork = Fork {
             db,
             journaled_state,
+            fork_block_number,
         };
         self.forks.push(Some(fork));
         (id, idx)
@@ -1857,8 +1887,22 @@ impl Default for BackendInner {
                 TEST_CONTRACT_ADDRESS,
                 CALLER,
             ]),
+            impure_cheatcodes: HashSet::default(),
         }
     }
+}
+
+/// Holds the initial (global) fork info
+#[derive(Clone, Debug)]
+pub struct LaunchedWithFork {
+    /// The fork id
+    pub fork_id: ForkId,
+    /// The local fork id
+    pub local_fork_id: LocalForkId,
+    /// The fork lookup index
+    pub fork_look_up_index: ForkLookupIndex,
+    /// The fork block number. If `None` that means implicitly "latest".
+    pub fork_block_number: Option<u64>,
 }
 
 /// This updates the currently used env with the fork's environment

--- a/crates/foundry/evm/core/src/fork/multi.rs
+++ b/crates/foundry/evm/core/src/fork/multi.rs
@@ -122,15 +122,11 @@ impl MultiFork {
     /// Returns a fork backend
     ///
     /// If no matching fork backend exists it will be created
-    pub fn create_fork(
-        &self,
-        fork: CreateFork,
-    ) -> eyre::Result<(ForkId, SharedBackend, Env, Option<u64>)> {
-        let fork_block_number = fork.evm_opts.fork_block_number;
+    pub fn create_fork(&self, fork: CreateFork) -> eyre::Result<(ForkId, SharedBackend, Env)> {
         trace!(
             "Creating new fork, url={}, block={:?}",
             fork.url,
-            fork_block_number
+            fork.evm_opts.fork_block_number
         );
         let (sender, rx) = oneshot_channel();
         let req = Request::CreateFork(Box::new(fork), sender);
@@ -139,7 +135,7 @@ impl MultiFork {
             .try_send(req)
             .map_err(|e| eyre::eyre!("{:?}", e))?;
         let (fork_id, shared_backend, env) = rx.recv()??;
-        Ok((fork_id, shared_backend, env, fork_block_number))
+        Ok((fork_id, shared_backend, env))
     }
 
     /// Rolls the block of the fork

--- a/crates/foundry/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/foundry/evm/evm/src/executors/fuzz/mod.rs
@@ -226,7 +226,7 @@ impl FuzzedExecutor {
         should_fail: bool,
         calldata: alloy_primitives::Bytes,
     ) -> Result<FuzzOutcome, TestCaseError> {
-        let (mut call, indeterminism_reasons) = self
+        let (mut call, cow_backend) = self
             .executor
             .call_raw(self.sender, address, calldata.clone(), U256::ZERO)
             .map_err(|_err| TestCaseError::fail(FuzzError::FailedContractCall))?;
@@ -260,7 +260,7 @@ impl FuzzedExecutor {
                 counterexample: CounterExampleData {
                     calldata,
                     call,
-                    indeterminism_reasons,
+                    indeterminism_reasons: cow_backend.backend.indeterminism_reasons(),
                 },
             }))
         }

--- a/crates/foundry/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/foundry/evm/evm/src/executors/fuzz/mod.rs
@@ -22,6 +22,8 @@ use crate::executors::{Executor, RawCallResult};
 mod types;
 pub use types::{CaseOutcome, CounterExampleOutcome, FuzzOutcome};
 
+use crate::executors::fuzz::types::CounterExampleData;
+
 /// Wrapper around an [`Executor`] which provides fuzzing support using
 /// [`proptest`].
 ///
@@ -76,7 +78,11 @@ impl FuzzedExecutor {
         let gas_by_case: RefCell<Vec<(u64, u64)>> = RefCell::default();
 
         // Stores the result and calldata of the last failed call, if any.
-        let counterexample: RefCell<(Bytes, RawCallResult)> = RefCell::default();
+        let counterexample: RefCell<CounterExampleData> = RefCell::new(CounterExampleData {
+            calldata: Bytes::default(),
+            call: RawCallResult::default(),
+            safe_to_re_execute: true,
+        });
 
         // We want to collect at least one trace which will be displayed to user.
         let max_traces_to_collect = std::cmp::max(1, self.config.gas_report_samples) as usize;
@@ -136,7 +142,7 @@ impl FuzzedExecutor {
                     // our failure - when a fuzz case fails, proptest will try
                     // to run at least one more case to find a minimal failure
                     // case.
-                    let call_res = _counterexample.1.result.clone();
+                    let call_res = _counterexample.call.result.clone();
                     *counterexample.borrow_mut() = _counterexample;
                     // HACK: we have to use an empty string here to denote `None`
                     let reason = rd.maybe_decode(&call_res, Some(status));
@@ -145,7 +151,11 @@ impl FuzzedExecutor {
             }
         });
 
-        let (calldata, call) = counterexample.into_inner();
+        let CounterExampleData {
+            calldata,
+            call,
+            safe_to_re_execute,
+        } = counterexample.into_inner();
 
         let mut traces = traces.into_inner();
         let last_run_traces = if run_result.is_ok() {
@@ -194,9 +204,13 @@ impl FuzzedExecutor {
                     vec![]
                 };
 
-                result.counterexample = Some(CounterExample::Single(
-                    BaseCounterExample::from_fuzz_call(calldata, args, call.traces),
-                ));
+                result.counterexample =
+                    Some(CounterExample::Single(BaseCounterExample::from_fuzz_call(
+                        calldata,
+                        args,
+                        call.traces,
+                        safe_to_re_execute,
+                    )));
             }
             _ => {}
         }
@@ -243,7 +257,11 @@ impl FuzzedExecutor {
         } else {
             Ok(FuzzOutcome::CounterExample(CounterExampleOutcome {
                 exit_reason: call.exit_reason,
-                counterexample: (calldata, call),
+                counterexample: CounterExampleData {
+                    calldata,
+                    call,
+                    safe_to_re_execute: self.executor.safe_to_re_execute(),
+                },
             }))
         }
     }

--- a/crates/foundry/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/foundry/evm/evm/src/executors/fuzz/mod.rs
@@ -81,7 +81,7 @@ impl FuzzedExecutor {
         let counterexample: RefCell<CounterExampleData> = RefCell::new(CounterExampleData {
             calldata: Bytes::default(),
             call: RawCallResult::default(),
-            safe_to_re_execute: true,
+            indeterminism_reasons: None,
         });
 
         // We want to collect at least one trace which will be displayed to user.
@@ -154,7 +154,7 @@ impl FuzzedExecutor {
         let CounterExampleData {
             calldata,
             call,
-            safe_to_re_execute,
+            indeterminism_reasons,
         } = counterexample.into_inner();
 
         let mut traces = traces.into_inner();
@@ -209,7 +209,7 @@ impl FuzzedExecutor {
                         calldata,
                         args,
                         call.traces,
-                        safe_to_re_execute,
+                        indeterminism_reasons,
                     )));
             }
             _ => {}
@@ -226,7 +226,7 @@ impl FuzzedExecutor {
         should_fail: bool,
         calldata: alloy_primitives::Bytes,
     ) -> Result<FuzzOutcome, TestCaseError> {
-        let mut call = self
+        let (mut call, indeterminism_reasons) = self
             .executor
             .call_raw(self.sender, address, calldata.clone(), U256::ZERO)
             .map_err(|_err| TestCaseError::fail(FuzzError::FailedContractCall))?;
@@ -260,7 +260,7 @@ impl FuzzedExecutor {
                 counterexample: CounterExampleData {
                     calldata,
                     call,
-                    safe_to_re_execute: self.executor.safe_to_re_execute(),
+                    indeterminism_reasons,
                 },
             }))
         }

--- a/crates/foundry/evm/evm/src/executors/fuzz/types.rs
+++ b/crates/foundry/evm/evm/src/executors/fuzz/types.rs
@@ -21,9 +21,19 @@ pub struct CaseOutcome {
 #[derive(Debug)]
 pub struct CounterExampleOutcome {
     /// Minimal reproduction test case for failing test
-    pub counterexample: (Bytes, RawCallResult),
+    pub counterexample: CounterExampleData,
     /// The status of the call
     pub exit_reason: InstructionResult,
+}
+
+#[derive(Debug)]
+pub struct CounterExampleData {
+    /// The calldata of the call
+    pub calldata: Bytes,
+    /// The call result
+    pub call: RawCallResult,
+    /// Whether when re-executing the calls the same results are guaranteed.
+    pub safe_to_re_execute: bool,
 }
 
 /// Outcome of a single fuzz

--- a/crates/foundry/evm/evm/src/executors/fuzz/types.rs
+++ b/crates/foundry/evm/evm/src/executors/fuzz/types.rs
@@ -1,4 +1,5 @@
 use alloy_primitives::Bytes;
+use foundry_evm_core::backend::IndeterminismReasons;
 use foundry_evm_coverage::HitMaps;
 use foundry_evm_fuzz::FuzzCase;
 use foundry_evm_traces::CallTraceArena;
@@ -32,8 +33,9 @@ pub struct CounterExampleData {
     pub calldata: Bytes,
     /// The call result
     pub call: RawCallResult,
-    /// Whether when re-executing the calls the same results are guaranteed.
-    pub safe_to_re_execute: bool,
+    /// If re-executing the counter example is not guaranteed to yield the same
+    /// results, this field contains the reason why.
+    pub indeterminism_reasons: Option<IndeterminismReasons>,
 }
 
 /// Outcome of a single fuzz

--- a/crates/foundry/evm/evm/src/executors/invariant/replay.rs
+++ b/crates/foundry/evm/evm/src/executors/invariant/replay.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use alloy_dyn_abi::JsonAbiExt;
 use alloy_primitives::Log;
-use edr_solidity::{contract_decoder::NestedTraceDecoder, solidity_stack_trace::StackTraceEntry};
+use edr_solidity::contract_decoder::NestedTraceDecoder;
 use eyre::Result;
 use foundry_evm_core::{
     constants::CALLER,
@@ -21,7 +21,7 @@ use revm::primitives::U256;
 
 use super::{error::FailedInvariantCaseData, shrink_sequence};
 use crate::executors::{
-    stack_trace::{get_stack_trace, StackTraceError},
+    stack_trace::{get_stack_trace, StackTraceResult},
     Executor,
 };
 
@@ -46,7 +46,7 @@ pub struct ReplayRunArgs<'a, NestedTraceDecoderT> {
 #[derive(Debug, Default)]
 pub struct ReplayResult {
     pub counterexample_sequence: Vec<BaseCounterExample>,
-    pub stack_trace_result: Option<Result<Vec<StackTraceEntry>, StackTraceError>>,
+    pub stack_trace_result: Option<StackTraceResult>,
     pub revert_reason: Option<String>,
 }
 
@@ -115,17 +115,20 @@ pub fn replay_run<NestedTraceDecoderT: NestedTraceDecoder>(
             &tx.call_details.calldata,
             &ided_contracts,
             call_result.traces,
-            executor.safe_to_re_execute(),
+            /* indeterminism_reason */ None,
         ));
 
         // If this call failed, but didn't revert, this is terminal for sure.
         // If this call reverted, only exit if `fail_on_revert` is true.
         if !call_result.exit_reason.is_ok() && (fail_on_revert || !call_result.reverted) {
-            let stack_trace_result = if executor.safe_to_re_execute() {
-                contract_decoder.and_then(|decoder| get_stack_trace(decoder, traces).transpose())
-            } else {
-                None
-            };
+            let stack_trace_result =
+                if let Some(indeterminism_reasons) = executor.indeterminism_reasons() {
+                    Some(indeterminism_reasons.into())
+                } else {
+                    contract_decoder
+                        .and_then(|decoder| get_stack_trace(decoder, traces).transpose())
+                        .map(StackTraceResult::from)
+                };
             let revert_reason = revert_decoder
                 .maybe_decode(call_result.result.as_ref(), Some(call_result.exit_reason));
             return Ok(ReplayResult {
@@ -141,7 +144,7 @@ pub fn replay_run<NestedTraceDecoderT: NestedTraceDecoder>(
     // Checking after each call doesn't add valuable info for passing scenario
     // (invariant call result is always success) nor for failed scenarios
     // (invariant call result is always success until the last call that breaks it).
-    let invariant_result = executor.call_raw(
+    let (invariant_result, indeterminism_reasons) = executor.call_raw(
         CALLER,
         invariant_contract.address,
         invariant_contract
@@ -157,11 +160,14 @@ pub fn replay_run<NestedTraceDecoderT: NestedTraceDecoder>(
     ));
     logs.extend(invariant_result.logs);
 
-    let stack_trace_result = if executor.safe_to_re_execute() {
-        contract_decoder.and_then(|decoder| get_stack_trace(decoder, traces).transpose())
-    } else {
-        None
-    };
+    let stack_trace_result: Option<StackTraceResult> =
+        if let Some(indeterminism_reasons) = indeterminism_reasons {
+            Some(indeterminism_reasons.into())
+        } else {
+            contract_decoder
+                .and_then(|decoder| get_stack_trace(decoder, traces).transpose())
+                .map(StackTraceResult::from)
+        };
 
     let revert_reason = revert_decoder.maybe_decode(
         invariant_result.result.as_ref(),

--- a/crates/foundry/evm/evm/src/executors/invariant/replay.rs
+++ b/crates/foundry/evm/evm/src/executors/invariant/replay.rs
@@ -144,7 +144,7 @@ pub fn replay_run<NestedTraceDecoderT: NestedTraceDecoder>(
     // Checking after each call doesn't add valuable info for passing scenario
     // (invariant call result is always success) nor for failed scenarios
     // (invariant call result is always success until the last call that breaks it).
-    let (invariant_result, indeterminism_reasons) = executor.call_raw(
+    let (invariant_result, cow_backend) = executor.call_raw(
         CALLER,
         invariant_contract.address,
         invariant_contract
@@ -161,7 +161,7 @@ pub fn replay_run<NestedTraceDecoderT: NestedTraceDecoder>(
     logs.extend(invariant_result.logs);
 
     let stack_trace_result: Option<StackTraceResult> =
-        if let Some(indeterminism_reasons) = indeterminism_reasons {
+        if let Some(indeterminism_reasons) = cow_backend.backend.indeterminism_reasons() {
             Some(indeterminism_reasons.into())
         } else {
             contract_decoder

--- a/crates/foundry/evm/evm/src/executors/invariant/result.rs
+++ b/crates/foundry/evm/evm/src/executors/invariant/result.rs
@@ -66,7 +66,7 @@ pub(crate) fn assert_invariants(
     }
 
     let func = invariant_contract.invariant_function;
-    let (mut call_result, _indeterminism_reasons) = executor.call_raw(
+    let (mut call_result, _cow_backend) = executor.call_raw(
         CALLER,
         invariant_contract.address,
         func.abi_encode_input(&[])

--- a/crates/foundry/evm/evm/src/executors/invariant/result.rs
+++ b/crates/foundry/evm/evm/src/executors/invariant/result.rs
@@ -66,7 +66,7 @@ pub(crate) fn assert_invariants(
     }
 
     let func = invariant_contract.invariant_function;
-    let mut call_result = executor.call_raw(
+    let (mut call_result, _indeterminism_reasons) = executor.call_raw(
         CALLER,
         invariant_contract.address,
         func.abi_encode_input(&[])

--- a/crates/foundry/evm/evm/src/executors/invariant/shrink.rs
+++ b/crates/foundry/evm/evm/src/executors/invariant/shrink.rs
@@ -94,7 +94,7 @@ pub(crate) fn shrink_sequence(
 
     // Special case test: the invariant is *unsatisfiable* - it took 0 calls to
     // break the invariant -- consider emitting a warning.
-    let error_call_result = executor.call_raw(
+    let (error_call_result, _indeterminism_reasons) = executor.call_raw(
         CALLER,
         failed_case.addr,
         failed_case.func.clone(),
@@ -156,7 +156,8 @@ pub fn check_sequence(
     }
 
     // Check the invariant for call sequence.
-    let mut call_result = executor.call_raw(CALLER, test_address, test_function, U256::ZERO)?;
+    let (mut call_result, _indeterminism_reasons) =
+        executor.call_raw(CALLER, test_address, test_function, U256::ZERO)?;
     Ok((
         executor.is_raw_call_success(
             test_address,

--- a/crates/foundry/evm/evm/src/executors/invariant/shrink.rs
+++ b/crates/foundry/evm/evm/src/executors/invariant/shrink.rs
@@ -94,7 +94,7 @@ pub(crate) fn shrink_sequence(
 
     // Special case test: the invariant is *unsatisfiable* - it took 0 calls to
     // break the invariant -- consider emitting a warning.
-    let (error_call_result, _indeterminism_reasons) = executor.call_raw(
+    let (error_call_result, _cow_backend) = executor.call_raw(
         CALLER,
         failed_case.addr,
         failed_case.func.clone(),
@@ -156,7 +156,7 @@ pub fn check_sequence(
     }
 
     // Check the invariant for call sequence.
-    let (mut call_result, _indeterminism_reasons) =
+    let (mut call_result, _cow_backend) =
         executor.call_raw(CALLER, test_address, test_function, U256::ZERO)?;
     Ok((
         executor.is_raw_call_success(

--- a/crates/foundry/evm/evm/src/executors/mod.rs
+++ b/crates/foundry/evm/evm/src/executors/mod.rs
@@ -597,6 +597,11 @@ impl Executor {
 
         EnvWithHandlerCfg::new_with_spec_id(Box::new(env), self.env.handler_cfg.spec_id)
     }
+
+    /// Whether when re-executing the calls the same results are guaranteed.
+    pub fn safe_to_re_execute(&self) -> bool {
+        self.backend.safe_to_re_execute()
+    }
 }
 
 /// Represents the context after an execution error occurred.

--- a/crates/foundry/evm/evm/src/executors/mod.rs
+++ b/crates/foundry/evm/evm/src/executors/mod.rs
@@ -36,6 +36,7 @@ use crate::inspectors::{Cheatcodes, InspectorData, InspectorStack};
 
 mod builder;
 pub use builder::ExecutorBuilder;
+use foundry_evm_core::backend::IndeterminismReasons;
 
 pub mod fuzz;
 pub use fuzz::FuzzedExecutor;
@@ -314,7 +315,7 @@ impl Executor {
         rd: Option<&RevertDecoder>,
     ) -> Result<CallResult, EvmError> {
         let calldata = Bytes::from(func.abi_encode_input(args)?);
-        let result = self.call_raw(from, to, calldata, value)?;
+        let (result, _indeterminism_reasons) = self.call_raw(from, to, calldata, value)?;
         result.into_decoded_result(func, rd)
     }
 
@@ -330,7 +331,7 @@ impl Executor {
         rd: Option<&RevertDecoder>,
     ) -> Result<CallResult<C::Return>, EvmError> {
         let calldata = Bytes::from(args.abi_encode());
-        let mut raw = self.call_raw(from, to, calldata, value)?;
+        let (mut raw, _indeterminism_reasons) = self.call_raw(from, to, calldata, value)?;
         raw = raw.into_result(rd)?;
         Ok(CallResult {
             decoded_result: C::abi_decode_returns(&raw.result, false)?,
@@ -345,13 +346,17 @@ impl Executor {
     /// This intended for fuzz calls, which try to minimize [Backend] clones by
     /// using a Cow of the underlying [Backend] so it only gets cloned when
     /// cheatcodes that require mutable access are used.
+    ///
+    /// This call returns the indeterminism reason in addition to the call
+    /// result, as the indeterminism reasons are not persisted on the executor's
+    /// backend.
     pub fn call_raw(
         &self,
         from: Address,
         to: Address,
         calldata: Bytes,
         value: U256,
-    ) -> eyre::Result<RawCallResult> {
+    ) -> eyre::Result<(RawCallResult, Option<IndeterminismReasons>)> {
         let mut inspector = self.inspector.clone();
         // Build VM
         let mut env = self.build_test_env(from, TxKind::Call(to), calldata, value);
@@ -360,7 +365,10 @@ impl Executor {
 
         // Persist the snapshot failure recorded on the fuzz backend wrapper.
         let has_snapshot_failure = db.has_snapshot_failure();
-        convert_executed_result(env, inspector, result, has_snapshot_failure)
+        Ok((
+            convert_executed_result(env, inspector, result, has_snapshot_failure)?,
+            db.backend.indeterminism_reasons(),
+        ))
     }
 
     /// Execute the transaction configured in `env.tx` and commit the changes
@@ -601,6 +609,10 @@ impl Executor {
     /// Whether when re-executing the calls the same results are guaranteed.
     pub fn safe_to_re_execute(&self) -> bool {
         self.backend.safe_to_re_execute()
+    }
+
+    pub fn indeterminism_reasons(&self) -> Option<IndeterminismReasons> {
+        self.backend.indeterminism_reasons()
     }
 }
 

--- a/crates/foundry/evm/fuzz/src/lib.rs
+++ b/crates/foundry/evm/fuzz/src/lib.rs
@@ -53,6 +53,9 @@ pub struct BaseCounterExample {
     pub signature: Option<String>,
     /// Args used to call the function
     pub args: Option<String>,
+    /// Whether re-executing the counter example is guaranteed to yield the same
+    /// results.
+    pub safe_to_re_execute: bool,
     /// Traces
     #[serde(skip)]
     pub traces: Option<CallTraceArena>,
@@ -67,6 +70,7 @@ impl BaseCounterExample {
         bytes: &Bytes,
         contracts: &ContractsByAddress,
         traces: Option<CallTraceArena>,
+        safe_to_re_execute: bool,
     ) -> Self {
         if let Some((name, abi)) = &contracts.get(&addr) {
             if let Some(func) = abi.functions().find(|f| f.selector() == bytes[..4]) {
@@ -84,6 +88,7 @@ impl BaseCounterExample {
                                 .to_string(),
                         ),
                         traces,
+                        safe_to_re_execute,
                     };
                 }
             }
@@ -97,6 +102,7 @@ impl BaseCounterExample {
             signature: None,
             args: None,
             traces,
+            safe_to_re_execute,
         }
     }
 
@@ -105,6 +111,7 @@ impl BaseCounterExample {
         bytes: Bytes,
         args: Vec<DynSolValue>,
         traces: Option<CallTraceArena>,
+        safe_to_re_execute: bool,
     ) -> Self {
         BaseCounterExample {
             sender: None,
@@ -118,6 +125,7 @@ impl BaseCounterExample {
                     .to_string(),
             ),
             traces,
+            safe_to_re_execute,
         }
     }
 }

--- a/js/integration-tests/solidity-tests/contracts/ForkCheatcode.t.sol
+++ b/js/integration-tests/solidity-tests/contracts/ForkCheatcode.t.sol
@@ -11,8 +11,20 @@ contract ForkCheatcodeTest is Test {
         fork = vm.createSelectFork("alchemyMainnet", 20_000_000);
     }
 
-    function testBlockNumber() public {
+    function testBlockNumber() public view {
         assertEq(fork, vm.activeFork());
         assertEq(block.number, 20_000_000);
+    }
+}
+
+contract LatestForkCheatcodeTest is Test {
+    uint256 fork;
+
+    function setUp() public {
+        fork = vm.createSelectFork("alchemyMainnet");
+    }
+
+    function testThatFails() public view {
+        revert("fail");
     }
 }

--- a/js/integration-tests/solidity-tests/contracts/ImpureFuzzSetup.sol
+++ b/js/integration-tests/solidity-tests/contracts/ImpureFuzzSetup.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/src/Test.sol";
+
+// Contract to be tested with overflow vulnerability
+contract MyContract {
+    function addWithOverflow(uint256 a, uint256 b) public pure returns (uint256) {
+        return a + b;
+    }
+}
+
+// A fuzz function that calls an impure function during setup that errors.
+contract ImpureFuzzSetup is Test {
+    MyContract public myContract;
+    string fileContents;
+
+    function setUp() public {
+        myContract = new MyContract();
+        fileContents = vm.readFile("./invalid-path");
+    }
+
+    function testFuzzAddWithOverflow(uint256 a, uint256 b) public {
+        uint256 result = myContract.addWithOverflow(a, b);
+        assertEq(result, a + b);
+    }
+}
+
+// A fuzz function that calls an impure function during contract execution that errors.
+contract ImpureFuzzTest is Test {
+    MyContract public myContract;
+
+    function setUp() public {
+        myContract = new MyContract();
+    }
+
+    function testFuzzAddWithOverflow(uint256 a, uint256 b) public {
+        uint256 result = myContract.addWithOverflow(a, b);
+        assertEq(result, a + b);
+        // Impure cheatcode + error
+        assertEq(vm.unixTime(), 42);
+    }
+}

--- a/js/integration-tests/solidity-tests/contracts/Invariant.t.sol
+++ b/js/integration-tests/solidity-tests/contracts/Invariant.t.sol
@@ -49,3 +49,16 @@ contract BuggyInvariantTest is Test {
     }
 }
 
+// Test where the invariant test is failing, but uses an impure cheatcode so we can't generate stack traces.
+contract ImpureInvariantTest is Test {
+    StochasticWrongContract wrongContract;
+
+    function setUp() external {
+        wrongContract = new StochasticWrongContract();
+    }
+
+    function invariant() external {
+        assertEq(wrongContract.a() + wrongContract.b(), wrongContract.both());
+        assertEq(vm.unixTime(), 43);
+    }
+}

--- a/js/integration-tests/solidity-tests/test/unit.ts
+++ b/js/integration-tests/solidity-tests/test/unit.ts
@@ -44,7 +44,7 @@ describe("Unit tests", () => {
     assert.equal(failedTests, 1);
     assert.equal(totalTests, 2);
     // When using forking from latest block, no stack trace should be generated as re-execution is unsafe.
-    assert.equal(stackTraces.get("testThatFails()"), undefined);
+    assert.equal(stackTraces.get("testThatFails()")?.globalForkLatest, true);
   });
 
   it("ContractEnvironment", async function () {
@@ -170,7 +170,14 @@ describe("Unit tests", () => {
     assert.equal(totalTests, 1);
 
     // When using forking from latest block, no stack trace should be generated as re-execution is unsafe.
-    assert.equal(stackTraces.get("testThatFails()"), undefined);
+    const impureCheatcodes =
+      stackTraces.get("testThatFails()")?.impureCheatcodes ?? [];
+    assert.equal(
+      impureCheatcodes.filter((cheatcode) =>
+        cheatcode.includes("createSelectFork")
+      ).length,
+      1
+    );
   });
 
   it("FailingSetup", async function () {

--- a/js/integration-tests/solidity-tests/test/unit.ts
+++ b/js/integration-tests/solidity-tests/test/unit.ts
@@ -31,6 +31,22 @@ describe("Unit tests", () => {
     assert.equal(totalTests, 2);
   });
 
+  it("Latest global fork stack trace", async function () {
+    if (testContext.rpcUrl === undefined) {
+      this.skip();
+    }
+
+    const { totalTests, failedTests, stackTraces } =
+      await testContext.runTestsWithStats("SuccessAndFailureTest", {
+        ethRpcUrl: testContext.rpcUrl,
+      });
+
+    assert.equal(failedTests, 1);
+    assert.equal(totalTests, 2);
+    // When using forking from latest block, no stack trace should be generated as re-execution is unsafe.
+    assert.equal(stackTraces.get("testThatFails()"), undefined);
+  });
+
   it("ContractEnvironment", async function () {
     const { totalTests, failedTests } = await testContext.runTestsWithStats(
       "ContractEnvironmentTest",
@@ -136,6 +152,25 @@ describe("Unit tests", () => {
 
     assert.equal(failedTests, 0);
     assert.equal(totalTests, 1);
+  });
+
+  it("Latest fork cheatcode", async function () {
+    if (testContext.rpcUrl === undefined) {
+      this.skip();
+    }
+
+    const { totalTests, failedTests, stackTraces } =
+      await testContext.runTestsWithStats("LatestForkCheatcodeTest", {
+        rpcEndpoints: {
+          alchemyMainnet: testContext.rpcUrl,
+        },
+      });
+
+    assert.equal(failedTests, 1);
+    assert.equal(totalTests, 1);
+
+    // When using forking from latest block, no stack trace should be generated as re-execution is unsafe.
+    assert.equal(stackTraces.get("testThatFails()"), undefined);
   });
 
   it("FailingSetup", async function () {


### PR DESCRIPTION
We generate stack traces via re-execution of failing tests for performance reasons (stack traces need expensive EVM step tracing). 

Normally EVM execution is deterministic: if you apply the same calls on top of the same state you get the same results. Solidity tests have some features that break this deterministic behavior:
- Forking a remote with the "latest" block number.[^1] 
- Cheatcodes that are impure in the sense that their output depends on things outside of the state managed by EDR (e.g. the `ffi` cheatcode that executes arbitrary CLI commands or cheatcodes that access the file system).

The changes in this PR ensure that we don't generate stack traces if EVM execution is indeterministic. The current changes don't implement notifying the user about this yet, as how we go about that will need a design doc first to align with the HH team. Instead the `TestResult::stackTrace()` method just returns `None` if we prevented stack trace generation.

If we detect impure cheatcode usage, we collect the Solidity declaration of the cheatcode for use later in warnings/error messages (example declaration: `"function createSelectFork(string calldata urlOrAlias) external returns (uint256 forkId);"`).

[^1]: Technically, forking with unsafe block numbers is inderministic too as they can be reorged out, but we decided to ignore this for now as unsafe block numbers become safe quickly, so if a user experiences problems because of this, they get resolved if they rerun their tests.