### PR TITLE
ci: increase benchmark runs to reduce CI false negatives

### DIFF
--- a/crates/tools/js/benchmark/src/solidity-tests.ts
+++ b/crates/tools/js/benchmark/src/solidity-tests.ts
@@ -50,8 +50,8 @@ const DEFAULT_SAMPLES = 5;
 export const FORGE_STD_SAMPLES = {
   [TOTAL_NAME]: DEFAULT_SAMPLES,
   StdCheatsTest: DEFAULT_SAMPLES,
-  StdCheatsForkTest: 15,
-  StdMathTest: 9,
+  StdCheatsForkTest: 45,
+  StdMathTest: 45,
   StdStorageTest: DEFAULT_SAMPLES,
   StdUtilsForkTest: 15,
 };


### PR DESCRIPTION
While merging several PRs into `feat/solidity-tests`, I've had to re-run the soltest benchmark  job numerous times due to variability in the small test suites, which take ~20ms (e.g. [CI log](https://github.com/NomicFoundation/edr/actions/runs/15262322988/attempts/2?pr=917)).

This PR increases the number of samples for both of these test suites to 45, which would still total to less than 1 second per test suite.

Compared to re-running the full 16-minute job and potentially waiting for or delaying other benchmark runs in the queue, this is a more than acceptable trade-off for me.

