### PR TITLE
test: allow transaction type for legacy receipts

### DIFF
--- a/crates/edr_op/tests/integration/rpc.rs
+++ b/crates/edr_op/tests/integration/rpc.rs
@@ -105,7 +105,8 @@ async fn transaction_and_receipt_pre_bedrock() -> anyhow::Result<()> {
         .expect("Failed to retrieve receipt")
         .expect("Receipt must exist");
 
-    assert_eq!(receipt.transaction_type, None);
+    // Archive providers return both None and Some(0) for legacy receipts
+    assert!(matches!(receipt.transaction_type, None | Some(0)));
 
     Ok(())
 }


### PR DESCRIPTION
We [previously removed](https://github.com/NomicFoundation/edr/pull/853) support for pre-Byzantium receipts from EDR, due to a change in archive nodes.

It seems that they're now also reporting the type of a transaction for pre-EIP-2718 receipts. I've inquired with Alchemy whether this is in fact the case.

Until then, the modification in this PR allows both cases to pass.