### PR TITLE
chore: fix ignored profile warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ edition = "2024"
 rpath = true
 
 [profile.release]
+lto = true
 rpath = true
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ edition = "2024"
 rpath = true
 
 [profile.release]
-lto = true
 rpath = true
 
 [workspace.dependencies]

--- a/crates/edr_napi/Cargo.toml
+++ b/crates/edr_napi/Cargo.toml
@@ -55,8 +55,5 @@ op = ["dep:edr_op"]
 scenarios = ["dep:edr_scenarios", "dep:rand"]
 tracing = ["edr_evm/tracing", "edr_napi_core/tracing", "edr_provider/tracing"]
 
-[profile.release]
-lto = true
-
 [lints]
 workspace = true


### PR DESCRIPTION
This fixes the following warning:

```
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   edr/crates/edr_napi/Cargo.toml
workspace: edr/Cargo.toml
```