### PR TITLE
edr-0.12.0-alpha.0

### DIFF
--- a/.changeset/eight-otters-love.md
+++ b/.changeset/eight-otters-love.md
@@ -1,5 +1,0 @@
----
-"@nomicfoundation/edr": minor
----
-
-Removed support for pre-Byzantium root field from RPC receipts

--- a/.changeset/nine-wasps-promise.md
+++ b/.changeset/nine-wasps-promise.md
@@ -1,5 +1,0 @@
----
-"@nomicfoundation/edr": minor
----
-
-Replaces the Provider constructor with an API for registering and creating chain-specific providers in the EdrContext

--- a/crates/edr_napi/CHANGELOG.md
+++ b/crates/edr_napi/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @nomicfoundation/edr
 
+## 0.12.0-alpha.0
+
+### Minor Changes
+
+- c9cc954: Removed support for pre-Byzantium root field from RPC receipts
+- 2a19726: Replaced the Provider constructor with an API for registering and creating chain-specific providers in the EdrContext
+
 ## 0.11.0
 
 ### Minor Changes

--- a/crates/edr_napi/package.json
+++ b/crates/edr_napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomicfoundation/edr",
-  "version": "0.11.0",
+  "version": "0.12.0-alpha.0",
   "devDependencies": {
     "@napi-rs/cli": "^2.18.4",
     "@nomicfoundation/ethereumjs-util": "^9.0.4",


### PR DESCRIPTION
A branch intended to test a prerelease version of EDR before performing the release. This branch should be merged manually.