### PR TITLE
ci: update op workflow to match 'feat/multichain'

### DIFF
--- a/.github/workflows/test-recent-optimism-block.yml
+++ b/.github/workflows/test-recent-optimism-block.yml
@@ -1,4 +1,4 @@
-name: Run a recent full Optimism block in the Hardhat Network
+name: Run a recent full OP block in the Hardhat Network
 
 on:
   schedule:
@@ -6,8 +6,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  test-recent-optimism-block:
-    name: Test recent Optimism block
+  test-recent-op-block:
+    name: Test recent OP block
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -21,9 +21,9 @@ jobs:
         with:
           path: |
             **/edr-cache
-          key: test-recent-optimism-block-rpc-cache-v1
+          key: test-recent-op-block-rpc-cache-v1
 
-      - run: cargo replay-block -u ${{ secrets.ALCHEMY_URL }} -c optimism
+      - run: cargo replay-block -u ${{ secrets.ALCHEMY_URL }} -c op
 
       - name: Notify failures
         if: failure()


### PR DESCRIPTION
We renamed Optimism to OP in `feat/multichain`. As our scheduled CI jobs are run from workflows in `main`, we also need to add this change to the `main` branch.