### PR TITLE
feat: require coverage library path to be specified

### DIFF
--- a/.changeset/poor-shirts-collect.md
+++ b/.changeset/poor-shirts-collect.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": minor
+---
+
+Changed the instrumentation API to require a coverage library path

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1708,7 +1708,7 @@ version = "0.3.5"
 dependencies = [
  "anyhow",
  "edr_eth",
- "semver 1.0.23",
+ "semver 1.0.26",
  "serde",
  "serde_json",
  "sha3",
@@ -1927,7 +1927,7 @@ dependencies = [
  "itertools 0.10.5",
  "log",
  "parking_lot 0.12.3",
- "semver 1.0.23",
+ "semver 1.0.26",
  "serde",
  "serde_json",
  "strum",
@@ -2842,13 +2842,12 @@ checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "metaslang_cst"
-version = "0.18.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f39368da9228d99987bd8885b74c98eb93bfa94e9d348b351e646447781f94"
+version = "1.1.0"
+source = "git+https://github.com/NomicFoundation/slang?rev=699de7e#699de7e9c93c71dc82393c37e7898172de447524"
 dependencies = [
  "nom",
  "serde",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -2968,7 +2967,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "semver 1.0.23",
+ "semver 1.0.26",
  "syn 2.0.99",
 ]
 
@@ -4131,7 +4130,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.23",
+ "semver 1.0.26",
 ]
 
 [[package]]
@@ -4273,9 +4272,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 dependencies = [
  "serde",
 ]
@@ -4470,16 +4469,15 @@ dependencies = [
 
 [[package]]
 name = "slang_solidity"
-version = "0.18.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8aedd5543605d5a69ac186cf0afe69e3472b1e3898bdd864b40aa87356298cb"
+version = "1.1.0"
+source = "git+https://github.com/NomicFoundation/slang?rev=699de7e#699de7e9c93c71dc82393c37e7898172de447524"
 dependencies = [
  "metaslang_cst",
- "semver 1.0.23",
+ "semver 1.0.26",
  "serde",
  "strum",
  "strum_macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ serde = { version = "1.0.209", default-features = false }
 serde_json = { version = "1.0.127", default-features = false }
 sha2 = { version = "0.10.8", default-features = false }
 sha3 = { version = "0.10.8", default-features = false }
-semver = { version = "1.0.23", default-features = false }
+semver = { version = "1.0.26", default-features = false }
 thiserror = { version = "1.0.58", default-features = false }
 
 [workspace.lints.rust]

--- a/crates/edr_instrument/Cargo.toml
+++ b/crates/edr_instrument/Cargo.toml
@@ -10,7 +10,7 @@ semver.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 sha3.workspace = true
-slang_solidity = "0.18.3"
+slang_solidity = { git = "https://github.com/NomicFoundation/slang", rev = "699de7e" }
 thiserror.workspace = true
 
 [lints]

--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -389,7 +389,7 @@ export interface InstrumentationMetadata {
  * Adds per-statement coverage instrumentation to the given Solidity source
  * code.
  */
-export declare function addStatementCoverageInstrumentation(sourceCode: string, sourceId: string, solidityVersion: string): InstrumentationResult
+export declare function addStatementCoverageInstrumentation(sourceCode: string, sourceId: string, solidityVersion: string, coverageLibraryPath: string): InstrumentationResult
 /** Ethereum execution log. */
 export interface ExecutionLog {
   address: Buffer

--- a/crates/edr_napi/src/instrument.rs
+++ b/crates/edr_napi/src/instrument.rs
@@ -83,6 +83,7 @@ pub fn add_statement_coverage_instrumentation(
     source_code: String,
     source_id: String,
     solidity_version: String,
+    coverage_library_path: String,
 ) -> napi::Result<InstrumentationResult> {
     let solidity_version = Version::parse(&solidity_version).map_err(|error| {
         napi::Error::new(
@@ -91,8 +92,13 @@ pub fn add_statement_coverage_instrumentation(
         )
     })?;
 
-    let instrumented = coverage::instrument_code(&source_code, &source_id, solidity_version)
-        .map_err(|error| napi::Error::new(napi::Status::GenericFailure, error.to_string()))?;
+    let instrumented = coverage::instrument_code(
+        &source_code,
+        &source_id,
+        solidity_version,
+        &coverage_library_path,
+    )
+    .map_err(|error| napi::Error::new(napi::Status::GenericFailure, error))?;
 
     instrumented.try_into().map_err(|location| {
         napi::Error::new(

--- a/crates/edr_napi/test/instrument.ts
+++ b/crates/edr_napi/test/instrument.ts
@@ -27,13 +27,16 @@ describe("Code coverage", () => {
 
   describe("instrumentation", function () {
     it("Statement coverage", async function () {
+      const coverageLibraryPath = "__hardhat_coverage.sol";
       const result = addStatementCoverageInstrumentation(
         incrementSourceCode,
         "instrumentation.sol",
-        "0.8.0"
+        "0.8.0",
+        coverageLibraryPath
       );
 
       expect(result.source).to.contain("__HardhatCoverage.sendHit(");
+      expect(result.source).to.contain(coverageLibraryPath);
 
       assert.lengthOf(result.metadata, 3);
       assertMetadata(result.metadata[0], {


### PR DESCRIPTION
Require specification of the coverage library path when adding coverage instrumentation.