### PR TITLE
doc: add code coverage documentation to API

### DIFF
--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -179,7 +179,16 @@ export interface ChainConfig {
 }
 /** Configuration for a code coverage reporter. */
 export interface CodeCoverageConfig {
-  /** The callback to be called when coverage has been collected. */
+  /**
+   * The callback to be called when coverage has been collected.
+   *
+   * The callback receives an array of unique coverage hit markers (i.e. no
+   * repetition) per transaction.
+   *
+   * # Safety
+   *
+   * Errors should not be thrown inside the callback.
+   */
   onCollectedCoverageCallback: (coverageHits: Buffer[]) => void
 }
 /** Configuration for forking a blockchain */
@@ -226,8 +235,9 @@ export interface MiningConfig {
   interval?: bigint | IntervalRange
   memPool: MemPoolConfig
 }
-/** Configuration for the provider's runtime observability. */
+/** Configuration for runtime observability. */
 export interface ObservabilityConfig {
+  /** If present, configures runtime observability to collect code coverage. */
   codeCoverage?: CodeCoverageConfig
 }
 /** Configuration for a provider */
@@ -337,15 +347,38 @@ export interface DebugTraceLogItem {
   storage?: Record<string, string>
 }
 export interface InstrumentationResult {
+  /** The generated source code with coverage instrumentation. */
   readonly source: string
+  /** The metadata for each instrumented code segment. */
   readonly metadata: Array<InstrumentationMetadata>
 }
 export interface InstrumentationMetadata {
+  /**
+   * The tag that identifies the instrumented code. Tags are
+   * deterministically generated from the source code, source id, and
+   * Solidity version.
+   */
   readonly tag: Buffer
+  /**
+   * The kind of instrumented code. Currently, the only supported kind
+   * is "statement".
+   */
   readonly kind: string
+  /**
+   * The starting position of the instrumented code - including trivia such
+   * as whitespace - in the source code, in UTF-16 code units.
+   */
   readonly startUtf16: number
+  /**
+   * The ending position of the instrumented code - including trivia such as
+   * whitespace - in the source code, in UTF-16 code units.
+   */
   readonly endUtf16: number
 }
+/**
+ * Adds per-statement coverage instrumentation to the given Solidity source
+ * code.
+ */
 export declare function addStatementCoverageInstrumentation(sourceCode: string, sourceId: string, solidityVersion: string): InstrumentationResult
 /** Ethereum execution log. */
 export interface ExecutionLog {

--- a/crates/edr_napi/src/config.rs
+++ b/crates/edr_napi/src/config.rs
@@ -33,6 +33,13 @@ pub struct ChainConfig {
 #[napi(object)]
 pub struct CodeCoverageConfig {
     /// The callback to be called when coverage has been collected.
+    ///
+    /// The callback receives an array of unique coverage hit markers (i.e. no
+    /// repetition) per transaction.
+    ///
+    /// # Safety
+    ///
+    /// Errors should not be thrown inside the callback.
     #[napi(ts_type = "(coverageHits: Buffer[]) => void")]
     pub on_collected_coverage_callback: JsFunction,
 }
@@ -93,9 +100,10 @@ pub struct MiningConfig {
     pub mem_pool: MemPoolConfig,
 }
 
-/// Configuration for the provider's runtime observability.
+/// Configuration for runtime observability.
 #[napi(object)]
 pub struct ObservabilityConfig {
+    /// If present, configures runtime observability to collect code coverage.
     pub code_coverage: Option<CodeCoverageConfig>,
 }
 

--- a/crates/edr_napi/src/instrument.rs
+++ b/crates/edr_napi/src/instrument.rs
@@ -4,8 +4,10 @@ use napi_derive::napi;
 
 #[napi(object)]
 pub struct InstrumentationResult {
+    /// The generated source code with coverage instrumentation.
     #[napi(readonly)]
     pub source: String,
+    /// The metadata for each instrumented code segment.
     #[napi(readonly)]
     pub metadata: Vec<InstrumentationMetadata>,
 }
@@ -31,12 +33,21 @@ impl TryFrom<edr_instrument::coverage::InstrumentationResult> for Instrumentatio
 
 #[napi(object)]
 pub struct InstrumentationMetadata {
+    /// The tag that identifies the instrumented code. Tags are
+    /// deterministically generated from the source code, source id, and
+    /// Solidity version.
     #[napi(readonly)]
     pub tag: Buffer,
+    /// The kind of instrumented code. Currently, the only supported kind
+    /// is "statement".
     #[napi(readonly)]
     pub kind: String,
+    /// The starting position of the instrumented code - including trivia such
+    /// as whitespace - in the source code, in UTF-16 code units.
     #[napi(readonly)]
     pub start_utf16: i64,
+    /// The ending position of the instrumented code - including trivia such as
+    /// whitespace - in the source code, in UTF-16 code units.
     #[napi(readonly)]
     pub end_utf16: i64,
 }
@@ -65,6 +76,8 @@ impl TryFrom<edr_instrument::coverage::InstrumentationMetadata> for Instrumentat
     }
 }
 
+/// Adds per-statement coverage instrumentation to the given Solidity source
+/// code.
 #[napi]
 pub fn add_statement_coverage_instrumentation(
     source_code: String,


### PR DESCRIPTION
This PR adds detailed documentation for code coverage and instrumentation.