### PR TITLE
fix: napi converts () to undefined so use Either type for reason

### DIFF
--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -1094,7 +1094,7 @@ export declare class TestResult {
   /** See [edr_solidity_tests::result::TestResult::status] */
   readonly status: TestStatus
   /** See [edr_solidity_tests::result::TestResult::reason] */
-  readonly reason?: string
+  readonly reason?: string | undefined
   /** See [edr_solidity_tests::result::TestResult::counterexample] */
   readonly counterexample?: BaseCounterExample | Array<BaseCounterExample>
   /** See [edr_solidity_tests::result::TestResult::decoded_logs] */

--- a/crates/edr_napi/src/solidity_tests/test_results.rs
+++ b/crates/edr_napi/src/solidity_tests/test_results.rs
@@ -71,7 +71,7 @@ pub struct TestResult {
     pub status: TestStatus,
     /// See [edr_solidity_tests::result::TestResult::reason]
     #[napi(readonly)]
-    pub reason: Option<String>,
+    pub reason: Option<Either<String, ()>>,
     /// See [edr_solidity_tests::result::TestResult::counterexample]
     #[napi(readonly)]
     pub counterexample: Option<Either<BaseCounterExample, Vec<BaseCounterExample>>>,
@@ -191,7 +191,9 @@ impl From<(String, edr_solidity_tests::result::TestResult)> for TestResult {
         Self {
             name,
             status: test_result.status.into(),
-            reason: test_result.reason,
+            reason: test_result
+                .reason
+                .map_or(Some(Either::B(())), |reason| Some(Either::A(reason))),
             counterexample: test_result
                 .counterexample
                 .map(|counterexample| match counterexample {


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #796

## Changes

- Changed the type of `reason` to `Option<Either<String, ()>>`

## How was this tested?

- By existing tests. All tests pass
