### PR TITLE
Normalise rpc debug trace format

### DIFF
--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -141,6 +141,34 @@ export interface DebugTraceLogItem {
   /** Map of all stored values with keys and values encoded as hex strings. */
   storage?: Record<string, string>
 }
+export interface RpcDebugTraceResult {
+  failed: boolean
+  gas: bigint
+  returnValue: string
+  structLogs: Array<RpcDebugTraceLogItem>
+}
+export interface RpcDebugTraceLogItem {
+  /** Program Counter */
+  pc: bigint
+  /** Name of the operation */
+  op: string
+  /** Gas left before executing this operation as hex number. */
+  gas: bigint
+  /** Gas cost of this operation as hex number. */
+  gasCost: bigint
+  /** Array of all values (hex numbers) on the stack */
+  stack?: Array<string>
+  /** Depth of the call stack */
+  depth: bigint
+  /** Size of memory array */
+  memSize: bigint
+  /** Description of an error as a hex string. */
+  error?: string
+  /** Array of all allocated values as hex strings. */
+  memory?: Array<string>
+  /** Map of all stored values with keys and values encoded as hex strings. */
+  storage?: Record<string, string>
+}
 /** Ethereum execution log. */
 export interface ExecutionLog {
   address: Buffer

--- a/crates/edr_napi/src/debug_trace.rs
+++ b/crates/edr_napi/src/debug_trace.rs
@@ -36,3 +36,35 @@ pub struct DebugTraceLogItem {
     /// Map of all stored values with keys and values encoded as hex strings.
     pub storage: Option<HashMap<String, String>>,
 }
+
+#[napi(object)]
+pub struct RpcDebugTraceResult {
+    pub failed: bool,
+    pub gas: BigInt,
+    pub return_value: String,
+    pub struct_logs: Vec<RpcDebugTraceLogItem>,
+}
+
+#[napi(object)]
+pub struct RpcDebugTraceLogItem {
+    /// Program Counter
+    pub pc: BigInt,
+    /// Name of the operation
+    pub op: String,
+    /// Gas left before executing this operation as hex number.
+    pub gas: BigInt,
+    /// Gas cost of this operation as hex number.
+    pub gas_cost: BigInt,
+    /// Array of all values (hex numbers) on the stack
+    pub stack: Option<Vec<String>>,
+    /// Depth of the call stack
+    pub depth: BigInt,
+    /// Size of memory array
+    pub mem_size: BigInt,
+    /// Description of an error as a hex string.
+    pub error: Option<String>,
+    /// Array of all allocated values as hex strings.
+    pub memory: Option<Vec<String>>,
+    /// Map of all stored values with keys and values encoded as hex strings.
+    pub storage: Option<HashMap<String, String>>,
+}

--- a/crates/edr_provider/src/lib.rs
+++ b/crates/edr_provider/src/lib.rs
@@ -39,8 +39,10 @@ pub use self::{
     logger::{Logger, NoopLogger},
     mock::CallOverrideResult,
     requests::{
-        hardhat::rpc_types as hardhat_rpc_types, IntervalConfig as IntervalConfigRequest,
-        InvalidRequestReason, MethodInvocation, ProviderRequest, Timestamp,
+        debug::{RpcDebugTraceLogItem, RpcDebugTraceResult},
+        hardhat::rpc_types as hardhat_rpc_types,
+        IntervalConfig as IntervalConfigRequest, InvalidRequestReason, MethodInvocation,
+        ProviderRequest, Timestamp,
     },
     subscribe::*,
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
 
 patchedDependencies:
   hardhat@2.22.18:
-    hash: ci64bym4pf7pcnjf7f5gwyloqe
+    hash: f61bb4a521a243eee9a5942999b80f94e435e5149d7085db7916820f5ad460e1
     path: patches/hardhat@2.22.18.patch
 
 importers:
@@ -129,7 +129,7 @@ importers:
         version: 5.2.1(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.2.5)
       hardhat:
         specifier: 2.22.18
-        version: 2.22.18(patch_hash=ci64bym4pf7pcnjf7f5gwyloqe)(ts-node@10.9.2(@types/node@20.16.1)(typescript@5.0.4))(typescript@5.0.4)
+        version: 2.22.18(patch_hash=f61bb4a521a243eee9a5942999b80f94e435e5149d7085db7916820f5ad460e1)(ts-node@10.9.2(@types/node@20.16.1)(typescript@5.0.4))(typescript@5.0.4)
       lodash:
         specifier: ^4.17.11
         version: 4.17.21
@@ -255,7 +255,7 @@ importers:
         version: 7.0.1
       hardhat:
         specifier: 2.22.18
-        version: 2.22.18(patch_hash=ci64bym4pf7pcnjf7f5gwyloqe)(ts-node@10.9.2(@types/node@20.16.1)(typescript@5.0.4))(typescript@5.0.4)
+        version: 2.22.18(patch_hash=f61bb4a521a243eee9a5942999b80f94e435e5149d7085db7916820f5ad460e1)(ts-node@10.9.2(@types/node@20.16.1)(typescript@5.0.4))(typescript@5.0.4)
       mocha:
         specifier: ^10.0.0
         version: 10.3.0
@@ -285,10 +285,10 @@ importers:
     devDependencies:
       '@defi-wonderland/smock':
         specifier: ^2.4.0
-        version: 2.4.0(@ethersproject/abi@5.7.0)(@ethersproject/abstract-provider@5.7.0)(@ethersproject/abstract-signer@5.7.0)(@nomiclabs/hardhat-ethers@2.2.3(ethers@5.7.2)(hardhat@2.22.18(patch_hash=ci64bym4pf7pcnjf7f5gwyloqe)(ts-node@10.9.2(@types/node@20.16.1)(typescript@5.0.4))(typescript@5.0.4)))(ethers@5.7.2)(hardhat@2.22.18(patch_hash=ci64bym4pf7pcnjf7f5gwyloqe)(ts-node@10.9.2(@types/node@20.16.1)(typescript@5.0.4))(typescript@5.0.4))
+        version: 2.4.0(@ethersproject/abi@5.7.0)(@ethersproject/abstract-provider@5.7.0)(@ethersproject/abstract-signer@5.7.0)(@nomiclabs/hardhat-ethers@2.2.3(ethers@5.7.2)(hardhat@2.22.18(patch_hash=f61bb4a521a243eee9a5942999b80f94e435e5149d7085db7916820f5ad460e1)(ts-node@10.9.2(@types/node@20.16.1)(typescript@5.0.4))(typescript@5.0.4)))(ethers@5.7.2)(hardhat@2.22.18(patch_hash=f61bb4a521a243eee9a5942999b80f94e435e5149d7085db7916820f5ad460e1)(ts-node@10.9.2(@types/node@20.16.1)(typescript@5.0.4))(typescript@5.0.4))
       '@nomiclabs/hardhat-ethers':
         specifier: ^2.2.3
-        version: 2.2.3(ethers@5.7.2)(hardhat@2.22.18(patch_hash=ci64bym4pf7pcnjf7f5gwyloqe)(ts-node@10.9.2(@types/node@20.16.1)(typescript@5.0.4))(typescript@5.0.4))
+        version: 2.2.3(ethers@5.7.2)(hardhat@2.22.18(patch_hash=f61bb4a521a243eee9a5942999b80f94e435e5149d7085db7916820f5ad460e1)(ts-node@10.9.2(@types/node@20.16.1)(typescript@5.0.4))(typescript@5.0.4))
       '@types/node':
         specifier: ^20.0.0
         version: 20.16.1
@@ -300,7 +300,7 @@ importers:
         version: 5.7.2
       hardhat:
         specifier: 2.22.18
-        version: 2.22.18(patch_hash=ci64bym4pf7pcnjf7f5gwyloqe)(ts-node@10.9.2(@types/node@20.16.1)(typescript@5.0.4))(typescript@5.0.4)
+        version: 2.22.18(patch_hash=f61bb4a521a243eee9a5942999b80f94e435e5149d7085db7916820f5ad460e1)(ts-node@10.9.2(@types/node@20.16.1)(typescript@5.0.4))(typescript@5.0.4)
       mocha:
         specifier: ^10.0.0
         version: 10.3.0
@@ -3351,16 +3351,16 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@defi-wonderland/smock@2.4.0(@ethersproject/abi@5.7.0)(@ethersproject/abstract-provider@5.7.0)(@ethersproject/abstract-signer@5.7.0)(@nomiclabs/hardhat-ethers@2.2.3(ethers@5.7.2)(hardhat@2.22.18(patch_hash=ci64bym4pf7pcnjf7f5gwyloqe)(ts-node@10.9.2(@types/node@20.16.1)(typescript@5.0.4))(typescript@5.0.4)))(ethers@5.7.2)(hardhat@2.22.18(patch_hash=ci64bym4pf7pcnjf7f5gwyloqe)(ts-node@10.9.2(@types/node@20.16.1)(typescript@5.0.4))(typescript@5.0.4))':
+  '@defi-wonderland/smock@2.4.0(@ethersproject/abi@5.7.0)(@ethersproject/abstract-provider@5.7.0)(@ethersproject/abstract-signer@5.7.0)(@nomiclabs/hardhat-ethers@2.2.3(ethers@5.7.2)(hardhat@2.22.18(patch_hash=f61bb4a521a243eee9a5942999b80f94e435e5149d7085db7916820f5ad460e1)(ts-node@10.9.2(@types/node@20.16.1)(typescript@5.0.4))(typescript@5.0.4)))(ethers@5.7.2)(hardhat@2.22.18(patch_hash=f61bb4a521a243eee9a5942999b80f94e435e5149d7085db7916820f5ad460e1)(ts-node@10.9.2(@types/node@20.16.1)(typescript@5.0.4))(typescript@5.0.4))':
     dependencies:
       '@ethersproject/abi': 5.7.0
       '@ethersproject/abstract-provider': 5.7.0
       '@ethersproject/abstract-signer': 5.7.0
       '@nomicfoundation/ethereumjs-util': 9.0.4
-      '@nomiclabs/hardhat-ethers': 2.2.3(ethers@5.7.2)(hardhat@2.22.18(patch_hash=ci64bym4pf7pcnjf7f5gwyloqe)(ts-node@10.9.2(@types/node@20.16.1)(typescript@5.0.4))(typescript@5.0.4))
+      '@nomiclabs/hardhat-ethers': 2.2.3(ethers@5.7.2)(hardhat@2.22.18(patch_hash=f61bb4a521a243eee9a5942999b80f94e435e5149d7085db7916820f5ad460e1)(ts-node@10.9.2(@types/node@20.16.1)(typescript@5.0.4))(typescript@5.0.4))
       diff: 5.0.0
       ethers: 5.7.2
-      hardhat: 2.22.18(patch_hash=ci64bym4pf7pcnjf7f5gwyloqe)(ts-node@10.9.2(@types/node@20.16.1)(typescript@5.0.4))(typescript@5.0.4)
+      hardhat: 2.22.18(patch_hash=f61bb4a521a243eee9a5942999b80f94e435e5149d7085db7916820f5ad460e1)(ts-node@10.9.2(@types/node@20.16.1)(typescript@5.0.4))(typescript@5.0.4)
       lodash.isequal: 4.5.0
       lodash.isequalwith: 4.4.0
       rxjs: 7.8.1
@@ -3876,10 +3876,10 @@ snapshots:
       '@nomicfoundation/solidity-analyzer-win32-ia32-msvc': 0.1.1
       '@nomicfoundation/solidity-analyzer-win32-x64-msvc': 0.1.1
 
-  '@nomiclabs/hardhat-ethers@2.2.3(ethers@5.7.2)(hardhat@2.22.18(patch_hash=ci64bym4pf7pcnjf7f5gwyloqe)(ts-node@10.9.2(@types/node@20.16.1)(typescript@5.0.4))(typescript@5.0.4))':
+  '@nomiclabs/hardhat-ethers@2.2.3(ethers@5.7.2)(hardhat@2.22.18(patch_hash=f61bb4a521a243eee9a5942999b80f94e435e5149d7085db7916820f5ad460e1)(ts-node@10.9.2(@types/node@20.16.1)(typescript@5.0.4))(typescript@5.0.4))':
     dependencies:
       ethers: 5.7.2
-      hardhat: 2.22.18(patch_hash=ci64bym4pf7pcnjf7f5gwyloqe)(ts-node@10.9.2(@types/node@20.16.1)(typescript@5.0.4))(typescript@5.0.4)
+      hardhat: 2.22.18(patch_hash=f61bb4a521a243eee9a5942999b80f94e435e5149d7085db7916820f5ad460e1)(ts-node@10.9.2(@types/node@20.16.1)(typescript@5.0.4))(typescript@5.0.4)
 
   '@pkgr/core@0.1.1': {}
 
@@ -5193,7 +5193,7 @@ snapshots:
 
   hard-rejection@2.1.0: {}
 
-  hardhat@2.22.18(patch_hash=ci64bym4pf7pcnjf7f5gwyloqe)(ts-node@10.9.2(@types/node@20.16.1)(typescript@5.0.4))(typescript@5.0.4):
+  hardhat@2.22.18(patch_hash=f61bb4a521a243eee9a5942999b80f94e435e5149d7085db7916820f5ad460e1)(ts-node@10.9.2(@types/node@20.16.1)(typescript@5.0.4))(typescript@5.0.4):
     dependencies:
       '@ethersproject/abi': 5.7.0
       '@metamask/eth-sig-util': 4.0.1


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #783 

## Changes

- Moved normalisation that Hardhat does on debug trace into EDR.
- Added new types `RpcDebugTraceResult` and `RpcDebugTraceLogItem` that conform to expected structure.
- Added tests to validate trace structure against expected normalised structure.

## How was this tested?

- Compared trace manually with output from Geth.
- Wrote test to validate normalised structure.
- Ran tests and verified all tests pass including old ones.
