### PR TITLE
fix: use fixed fork block number in tests

### DIFF
--- a/hardhat-tests/test/internal/hardhat-network/provider/modules/debug/traceTransaction.ts
+++ b/hardhat-tests/test/internal/hardhat-network/provider/modules/debug/traceTransaction.ts
@@ -40,7 +40,7 @@ describe("Debug module", function () {
   PROVIDERS.forEach(({ name, useProvider }) => {
     describe(`${name} provider`, function () {
       setCWD();
-      useProvider();
+      useProvider({ forkBlockNumber: 22559592 });
 
       describe("debug_traceTransaction", function () {
         it("Should throw for unknown txs", async function () {
@@ -193,7 +193,7 @@ describe("Debug module", function () {
         });
 
         describe("berlin", function () {
-          useProvider({ hardfork: "berlin" });
+          useProvider({ hardfork: "berlin", forkBlockNumber: 22559592 });
 
           it("Should work with EIP-2930 txs", async function () {
             const txHash = await sendDummyTransaction(this.provider, 0, {

--- a/hardhat-tests/test/internal/hardhat-network/provider/modules/eth/methods/feeHistory.ts
+++ b/hardhat-tests/test/internal/hardhat-network/provider/modules/eth/methods/feeHistory.ts
@@ -19,7 +19,7 @@ describe("Eth module", function () {
 
     describe(`${name} provider`, function () {
       setCWD();
-      useProvider();
+      useProvider({ forkBlockNumber: 22559592 });
 
       describe("eth_feeHistory", function () {
         describe("Params validation", function () {

--- a/hardhat-tests/test/internal/hardhat-network/provider/modules/eth/methods/getStorageAt.ts
+++ b/hardhat-tests/test/internal/hardhat-network/provider/modules/eth/methods/getStorageAt.ts
@@ -26,7 +26,7 @@ describe("Eth module", function () {
 
     describe(`${name} provider`, function () {
       setCWD();
-      useProvider();
+      useProvider({ forkBlockNumber: 22559592 });
 
       describe("eth_getStorageAt", function () {
         describe("Imitating Ganache", function () {

--- a/hardhat-tests/test/internal/hardhat-network/provider/modules/eth/receiptsRoot.ts
+++ b/hardhat-tests/test/internal/hardhat-network/provider/modules/eth/receiptsRoot.ts
@@ -22,7 +22,7 @@ describe("Eth module", function () {
 
     describe(`${name} provider`, function () {
       setCWD();
-      useProvider();
+      useProvider({ forkBlockNumber: 22559592 });
 
       describe("receiptsRoot", function () {
         let firstBlockNumber: number;

--- a/hardhat-tests/test/internal/hardhat-network/provider/modules/hardhat.ts
+++ b/hardhat-tests/test/internal/hardhat-network/provider/modules/hardhat.ts
@@ -52,7 +52,7 @@ describe("Hardhat module", function () {
       const safeBlockInThePast = 11_200_000; // this should resolve CI errors probably caused by using a block too far in the past
 
       setCWD();
-      useProvider();
+      useProvider({ forkBlockNumber: 22559592 });
 
       describe("hardhat_impersonateAccount", function () {
         it("validates input parameter", async function () {


### PR DESCRIPTION
The reason tests are failing is that someone has set up an [EIP-7702 delegation on Hardhat's default accounts](https://etherscan.io/address/0xbe862ad9abfe6f22bcb087716c7d89a26051f74c#authlist7702) that drains any ETH sent to it. Since fork tests run on the latest block, some of the tests have begun to fail. This PR changes the affected `useProvider` calls to configure the fork block as the last one before these delegations were set up.