### PR TITLE
fix: optimize cow backend impure cheatcode collection

### DIFF
--- a/crates/foundry/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/foundry/evm/evm/src/executors/fuzz/mod.rs
@@ -260,7 +260,7 @@ impl FuzzedExecutor {
                 counterexample: CounterExampleData {
                     calldata,
                     call,
-                    indeterminism_reasons: cow_backend.backend.indeterminism_reasons(),
+                    indeterminism_reasons: cow_backend.indeterminism_reasons(),
                 },
             }))
         }

--- a/crates/foundry/evm/evm/src/executors/invariant/replay.rs
+++ b/crates/foundry/evm/evm/src/executors/invariant/replay.rs
@@ -161,7 +161,7 @@ pub fn replay_run<NestedTraceDecoderT: NestedTraceDecoder>(
     logs.extend(invariant_result.logs);
 
     let stack_trace_result: Option<StackTraceResult> =
-        if let Some(indeterminism_reasons) = cow_backend.backend.indeterminism_reasons() {
+        if let Some(indeterminism_reasons) = cow_backend.indeterminism_reasons() {
             Some(indeterminism_reasons.into())
         } else {
             contract_decoder


### PR DESCRIPTION
Optimize impure cheatcode collection when using `CowBackend`: store the impure cheatcodes on the `CowBackend` instead of the inner `Backend` to avoid having to clone it to record impure cheatcodes.