### PR TITLE
fix: elasticity multiplier for Base network

### DIFF
--- a/book/src/04_multichain/01_chain_spec.md
+++ b/book/src/04_multichain/01_chain_spec.md
@@ -5,7 +5,7 @@ EDR uses a concept called _chain specification_ to define all necessary types an
 This is achieved through the usage of multiple traits, some of which are supertraits of each other, providing increasing scope of functionality in the EDR ecosystem:
 
 - Primitives: `edr_eth::ChainSpec`
-- Header builder: `edr_eth::EthHeaderConstants`
+- Header builder: `edr_eth::EthHeaderParams`
 - RPC client: `edr_rpc_eth::RpcSpec`
 - EVM runtime: `edr_evm::RuntimeSpec`
 - EVM provider: `edr_provider::ProviderSpec`

--- a/crates/edr_eth/src/block.rs
+++ b/crates/edr_eth/src/block.rs
@@ -25,7 +25,7 @@ use crate::{
     Address, B64, B256, Bloom, Bytes, U256, b256,
     eips::{eip1559::ConstantBaseFeeParams, eip4844, eip7691},
     keccak256, l1,
-    spec::EthHeaderConstants,
+    spec::EthHeaderParams,
     trie::KECCAK_NULL_RLP,
 };
 
@@ -209,7 +209,7 @@ pub struct PartialHeader {
 impl PartialHeader {
     /// Constructs a new instance based on the provided [`BlockOptions`] and
     /// parent [`Header`] for the given [`l1::SpecId`].
-    pub fn new<ChainSpecT: EthHeaderConstants>(
+    pub fn new<ChainSpecT: EthHeaderParams>(
         hardfork: ChainSpecT::Hardfork,
         base_fee_params: ConstantBaseFeeParams,
         options: BlockOptions,

--- a/crates/edr_eth/src/block.rs
+++ b/crates/edr_eth/src/block.rs
@@ -23,7 +23,7 @@ pub use self::{
 };
 use crate::{
     Address, B64, B256, Bloom, Bytes, U256, b256,
-    eips::{eip4844, eip7691},
+    eips::{eip1559::ConstantBaseFeeParams, eip4844, eip7691},
     keccak256, l1,
     spec::EthHeaderConstants,
     trie::KECCAK_NULL_RLP,
@@ -211,6 +211,7 @@ impl PartialHeader {
     /// parent [`Header`] for the given [`l1::SpecId`].
     pub fn new<ChainSpecT: EthHeaderConstants>(
         hardfork: ChainSpecT::Hardfork,
+        base_fee_params: ConstantBaseFeeParams,
         options: BlockOptions,
         parent: Option<&Header>,
     ) -> Self {
@@ -267,7 +268,7 @@ impl PartialHeader {
             base_fee: options.base_fee.or_else(|| {
                 if hardfork.into() >= l1::SpecId::LONDON {
                     Some(if let Some(parent) = &parent {
-                        calculate_next_base_fee_per_gas::<ChainSpecT>(hardfork, parent)
+                        calculate_next_base_fee_per_gas(base_fee_params, parent)
                     } else {
                         u128::from(alloy_eips::eip1559::INITIAL_BASE_FEE)
                     })
@@ -389,14 +390,10 @@ impl From<Header> for PartialHeader {
 /// # Panics
 ///
 /// Panics if the parent header does not contain a base fee.
-pub fn calculate_next_base_fee_per_gas<ChainSpecT: EthHeaderConstants>(
-    hardfork: ChainSpecT::Hardfork,
+pub fn calculate_next_base_fee_per_gas(
+    base_fee_params: ConstantBaseFeeParams,
     parent: &Header,
 ) -> u128 {
-    let base_fee_params = ChainSpecT::BASE_FEE_PARAMS
-        .at_hardfork(hardfork)
-        .expect("Chain spec must have base fee params for post-London hardforks");
-
     // Adapted from https://github.com/alloy-rs/alloy/blob/main/crates/eips/src/eip1559/helpers.rs#L41
     // modifying it to support `u128`.
     // TODO: Remove once https://github.com/alloy-rs/alloy/issues/2181 has been addressed.

--- a/crates/edr_eth/src/block/difficulty.rs
+++ b/crates/edr_eth/src/block/difficulty.rs
@@ -1,4 +1,4 @@
-use crate::{U256, block::Header, l1, spec::EthHeaderConstants, trie::KECCAK_RLP_EMPTY_ARRAY};
+use crate::{U256, block::Header, l1, spec::EthHeaderParams, trie::KECCAK_RLP_EMPTY_ARRAY};
 
 fn bomb_delay(spec_id: l1::SpecId) -> u64 {
     match spec_id {
@@ -21,7 +21,7 @@ fn bomb_delay(spec_id: l1::SpecId) -> u64 {
 }
 
 /// Calculates the mining difficulty of a block.
-pub fn calculate_ethash_canonical_difficulty<ChainSpecT: EthHeaderConstants>(
+pub fn calculate_ethash_canonical_difficulty<ChainSpecT: EthHeaderParams>(
     spec_id: l1::SpecId,
     parent: &Header,
     block_number: u64,

--- a/crates/edr_eth/src/eips/eip1559.rs
+++ b/crates/edr_eth/src/eips/eip1559.rs
@@ -2,7 +2,7 @@ pub use alloy_eips::eip1559::BaseFeeParams as ConstantBaseFeeParams;
 
 /// A mapping of hardfork to [`ConstantBaseFeeParams`]. This is used to specify
 /// dynamic EIP-1559 parameters for chains like OP.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ForkBaseFeeParams<HardforkT: 'static> {
     activations: &'static [(HardforkT, ConstantBaseFeeParams)],
 }
@@ -16,6 +16,7 @@ impl<HardforkT> ForkBaseFeeParams<HardforkT> {
 
 /// Type that allows specifying constant or dynamic EIP-1559 parameters based on
 /// the active hardfork.
+#[derive(Clone, Copy)]
 pub enum BaseFeeParams<HardforkT: 'static> {
     /// Constant [`ConstantBaseFeeParams`]; used for chains that don't have
     /// dynamic EIP-1559 parameters

--- a/crates/edr_eth/src/eips/eip1559.rs
+++ b/crates/edr_eth/src/eips/eip1559.rs
@@ -16,7 +16,7 @@ impl<HardforkT> ForkBaseFeeParams<HardforkT> {
 
 /// Type that allows specifying constant or dynamic EIP-1559 parameters based on
 /// the active hardfork.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub enum BaseFeeParams<HardforkT: 'static> {
     /// Constant [`ConstantBaseFeeParams`]; used for chains that don't have
     /// dynamic EIP-1559 parameters

--- a/crates/edr_eth/src/eips/eip1559.rs
+++ b/crates/edr_eth/src/eips/eip1559.rs
@@ -16,7 +16,7 @@ impl<HardforkT> ForkBaseFeeParams<HardforkT> {
 
 /// Type that allows specifying constant or dynamic EIP-1559 parameters based on
 /// the active hardfork.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum BaseFeeParams<HardforkT: 'static> {
     /// Constant [`ConstantBaseFeeParams`]; used for chains that don't have
     /// dynamic EIP-1559 parameters

--- a/crates/edr_eth/src/l1.rs
+++ b/crates/edr_eth/src/l1.rs
@@ -24,9 +24,6 @@ impl ChainSpec for L1ChainSpec {
 }
 
 impl EthHeaderConstants for L1ChainSpec {
-    const BASE_FEE_PARAMS: BaseFeeParams<Self::Hardfork> =
-        BaseFeeParams::Constant(ConstantBaseFeeParams::ethereum());
-
     const MIN_ETHASH_DIFFICULTY: u64 = 131072;
 
     fn chain_base_fee_params(_chain_id: u64) -> BaseFeeParams<Self::Hardfork> {

--- a/crates/edr_eth/src/l1.rs
+++ b/crates/edr_eth/src/l1.rs
@@ -7,7 +7,7 @@ pub use revm_primitives::hardfork::{self, SpecId};
 
 use crate::{
     eips::eip1559::{BaseFeeParams, ConstantBaseFeeParams},
-    spec::{ChainSpec, EthHeaderConstants},
+    spec::{ChainSpec, EthHeaderParams},
     transaction,
 };
 
@@ -23,7 +23,7 @@ impl ChainSpec for L1ChainSpec {
     type SignedTransaction = transaction::Signed;
 }
 
-impl EthHeaderConstants for L1ChainSpec {
+impl EthHeaderParams for L1ChainSpec {
     const MIN_ETHASH_DIFFICULTY: u64 = 131072;
 
     fn chain_base_fee_params(_chain_id: u64) -> BaseFeeParams<Self::Hardfork> {

--- a/crates/edr_eth/src/l1.rs
+++ b/crates/edr_eth/src/l1.rs
@@ -28,4 +28,8 @@ impl EthHeaderConstants for L1ChainSpec {
         BaseFeeParams::Constant(ConstantBaseFeeParams::ethereum());
 
     const MIN_ETHASH_DIFFICULTY: u64 = 131072;
+
+    fn chain_base_fee_params(_chain_id: u64) -> BaseFeeParams<Self::Hardfork> {
+        BaseFeeParams::Constant(ConstantBaseFeeParams::ethereum())
+    }
 }

--- a/crates/edr_eth/src/spec.rs
+++ b/crates/edr_eth/src/spec.rs
@@ -27,9 +27,6 @@ pub trait ChainSpec {
 
 /// Constants for constructing Ethereum headers.
 pub trait EthHeaderConstants: ChainSpec<Hardfork: 'static + PartialOrd> {
-    /// Parameters for the EIP-1559 base fee calculation.
-    const BASE_FEE_PARAMS: BaseFeeParams<Self::Hardfork>;
-
     /// The minimum difficulty for the Ethash proof-of-work algorithm.
     const MIN_ETHASH_DIFFICULTY: u64;
 

--- a/crates/edr_eth/src/spec.rs
+++ b/crates/edr_eth/src/spec.rs
@@ -32,4 +32,7 @@ pub trait EthHeaderConstants: ChainSpec<Hardfork: 'static + PartialOrd> {
 
     /// The minimum difficulty for the Ethash proof-of-work algorithm.
     const MIN_ETHASH_DIFFICULTY: u64;
+
+    /// Parameters for the EIP-1559 base fee calculation.
+    fn chain_base_fee_params(chain_id: u64) -> BaseFeeParams<Self::Hardfork>;
 }

--- a/crates/edr_eth/src/spec.rs
+++ b/crates/edr_eth/src/spec.rs
@@ -26,7 +26,7 @@ pub trait ChainSpec {
 }
 
 /// Constants for constructing Ethereum headers.
-pub trait EthHeaderConstants: ChainSpec<Hardfork: 'static + PartialOrd> {
+pub trait EthHeaderParams: ChainSpec<Hardfork: 'static + PartialOrd> {
     /// The minimum difficulty for the Ethash proof-of-work algorithm.
     const MIN_ETHASH_DIFFICULTY: u64;
 

--- a/crates/edr_evm/src/block/builder/l1.rs
+++ b/crates/edr_evm/src/block/builder/l1.rs
@@ -153,7 +153,12 @@ where
         });
 
         options.parent_hash = Some(*parent_block.block_hash());
-        let header = PartialHeader::new::<ChainSpecT>(cfg.spec, blockchain.base_fee_params(), options, Some(parent_header));
+        let header = PartialHeader::new::<ChainSpecT>(
+            cfg.spec,
+            blockchain.base_fee_params(),
+            options,
+            Some(parent_header),
+        );
 
         Ok(Self {
             blockchain,

--- a/crates/edr_evm/src/block/builder/l1.rs
+++ b/crates/edr_evm/src/block/builder/l1.rs
@@ -153,7 +153,7 @@ where
         });
 
         options.parent_hash = Some(*parent_block.block_hash());
-        let header = PartialHeader::new::<ChainSpecT>(cfg.spec, options, Some(parent_header));
+        let header = PartialHeader::new::<ChainSpecT>(cfg.spec, blockchain.base_fee_params(), options, Some(parent_header));
 
         Ok(Self {
             blockchain,

--- a/crates/edr_evm/src/blockchain.rs
+++ b/crates/edr_evm/src/blockchain.rs
@@ -8,7 +8,8 @@ use std::{collections::BTreeMap, fmt::Debug, ops::Bound::Included, sync::Arc};
 
 use auto_impl::auto_impl;
 use edr_eth::{
-    eips::eip1559::ConstantBaseFeeParams, l1, log::FilterLog, receipt::ReceiptTrait, spec::ChainSpec, Address, HashSet, B256, U256
+    Address, B256, HashSet, U256, eips::eip1559::ConstantBaseFeeParams, l1, log::FilterLog,
+    receipt::ReceiptTrait, spec::ChainSpec,
 };
 
 use self::storage::ReservableSparseBlockchainStorage;

--- a/crates/edr_evm/src/blockchain.rs
+++ b/crates/edr_evm/src/blockchain.rs
@@ -8,7 +8,7 @@ use std::{collections::BTreeMap, fmt::Debug, ops::Bound::Included, sync::Arc};
 
 use auto_impl::auto_impl;
 use edr_eth::{
-    Address, B256, HashSet, U256, l1, log::FilterLog, receipt::ReceiptTrait, spec::ChainSpec,
+    eips::eip1559::ConstantBaseFeeParams, l1, log::FilterLog, receipt::ReceiptTrait, spec::ChainSpec, Address, HashSet, B256, U256
 };
 
 use self::storage::ReservableSparseBlockchainStorage;
@@ -189,6 +189,9 @@ where
 
     /// Retrieves the total difficulty at the block with the provided hash.
     fn total_difficulty_by_hash(&self, hash: &B256) -> Result<Option<U256>, Self::BlockchainError>;
+
+    /// Retrieves the EIP-1559 base fee parameters used for new blocks.
+    fn base_fee_params(&self) -> ConstantBaseFeeParams;
 }
 
 /// Trait for implementations of a mutable Ethereum blockchain

--- a/crates/edr_evm/src/blockchain/forked.rs
+++ b/crates/edr_evm/src/blockchain/forked.rs
@@ -583,7 +583,8 @@ where
     }
 
     fn base_fee_params(&self) -> ConstantBaseFeeParams {
-        *self.base_fee_params
+        *self
+            .base_fee_params
             .at_hardfork(self.hardfork())
             .expect("Chain spec must have base fee params for post-London hardforks")
     }

--- a/crates/edr_evm/src/blockchain/local.rs
+++ b/crates/edr_evm/src/blockchain/local.rs
@@ -138,7 +138,8 @@ where
 
         options.extra_data = Some(Bytes::from(EXTRA_DATA));
 
-        let partial_header = PartialHeader::new::<ChainSpecT>(hardfork, base_fee_params, options, None);
+        let partial_header =
+            PartialHeader::new::<ChainSpecT>(hardfork, base_fee_params, options, None);
         Ok(unsafe {
             Self::with_genesis_block_unchecked(
                 ChainSpecT::LocalBlock::empty(hardfork, partial_header),
@@ -174,7 +175,13 @@ where
         }
 
         Ok(unsafe {
-            Self::with_genesis_block_unchecked(genesis_block, genesis_diff, chain_id, hardfork, base_fee_params)
+            Self::with_genesis_block_unchecked(
+                genesis_block,
+                genesis_diff,
+                chain_id,
+                hardfork,
+                base_fee_params,
+            )
         })
     }
 

--- a/crates/edr_evm/src/spec.rs
+++ b/crates/edr_evm/src/spec.rs
@@ -8,7 +8,7 @@ use edr_eth::{
     log::{ExecutionLog, FilterLog},
     receipt::{BlockReceipt, ExecutionReceipt, MapReceiptLogs, ReceiptTrait},
     result::ResultAndState,
-    spec::{ChainSpec, EthHeaderConstants},
+    spec::{ChainSpec, EthHeaderParams},
 };
 use edr_rpc_eth::{RpcTypeFrom, TransactionConversionError, spec::RpcSpec};
 use edr_utils::types::TypeConstructor;
@@ -95,7 +95,7 @@ impl<TypeConstructorT> ExecutionReceiptTypeConstructorBounds for TypeConstructor
 pub trait RuntimeSpec:
     alloy_rlp::Encodable
     // Defines the chain's internal types like blocks/headers or transactions
-    + EthHeaderConstants
+    + EthHeaderParams
     + ChainSpec<
         BlockEnv: BlockEnvConstructor<block::Header> + BlockEnvConstructor<PartialHeader> + Default,
         Hardfork: Debug,

--- a/crates/edr_generic/src/spec.rs
+++ b/crates/edr_generic/src/spec.rs
@@ -35,6 +35,10 @@ impl EthHeaderConstants for GenericChainSpec {
     const BASE_FEE_PARAMS: BaseFeeParams<Self::Hardfork> = L1ChainSpec::BASE_FEE_PARAMS;
 
     const MIN_ETHASH_DIFFICULTY: u64 = L1ChainSpec::MIN_ETHASH_DIFFICULTY;
+
+    fn chain_base_fee_params(chain_id: u64) -> BaseFeeParams<Self::Hardfork> {
+        L1ChainSpec::chain_base_fee_params(chain_id)
+    }
 }
 
 impl RuntimeSpec for GenericChainSpec {

--- a/crates/edr_generic/src/spec.rs
+++ b/crates/edr_generic/src/spec.rs
@@ -32,8 +32,6 @@ impl ChainSpec for GenericChainSpec {
 }
 
 impl EthHeaderConstants for GenericChainSpec {
-    const BASE_FEE_PARAMS: BaseFeeParams<Self::Hardfork> = L1ChainSpec::BASE_FEE_PARAMS;
-
     const MIN_ETHASH_DIFFICULTY: u64 = L1ChainSpec::MIN_ETHASH_DIFFICULTY;
 
     fn chain_base_fee_params(chain_id: u64) -> BaseFeeParams<Self::Hardfork> {

--- a/crates/edr_generic/src/spec.rs
+++ b/crates/edr_generic/src/spec.rs
@@ -5,7 +5,7 @@ use edr_eth::{
     l1::{self, InvalidTransaction, L1ChainSpec},
     log::FilterLog,
     receipt::BlockReceipt,
-    spec::{ChainSpec, EthHeaderConstants},
+    spec::{ChainSpec, EthHeaderParams},
     transaction::TransactionValidation,
 };
 use edr_evm::{
@@ -31,7 +31,7 @@ impl ChainSpec for GenericChainSpec {
     type SignedTransaction = crate::transaction::SignedWithFallbackToPostEip155;
 }
 
-impl EthHeaderConstants for GenericChainSpec {
+impl EthHeaderParams for GenericChainSpec {
     const MIN_ETHASH_DIFFICULTY: u64 = L1ChainSpec::MIN_ETHASH_DIFFICULTY;
 
     fn chain_base_fee_params(chain_id: u64) -> BaseFeeParams<Self::Hardfork> {

--- a/crates/edr_op/src/hardfork.rs
+++ b/crates/edr_op/src/hardfork.rs
@@ -53,3 +53,11 @@ pub fn chain_hardfork_activations(chain_id: u64) -> Option<&'static Activations<
         .get(&chain_id)
         .map(|config| &config.hardfork_activations)
 }
+
+/// Returns the base fee params corresponding to the provided chain ID, if
+/// it is supported and known.
+pub fn chain_base_fee_params(chain_id: u64) -> Option<&'static BaseFeeParams<OpSpecId>> {
+    chain_configs()
+        .get(&chain_id)
+        .map(|config| &config.base_fee_params)
+}

--- a/crates/edr_op/src/hardfork.rs
+++ b/crates/edr_op/src/hardfork.rs
@@ -1,7 +1,7 @@
 use std::sync::OnceLock;
 
-use edr_eth::HashMap;
-use edr_evm::hardfork::{Activations, ChainConfig};
+use edr_eth::{eips::eip1559::BaseFeeParams, HashMap};
+use edr_evm::hardfork::Activations;
 pub use op_revm::name;
 
 use crate::OpSpecId;
@@ -11,10 +11,20 @@ pub mod base;
 /// OP chain configs
 pub mod op;
 
+/// Type that stores the configuration for a chain.
+pub struct OpChainConfig<HardforkT: 'static> {
+    /// Chain name
+    pub name: String,
+    /// Hardfork activations for the chain
+    pub hardfork_activations: Activations<HardforkT>,
+    /// Base fee parameters for the chain
+    pub base_fee_params: BaseFeeParams<HardforkT>,
+}
+
 // Source:
 // <https://docs.optimism.io/builders/node-operators/network-upgrades>
-fn chain_configs() -> &'static HashMap<u64, &'static ChainConfig<OpSpecId>> {
-    static CONFIGS: OnceLock<HashMap<u64, &'static ChainConfig<OpSpecId>>> = OnceLock::new();
+fn chain_configs() -> &'static HashMap<u64, &'static OpChainConfig<OpSpecId>> {
+    static CONFIGS: OnceLock<HashMap<u64, &'static OpChainConfig<OpSpecId>>> = OnceLock::new();
 
     CONFIGS.get_or_init(|| {
         let mut hardforks = HashMap::new();

--- a/crates/edr_op/src/hardfork.rs
+++ b/crates/edr_op/src/hardfork.rs
@@ -1,6 +1,6 @@
 use std::sync::{LazyLock, OnceLock};
 
-use edr_eth::{eips::eip1559::BaseFeeParams, HashMap};
+use edr_eth::{HashMap, eips::eip1559::BaseFeeParams};
 use edr_evm::hardfork::Activations;
 pub use op_revm::name;
 
@@ -24,7 +24,8 @@ pub struct OpChainConfig<HardforkT: 'static> {
 // Source:
 // <https://docs.optimism.io/builders/node-operators/network-upgrades>
 fn chain_configs() -> &'static HashMap<u64, &'static LazyLock<OpChainConfig<OpSpecId>>> {
-    static CONFIGS: OnceLock<HashMap<u64, &'static LazyLock<OpChainConfig<OpSpecId>>>> = OnceLock::new();
+    static CONFIGS: OnceLock<HashMap<u64, &'static LazyLock<OpChainConfig<OpSpecId>>>> =
+        OnceLock::new();
 
     CONFIGS.get_or_init(|| {
         let mut hardforks = HashMap::new();
@@ -39,7 +40,8 @@ fn chain_configs() -> &'static HashMap<u64, &'static LazyLock<OpChainConfig<OpSp
     })
 }
 
-/// Returns the name corresponding to the provided chain ID, if it is supported and known.
+/// Returns the name corresponding to the provided chain ID, if it is supported
+/// and known.
 pub fn chain_name(chain_id: u64) -> Option<&'static str> {
     chain_configs()
         .get(&chain_id)

--- a/crates/edr_op/src/hardfork.rs
+++ b/crates/edr_op/src/hardfork.rs
@@ -1,4 +1,4 @@
-use std::sync::OnceLock;
+use std::sync::{LazyLock, OnceLock};
 
 use edr_eth::{eips::eip1559::BaseFeeParams, HashMap};
 use edr_evm::hardfork::Activations;
@@ -23,17 +23,17 @@ pub struct OpChainConfig<HardforkT: 'static> {
 
 // Source:
 // <https://docs.optimism.io/builders/node-operators/network-upgrades>
-fn chain_configs() -> &'static HashMap<u64, &'static OpChainConfig<OpSpecId>> {
-    static CONFIGS: OnceLock<HashMap<u64, &'static OpChainConfig<OpSpecId>>> = OnceLock::new();
+fn chain_configs() -> &'static HashMap<u64, &'static LazyLock<OpChainConfig<OpSpecId>>> {
+    static CONFIGS: OnceLock<HashMap<u64, &'static LazyLock<OpChainConfig<OpSpecId>>>> = OnceLock::new();
 
     CONFIGS.get_or_init(|| {
         let mut hardforks = HashMap::new();
 
-        hardforks.insert(op::MAINNET_CHAIN_ID, &*op::MAINNET_CONFIG);
-        hardforks.insert(op::SEPOLIA_CHAIN_ID, &*op::SEPOLIA_CONFIG);
+        hardforks.insert(op::MAINNET_CHAIN_ID, &op::MAINNET_CONFIG);
+        hardforks.insert(op::SEPOLIA_CHAIN_ID, &op::SEPOLIA_CONFIG);
 
-        hardforks.insert(base::MAINNET_CHAIN_ID, &*base::MAINNET_CONFIG);
-        hardforks.insert(base::SEPOLIA_CHAIN_ID, &*base::SEPOLIA_CONFIG);
+        hardforks.insert(base::MAINNET_CHAIN_ID, &base::MAINNET_CONFIG);
+        hardforks.insert(base::SEPOLIA_CHAIN_ID, &base::SEPOLIA_CONFIG);
 
         hardforks
     })

--- a/crates/edr_op/src/hardfork.rs
+++ b/crates/edr_op/src/hardfork.rs
@@ -39,7 +39,7 @@ fn chain_configs() -> &'static HashMap<u64, &'static LazyLock<OpChainConfig<OpSp
     })
 }
 
-/// Returns the name corresponding to the provided chain ID, if it is supported.
+/// Returns the name corresponding to the provided chain ID, if it is supported and known.
 pub fn chain_name(chain_id: u64) -> Option<&'static str> {
     chain_configs()
         .get(&chain_id)
@@ -47,7 +47,7 @@ pub fn chain_name(chain_id: u64) -> Option<&'static str> {
 }
 
 /// Returns the hardfork activations corresponding to the provided chain ID, if
-/// it is supported.
+/// it is supported and known.
 pub fn chain_hardfork_activations(chain_id: u64) -> Option<&'static Activations<OpSpecId>> {
     chain_configs()
         .get(&chain_id)

--- a/crates/edr_op/src/hardfork/base.rs
+++ b/crates/edr_op/src/hardfork/base.rs
@@ -14,8 +14,9 @@ pub const MAINNET_CHAIN_ID: u64 = 8453;
 /// <https://github.com/ethereum-optimism/superchain-registry/blob/51804a33655ddb4feeb0ad88960d9a81acdf6e62/superchain/configs/mainnet/base.toml>
 pub static MAINNET_CONFIG: LazyLock<OpChainConfig<OpSpecId>> = LazyLock::new(|| {
     const FORK_BASE_FEE_PARAMS: &[(OpSpecId, ConstantBaseFeeParams)] = &[
-        (OpSpecId::BEDROCK, ConstantBaseFeeParams::new(50, 2)),
-        (OpSpecId::CANYON, ConstantBaseFeeParams::new(250, 2)),
+        (OpSpecId::BEDROCK, ConstantBaseFeeParams::new(50, 6)),
+        (OpSpecId::CANYON, ConstantBaseFeeParams::new(250, 6)),
+        (OpSpecId::HOLOCENE, ConstantBaseFeeParams::new(250, 2)),
     ];
 
     OpChainConfig {
@@ -41,8 +42,8 @@ pub const SEPOLIA_CHAIN_ID: u64 = 84532;
 /// <https://github.com/ethereum-optimism/superchain-registry/blob/51804a33655ddb4feeb0ad88960d9a81acdf6e62/superchain/configs/sepolia/base.toml>
 pub static SEPOLIA_CONFIG: LazyLock<OpChainConfig<OpSpecId>> = LazyLock::new(|| {
     const FORK_BASE_FEE_PARAMS: &[(OpSpecId, ConstantBaseFeeParams)] = &[
-        (OpSpecId::BEDROCK, ConstantBaseFeeParams::new(50, 2)),
-        (OpSpecId::CANYON, ConstantBaseFeeParams::new(250, 2)),
+        (OpSpecId::BEDROCK, ConstantBaseFeeParams::new(50, 6)),
+        (OpSpecId::CANYON, ConstantBaseFeeParams::new(250, 6)),
     ];
 
     OpChainConfig {

--- a/crates/edr_op/src/hardfork/base.rs
+++ b/crates/edr_op/src/hardfork/base.rs
@@ -1,7 +1,10 @@
 use std::sync::LazyLock;
 
-use edr_evm::hardfork::{Activations, ChainConfig, ForkCondition};
+use edr_evm::hardfork::{Activations, ForkCondition};
+use edr_eth::eips::eip1559::{BaseFeeParams, ConstantBaseFeeParams, ForkBaseFeeParams};
 use op_revm::OpSpecId;
+
+use super::OpChainConfig;
 
 /// Base Mainnet chain ID
 pub const MAINNET_CHAIN_ID: u64 = 8453;
@@ -9,17 +12,25 @@ pub const MAINNET_CHAIN_ID: u64 = 8453;
 /// Base Mainnet chain config
 ///
 /// <https://github.com/ethereum-optimism/superchain-registry/blob/51804a33655ddb4feeb0ad88960d9a81acdf6e62/superchain/configs/mainnet/base.toml>
-pub static MAINNET_CONFIG: LazyLock<ChainConfig<OpSpecId>> = LazyLock::new(|| ChainConfig {
-    name: "Base Mainnet".into(),
-    hardfork_activations: Activations::new(vec![
-        (ForkCondition::Block(0), OpSpecId::BEDROCK),
-        (ForkCondition::Block(0), OpSpecId::REGOLITH),
-        (ForkCondition::Timestamp(1_704_992_401), OpSpecId::CANYON),
-        (ForkCondition::Timestamp(1_710_374_401), OpSpecId::ECOTONE),
-        (ForkCondition::Timestamp(1_720_627_201), OpSpecId::FJORD),
-        (ForkCondition::Timestamp(1_726_070_401), OpSpecId::GRANITE),
-        (ForkCondition::Timestamp(1_736_445_601), OpSpecId::HOLOCENE),
-    ]),
+pub static MAINNET_CONFIG: LazyLock<OpChainConfig<OpSpecId>> = LazyLock::new(|| {
+    static FORK_BASE_FEE_PARAMS: &[(OpSpecId, ConstantBaseFeeParams)] = &[
+        (OpSpecId::BEDROCK, ConstantBaseFeeParams::new(50, 6)),
+        (OpSpecId::CANYON, ConstantBaseFeeParams::new(250, 6)),
+    ];
+
+    OpChainConfig {
+        name: "Base Mainnet".into(),
+        hardfork_activations: Activations::new(vec![
+            (ForkCondition::Block(0), OpSpecId::BEDROCK),
+            (ForkCondition::Block(0), OpSpecId::REGOLITH),
+            (ForkCondition::Timestamp(1_704_992_401), OpSpecId::CANYON),
+            (ForkCondition::Timestamp(1_710_374_401), OpSpecId::ECOTONE),
+            (ForkCondition::Timestamp(1_720_627_201), OpSpecId::FJORD),
+            (ForkCondition::Timestamp(1_726_070_401), OpSpecId::GRANITE),
+            (ForkCondition::Timestamp(1_736_445_601), OpSpecId::HOLOCENE),
+        ]),
+        base_fee_params: BaseFeeParams::Variable(ForkBaseFeeParams::new(&FORK_BASE_FEE_PARAMS)),
+    }
 });
 
 /// Base Sepolia chain ID
@@ -28,15 +39,23 @@ pub const SEPOLIA_CHAIN_ID: u64 = 84532;
 /// Base Sepolia chain config
 ///
 /// <https://github.com/ethereum-optimism/superchain-registry/blob/51804a33655ddb4feeb0ad88960d9a81acdf6e62/superchain/configs/sepolia/base.toml>
-pub static SEPOLIA_CONFIG: LazyLock<ChainConfig<OpSpecId>> = LazyLock::new(|| ChainConfig {
-    name: "Base Sepolia".into(),
-    hardfork_activations: Activations::new(vec![
-        (ForkCondition::Block(0), OpSpecId::BEDROCK),
-        (ForkCondition::Block(0), OpSpecId::REGOLITH),
-        (ForkCondition::Timestamp(1_699_981_200), OpSpecId::CANYON),
-        (ForkCondition::Timestamp(1_708_534_800), OpSpecId::ECOTONE),
-        (ForkCondition::Timestamp(1_716_998_400), OpSpecId::FJORD),
-        (ForkCondition::Timestamp(1_723_478_400), OpSpecId::GRANITE),
-        (ForkCondition::Timestamp(1_732_633_200), OpSpecId::HOLOCENE),
-    ]),
+pub static SEPOLIA_CONFIG: LazyLock<OpChainConfig<OpSpecId>> = LazyLock::new(|| {
+    static FORK_BASE_FEE_PARAMS: &[(OpSpecId, ConstantBaseFeeParams)] = &[
+        (OpSpecId::BEDROCK, ConstantBaseFeeParams::new(50, 6)),
+        (OpSpecId::CANYON, ConstantBaseFeeParams::new(250, 6)),
+    ];
+
+    OpChainConfig {
+        name: "Base Sepolia".into(),
+        hardfork_activations: Activations::new(vec![
+            (ForkCondition::Block(0), OpSpecId::BEDROCK),
+            (ForkCondition::Block(0), OpSpecId::REGOLITH),
+            (ForkCondition::Timestamp(1_699_981_200), OpSpecId::CANYON),
+            (ForkCondition::Timestamp(1_708_534_800), OpSpecId::ECOTONE),
+            (ForkCondition::Timestamp(1_716_998_400), OpSpecId::FJORD),
+            (ForkCondition::Timestamp(1_723_478_400), OpSpecId::GRANITE),
+            (ForkCondition::Timestamp(1_732_633_200), OpSpecId::HOLOCENE),
+        ]),
+        base_fee_params: BaseFeeParams::Variable(ForkBaseFeeParams::new(FORK_BASE_FEE_PARAMS)),
+    }
 });

--- a/crates/edr_op/src/hardfork/base.rs
+++ b/crates/edr_op/src/hardfork/base.rs
@@ -14,8 +14,8 @@ pub const MAINNET_CHAIN_ID: u64 = 8453;
 /// <https://github.com/ethereum-optimism/superchain-registry/blob/51804a33655ddb4feeb0ad88960d9a81acdf6e62/superchain/configs/mainnet/base.toml>
 pub static MAINNET_CONFIG: LazyLock<OpChainConfig<OpSpecId>> = LazyLock::new(|| {
     const FORK_BASE_FEE_PARAMS: &[(OpSpecId, ConstantBaseFeeParams)] = &[
-        (OpSpecId::BEDROCK, ConstantBaseFeeParams::new(50, 6)),
-        (OpSpecId::CANYON, ConstantBaseFeeParams::new(250, 6)),
+        (OpSpecId::BEDROCK, ConstantBaseFeeParams::new(50, 2)),
+        (OpSpecId::CANYON, ConstantBaseFeeParams::new(250, 2)),
     ];
 
     OpChainConfig {
@@ -41,8 +41,8 @@ pub const SEPOLIA_CHAIN_ID: u64 = 84532;
 /// <https://github.com/ethereum-optimism/superchain-registry/blob/51804a33655ddb4feeb0ad88960d9a81acdf6e62/superchain/configs/sepolia/base.toml>
 pub static SEPOLIA_CONFIG: LazyLock<OpChainConfig<OpSpecId>> = LazyLock::new(|| {
     const FORK_BASE_FEE_PARAMS: &[(OpSpecId, ConstantBaseFeeParams)] = &[
-        (OpSpecId::BEDROCK, ConstantBaseFeeParams::new(50, 6)),
-        (OpSpecId::CANYON, ConstantBaseFeeParams::new(250, 6)),
+        (OpSpecId::BEDROCK, ConstantBaseFeeParams::new(50, 2)),
+        (OpSpecId::CANYON, ConstantBaseFeeParams::new(250, 2)),
     ];
 
     OpChainConfig {

--- a/crates/edr_op/src/hardfork/base.rs
+++ b/crates/edr_op/src/hardfork/base.rs
@@ -13,7 +13,7 @@ pub const MAINNET_CHAIN_ID: u64 = 8453;
 ///
 /// <https://github.com/ethereum-optimism/superchain-registry/blob/51804a33655ddb4feeb0ad88960d9a81acdf6e62/superchain/configs/mainnet/base.toml>
 pub static MAINNET_CONFIG: LazyLock<OpChainConfig<OpSpecId>> = LazyLock::new(|| {
-    static FORK_BASE_FEE_PARAMS: &[(OpSpecId, ConstantBaseFeeParams)] = &[
+    const FORK_BASE_FEE_PARAMS: &[(OpSpecId, ConstantBaseFeeParams)] = &[
         (OpSpecId::BEDROCK, ConstantBaseFeeParams::new(50, 6)),
         (OpSpecId::CANYON, ConstantBaseFeeParams::new(250, 6)),
     ];
@@ -29,7 +29,7 @@ pub static MAINNET_CONFIG: LazyLock<OpChainConfig<OpSpecId>> = LazyLock::new(|| 
             (ForkCondition::Timestamp(1_726_070_401), OpSpecId::GRANITE),
             (ForkCondition::Timestamp(1_736_445_601), OpSpecId::HOLOCENE),
         ]),
-        base_fee_params: BaseFeeParams::Variable(ForkBaseFeeParams::new(&FORK_BASE_FEE_PARAMS)),
+        base_fee_params: BaseFeeParams::Variable(ForkBaseFeeParams::new(FORK_BASE_FEE_PARAMS)),
     }
 });
 
@@ -40,7 +40,7 @@ pub const SEPOLIA_CHAIN_ID: u64 = 84532;
 ///
 /// <https://github.com/ethereum-optimism/superchain-registry/blob/51804a33655ddb4feeb0ad88960d9a81acdf6e62/superchain/configs/sepolia/base.toml>
 pub static SEPOLIA_CONFIG: LazyLock<OpChainConfig<OpSpecId>> = LazyLock::new(|| {
-    static FORK_BASE_FEE_PARAMS: &[(OpSpecId, ConstantBaseFeeParams)] = &[
+    const FORK_BASE_FEE_PARAMS: &[(OpSpecId, ConstantBaseFeeParams)] = &[
         (OpSpecId::BEDROCK, ConstantBaseFeeParams::new(50, 6)),
         (OpSpecId::CANYON, ConstantBaseFeeParams::new(250, 6)),
     ];

--- a/crates/edr_op/src/hardfork/base.rs
+++ b/crates/edr_op/src/hardfork/base.rs
@@ -1,7 +1,7 @@
 use std::sync::LazyLock;
 
-use edr_evm::hardfork::{Activations, ForkCondition};
 use edr_eth::eips::eip1559::{BaseFeeParams, ConstantBaseFeeParams, ForkBaseFeeParams};
+use edr_evm::hardfork::{Activations, ForkCondition};
 use op_revm::OpSpecId;
 
 use super::OpChainConfig;

--- a/crates/edr_op/src/hardfork/op.rs
+++ b/crates/edr_op/src/hardfork/op.rs
@@ -1,7 +1,10 @@
 use std::sync::LazyLock;
 
-use edr_evm::hardfork::{Activations, ChainConfig, ForkCondition};
+use edr_evm::hardfork::{Activations, ForkCondition};
+use edr_eth::eips::eip1559::{BaseFeeParams, ConstantBaseFeeParams, ForkBaseFeeParams};
 use op_revm::OpSpecId;
+
+use super::OpChainConfig;
 
 /// OP Mainnet chain ID
 pub const MAINNET_CHAIN_ID: u64 = 0xa;
@@ -9,17 +12,25 @@ pub const MAINNET_CHAIN_ID: u64 = 0xa;
 /// OP Mainnet chain config
 ///
 /// <https://github.com/ethereum-optimism/superchain-registry/blob/51804a33655ddb4feeb0ad88960d9a81acdf6e62/superchain/configs/mainnet/op.toml>
-pub static MAINNET_CONFIG: LazyLock<ChainConfig<OpSpecId>> = LazyLock::new(|| ChainConfig {
-    name: "OP Mainnet".into(),
-    hardfork_activations: Activations::new(vec![
-        (ForkCondition::Block(105_235_063), OpSpecId::BEDROCK),
-        (ForkCondition::Block(105_235_063), OpSpecId::REGOLITH),
-        (ForkCondition::Timestamp(1_704_992_401), OpSpecId::CANYON),
-        (ForkCondition::Timestamp(1_710_374_401), OpSpecId::ECOTONE),
-        (ForkCondition::Timestamp(1_720_627_201), OpSpecId::FJORD),
-        (ForkCondition::Timestamp(1_726_070_401), OpSpecId::GRANITE),
-        (ForkCondition::Timestamp(1_736_445_601), OpSpecId::HOLOCENE),
-    ]),
+pub static MAINNET_CONFIG: LazyLock<OpChainConfig<OpSpecId>> = LazyLock::new(|| {
+    static FORK_BASE_FEE_PARAMS: &[(OpSpecId, ConstantBaseFeeParams)] = &[
+        (OpSpecId::BEDROCK, ConstantBaseFeeParams::new(50, 6)),
+        (OpSpecId::CANYON, ConstantBaseFeeParams::new(250, 6)),
+    ];
+
+    OpChainConfig {
+        name: "OP Mainnet".into(),
+        hardfork_activations: Activations::new(vec![
+            (ForkCondition::Block(105_235_063), OpSpecId::BEDROCK),
+            (ForkCondition::Block(105_235_063), OpSpecId::REGOLITH),
+            (ForkCondition::Timestamp(1_704_992_401), OpSpecId::CANYON),
+            (ForkCondition::Timestamp(1_710_374_401), OpSpecId::ECOTONE),
+            (ForkCondition::Timestamp(1_720_627_201), OpSpecId::FJORD),
+            (ForkCondition::Timestamp(1_726_070_401), OpSpecId::GRANITE),
+            (ForkCondition::Timestamp(1_736_445_601), OpSpecId::HOLOCENE),
+        ]),
+        base_fee_params: BaseFeeParams::Variable(ForkBaseFeeParams::new(&FORK_BASE_FEE_PARAMS)),
+    }
 });
 
 /// OP Sepolia chain ID
@@ -28,15 +39,23 @@ pub const SEPOLIA_CHAIN_ID: u64 = 0xaa37dc;
 /// OP Sepolia chain config
 ///
 /// <https://github.com/ethereum-optimism/superchain-registry/blob/51804a33655ddb4feeb0ad88960d9a81acdf6e62/superchain/configs/sepolia/op.toml>
-pub static SEPOLIA_CONFIG: LazyLock<ChainConfig<OpSpecId>> = LazyLock::new(|| ChainConfig {
-    name: "OP Sepolia".into(),
-    hardfork_activations: Activations::new(vec![
-        (ForkCondition::Block(0), OpSpecId::BEDROCK),
-        (ForkCondition::Block(0), OpSpecId::REGOLITH),
-        (ForkCondition::Timestamp(1_699_981_200), OpSpecId::CANYON),
-        (ForkCondition::Timestamp(1_708_534_800), OpSpecId::ECOTONE),
-        (ForkCondition::Timestamp(1_716_998_400), OpSpecId::FJORD),
-        (ForkCondition::Timestamp(1_723_478_400), OpSpecId::GRANITE),
-        (ForkCondition::Timestamp(1_732_633_200), OpSpecId::HOLOCENE),
-    ]),
+pub static SEPOLIA_CONFIG: LazyLock<OpChainConfig<OpSpecId>> = LazyLock::new(|| {
+    static FORK_BASE_FEE_PARAMS: &[(OpSpecId, ConstantBaseFeeParams)] = &[
+        (OpSpecId::BEDROCK, ConstantBaseFeeParams::new(50, 6)),
+        (OpSpecId::CANYON, ConstantBaseFeeParams::new(250, 6)),
+    ];
+
+    OpChainConfig {
+        name: "OP Sepolia".into(),
+        hardfork_activations: Activations::new(vec![
+            (ForkCondition::Block(0), OpSpecId::BEDROCK),
+            (ForkCondition::Block(0), OpSpecId::REGOLITH),
+            (ForkCondition::Timestamp(1_699_981_200), OpSpecId::CANYON),
+            (ForkCondition::Timestamp(1_708_534_800), OpSpecId::ECOTONE),
+            (ForkCondition::Timestamp(1_716_998_400), OpSpecId::FJORD),
+            (ForkCondition::Timestamp(1_723_478_400), OpSpecId::GRANITE),
+            (ForkCondition::Timestamp(1_732_633_200), OpSpecId::HOLOCENE),
+        ]),
+        base_fee_params: BaseFeeParams::Variable(ForkBaseFeeParams::new(&FORK_BASE_FEE_PARAMS)),
+    }
 });

--- a/crates/edr_op/src/hardfork/op.rs
+++ b/crates/edr_op/src/hardfork/op.rs
@@ -1,7 +1,7 @@
 use std::sync::LazyLock;
 
-use edr_evm::hardfork::{Activations, ForkCondition};
 use edr_eth::eips::eip1559::{BaseFeeParams, ConstantBaseFeeParams, ForkBaseFeeParams};
+use edr_evm::hardfork::{Activations, ForkCondition};
 use op_revm::OpSpecId;
 
 use super::OpChainConfig;

--- a/crates/edr_op/src/hardfork/op.rs
+++ b/crates/edr_op/src/hardfork/op.rs
@@ -13,7 +13,7 @@ pub const MAINNET_CHAIN_ID: u64 = 0xa;
 ///
 /// <https://github.com/ethereum-optimism/superchain-registry/blob/51804a33655ddb4feeb0ad88960d9a81acdf6e62/superchain/configs/mainnet/op.toml>
 pub static MAINNET_CONFIG: LazyLock<OpChainConfig<OpSpecId>> = LazyLock::new(|| {
-    static FORK_BASE_FEE_PARAMS: &[(OpSpecId, ConstantBaseFeeParams)] = &[
+    const FORK_BASE_FEE_PARAMS: &[(OpSpecId, ConstantBaseFeeParams)] = &[
         (OpSpecId::BEDROCK, ConstantBaseFeeParams::new(50, 6)),
         (OpSpecId::CANYON, ConstantBaseFeeParams::new(250, 6)),
     ];
@@ -29,7 +29,7 @@ pub static MAINNET_CONFIG: LazyLock<OpChainConfig<OpSpecId>> = LazyLock::new(|| 
             (ForkCondition::Timestamp(1_726_070_401), OpSpecId::GRANITE),
             (ForkCondition::Timestamp(1_736_445_601), OpSpecId::HOLOCENE),
         ]),
-        base_fee_params: BaseFeeParams::Variable(ForkBaseFeeParams::new(&FORK_BASE_FEE_PARAMS)),
+        base_fee_params: BaseFeeParams::Variable(ForkBaseFeeParams::new(FORK_BASE_FEE_PARAMS)),
     }
 });
 
@@ -40,7 +40,7 @@ pub const SEPOLIA_CHAIN_ID: u64 = 0xaa37dc;
 ///
 /// <https://github.com/ethereum-optimism/superchain-registry/blob/51804a33655ddb4feeb0ad88960d9a81acdf6e62/superchain/configs/sepolia/op.toml>
 pub static SEPOLIA_CONFIG: LazyLock<OpChainConfig<OpSpecId>> = LazyLock::new(|| {
-    static FORK_BASE_FEE_PARAMS: &[(OpSpecId, ConstantBaseFeeParams)] = &[
+    const FORK_BASE_FEE_PARAMS: &[(OpSpecId, ConstantBaseFeeParams)] = &[
         (OpSpecId::BEDROCK, ConstantBaseFeeParams::new(50, 6)),
         (OpSpecId::CANYON, ConstantBaseFeeParams::new(250, 6)),
     ];
@@ -56,6 +56,6 @@ pub static SEPOLIA_CONFIG: LazyLock<OpChainConfig<OpSpecId>> = LazyLock::new(|| 
             (ForkCondition::Timestamp(1_723_478_400), OpSpecId::GRANITE),
             (ForkCondition::Timestamp(1_732_633_200), OpSpecId::HOLOCENE),
         ]),
-        base_fee_params: BaseFeeParams::Variable(ForkBaseFeeParams::new(&FORK_BASE_FEE_PARAMS)),
+        base_fee_params: BaseFeeParams::Variable(ForkBaseFeeParams::new(FORK_BASE_FEE_PARAMS)),
     }
 });

--- a/crates/edr_op/src/spec.rs
+++ b/crates/edr_op/src/spec.rs
@@ -162,6 +162,16 @@ impl EthHeaderConstants for OpChainSpec {
         ]));
 
     const MIN_ETHASH_DIFFICULTY: u64 = 0;
+
+    fn chain_base_fee_params(chain_id: u64) -> BaseFeeParams<Self::Hardfork> {
+        const DEFAULT_BASE_FEE_PARAMS: BaseFeeParams<OpSpecId> =
+            BaseFeeParams::Variable(ForkBaseFeeParams::new(&[
+                (OpSpecId::BEDROCK, ConstantBaseFeeParams::new(50, 6)),
+                (OpSpecId::CANYON, ConstantBaseFeeParams::new(250, 6)),
+            ]));
+
+        hardfork::chain_base_fee_params(chain_id).copied().unwrap_or(DEFAULT_BASE_FEE_PARAMS)
+    }
 }
 
 impl SyncNapiSpec for OpChainSpec {

--- a/crates/edr_op/src/spec.rs
+++ b/crates/edr_op/src/spec.rs
@@ -165,7 +165,7 @@ impl EthHeaderParams for OpChainSpec {
             ]));
 
         hardfork::chain_base_fee_params(chain_id)
-            .copied()
+            .cloned()
             .unwrap_or(DEFAULT_BASE_FEE_PARAMS)
     }
 }

--- a/crates/edr_op/src/spec.rs
+++ b/crates/edr_op/src/spec.rs
@@ -155,12 +155,6 @@ impl RuntimeSpec for OpChainSpec {
 }
 
 impl EthHeaderConstants for OpChainSpec {
-    const BASE_FEE_PARAMS: BaseFeeParams<OpSpecId> =
-        BaseFeeParams::Variable(ForkBaseFeeParams::new(&[
-            (OpSpecId::BEDROCK, ConstantBaseFeeParams::new(50, 6)),
-            (OpSpecId::CANYON, ConstantBaseFeeParams::new(250, 6)),
-        ]));
-
     const MIN_ETHASH_DIFFICULTY: u64 = 0;
 
     fn chain_base_fee_params(chain_id: u64) -> BaseFeeParams<Self::Hardfork> {

--- a/crates/edr_op/src/spec.rs
+++ b/crates/edr_op/src/spec.rs
@@ -5,7 +5,7 @@ use alloy_rlp::RlpEncodable;
 use edr_eth::{
     eips::eip1559::{BaseFeeParams, ConstantBaseFeeParams, ForkBaseFeeParams},
     l1,
-    spec::{ChainSpec, EthHeaderConstants},
+    spec::{ChainSpec, EthHeaderParams},
 };
 use edr_evm::{
     BlockReceipts, RemoteBlock, RemoteBlockConversionError, SyncBlock,
@@ -154,7 +154,7 @@ impl RuntimeSpec for OpChainSpec {
     }
 }
 
-impl EthHeaderConstants for OpChainSpec {
+impl EthHeaderParams for OpChainSpec {
     const MIN_ETHASH_DIFFICULTY: u64 = 0;
 
     fn chain_base_fee_params(chain_id: u64) -> BaseFeeParams<Self::Hardfork> {

--- a/crates/edr_op/src/spec.rs
+++ b/crates/edr_op/src/spec.rs
@@ -164,7 +164,9 @@ impl EthHeaderParams for OpChainSpec {
                 (OpSpecId::CANYON, ConstantBaseFeeParams::new(250, 6)),
             ]));
 
-        hardfork::chain_base_fee_params(chain_id).copied().unwrap_or(DEFAULT_BASE_FEE_PARAMS)
+        hardfork::chain_base_fee_params(chain_id)
+            .copied()
+            .unwrap_or(DEFAULT_BASE_FEE_PARAMS)
     }
 }
 

--- a/crates/edr_op/tests/integration/full_block.rs
+++ b/crates/edr_op/tests/integration/full_block.rs
@@ -3,7 +3,7 @@
 use edr_evm::impl_full_block_tests;
 use edr_op::OpChainSpec;
 
-use super::{op, base};
+use super::{base, op};
 
 impl_full_block_tests! {
     op_mainnet_regolith => OpChainSpec {

--- a/crates/edr_op/tests/integration/full_block.rs
+++ b/crates/edr_op/tests/integration/full_block.rs
@@ -3,31 +3,36 @@
 use edr_evm::impl_full_block_tests;
 use edr_op::OpChainSpec;
 
-use super::op::mainnet_url;
+use super::{op, base};
 
 impl_full_block_tests! {
-    mainnet_regolith => OpChainSpec {
+    op_mainnet_regolith => OpChainSpec {
         block_number: 105_235_064,
-        url: mainnet_url(),
+        url: op::mainnet_url(),
     },
-    mainnet_canyon => OpChainSpec {
+    op_mainnet_canyon => OpChainSpec {
         block_number: 115_235_064,
-        url: mainnet_url(),
+        url: op::mainnet_url(),
     },
-    mainnet_ecotone => OpChainSpec {
+    op_mainnet_ecotone => OpChainSpec {
         block_number: 121_874_088,
-        url: mainnet_url(),
+        url: op::mainnet_url(),
     },
-    mainnet_fjord => OpChainSpec {
+    op_mainnet_fjord => OpChainSpec {
         block_number: 122_514_212,
-        url: mainnet_url(),
+        url: op::mainnet_url(),
     },
-    mainnet_granite => OpChainSpec {
+    op_mainnet_granite => OpChainSpec {
         block_number: 125_235_823,
-        url: mainnet_url(),
+        url: op::mainnet_url(),
     },
-    mainnet_holocene => OpChainSpec {
+    op_mainnet_holocene => OpChainSpec {
         block_number: 130_423_412,
-        url: mainnet_url(),
+        url: op::mainnet_url(),
+    },
+
+    base_mainnet_holocene => OpChainSpec {
+        block_number: 24_828_127,
+        url: base::mainnet_url(),
     },
 }

--- a/crates/edr_provider/src/data.rs
+++ b/crates/edr_provider/src/data.rs
@@ -20,6 +20,7 @@ use edr_eth::{
         BlockOptions, calculate_next_base_fee_per_blob_gas, calculate_next_base_fee_per_gas,
         miner_reward,
     },
+    eips::eip1559::ConstantBaseFeeParams,
     fee_history::FeeHistoryResult,
     filter::{FilteredEvents, LogOutput, SubscriptionType},
     l1,
@@ -1593,6 +1594,10 @@ where
         self.blockchain.hardfork()
     }
 
+    pub fn base_fee_params(&self) -> ConstantBaseFeeParams {
+        self.blockchain.base_fee_params()
+    }
+
     /// Returns the last block in the blockchain.
     pub fn last_block(
         &self,
@@ -1641,8 +1646,8 @@ where
                 || {
                     let last_block = self.last_block()?;
 
-                    Ok(calculate_next_base_fee_per_gas::<ChainSpecT>(
-                        self.blockchain.hardfork(),
+                    Ok(calculate_next_base_fee_per_gas(
+                        self.base_fee_params(),
                         last_block.header(),
                     ))
                 },
@@ -1920,8 +1925,8 @@ where
                 let block = pending_block.as_ref().expect("We mined the pending block");
                 result
                     .base_fee_per_gas
-                    .push(calculate_next_base_fee_per_gas::<ChainSpecT>(
-                        self.blockchain.hardfork(),
+                    .push(calculate_next_base_fee_per_gas(
+                        self.base_fee_params(),
                         block.header(),
                     ));
             }

--- a/crates/edr_provider/src/pending.rs
+++ b/crates/edr_provider/src/pending.rs
@@ -2,7 +2,8 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use derive_where::derive_where;
 use edr_eth::{
-    eips::eip1559::ConstantBaseFeeParams, receipt::ReceiptTrait as _, transaction::ExecutableTransaction as _, HashSet, B256, U256
+    B256, HashSet, U256, eips::eip1559::ConstantBaseFeeParams, receipt::ReceiptTrait as _,
+    transaction::ExecutableTransaction as _,
 };
 use edr_evm::{
     Block as _, BlockAndTotalDifficulty, BlockReceipts,

--- a/crates/edr_provider/src/pending.rs
+++ b/crates/edr_provider/src/pending.rs
@@ -2,7 +2,7 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use derive_where::derive_where;
 use edr_eth::{
-    B256, HashSet, U256, receipt::ReceiptTrait as _, transaction::ExecutableTransaction as _,
+    eips::eip1559::ConstantBaseFeeParams, receipt::ReceiptTrait as _, transaction::ExecutableTransaction as _, HashSet, B256, U256
 };
 use edr_evm::{
     Block as _, BlockAndTotalDifficulty, BlockReceipts,
@@ -204,6 +204,10 @@ where
         } else {
             self.blockchain.total_difficulty_by_hash(hash)
         }
+    }
+
+    fn base_fee_params(&self) -> ConstantBaseFeeParams {
+        self.blockchain.base_fee_params()
     }
 }
 

--- a/crates/edr_provider/src/spec.rs
+++ b/crates/edr_provider/src/spec.rs
@@ -1,7 +1,7 @@
 use core::fmt::Debug;
 use std::sync::Arc;
 
-pub use edr_eth::spec::EthHeaderConstants;
+pub use edr_eth::spec::EthHeaderParams;
 use edr_eth::{
     Address, B256, Blob, BlockSpec,
     eips::{eip2930, eip7702},


### PR DESCRIPTION
Fixes https://github.com/NomicFoundation/edr/issues/887

Base fee parameters were a constant, this PR turns them into a function of chain id. This also prepares things for the ability to provide overrides for the parameters via config like with hardfork activations.

- In `calculate_next_base_fee_per_gas` and `PartialHeader::new` they are now passed as an argument rather than taken from `ChainSpecT`.
- Added `Blockchain::base_fee_params`.
- In `LocalBlockchain::new` we get the constant params for the hardfork from `ChainSpecT` and store them in the struct.
- In `ForkedBlockchain::new` we get the hardfork-variable params for the remote chain id and store them in the struct.