### PR TITLE
Add contributor guidelines for small PRs and airdrop farming

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+## Note about small PRs and airdrop farming
+
+We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:
+
+- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
+- It introduces inconsequential changes (e.g. rewording phrases)
+- The author of the PR does not respond in a timely manner
+- We suspect the Github account of the author was created for airdrop farming


### PR DESCRIPTION
For now just added guidelines on small PRs and airdrop farming based on Hardhat's [CONTRIBUTING](https://github.com/NomicFoundation/hardhat/blob/main/CONTRIBUTING.md). We should consider extending this with development guidelines on EDR (filed https://github.com/NomicFoundation/edr/issues/829).