### PR TITLE
feat: add statement coverage instrumentation

### DIFF
--- a/.changeset/lemon-pumas-walk.md
+++ b/.changeset/lemon-pumas-walk.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": minor
+---
+
+Added instrumenting of source code for statement code coverage measurement

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1627,7 +1627,7 @@ dependencies = [
  "sha2 0.10.8",
  "sha3",
  "tempfile",
- "thiserror 1.0.58",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
  "triehash",
@@ -1671,7 +1671,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "tempfile",
- "thiserror 1.0.58",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]
@@ -1698,8 +1698,22 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
- "thiserror 1.0.58",
+ "thiserror 1.0.69",
  "tokio",
+]
+
+[[package]]
+name = "edr_instrument"
+version = "0.3.5"
+dependencies = [
+ "anyhow",
+ "edr_eth",
+ "semver 1.0.23",
+ "serde",
+ "serde_json",
+ "sha3",
+ "slang_solidity",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1713,6 +1727,7 @@ dependencies = [
  "edr_eth",
  "edr_evm",
  "edr_generic",
+ "edr_instrument",
  "edr_napi_core",
  "edr_op",
  "edr_provider",
@@ -1752,7 +1767,7 @@ dependencies = [
  "napi",
  "serde",
  "serde_json",
- "thiserror 1.0.58",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1779,7 +1794,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
- "thiserror 1.0.58",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
@@ -1819,7 +1834,7 @@ dependencies = [
  "serial_test",
  "sha3",
  "tempfile",
- "thiserror 1.0.58",
+ "thiserror 1.0.69",
  "tokio",
  "toml 0.5.11",
  "tracing",
@@ -1846,7 +1861,7 @@ dependencies = [
  "serde_json",
  "sha3",
  "tempfile",
- "thiserror 1.0.58",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
  "url",
@@ -1876,7 +1891,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 1.0.58",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
  "walkdir",
@@ -1916,7 +1931,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "thiserror 1.0.58",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2826,6 +2841,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
+name = "metaslang_cst"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77f39368da9228d99987bd8885b74c98eb93bfa94e9d348b351e646447781f94"
+dependencies = [
+ "nom",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "mimalloc"
 version = "0.1.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2849,6 +2875,12 @@ dependencies = [
  "mime",
  "unicase",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -2965,6 +2997,16 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -3333,7 +3375,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "311fb059dee1a7b802f036316d790138c613a4e8b180c822e3925a662e9f0c95"
 dependencies = [
  "memchr",
- "thiserror 1.0.58",
+ "thiserror 1.0.69",
  "ucd-trie",
 ]
 
@@ -3748,7 +3790,7 @@ dependencies = [
  "reqwest",
  "serde",
  "task-local-extensions",
- "thiserror 1.0.58",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4234,6 +4276,9 @@ name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "semver-parser"
@@ -4246,18 +4291,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.209"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.209"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4421,6 +4466,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "slang_solidity"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8aedd5543605d5a69ac186cf0afe69e3472b1e3898bdd864b40aa87356298cb"
+dependencies = [
+ "metaslang_cst",
+ "semver 1.0.23",
+ "serde",
+ "strum",
+ "strum_macros",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4609,11 +4668,11 @@ checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
-version = "1.0.58"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl 1.0.58",
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -4627,9 +4686,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.58"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/edr_defaults",
     "crates/edr_eth",
     "crates/edr_evm",
+    "crates/edr_instrument",
     "crates/edr_napi",
     "crates/edr_op",
     "crates/edr_provider",
@@ -32,6 +33,12 @@ alloy-eips = { version = "0.13.0", default-features = false }
 alloy-serde = { version = "0.13.0", default-features = false }
 anyhow = { version = "1.0.89", default-features = false }
 paste = { version = "1.0.14", default-features = false }
+serde = { version = "1.0.209", default-features = false }
+serde_json = { version = "1.0.127", default-features = false }
+sha2 = { version = "0.10.8", default-features = false }
+sha3 = { version = "0.10.8", default-features = false }
+semver = { version = "1.0.23", default-features = false }
+thiserror = { version = "1.0.58", default-features = false }
 
 [workspace.lints.rust]
 future_incompatible = "warn"

--- a/crates/edr_eth/Cargo.toml
+++ b/crates/edr_eth/Cargo.toml
@@ -24,10 +24,10 @@ revm-context = { version = "2.0.0", default-features = false }
 revm-context-interface = { version = "2.0.0", default-features = false }
 revm-primitives = { version = "17.0.0", default-features = false, features = ["hashbrown", "rand"] }
 revm-state = { version = "2.0.0", default-features = false }
-serde = { version = "1.0.209", default-features = false, features = ["derive"], optional = true }
-sha2 = { version = "0.10.8", default-features = false }
-sha3 = { version = "0.10.8", default-features = false }
-thiserror = { version = "1.0.37", default-features = false }
+serde = { workspace = true, features = ["derive"], optional = true }
+sha2.workspace = true
+sha3.workspace = true
+thiserror.workspace = true
 tracing = { version = "0.1.37", features = ["attributes", "std"], optional = true }
 triehash = { version = "0.8.4", default-features = false }
 
@@ -39,7 +39,7 @@ edr_rpc_eth = { version = "0.3.5", path = "../edr_rpc_eth" }
 edr_test_utils = { version = "0.3.5", path = "../edr_test_utils" }
 lazy_static = "1.4.0"
 paste.workspace = true
-serde_json = { version = "1.0.127" }
+serde_json.workspace = true
 serial_test = "2.0.0"
 tempfile = { version = "3.7.1", default-features = false }
 tokio = { version = "1.23.0", features = ["macros"] }

--- a/crates/edr_evm/Cargo.toml
+++ b/crates/edr_evm/Cargo.toml
@@ -29,9 +29,9 @@ revm-database-interface = { version = "2.0.0", default-features = false }
 revm-handler = { version = "2.0.0", default-features = false }
 revm-interpreter = { version = "17.0.0", default-features = false }
 rpds = { version = "1.1.0", default-features = false, features = ["std"] }
-serde = { version = "1.0.209", default-features = false, features = ["std"] }
+serde = { workspace = true, features = ["std"] }
 serde_json = { version = "1.0.127", default-features = false, features = ["std"] }
-thiserror = { version = "1.0.38", default-features = false }
+thiserror.workspace = true
 tokio = { version = "1.21.2", default-features = false, features = ["macros", "rt-multi-thread", "sync"] }
 tracing = { version = "0.1.37", features = ["attributes", "std"], optional = true }
 

--- a/crates/edr_generic/Cargo.toml
+++ b/crates/edr_generic/Cargo.toml
@@ -14,8 +14,8 @@ edr_provider = { path = "../edr_provider" }
 edr_rpc_eth = { path = "../edr_rpc_eth" }
 edr_solidity = { path = "../edr_solidity" }
 log = { version = "0.4.17", default-features = false }
-serde = { version = "1.0.209", default-features = false, features = ["derive"] }
-thiserror = { version = "1.0.37", default-features = false }
+serde = { workspace = true, features = ["derive"] }
+thiserror.workspace = true
 
 [dev-dependencies]
 anyhow = "1.0.89"
@@ -27,7 +27,7 @@ edr_rpc_client = { path = "../edr_rpc_client" }
 edr_test_utils = { path = "../edr_test_utils" }
 parking_lot = { version = "0.12.1", default-features = false }
 paste = { version = "1.0.14", default-features = false }
-serde_json = { version = "1.0.127" }
+serde_json.workspace = true
 serial_test = "2.0.0"
 tokio = { version = "1.21.2", default-features = false, features = ["macros", "rt-multi-thread", "sync"] }
 

--- a/crates/edr_instrument/Cargo.toml
+++ b/crates/edr_instrument/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "edr_instrument"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+edr_eth = { path = "../edr_eth" }
+semver.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+sha3.workspace = true
+slang_solidity = "0.18.3"
+thiserror.workspace = true
+
+[lints]
+workspace = true

--- a/crates/edr_instrument/src/coverage.rs
+++ b/crates/edr_instrument/src/coverage.rs
@@ -1,0 +1,209 @@
+use edr_eth::B256;
+pub use semver::Version;
+use serde::Serialize;
+use sha3::{Digest, Keccak256};
+use slang_solidity::{
+    cst::{Node, NonterminalKind},
+    parser::{ParseError, Parser as SolidityParser, ParserInitializationError},
+};
+
+#[derive(Serialize)]
+pub struct InstrumentationMetadata {
+    pub tag: B256,
+    pub kind: &'static str,
+    pub start_utf16: usize,
+    pub end_utf16: usize,
+}
+
+pub struct InstrumentationResult {
+    pub source: String,
+    pub metadata: Vec<InstrumentationMetadata>,
+}
+
+/// Computes a deterministic hash for a statement in a Solidity file.
+///
+/// For the time being, we're assuming that compilation configuration has no
+/// impact on the statement hash. This is a simplification, but is considered a
+/// reasonable trade-off for the current use case.
+fn compute_deterministic_hash_for_statement(
+    source_id: &str,
+    content_hash: &B256,
+    statement_counter: u64,
+) -> B256 {
+    let mut hasher = Keccak256::new();
+
+    hasher.update(source_id);
+    hasher.update(content_hash);
+    hasher.update(statement_counter.to_le_bytes());
+
+    let hash = hasher.finalize();
+    B256::new(hash.into())
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum InstrumentationError {
+    #[error(transparent)]
+    Initialization(#[from] ParserInitializationError),
+    #[error("Failed to parse Solidity file.")]
+    ParseError { errors: Vec<ParseError> },
+}
+
+pub fn instrument_code(
+    source_code: &str,
+    source_id: &str,
+    solidity_version: Version,
+) -> Result<InstrumentationResult, InstrumentationError> {
+    let parser = SolidityParser::create(solidity_version)?;
+    let parse_result = parser.parse(SolidityParser::ROOT_KIND, source_code);
+    if !parse_result.is_valid() {
+        return Err(InstrumentationError::ParseError {
+            errors: parse_result.errors().clone(),
+        });
+    }
+
+    // Compute the content hash once
+    let content_hash = B256::new(Keccak256::digest(source_code).into());
+
+    let mut instrumented_source = String::new();
+    let mut metadata = Vec::new();
+
+    let mut statement_counter: u64 = 0;
+    let mut cursor = parse_result.create_tree_cursor();
+    while cursor.go_to_next() {
+        match cursor.node() {
+            Node::Nonterminal(node) if node.kind == NonterminalKind::Statement => {
+                statement_counter += 1;
+
+                let hash = compute_deterministic_hash_for_statement(
+                    source_id,
+                    &content_hash,
+                    statement_counter,
+                );
+
+                instrumented_source.push_str(&format!("__HardhatCoverage.sendHit({hash}); "));
+
+                let range = cursor.text_range();
+                metadata.push(InstrumentationMetadata {
+                    tag: hash,
+                    kind: "statement",
+                    start_utf16: range.start.utf16,
+                    end_utf16: range.end.utf16,
+                });
+            }
+            Node::Terminal(node) => {
+                instrumented_source.push_str(&node.text);
+            }
+            Node::Nonterminal(_) => {}
+        }
+    }
+
+    instrumented_source.push_str("\nimport \"hardhat/coverage.sol\";");
+
+    Ok(InstrumentationResult {
+        source: instrumented_source,
+        metadata,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use edr_eth::b256;
+
+    use super::*;
+
+    const FIXTURE: &str = include_str!("../../../data/contracts/instrumentation.sol");
+
+    fn assert_metadata(
+        metadata: &InstrumentationMetadata,
+        expected_tag: B256,
+        expected_text: &str,
+    ) {
+        assert_eq!(metadata.tag, expected_tag);
+        assert_eq!(metadata.kind, "statement");
+
+        let text = select_text(FIXTURE, metadata.start_utf16, metadata.end_utf16);
+        assert_eq!(text, expected_text);
+    }
+
+    fn select_text(content: &str, start_utf16: usize, end_utf16: usize) -> String {
+        let start = content
+            .char_indices()
+            .nth(start_utf16)
+            .map_or(0, |(i, _)| i);
+        let end = content
+            .char_indices()
+            .nth(end_utf16)
+            .map_or(content.len(), |(i, _)| i);
+
+        content[start..end].to_string()
+    }
+
+    #[test]
+    fn determinism() {
+        let version = Version::parse("0.8.0").expect("Failed to parse version");
+        let result =
+            instrument_code(FIXTURE, "instrumentation.sol", version).expect("Failed to instrument");
+
+        let tags = result
+            .metadata
+            .iter()
+            .map(|InstrumentationMetadata { tag, .. }| tag)
+            .cloned()
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            tags,
+            vec![
+                b256!("0xdaa9804f41c839f316b418296d7b0ad8d91ca024d803ab632e9fd32d896f429b"),
+                b256!("0x4b739f4956f43f9e2e753cecfe2569672686cba78a199684075dc494bc60b06b"),
+                b256!("0x9f4fc9ded31350bade85ee54fc2d6dd8d0609fbe0f42203ab07c9a32b95fa4c4"),
+            ]
+        );
+    }
+
+    #[test]
+    fn import() {
+        let version = Version::parse("0.8.0").expect("Failed to parse version");
+        let result =
+            instrument_code(FIXTURE, "instrumentation.sol", version).expect("Failed to instrument");
+
+        assert!(result.source.contains("import \"hardhat/coverage.sol\";"));
+    }
+
+    #[test]
+    fn instrumentation() {
+        let version = Version::parse("0.8.0").expect("Failed to parse version");
+        let result =
+            instrument_code(FIXTURE, "instrumentation.sol", version).expect("Failed to instrument");
+
+        assert!(result.source.contains("__HardhatCoverage.sendHit("));
+        assert!(result.source.contains(");"));
+    }
+
+    #[test]
+    fn mapping() {
+        let version = Version::parse("0.8.0").expect("Failed to parse version");
+        let result =
+            instrument_code(FIXTURE, "instrumentation.sol", version).expect("Failed to instrument");
+
+        assert_eq!(result.metadata.len(), 3);
+
+        assert_metadata(
+            &result.metadata[0],
+            b256!("0xdaa9804f41c839f316b418296d7b0ad8d91ca024d803ab632e9fd32d896f429b"),
+            "    uint x = 1;\n",
+        );
+
+        assert_metadata(
+            &result.metadata[1],
+            b256!("0x4b739f4956f43f9e2e753cecfe2569672686cba78a199684075dc494bc60b06b"),
+            "    uint y = 2;\n",
+        );
+
+        assert_metadata(
+            &result.metadata[2],
+            b256!("0x9f4fc9ded31350bade85ee54fc2d6dd8d0609fbe0f42203ab07c9a32b95fa4c4"),
+            "    uint z = x + y;\n",
+        );
+    }
+}

--- a/crates/edr_instrument/src/lib.rs
+++ b/crates/edr_instrument/src/lib.rs
@@ -1,0 +1,2 @@
+/// Types for instrumenting code for the purpose of code coverage.
+pub mod coverage;

--- a/crates/edr_napi/Cargo.toml
+++ b/crates/edr_napi/Cargo.toml
@@ -14,6 +14,7 @@ derive-where = { version = "1.2.7", default-features = false }
 edr_eth = { path = "../edr_eth" }
 edr_evm = { path = "../edr_evm" }
 edr_generic = { path = "../edr_generic" }
+edr_instrument = { path = "../edr_instrument" }
 edr_napi_core = { path = "../edr_napi_core" }
 edr_op = { path = "../edr_op", optional = true }
 edr_provider = { path = "../edr_provider" }
@@ -26,8 +27,8 @@ mimalloc = { version = "0.1.39", default-features = false, features = ["local_dy
 napi = { version = "2.16.17", default-features = false, features = ["async", "error_anyhow", "napi8", "serde-json"] }
 napi-derive = "2.16.13"
 rand = { version = "0.8.4", optional = true }
-serde = { version = "1.0.209", features = ["derive"] }
-serde_json = { version = "1.0.127" }
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
 static_assertions = "1.1.0"
 strum = { version = "0.26.0", features = ["derive"] }
 tracing = { version = "0.1.37", default-features = false, features = ["std"] }

--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -336,6 +336,17 @@ export interface DebugTraceLogItem {
   /** Map of all stored values with keys and values encoded as hex strings. */
   storage?: Record<string, string>
 }
+export interface InstrumentationResult {
+  readonly source: string
+  readonly metadata: Array<InstrumentationMetadata>
+}
+export interface InstrumentationMetadata {
+  readonly tag: Buffer
+  readonly kind: string
+  readonly startUtf16: number
+  readonly endUtf16: number
+}
+export declare function addStatementCoverageInstrumentation(sourceCode: string, sourceId: string, solidityVersion: string): InstrumentationResult
 /** Ethereum execution log. */
 export interface ExecutionLog {
   address: Buffer

--- a/crates/edr_napi/index.js
+++ b/crates/edr_napi/index.js
@@ -310,7 +310,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { GENERIC_CHAIN_TYPE, genericChainProviderFactory, L1_CHAIN_TYPE, l1GenesisState, l1ProviderFactory, SpecId, l1HardforkFromString, l1HardforkToString, l1HardforkLatest, FRONTIER, FRONTIER_THAWING, HOMESTEAD, DAO_FORK, TANGERINE, SPURIOUS_DRAGON, BYZANTIUM, CONSTANTINOPLE, PETERSBURG, ISTANBUL, MUIR_GLACIER, BERLIN, LONDON, ARROW_GLACIER, GRAY_GLACIER, MERGE, SHANGHAI, CANCUN, PRAGUE, MineOrdering, EdrContext, ProviderFactory, Response, Provider, SuccessReason, ExceptionalHalt, linkHexStringBytecode, printStackTrace, Exit, ExitCode, BytecodeWrapper, ContractFunctionType, ReturnData, StackTraceEntryType, stackTraceEntryTypeToString, FALLBACK_FUNCTION_NAME, RECEIVE_FUNCTION_NAME, CONSTRUCTOR_FUNCTION_NAME, UNRECOGNIZED_FUNCTION_NAME, UNKNOWN_FUNCTION_NAME, PRECOMPILE_FUNCTION_NAME, UNRECOGNIZED_CONTRACT_NAME, RawTrace, getLatestSupportedSolcVersion } = nativeBinding
+const { GENERIC_CHAIN_TYPE, genericChainProviderFactory, L1_CHAIN_TYPE, l1GenesisState, l1ProviderFactory, SpecId, l1HardforkFromString, l1HardforkToString, l1HardforkLatest, FRONTIER, FRONTIER_THAWING, HOMESTEAD, DAO_FORK, TANGERINE, SPURIOUS_DRAGON, BYZANTIUM, CONSTANTINOPLE, PETERSBURG, ISTANBUL, MUIR_GLACIER, BERLIN, LONDON, ARROW_GLACIER, GRAY_GLACIER, MERGE, SHANGHAI, CANCUN, PRAGUE, MineOrdering, EdrContext, addStatementCoverageInstrumentation, ProviderFactory, Response, Provider, SuccessReason, ExceptionalHalt, linkHexStringBytecode, printStackTrace, Exit, ExitCode, BytecodeWrapper, ContractFunctionType, ReturnData, StackTraceEntryType, stackTraceEntryTypeToString, FALLBACK_FUNCTION_NAME, RECEIVE_FUNCTION_NAME, CONSTRUCTOR_FUNCTION_NAME, UNRECOGNIZED_FUNCTION_NAME, UNKNOWN_FUNCTION_NAME, PRECOMPILE_FUNCTION_NAME, UNRECOGNIZED_CONTRACT_NAME, RawTrace, getLatestSupportedSolcVersion } = nativeBinding
 
 module.exports.GENERIC_CHAIN_TYPE = GENERIC_CHAIN_TYPE
 module.exports.genericChainProviderFactory = genericChainProviderFactory
@@ -342,6 +342,7 @@ module.exports.CANCUN = CANCUN
 module.exports.PRAGUE = PRAGUE
 module.exports.MineOrdering = MineOrdering
 module.exports.EdrContext = EdrContext
+module.exports.addStatementCoverageInstrumentation = addStatementCoverageInstrumentation
 module.exports.ProviderFactory = ProviderFactory
 module.exports.Response = Response
 module.exports.Provider = Provider

--- a/crates/edr_napi/src/instrument.rs
+++ b/crates/edr_napi/src/instrument.rs
@@ -1,0 +1,90 @@
+use edr_instrument::coverage::{self, Version};
+use napi::bindgen_prelude::Buffer;
+use napi_derive::napi;
+
+#[napi(object)]
+pub struct InstrumentationResult {
+    #[napi(readonly)]
+    pub source: String,
+    #[napi(readonly)]
+    pub metadata: Vec<InstrumentationMetadata>,
+}
+
+impl TryFrom<edr_instrument::coverage::InstrumentationResult> for InstrumentationResult {
+    type Error = usize;
+
+    fn try_from(
+        value: edr_instrument::coverage::InstrumentationResult,
+    ) -> Result<Self, Self::Error> {
+        let metadata = value
+            .metadata
+            .into_iter()
+            .map(InstrumentationMetadata::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(InstrumentationResult {
+            source: value.source,
+            metadata,
+        })
+    }
+}
+
+#[napi(object)]
+pub struct InstrumentationMetadata {
+    #[napi(readonly)]
+    pub tag: Buffer,
+    #[napi(readonly)]
+    pub kind: String,
+    #[napi(readonly)]
+    pub start_utf16: i64,
+    #[napi(readonly)]
+    pub end_utf16: i64,
+}
+
+impl TryFrom<edr_instrument::coverage::InstrumentationMetadata> for InstrumentationMetadata {
+    type Error = usize;
+
+    fn try_from(
+        value: edr_instrument::coverage::InstrumentationMetadata,
+    ) -> Result<Self, Self::Error> {
+        let start_utf16 = value
+            .start_utf16
+            .try_into()
+            .map_err(|_error| value.start_utf16)?;
+        let end_utf16 = value
+            .end_utf16
+            .try_into()
+            .map_err(|_error| value.end_utf16)?;
+
+        Ok(InstrumentationMetadata {
+            tag: Buffer::from(value.tag.as_slice()),
+            kind: value.kind.to_owned(),
+            start_utf16,
+            end_utf16,
+        })
+    }
+}
+
+#[napi]
+pub fn add_statement_coverage_instrumentation(
+    source_code: String,
+    source_id: String,
+    solidity_version: String,
+) -> napi::Result<InstrumentationResult> {
+    let solidity_version = Version::parse(&solidity_version).map_err(|error| {
+        napi::Error::new(
+            napi::Status::InvalidArg,
+            format!("Invalid Solidity version: {error}"),
+        )
+    })?;
+
+    let instrumented = coverage::instrument_code(&source_code, &source_id, solidity_version)
+        .map_err(|error| napi::Error::new(napi::Status::GenericFailure, error.to_string()))?;
+
+    instrumented.try_into().map_err(|location| {
+        napi::Error::new(
+            napi::Status::GenericFailure,
+            format!("Cannot represent source locations in JavaScript: {location}."),
+        )
+    })
+}

--- a/crates/edr_napi/src/lib.rs
+++ b/crates/edr_napi/src/lib.rs
@@ -18,6 +18,8 @@ pub mod config;
 /// Types related to an EDR N-API context.
 pub mod context;
 mod debug_trace;
+/// Types and functions related to code coverage instrumentation.
+pub mod instrument;
 /// Types for EVM execution logs.
 pub mod log;
 /// Types for an RPC request logger.

--- a/crates/edr_napi/test/instrument.ts
+++ b/crates/edr_napi/test/instrument.ts
@@ -1,0 +1,67 @@
+import { assert, expect } from "chai";
+import * as fs from "fs";
+
+import {
+  addStatementCoverageInstrumentation,
+  InstrumentationMetadata,
+} from "..";
+import { toBuffer } from "./helpers";
+
+function assertMetadata(
+  metadata: InstrumentationMetadata,
+  expected: InstrumentationMetadata
+) {
+  assert.deepEqual(metadata.tag, expected.tag);
+  assert.strictEqual(metadata.kind, expected.kind);
+  assert.strictEqual(metadata.startUtf16, expected.startUtf16);
+  assert.strictEqual(metadata.endUtf16, expected.endUtf16);
+}
+
+function readSourceCode(): string {
+  const filePath = `${__dirname}/../../../data/contracts/instrumentation.sol`;
+  return fs.readFileSync(filePath, "utf8");
+}
+
+describe("Code coverage", () => {
+  const incrementSourceCode = readSourceCode();
+
+  describe("instrumentation", function () {
+    it("Statement coverage", async function () {
+      const result = addStatementCoverageInstrumentation(
+        incrementSourceCode,
+        "instrumentation.sol",
+        "0.8.0"
+      );
+
+      expect(result.source).to.contain("__HardhatCoverage.sendHit(");
+
+      assert.lengthOf(result.metadata, 3);
+      assertMetadata(result.metadata[0], {
+        tag: toBuffer(
+          "0xdaa9804f41c839f316b418296d7b0ad8d91ca024d803ab632e9fd32d896f429b"
+        ),
+        kind: "statement",
+        startUtf16: 43,
+        endUtf16: 59,
+      });
+
+      assertMetadata(result.metadata[1], {
+        tag: toBuffer(
+          "0x4b739f4956f43f9e2e753cecfe2569672686cba78a199684075dc494bc60b06b"
+        ),
+        kind: "statement",
+        startUtf16: 59,
+        endUtf16: 75,
+      });
+
+      assertMetadata(result.metadata[2], {
+        tag: toBuffer(
+          "0x9f4fc9ded31350bade85ee54fc2d6dd8d0609fbe0f42203ab07c9a32b95fa4c4"
+        ),
+        kind: "statement",
+        startUtf16: 75,
+        endUtf16: 95,
+      });
+    });
+  });
+});

--- a/crates/edr_napi_core/Cargo.toml
+++ b/crates/edr_napi_core/Cargo.toml
@@ -15,9 +15,9 @@ edr_solidity = { path = "../edr_solidity" }
 edr_rpc_client = { path = "../edr_rpc_client" }
 itertools = { version = "0.12.0", default-features = false }
 napi = { version = "2.16.10", default-features = false, features = ["async", "error_anyhow", "napi8", "serde-json"] }
-serde = { version = "1.0.209", features = ["derive"] }
-serde_json = { version = "1.0.127" }
-thiserror = { version = "1.0.37", default-features = false }
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+thiserror.workspace = true
 
 [features]
 tracing = ["edr_provider/tracing"]

--- a/crates/edr_op/Cargo.toml
+++ b/crates/edr_op/Cargo.toml
@@ -16,8 +16,8 @@ edr_solidity = { path = "../edr_solidity" }
 log = { version = "0.4.17", default-features = false }
 op-alloy-rpc-types = { version = "0.12.0", default-features = false }
 op-revm = { version = "2.0.0", default-features = false, features = ["c-kzg", "dev", "serde", "std"] }
-serde = { version = "1.0.209", default-features = false, features = ["derive", "std"] }
-thiserror = { version = "1.0.37", default-features = false }
+serde = { workspace = true, features = ["derive", "std"] }
+thiserror.workspace = true
 tokio = { version = "1.21.2", default-features = false, features = ["macros", "rt-multi-thread", "sync"] }
 
 [dev-dependencies]
@@ -29,7 +29,7 @@ edr_rpc_eth = { path = "../edr_rpc_eth", features = ["test-utils"] }
 edr_test_utils = { path = "../edr_test_utils" }
 parking_lot = { version = "0.12.1", default-features = false }
 paste.workspace = true
-serde_json = { version = "1.0.127" }
+serde_json.workspace = true
 serial_test = "2.0.0"
 tokio = { version = "1.21.2", default-features = false, features = ["macros", "rt-multi-thread", "sync"] }
 

--- a/crates/edr_provider/Cargo.toml
+++ b/crates/edr_provider/Cargo.toml
@@ -29,10 +29,10 @@ parking_lot = { version = "0.12.1", default-features = false }
 rand = { version = "0.8.5", default-features = false }
 revm-precompile = { version = "18.0.0", default-features = false, features = ["blst", "c-kzg", "secp256r1", "std"] }
 rpds = { version = "1.1.0", default-features = false, features = ["std"] }
-serde = { version = "1.0.209", default-features = false, features = ["derive"] }
-serde_json = { version = "1.0.127" }
-sha3 = { version = "0.10.6", default-features = false }
-thiserror = { version = "1.0.37", default-features = false }
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+sha3.workspace = true
+thiserror.workspace = true
 tokio = { version = "1.21.2", default-features = false, features = ["macros"] }
 tracing = { version = "0.1.37", features = ["attributes", "std"], optional = true }
 

--- a/crates/edr_rpc_client/Cargo.toml
+++ b/crates/edr_rpc_client/Cargo.toml
@@ -16,10 +16,10 @@ reqwest = { version = "0.11", features = ["blocking", "json"] }
 reqwest-middleware = { version = "0.2.4", default-features = false }
 reqwest-retry = { version = "0.3.0", default-features = false }
 reqwest-tracing = { version = "0.4.7", default-features = false, optional = true }
-serde = { version = "1.0.209", default-features = false, features = ["derive", "std"] }
-serde_json = { version = "1.0.127" }
-sha3 = { version = "0.10.8", default-features = false, features = ["std"] }
-thiserror = { version = "1.0.37", default-features = false }
+serde = { workspace = true, features = ["derive", "std"] }
+serde_json.workspace = true
+sha3.workspace = true
+thiserror.workspace = true
 tokio = { version = "1.21.2", default-features = false, features = ["fs", "macros", "sync"] }
 tracing = { version = "0.1.37", default-features = false, features = ["attributes", "std"], optional = true }
 url = { version = "2.4.1", default-features = false }

--- a/crates/edr_rpc_eth/Cargo.toml
+++ b/crates/edr_rpc_eth/Cargo.toml
@@ -12,8 +12,8 @@ edr_rpc_client = { version = "0.3.5", path = "../edr_rpc_client" }
 futures = { version = "0.3.28", default-features = false, features = ["std"] }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 log = { version = "0.4.17", default-features = false }
-serde = { version = "1.0.209", default-features = false, features = ["derive", "std"] }
-thiserror = { version = "1.0.37", default-features = false }
+serde = { workspace = true, features = ["derive", "std"] }
+thiserror.workspace = true
 tokio = { version = "1.21.2", default-features = false, features = ["macros"] }
 tracing = { version = "0.1.37", default-features = false, features = ["attributes", "std"], optional = true }
 
@@ -25,7 +25,7 @@ edr_test_utils = { version = "0.3.5", path = "../edr_test_utils" }
 mockito = { version = "1.0.2", default-features = false }
 paste = { version = "1.0.14", default-features = false }
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "json"] }
-serde_json = { version = "1.0.127" }
+serde_json.workspace = true
 tempfile = { version = "3.7.1", default-features = false }
 walkdir = { version = "2.3.3", default-features = false }
 

--- a/crates/edr_scenarios/Cargo.toml
+++ b/crates/edr_scenarios/Cargo.toml
@@ -11,7 +11,7 @@ edr_evm = { version = "0.3.5", path = "../edr_evm", features = ["tracing"] }
 edr_napi_core = { path = "../edr_napi_core" }
 edr_provider = { version = "0.3.5", path = "../edr_provider", features = ["test-utils"] }
 k256 = { version = "0.13.1", default-features = false, features = ["arithmetic", "ecdsa", "pem", "pkcs8", "precomputed-tables", "std"] }
-serde = { version = "1.0.197", features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }
 
 [lints]
 workspace = true

--- a/crates/edr_solidity/Cargo.toml
+++ b/crates/edr_solidity/Cargo.toml
@@ -14,11 +14,11 @@ edr_evm = { version = "0.3.5", path = "../edr_evm" }
 indexmap = { version = "2", features = ["serde"] }
 log = { version = "0.4.17", default-features = false }
 parking_lot = { version = "0.12.1", default-features = false }
-serde = { version = "1.0.158", default-features = false, features = ["std"] }
-serde_json = { version = "1.0.89", features = ["preserve_order"] }
+serde = { workspace = true, features = ["std"] }
+serde_json = { workspace = true, features = ["preserve_order"] }
 strum = { version = "0.26.0", features = ["derive"] }
-semver = "1.0.23"
-thiserror = "1.0.58"
+semver = { workspace = true, features = ["std"] }
+thiserror.workspace = true
 itertools = "0.10.5"
 
 [dev-dependencies]

--- a/crates/edr_test_utils/Cargo.toml
+++ b/crates/edr_test_utils/Cargo.toml
@@ -7,8 +7,8 @@ edition.workspace = true
 edr_eth = { version = "0.3.5", path = "../edr_eth", features = ["rand", "serde"] }
 hex = "0.4.3"
 k256 = { version = "0.13.1", default-features = false, features = ["arithmetic", "ecdsa", "pkcs8", ] }
-serde = { version = "1.0.209", default-features = false, features = ["derive"] }
-serde_json = { version = "1.0.127" }
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
 
 
 [lints]

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -24,8 +24,8 @@ indicatif = { version = "0.17.7", features = ["rayon"] }
 mimalloc = { version = "0.1.39", default-features = false }
 parking_lot = { version = "0.12.1", default-features = false }
 reqwest = { version = "0.11.12", features = ["blocking"] }
-serde_json = "1.0.127"
-serde = { version = "1.0.209", features = ["derive"] }
+serde_json.workspace = true
+serde = { workspace = true, features = ["derive"] }
 tempfile = "3.7.1"
 tokio = "1.33.0"
 tracing = { version = "0.1.37", features = ["attributes", "std"], optional = true }

--- a/data/contracts/instrumentation.sol
+++ b/data/contracts/instrumentation.sol
@@ -1,0 +1,7 @@
+contract Test {
+  function test() public {
+    uint x = 1;
+    uint y = 2;
+    uint z = x + y;
+  }
+}


### PR DESCRIPTION
This PR adds an API for instrumenting statement code coverage, based on [this research spike](https://github.com/NomicFoundation/hardhat-coverage-spike/blob/main/src/lib.rs).

Should be merged after #866!