### PR TITLE
feat: error for unsupported cheatcodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2663,7 +2663,8 @@ dependencies = [
  "edr_common",
  "edr_defaults",
  "eyre",
- "foundry-cheatcodes-spec",
+ "foundry-cheatcodes-spec 0.3.8",
+ "foundry-cheatcodes-spec 1.0.0",
  "foundry-compilers",
  "foundry-evm-core",
  "itertools 0.12.1",
@@ -2690,6 +2691,16 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "foundry-cheatcodes-spec"
+version = "1.0.0"
+source = "git+https://github.com/foundry-rs/foundry?rev=539fd96#539fd9611e213c0e72e5524b6030d00bf21c9587"
+dependencies = [
+ "alloy-sol-types 0.8.22",
+ "foundry-macros",
+ "serde",
 ]
 
 [[package]]
@@ -2856,7 +2867,7 @@ dependencies = [
  "edr_solidity",
  "edr_test_utils",
  "eyre",
- "foundry-cheatcodes-spec",
+ "foundry-cheatcodes-spec 0.3.8",
  "foundry-compilers",
  "foundry-fork-db",
  "futures",
@@ -2961,6 +2972,17 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "foundry-macros"
+version = "1.0.0"
+source = "git+https://github.com/foundry-rs/foundry?rev=539fd96#539fd9611e213c0e72e5524b6030d00bf21c9587"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
 ]
 
 [[package]]

--- a/crates/foundry/cheatcodes/Cargo.toml
+++ b/crates/foundry/cheatcodes/Cargo.toml
@@ -9,6 +9,8 @@ edition.workspace = true
 edr_defaults.workspace = true
 
 foundry-cheatcodes-spec.workspace = true
+# Version 2025-03-26
+upstream-foundry-cheatcodes-spec = { git = "https://github.com/foundry-rs/foundry", rev = "539fd96", package = "foundry-cheatcodes-spec" }
 edr_common.workspace = true
 foundry-compilers.workspace = true
 foundry-evm-core.workspace = true

--- a/js/integration-tests/solidity-tests/contracts/UnsupportedCheatcode.t.sol
+++ b/js/integration-tests/solidity-tests/contracts/UnsupportedCheatcode.t.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/src/Test.sol";
+
+// Test that we report legible error messages for unsupported cheatcodes
+contract UnsupportedCheatcodeTest is Test {
+    function testUnsupportedCheatcode() public {
+        vm.broadcast();
+    }
+}
+

--- a/js/integration-tests/solidity-tests/package.json
+++ b/js/integration-tests/solidity-tests/package.json
@@ -11,7 +11,7 @@
     "@types/mocha": ">=9.1.0",
     "@types/node": "^20.0.0",
     "chai": "^4.3.6",
-    "forge-std": "github:foundry-rs/forge-std#v1.9.5",
+    "forge-std": "github:foundry-rs/forge-std#v1.9.6",
     "hardhat": "2.22.18",
     "prettier": "^3.2.5",
     "ts-node": "^10.8.0",

--- a/js/integration-tests/solidity-tests/test/unit.ts
+++ b/js/integration-tests/solidity-tests/test/unit.ts
@@ -213,4 +213,22 @@ describe("Unit tests", () => {
     assert.equal(failedTests, 0);
     assert.equal(totalTests, 1);
   });
+
+  it("UnsupportedCheatcode", async function () {
+    const { totalTests, failedTests, stackTraces } =
+      await testContext.runTestsWithStats("UnsupportedCheatcodeTest");
+
+    assertStackTraces(
+      stackTraces.get("testUnsupportedCheatcode()"),
+      "cheatcode 'broadcast()' is not supported",
+      [
+        {
+          contract: "UnsupportedCheatcodeTest",
+          function: "testUnsupportedCheatcode",
+        },
+      ]
+    );
+    assert.equal(failedTests, 1);
+    assert.equal(totalTests, 1);
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -399,8 +399,8 @@ importers:
         specifier: ^4.3.6
         version: 4.4.1
       forge-std:
-        specifier: github:foundry-rs/forge-std#v1.9.5
-        version: https://codeload.github.com/foundry-rs/forge-std/tar.gz/b93cf4bc34ff214c099dc970b153f85ade8c9f66
+        specifier: github:foundry-rs/forge-std#v1.9.6
+        version: https://codeload.github.com/foundry-rs/forge-std/tar.gz/3b20d60d14b343ee4f908cb8079495c07f5e8981
       hardhat:
         specifier: 2.22.18
         version: 2.22.18(patch_hash=nokgagpzpldos6zqjhxdh4djpm)(ts-node@10.9.2(@types/node@20.16.1)(typescript@5.5.4))(typescript@5.5.4)
@@ -1938,9 +1938,9 @@ packages:
   for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
 
-  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/b93cf4bc34ff214c099dc970b153f85ade8c9f66:
-    resolution: {tarball: https://codeload.github.com/foundry-rs/forge-std/tar.gz/b93cf4bc34ff214c099dc970b153f85ade8c9f66}
-    version: 1.9.5
+  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/3b20d60d14b343ee4f908cb8079495c07f5e8981:
+    resolution: {tarball: https://codeload.github.com/foundry-rs/forge-std/tar.gz/3b20d60d14b343ee4f908cb8079495c07f5e8981}
+    version: 1.9.6
 
   fp-ts@1.19.3:
     resolution: {integrity: sha512-H5KQDspykdHuztLTg+ajGN0Z2qUjcEf3Ybxc6hLt0k7/zPkn29XnKnxlBPyW2XIddWrGaJBzBl4VLYOtk39yZg==}
@@ -5284,7 +5284,7 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
-  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/b93cf4bc34ff214c099dc970b153f85ade8c9f66: {}
+  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/3b20d60d14b343ee4f908cb8079495c07f5e8981: {}
 
   fp-ts@1.19.3: {}
 


### PR DESCRIPTION
Adds better error messages when invoking unsupported cheatcodes. Previously we'd just return `"unknown selector 0xafc98040"`, now we return `"cheatcode 'broadcast()' is not supported"` instead.

In order to know if an unknown selector refers to an unsupported cheatcode, we have to have access to the latest cheatcode abi from the Foundry repo. I solved this by including the `foundry-cheatcodes-spec` package from the Foundry repo as a git dependency. This'll not work if we want to publish the `edr_solidity_tests` package on crates.io, but I think it's fine until then. The alternative would be to copy over the cheatcode abi from the Foundry repo, but that's more difficult to keep up-to-date.

No changeset needed, as we don't use changesets for the `feat/solidity-tests` branch.