### PR TITLE
ci: create hardhat regression tests workflow

### DIFF
--- a/.github/workflows/hardhat-regression-tests.yml
+++ b/.github/workflows/hardhat-regression-tests.yml
@@ -1,0 +1,49 @@
+name: Hardhat Regression Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      preset:
+        description: 'The preset to use'
+        required: false
+        type: choice
+        options:
+          - solidity-test
+          - solidity-compile
+          - default
+        default: 'default'
+      hardhat-ref:
+        description: 'The branch, tag or SHA of hardhat to test against'
+        required: false
+        type: string
+      edr-ref:
+        description: 'The branch, tag or SHA of edr to test against'
+        required: false
+        type: string
+      repositories:
+        description: 'A list of repositories to test against'
+        required: false
+        type: string
+      runners:
+        description: 'A list of runners to test against'
+        required: false
+        type: string
+      commands:
+        description: 'A list of commands to test against'
+        required: false
+        type: string
+
+jobs:
+  test:
+    name: Run the regression tests
+    # TODO: Change the ref to v-next once the reusable-regression-tests branch is merged
+    uses: NomicFoundation/hardhat/.github/workflows/regression-tests.yml@reusable-regression-tests
+    with:
+      # TODO: Change the ref to v-next once the reusable-regression-tests branch is merged
+      ref: reusable-regression-tests
+      preset: ${{ inputs.preset }}
+      hardhat-ref: ${{ inputs.hardhat-ref }}
+      edr-ref: ${{ inputs.edr-ref || github.ref }}
+      repositories: ${{ inputs.repositories }}
+      runners: ${{ inputs.runners }}
+      commands: ${{ inputs.commands }}


### PR DESCRIPTION
This PR introduces a Hardhat regression tests workflow to EDR.

The added workflow can be triggered manually. When triggered, it will behave almost exactly as https://github.com/NomicFoundation/hardhat/actions/workflows/regression-tests.yml from Hardhat. The main difference is, the default value for `edr-ref` input when the workflow is triggered from the edr repository will be the git ref from which the workflow is triggered. This will make the workflow build EDR from source and use it as a dependency in hardhat that will be used for executing the tests.

Currently, the workflow has 2 presets - `solidity-test` and `solidity-compile`. The former runs `hardhat test solidity` and `forge test` commands in a number of repositories, while the latter runs `hardhat2 compile` and `hardhat3 compile` in a number of repositories.

After running the tests, the workflow produces a summary table that outlines which commands succeeded and how much time they took, e.g. https://github.com/NomicFoundation/edr/actions/runs/15506508711/attempts/2#summary-43662417460. Disclaimer: the tests are currently run on GitHub hosted runners so the durations might not always be accurate.

#### Testing

I ran the workflow by temporarily adding a push trigger to the workflow and using `solidity-compile` as a default preset. You can inspect the run here: https://github.com/NomicFoundation/edr/actions/runs/15506508711