### PR TITLE
edr-0.10.0-alpha.5

### DIFF
--- a/crates/edr_napi/npm/darwin-arm64/package.json
+++ b/crates/edr_napi/npm/darwin-arm64/package.json
@@ -4,7 +4,7 @@
     "url": "https://github.com/NomicFoundation/edr.git",
     "type": "git"
   },
-  "version": "0.10.0-alpha.4",
+  "version": "0.10.0-alpha.5",
   "main": "edr.darwin-arm64.node",
   "files": [
     "edr.darwin-arm64.node"

--- a/crates/edr_napi/npm/darwin-x64/package.json
+++ b/crates/edr_napi/npm/darwin-x64/package.json
@@ -4,7 +4,7 @@
     "url": "https://github.com/NomicFoundation/edr.git",
     "type": "git"
   },
-  "version": "0.10.0-alpha.4",
+  "version": "0.10.0-alpha.5",
   "main": "edr.darwin-x64.node",
   "files": [
     "edr.darwin-x64.node"

--- a/crates/edr_napi/npm/linux-arm64-gnu/package.json
+++ b/crates/edr_napi/npm/linux-arm64-gnu/package.json
@@ -4,7 +4,7 @@
     "url": "https://github.com/NomicFoundation/edr.git",
     "type": "git"
   },
-  "version": "0.10.0-alpha.4",
+  "version": "0.10.0-alpha.5",
   "main": "edr.linux-arm64-gnu.node",
   "files": [
     "edr.linux-arm64-gnu.node"

--- a/crates/edr_napi/npm/linux-arm64-musl/package.json
+++ b/crates/edr_napi/npm/linux-arm64-musl/package.json
@@ -4,7 +4,7 @@
     "url": "https://github.com/NomicFoundation/edr.git",
     "type": "git"
   },
-  "version": "0.10.0-alpha.4",
+  "version": "0.10.0-alpha.5",
   "main": "edr.linux-arm64-musl.node",
   "files": [
     "edr.linux-arm64-musl.node"

--- a/crates/edr_napi/npm/linux-x64-gnu/package.json
+++ b/crates/edr_napi/npm/linux-x64-gnu/package.json
@@ -4,7 +4,7 @@
     "url": "https://github.com/NomicFoundation/edr.git",
     "type": "git"
   },
-  "version": "0.10.0-alpha.4",
+  "version": "0.10.0-alpha.5",
   "main": "edr.linux-x64-gnu.node",
   "files": [
     "edr.linux-x64-gnu.node"

--- a/crates/edr_napi/npm/linux-x64-musl/package.json
+++ b/crates/edr_napi/npm/linux-x64-musl/package.json
@@ -4,7 +4,7 @@
     "url": "https://github.com/NomicFoundation/edr.git",
     "type": "git"
   },
-  "version": "0.10.0-alpha.4",
+  "version": "0.10.0-alpha.5",
   "main": "edr.linux-x64-musl.node",
   "files": [
     "edr.linux-x64-musl.node"

--- a/crates/edr_napi/npm/win32-x64-msvc/package.json
+++ b/crates/edr_napi/npm/win32-x64-msvc/package.json
@@ -4,7 +4,7 @@
     "url": "https://github.com/NomicFoundation/edr.git",
     "type": "git"
   },
-  "version": "0.10.0-alpha.4",
+  "version": "0.10.0-alpha.5",
   "main": "edr.win32-x64-msvc.node",
   "files": [
     "edr.win32-x64-msvc.node"

--- a/crates/edr_napi/package.json
+++ b/crates/edr_napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ignored/edr",
-  "version": "0.10.0-alpha.4",
+  "version": "0.10.0-alpha.5",
   "devDependencies": {
     "@napi-rs/cli": "^2.18.4",
     "@types/chai": "^4.2.0",


### PR DESCRIPTION
> **⚠️ This branch is intended to test the upcoming release and should be merged manually, to trigger the release**

This release contains the following changes:
- Deprecated `deleteSnapshot`, `deleteSnapshots`, `revertTo`, `revertToAndDelete`, and `snapshot` cheatcodes in favor of `deleteStateSnapshot`, `deleteStateSnapshots`, `revertToState`, `revertToStateAndDelete`, and `snapshotState`