### PR TITLE
chore: add hh2 branch to npm release workflow (cherry-pick)

### DIFF
--- a/.github/workflows/edr-npm-release.yml
+++ b/.github/workflows/edr-npm-release.yml
@@ -13,6 +13,7 @@ on:
     branches:
       - main
       - prerelease
+      - hh2
     tags-ignore:
       - "**"
     paths-ignore:
@@ -408,12 +409,12 @@ jobs:
             fi
           elif git log -1 --pretty=%B | grep "^edr-[0-9]\+\.[0-9]\+\.[0-9]\+\s*";
           then
-            if [ "$GITHUB_REF" == "refs/heads/main" ]; then
+            if [ "$GITHUB_REF" == "refs/heads/main" -o "$GITHUB_REF" == "refs/heads/hh2" ]; then
               echo "Publishing release"
               echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
               pnpm publish --no-git-checks --provenance --access public
             else
-              echo "Trying to publish a release from a branch that is not 'main'"
+              echo "Trying to publish a release from a branch that is not 'main' or 'h2'"
             fi
           else
             echo "Not a release, skipping publish"


### PR DESCRIPTION
Cherry picked #937 from `main`. Needed for both automated releases and manual dispatch.