### PR TITLE
chore: downgrade to rust edition 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ resolver = "2"
 
 [workspace.package]
 version = "0.3.5"
-edition = "2024"
+edition = "2021"
 
 [profile.dev]
 rpath = true

--- a/crates/edr_coverage/src/lib.rs
+++ b/crates/edr_coverage/src/lib.rs
@@ -1,6 +1,6 @@
 mod collector;
 
-use edr_eth::{Address, address};
+use edr_eth::{address, Address};
 
 pub use self::collector::CoverageHitCollector;
 

--- a/crates/edr_coverage/tests/integration/e2e.rs
+++ b/crates/edr_coverage/tests/integration/e2e.rs
@@ -2,11 +2,12 @@ use std::{collections::BTreeMap, str::FromStr};
 
 use edr_coverage::CoverageHitCollector;
 use edr_eth::{
-    Address, B256, Bytes, HashMap, HashSet, U256, bytes,
+    bytes,
     l1::{self, L1ChainSpec},
     result::{ExecutionResult, Output},
     signature::public_key_to_address,
     transaction::{self, TxKind},
+    Address, Bytes, HashMap, HashSet, B256, U256,
 };
 use edr_evm::{
     blockchain::{Blockchain, GenesisBlockOptions, LocalBlockchain},

--- a/crates/edr_eth/src/account.rs
+++ b/crates/edr_eth/src/account.rs
@@ -10,7 +10,7 @@ use alloy_rlp::{RlpDecodable, RlpEncodable};
 pub use revm_primitives::KECCAK_EMPTY;
 pub use revm_state::{Account, AccountInfo, AccountStatus};
 
-use crate::{B256, U256, trie::KECCAK_NULL_RLP};
+use crate::{trie::KECCAK_NULL_RLP, B256, U256};
 
 /// Basic account type.
 #[derive(Debug, Clone, PartialEq, Eq, RlpDecodable, RlpEncodable)]

--- a/crates/edr_eth/src/block.rs
+++ b/crates/edr_eth/src/block.rs
@@ -16,17 +16,18 @@ use self::difficulty::calculate_ethash_canonical_difficulty;
 pub use self::{
     options::BlockOptions,
     reorg::{
-        IsSafeBlockNumberArgs, LargestSafeBlockNumberArgs, block_time, is_safe_block_number,
-        largest_safe_block_number, safe_block_depth,
+        block_time, is_safe_block_number, largest_safe_block_number, safe_block_depth,
+        IsSafeBlockNumberArgs, LargestSafeBlockNumberArgs,
     },
     reward::miner_reward,
 };
 use crate::{
-    Address, B64, B256, Bloom, Bytes, U256, b256,
+    b256,
     eips::{eip4844, eip7691},
     keccak256, l1,
     spec::EthHeaderConstants,
     trie::KECCAK_NULL_RLP,
+    Address, Bloom, Bytes, B256, B64, U256,
 };
 
 /// ethereum block header

--- a/crates/edr_eth/src/block/difficulty.rs
+++ b/crates/edr_eth/src/block/difficulty.rs
@@ -1,4 +1,4 @@
-use crate::{U256, block::Header, l1, spec::EthHeaderConstants, trie::KECCAK_RLP_EMPTY_ARRAY};
+use crate::{block::Header, l1, spec::EthHeaderConstants, trie::KECCAK_RLP_EMPTY_ARRAY, U256};
 
 fn bomb_delay(spec_id: l1::SpecId) -> u64 {
     match spec_id {

--- a/crates/edr_eth/src/block/options.rs
+++ b/crates/edr_eth/src/block/options.rs
@@ -1,5 +1,5 @@
 use super::BlobGas;
-use crate::{Address, B64, B256, Bytes, U256, withdrawal::Withdrawal};
+use crate::{withdrawal::Withdrawal, Address, Bytes, B256, B64, U256};
 
 /// Data of a block header
 #[derive(Debug, Default)]

--- a/crates/edr_eth/src/eips/eip2718.rs
+++ b/crates/edr_eth/src/eips/eip2718.rs
@@ -1,9 +1,9 @@
 use alloy_rlp::Buf as _;
 
 use crate::{
-    Bloom,
     receipt::{self, ExecutionReceipt, MapReceiptLogs},
     transaction::{self, TransactionType},
+    Bloom,
 };
 
 /// An compile-time typed EIP-2718 envelope for L1 Ethereum.

--- a/crates/edr_eth/src/eips/eip4844.rs
+++ b/crates/edr_eth/src/eips/eip4844.rs
@@ -1,7 +1,7 @@
 pub use alloy_eips::eip4844::TARGET_BLOBS_PER_BLOCK;
-pub use c_kzg::{KzgSettings, ethereum_kzg_settings};
+pub use c_kzg::{ethereum_kzg_settings, KzgSettings};
 pub use revm_context_interface::block::{
-    BlobExcessGasAndPrice, calc_blob_gasprice, calc_excess_blob_gas,
+    calc_blob_gasprice, calc_excess_blob_gas, BlobExcessGasAndPrice,
 };
 pub use revm_primitives::eip4844::{
     GAS_PER_BLOB, MAX_BLOB_GAS_PER_BLOCK_CANCUN, TARGET_BLOB_GAS_PER_BLOCK_CANCUN,

--- a/crates/edr_eth/src/filter.rs
+++ b/crates/edr_eth/src/filter.rs
@@ -1,6 +1,6 @@
 use std::mem::take;
 
-use crate::{Address, B256, Bytes, block_spec::BlockSpec, log::FilterLog};
+use crate::{block_spec::BlockSpec, log::FilterLog, Address, Bytes, B256};
 
 /// A type that can be used to pass either one or many objects to a JSON-RPC
 /// request

--- a/crates/edr_eth/src/lib.rs
+++ b/crates/edr_eth/src/lib.rs
@@ -48,9 +48,10 @@ pub mod withdrawal;
 pub use c_kzg::{Blob, Bytes48};
 pub use revm_bytecode::{self as bytecode, Bytecode};
 pub use revm_primitives::{
-    Address, B256, Bytes, HashMap, HashSet, KECCAK_EMPTY, MAX_INITCODE_SIZE, U256, address,
-    alloy_primitives::{B64, B512, Bloom, BloomInput, ChainId, U8, U64, U128, U160},
-    b256, bytes, hash_map, hash_set, hex, hex_literal, keccak256,
+    address,
+    alloy_primitives::{Bloom, BloomInput, ChainId, B512, B64, U128, U160, U64, U8},
+    b256, bytes, hash_map, hash_set, hex, hex_literal, keccak256, Address, Bytes, HashMap, HashSet,
+    B256, KECCAK_EMPTY, MAX_INITCODE_SIZE, U256,
 };
 
 pub use self::block_spec::{BlockSpec, BlockTag, Eip1898BlockSpec, PreEip1898BlockSpec};

--- a/crates/edr_eth/src/log.rs
+++ b/crates/edr_eth/src/log.rs
@@ -9,7 +9,7 @@ pub use self::{
     filter::FilterLog,
     receipt::ReceiptLog,
 };
-use crate::{Address, B256, Bloom, BloomInput, HashSet};
+use crate::{Address, Bloom, BloomInput, HashSet, B256};
 
 /// Constructs a bloom filter from the provided logs.
 pub fn logs_to_bloom(logs: &[ExecutionLog]) -> Bloom {

--- a/crates/edr_eth/src/log/block.rs
+++ b/crates/edr_eth/src/log/block.rs
@@ -77,7 +77,7 @@ mod tests {
     use std::str::FromStr;
 
     use super::*;
-    use crate::{Address, Bytes, log::ExecutionLog};
+    use crate::{log::ExecutionLog, Address, Bytes};
 
     #[test]
     fn test_block_log_full_serde() -> anyhow::Result<()> {

--- a/crates/edr_eth/src/log/filter.rs
+++ b/crates/edr_eth/src/log/filter.rs
@@ -46,8 +46,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        Address, B256, Bytes,
         log::{ExecutionLog, FullBlockLog, ReceiptLog},
+        Address, Bytes, B256,
     };
 
     #[test]

--- a/crates/edr_eth/src/log/receipt.rs
+++ b/crates/edr_eth/src/log/receipt.rs
@@ -2,7 +2,7 @@ use std::ops::Deref;
 
 use alloy_rlp::BufMut;
 
-use crate::{B256, log::ExecutionLog};
+use crate::{log::ExecutionLog, B256};
 
 /// A log that's part of a transaction receipt.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -39,7 +39,7 @@ mod tests {
     use std::str::FromStr;
 
     use super::*;
-    use crate::{Address, Bytes, log::ExecutionLog};
+    use crate::{log::ExecutionLog, Address, Bytes};
 
     #[test]
     fn test_receipt_log_serde() -> anyhow::Result<()> {

--- a/crates/edr_eth/src/receipt.rs
+++ b/crates/edr_eth/src/receipt.rs
@@ -15,7 +15,7 @@ mod transaction;
 use auto_impl::auto_impl;
 
 pub use self::{block::BlockReceipt, factory::ReceiptFactory, transaction::TransactionReceipt};
-use crate::{Address, B256, Bloom};
+use crate::{Address, Bloom, B256};
 
 /// Log generated after execution of a transaction.
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/edr_eth/src/receipt/block.rs
+++ b/crates/edr_eth/src/receipt/block.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 use alloy_rlp::BufMut;
 
 use super::{AsExecutionReceipt, ExecutionReceipt, ReceiptTrait, RootOrStatus, TransactionReceipt};
-use crate::{Address, B256, Bloom, log::FilterLog};
+use crate::{log::FilterLog, Address, Bloom, B256};
 
 /// Type for a receipt that's included in a block.
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/edr_eth/src/receipt/execution.rs
+++ b/crates/edr_eth/src/receipt/execution.rs
@@ -4,7 +4,7 @@ mod legacy;
 use alloy_rlp::{RlpDecodable, RlpEncodable};
 
 use super::{Execution, ExecutionReceipt, MapReceiptLogs};
-use crate::{B256, Bloom};
+use crate::{Bloom, B256};
 
 #[derive(Clone, Debug, PartialEq, Eq, RlpDecodable, RlpEncodable)]
 #[cfg_attr(
@@ -158,7 +158,7 @@ mod tests {
     use alloy_rlp::Decodable as _;
 
     use super::*;
-    use crate::{Address, Bytes, eips::eip2718::TypedEnvelope, log::ExecutionLog};
+    use crate::{eips::eip2718::TypedEnvelope, log::ExecutionLog, Address, Bytes};
 
     macro_rules! impl_execution_receipt_tests {
         ($(

--- a/crates/edr_eth/src/receipt/execution/eip658.rs
+++ b/crates/edr_eth/src/receipt/execution/eip658.rs
@@ -1,7 +1,7 @@
 use super::Eip658;
 use crate::{
-    Bloom,
     receipt::{ExecutionReceipt, MapReceiptLogs, RootOrStatus},
+    Bloom,
 };
 
 impl<LogT, NewLogT> MapReceiptLogs<LogT, NewLogT, Eip658<NewLogT>> for Eip658<LogT> {

--- a/crates/edr_eth/src/receipt/factory.rs
+++ b/crates/edr_eth/src/receipt/factory.rs
@@ -1,9 +1,9 @@
 use auto_impl::auto_impl;
 
 use crate::{
-    B256,
     log::FilterLog,
     receipt::{ExecutionReceipt, ReceiptTrait, TransactionReceipt},
+    B256,
 };
 
 /// Trait for constructing a receipt from a transaction receipt and the block it

--- a/crates/edr_eth/src/receipt/transaction.rs
+++ b/crates/edr_eth/src/receipt/transaction.rs
@@ -2,10 +2,11 @@ use alloy_rlp::BufMut;
 
 use super::{AsExecutionReceipt, ExecutionReceipt, MapReceiptLogs};
 use crate::{
-    Address, B256, Bloom, l1,
+    l1,
     result::{ExecutionResult, Output},
     spec::HaltReasonTrait,
     transaction::{ExecutableTransaction, TransactionType},
+    Address, Bloom, B256,
 };
 
 /// Type for a receipt that's created when processing a transaction.

--- a/crates/edr_eth/src/rlp.rs
+++ b/crates/edr_eth/src/rlp.rs
@@ -1,1 +1,1 @@
-pub use alloy_rlp::{Decodable, Encodable, Error, encode};
+pub use alloy_rlp::{encode, Decodable, Encodable, Error};

--- a/crates/edr_eth/src/serde.rs
+++ b/crates/edr_eth/src/serde.rs
@@ -1,7 +1,7 @@
 //! Helper utilities for serde
 
 use serde::{
-    Deserialize, Deserializer, Serialize, Serializer, de::DeserializeOwned, ser::SerializeSeq,
+    de::DeserializeOwned, ser::SerializeSeq, Deserialize, Deserializer, Serialize, Serializer,
 };
 
 /// for use with serde's `serialize_with` on an optional single value that

--- a/crates/edr_eth/src/signature.rs
+++ b/crates/edr_eth/src/signature.rs
@@ -9,7 +9,7 @@ mod recovery_id;
 mod y_parity;
 
 pub use k256::SecretKey;
-use k256::{FieldBytes, PublicKey, elliptic_curve::sec1::ToEncodedPoint};
+use k256::{elliptic_curve::sec1::ToEncodedPoint, FieldBytes, PublicKey};
 use sha3::{Digest, Keccak256};
 
 pub use self::{

--- a/crates/edr_eth/src/signature/fakeable.rs
+++ b/crates/edr_eth/src/signature/fakeable.rs
@@ -178,7 +178,11 @@ impl<SignatureT: Recoverable + Signature> Signature for Fakeable<SignatureT> {
             FakeableData::Fake { recovery_id } => {
                 // We add the +27 magic number that originates from Bitcoin as the
                 // `Signature::new` function adds it as well.
-                if *recovery_id == 28 { Some(true) } else { None }
+                if *recovery_id == 28 {
+                    Some(true)
+                } else {
+                    None
+                }
             }
             FakeableData::Recoverable { signature } => signature.y_parity(),
         }

--- a/crates/edr_eth/src/signature/recovery_id.rs
+++ b/crates/edr_eth/src/signature/recovery_id.rs
@@ -4,15 +4,15 @@ use std::str::FromStr;
 
 use alloy_rlp::BufMut;
 use k256::{
-    FieldBytes, SecretKey,
     ecdsa::{
-        RecoveryId, Signature as ECDSASignature, SigningKey, VerifyingKey,
-        signature::hazmat::PrehashSigner,
+        signature::hazmat::PrehashSigner, RecoveryId, Signature as ECDSASignature, SigningKey,
+        VerifyingKey,
     },
+    FieldBytes, SecretKey,
 };
 
-use super::{Recoverable, RecoveryMessage, Signature, SignatureError, public_key_to_address};
-use crate::{Address, B256, Bytes, U256, utils::hash_message};
+use super::{public_key_to_address, Recoverable, RecoveryMessage, Signature, SignatureError};
+use crate::{utils::hash_message, Address, Bytes, B256, U256};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/crates/edr_eth/src/state.rs
+++ b/crates/edr_eth/src/state.rs
@@ -1,4 +1,4 @@
-use crate::{Address, B256, HashMap, U256, account::BasicAccount, trie::sec_trie_root};
+use crate::{account::BasicAccount, trie::sec_trie_root, Address, HashMap, B256, U256};
 
 /// Account storage mapping of indices to values.
 pub type AccountStorage = HashMap<U256, U256>;

--- a/crates/edr_eth/src/transaction.rs
+++ b/crates/edr_eth/src/transaction.rs
@@ -17,12 +17,12 @@ use std::str::FromStr;
 
 pub use revm_context_interface::Transaction;
 pub use revm_primitives::alloy_primitives::TxKind;
-use revm_primitives::{B256, ruint};
+use revm_primitives::{ruint, B256};
 
 use crate::{
-    Address, Bytes, U8, U256,
     eips::{eip2930, eip7702},
     signature::Signature,
+    Address, Bytes, U256, U8,
 };
 
 pub const INVALID_TX_TYPE_ERROR_MESSAGE: &str = "invalid tx type";

--- a/crates/edr_eth/src/transaction/pooled.rs
+++ b/crates/edr_eth/src/transaction/pooled.rs
@@ -2,13 +2,13 @@ mod eip4844;
 
 pub use self::eip4844::Eip4844;
 use crate::{
-    Address, B256, Bytes, U256,
     eips::{eip2930, eip7702},
     transaction::{
-        ExecutableTransaction, INVALID_TX_TYPE_ERROR_MESSAGE, IsEip155, Signed, TxKind,
-        signed::PreOrPostEip155,
+        signed::PreOrPostEip155, ExecutableTransaction, IsEip155, Signed, TxKind,
+        INVALID_TX_TYPE_ERROR_MESSAGE,
     },
     utils::enveloped,
+    Address, Bytes, B256, U256,
 };
 
 pub type Legacy = super::signed::Legacy;
@@ -401,10 +401,11 @@ mod tests {
 
     use super::*;
     use crate::{
-        Address, B256, Bytes, U256, address,
+        address,
         eips::eip7702,
         signature::{self, SignatureWithYParity, SignatureWithYParityArgs},
         transaction::{self, TxKind},
+        Address, Bytes, B256, U256,
     };
 
     fn fake_eip4844_blob() -> c_kzg::Blob {

--- a/crates/edr_eth/src/transaction/pooled/eip4844.rs
+++ b/crates/edr_eth/src/transaction/pooled/eip4844.rs
@@ -4,7 +4,6 @@ use alloy_rlp::Encodable as _;
 use sha2::Digest;
 
 use crate::{
-    Address, B256, Blob, Bytes, Bytes48, U256,
     eips::{
         eip2930,
         eip4844::{KzgSettings, VERSIONED_HASH_VERSION_KZG},
@@ -12,6 +11,7 @@ use crate::{
     },
     transaction::{self, ExecutableTransaction, TxKind},
     utils::enveloped,
+    Address, Blob, Bytes, Bytes48, B256, U256,
 };
 
 /// An EIP-4844 pooled transaction.

--- a/crates/edr_eth/src/transaction/request.rs
+++ b/crates/edr_eth/src/transaction/request.rs
@@ -12,10 +12,10 @@ pub use self::{
     legacy::Legacy,
 };
 use super::{
-    Request, Signed,
     signed::{FakeSign, Sign},
+    Request, Signed,
 };
-use crate::{Address, eips, signature::SignatureError};
+use crate::{eips, signature::SignatureError, Address};
 
 impl Request {
     /// Retrieves the instance's authorization list (EIP-7702).

--- a/crates/edr_eth/src/transaction/request/eip155.rs
+++ b/crates/edr_eth/src/transaction/request/eip155.rs
@@ -4,9 +4,10 @@ use alloy_rlp::{BufMut, Encodable};
 use k256::SecretKey;
 
 use crate::{
-    Address, B256, Bytes, U256, keccak256,
-    signature::{self, Fakeable, SignatureError, public_key_to_address},
+    keccak256,
+    signature::{self, public_key_to_address, Fakeable, SignatureError},
     transaction::{self, TxKind},
+    Address, Bytes, B256, U256,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/edr_eth/src/transaction/request/eip1559.rs
+++ b/crates/edr_eth/src/transaction/request/eip1559.rs
@@ -4,12 +4,12 @@ use alloy_rlp::{RlpDecodable, RlpEncodable};
 use k256::SecretKey;
 
 use crate::{
-    Address, B256, Bytes, U256,
     eips::eip2930,
     keccak256,
-    signature::{self, Fakeable, SignatureError, public_key_to_address},
+    signature::{self, public_key_to_address, Fakeable, SignatureError},
     transaction::{self, TxKind},
     utils::envelop_bytes,
+    Address, Bytes, B256, U256,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq, RlpDecodable, RlpEncodable)]

--- a/crates/edr_eth/src/transaction/request/eip2930.rs
+++ b/crates/edr_eth/src/transaction/request/eip2930.rs
@@ -4,12 +4,12 @@ use alloy_rlp::RlpEncodable;
 use k256::SecretKey;
 
 use crate::{
-    Address, B256, Bytes, U256,
     eips::eip2930,
     keccak256,
-    signature::{self, Fakeable, SignatureError, public_key_to_address},
+    signature::{self, public_key_to_address, Fakeable, SignatureError},
     transaction::{self, TxKind},
     utils::envelop_bytes,
+    Address, Bytes, B256, U256,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq, RlpEncodable)]

--- a/crates/edr_eth/src/transaction/request/eip4844.rs
+++ b/crates/edr_eth/src/transaction/request/eip4844.rs
@@ -4,12 +4,12 @@ use alloy_rlp::RlpEncodable;
 use k256::SecretKey;
 
 use crate::{
-    Address, B256, Bytes, U256,
     eips::eip2930,
     keccak256,
-    signature::{self, Fakeable, SignatureError, public_key_to_address},
+    signature::{self, public_key_to_address, Fakeable, SignatureError},
     transaction,
     utils::envelop_bytes,
+    Address, Bytes, B256, U256,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq, RlpEncodable)]

--- a/crates/edr_eth/src/transaction/request/eip7702.rs
+++ b/crates/edr_eth/src/transaction/request/eip7702.rs
@@ -4,11 +4,11 @@ use alloy_rlp::RlpEncodable;
 use revm_primitives::keccak256;
 
 use crate::{
-    Address, B256, Bytes, U256,
     eips::{eip2930, eip7702},
-    signature::{self, SecretKey, SignatureError, SignatureWithYParity, public_key_to_address},
+    signature::{self, public_key_to_address, SecretKey, SignatureError, SignatureWithYParity},
     transaction::{self, ComputeTransactionHash},
     utils::envelop_bytes,
+    Address, Bytes, B256, U256,
 };
 
 /// An [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) transaction.

--- a/crates/edr_eth/src/transaction/request/legacy.rs
+++ b/crates/edr_eth/src/transaction/request/legacy.rs
@@ -4,9 +4,10 @@ use alloy_rlp::RlpEncodable;
 use k256::SecretKey;
 
 use crate::{
-    Address, B256, Bytes, U256, keccak256,
-    signature::{self, Fakeable, SignatureError, public_key_to_address},
+    keccak256,
+    signature::{self, public_key_to_address, Fakeable, SignatureError},
     transaction::{self, TxKind},
+    Address, Bytes, B256, U256,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq, RlpEncodable)]

--- a/crates/edr_eth/src/transaction/signed.rs
+++ b/crates/edr_eth/src/transaction/signed.rs
@@ -19,13 +19,13 @@ pub use self::{
     legacy::{Legacy, PreOrPostEip155},
 };
 use super::{
-    ExecutableTransaction, INVALID_TX_TYPE_ERROR_MESSAGE, IsEip155, IsEip4844, IsLegacy,
-    IsSupported, Signed, SignedTransaction, TransactionMut, TransactionType, TransactionValidation,
-    TxKind,
+    ExecutableTransaction, IsEip155, IsEip4844, IsLegacy, IsSupported, Signed, SignedTransaction,
+    TransactionMut, TransactionType, TransactionValidation, TxKind, INVALID_TX_TYPE_ERROR_MESSAGE,
 };
 use crate::{
-    Address, B256, Bytes, U256, eips, impl_revm_transaction_trait, l1,
+    eips, impl_revm_transaction_trait, l1,
     signature::{Fakeable, Signature, SignatureError},
+    Address, Bytes, B256, U256,
 };
 
 /// Trait for signing a transaction request with a fake signature.
@@ -477,10 +477,9 @@ mod tests {
 
     use super::*;
     use crate::{
-        Bytes,
         eips::eip7702,
         signature::{self, SignatureWithYParity, SignatureWithYParityArgs},
-        transaction,
+        transaction, Bytes,
     };
 
     #[test]

--- a/crates/edr_eth/src/transaction/signed/eip155.rs
+++ b/crates/edr_eth/src/transaction/signed/eip155.rs
@@ -3,11 +3,11 @@ use std::sync::OnceLock;
 use alloy_rlp::RlpEncodable;
 
 use crate::{
-    Address, B256, Bytes, U256,
     eips::{eip2930, eip7702},
     keccak256,
     signature::{self, Signature},
     transaction::{self, ExecutableTransaction, TxKind},
+    Address, Bytes, B256, U256,
 };
 
 #[derive(Clone, Debug, Eq, RlpEncodable)]

--- a/crates/edr_eth/src/transaction/signed/eip1559.rs
+++ b/crates/edr_eth/src/transaction/signed/eip1559.rs
@@ -3,12 +3,12 @@ use std::sync::OnceLock;
 use alloy_rlp::{Encodable as _, RlpDecodable, RlpEncodable};
 
 use crate::{
-    Address, B256, Bytes, U256,
     eips::{eip2930, eip7702},
     keccak256,
     signature::{self, Fakeable},
     transaction::{self, ExecutableTransaction, TxKind},
     utils::enveloped,
+    Address, Bytes, B256, U256,
 };
 
 #[derive(Clone, Debug, Eq, RlpEncodable)]

--- a/crates/edr_eth/src/transaction/signed/eip2930.rs
+++ b/crates/edr_eth/src/transaction/signed/eip2930.rs
@@ -3,12 +3,12 @@ use std::sync::OnceLock;
 use alloy_rlp::{Encodable as _, RlpDecodable, RlpEncodable};
 
 use crate::{
-    Address, B256, Bytes, U256,
     eips::{eip2930, eip7702},
     keccak256,
     signature::{self, Fakeable},
     transaction::{self, ExecutableTransaction, TxKind},
     utils::enveloped,
+    Address, Bytes, B256, U256,
 };
 
 #[derive(Clone, Debug, Eq, RlpEncodable)]

--- a/crates/edr_eth/src/transaction/signed/eip4844.rs
+++ b/crates/edr_eth/src/transaction/signed/eip4844.rs
@@ -4,11 +4,11 @@ use alloy_rlp::{Encodable as _, RlpDecodable, RlpEncodable};
 use revm_primitives::keccak256;
 
 use crate::{
-    Address, B256, Bytes, U256,
     eips::{eip2930, eip4844::GAS_PER_BLOB, eip7702},
     signature::{self, Fakeable},
     transaction::{self, ExecutableTransaction, TxKind},
     utils::enveloped,
+    Address, Bytes, B256, U256,
 };
 
 #[derive(Clone, Debug, Eq, RlpEncodable)]
@@ -245,12 +245,10 @@ mod tests {
             input: Bytes::default(),
             access_list: Vec::new(),
             max_fee_per_blob_gas: 0xb2d05e00,
-            blob_hashes: vec![
-                B256::from_str(
-                    "0x01b0a4cdd5f55589f5c5b4d46c76704bb6ce95c0a8c09f77f197a57808dded28",
-                )
-                .unwrap(),
-            ],
+            blob_hashes: vec![B256::from_str(
+                "0x01b0a4cdd5f55589f5c5b4d46c76704bb6ce95c0a8c09f77f197a57808dded28",
+            )
+            .unwrap()],
         };
 
         let signature =

--- a/crates/edr_eth/src/transaction/signed/eip7702.rs
+++ b/crates/edr_eth/src/transaction/signed/eip7702.rs
@@ -3,11 +3,11 @@ use std::sync::OnceLock;
 use alloy_rlp::{Encodable as _, RlpDecodable, RlpEncodable};
 
 use crate::{
-    Address, B256, Bytes, U256,
     eips::{eip2930, eip7702},
     keccak256, signature,
-    transaction::{self, ComputeTransactionHash as _, ExecutableTransaction, TxKind, request},
+    transaction::{self, request, ComputeTransactionHash as _, ExecutableTransaction, TxKind},
     utils::enveloped,
+    Address, Bytes, B256, U256,
 };
 
 #[derive(Clone, Debug, Eq, RlpEncodable)]
@@ -210,7 +210,7 @@ mod tests {
         use core::str::FromStr as _;
 
         use edr_defaults::SECRET_KEYS;
-        use edr_test_utils::secret_key::{SecretKey, SignatureError, secret_key_from_str};
+        use edr_test_utils::secret_key::{secret_key_from_str, SecretKey, SignatureError};
         use hex::FromHexError;
 
         use super::*;

--- a/crates/edr_eth/src/transaction/signed/legacy.rs
+++ b/crates/edr_eth/src/transaction/signed/legacy.rs
@@ -3,11 +3,11 @@ use std::sync::OnceLock;
 use alloy_rlp::{RlpDecodable, RlpEncodable};
 
 use crate::{
-    Address, B256, Bytes, U256,
     eips::{eip2930, eip7702},
     keccak256,
     signature::{self, Fakeable},
     transaction::{self, ExecutableTransaction, TxKind},
+    Address, Bytes, B256, U256,
 };
 
 #[derive(Clone, Debug, Eq, RlpEncodable)]

--- a/crates/edr_eth/src/trie.rs
+++ b/crates/edr_eth/src/trie.rs
@@ -8,8 +8,8 @@
 
 use hash256_std_hasher::Hash256StdHasher;
 use sha3::{
+    digest::generic_array::{typenum::consts::U32, GenericArray},
     Digest, Keccak256,
-    digest::generic_array::{GenericArray, typenum::consts::U32},
 };
 
 use crate::B256;

--- a/crates/edr_eth/src/utils.rs
+++ b/crates/edr_eth/src/utils.rs
@@ -12,7 +12,7 @@
 
 use alloy_rlp::{BufMut, Encodable};
 
-use crate::{B256, U64, U256, keccak256};
+use crate::{keccak256, B256, U256, U64};
 
 /// RLP-encodes the provided value and prepends it with the provided ID.
 pub fn enveloped<T: Encodable>(id: u8, v: &T, out: &mut dyn BufMut) {

--- a/crates/edr_evm/src/block.rs
+++ b/crates/edr_evm/src/block.rs
@@ -8,12 +8,12 @@ use std::{fmt::Debug, marker::PhantomData, sync::Arc};
 
 use auto_impl::auto_impl;
 use edr_eth::{
-    B256, U256,
     block::{self, BlobGas, Header, PartialHeader},
     receipt::ReceiptTrait,
     spec::ChainSpec,
     transaction::ExecutableTransaction,
     withdrawal::Withdrawal,
+    B256, U256,
 };
 
 pub use self::{

--- a/crates/edr_evm/src/block/builder.rs
+++ b/crates/edr_evm/src/block/builder.rs
@@ -3,21 +3,21 @@ mod l1;
 use std::fmt::Debug;
 
 use edr_eth::{
-    Address,
     block::{BlockOptions, PartialHeader},
     spec::ChainSpec,
     transaction::TransactionValidation,
+    Address,
 };
 use revm::Inspector;
 
 pub use self::l1::{EthBlockBuilder, EthBlockReceiptFactory};
 use crate::{
-    MineBlockResultAndStateForChainSpec,
     blockchain::SyncBlockchain,
     config::CfgEnv,
     spec::{ContextForChainSpec, RuntimeSpec},
     state::{DatabaseComponentError, DatabaseComponents, SyncState, WrapDatabaseRef},
     transaction::TransactionError,
+    MineBlockResultAndStateForChainSpec,
 };
 
 /// An error caused during construction of a block builder.
@@ -87,7 +87,11 @@ where
 
     /// Creates a new block builder.
     fn new_block_builder(
-        blockchain: &'builder dyn SyncBlockchain<ChainSpecT, Self::BlockchainError, Self::StateError>,
+        blockchain: &'builder dyn SyncBlockchain<
+            ChainSpecT,
+            Self::BlockchainError,
+            Self::StateError,
+        >,
         state: Box<dyn SyncState<Self::StateError>>,
         cfg: CfgEnv<ChainSpecT::Hardfork>,
         options: BlockOptions,

--- a/crates/edr_evm/src/block/builder/l1.rs
+++ b/crates/edr_evm/src/block/builder/l1.rs
@@ -3,7 +3,6 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use derive_where::derive_where;
 use edr_eth::{
-    Address, B256, Bloom, HashMap, U256,
     block::{BlobGas, BlockOptions, PartialHeader},
     eips::{eip4844, eip7691},
     l1,
@@ -11,14 +10,14 @@ use edr_eth::{
     receipt::{BlockReceipt, ExecutionReceipt, TransactionReceipt},
     result::{ExecutionResult, ExecutionResultAndState},
     transaction::ExecutableTransaction as _,
-    trie::{KECCAK_NULL_RLP, ordered_trie_root},
+    trie::{ordered_trie_root, KECCAK_NULL_RLP},
     withdrawal::Withdrawal,
+    Address, Bloom, HashMap, B256, U256,
 };
 use revm::Inspector;
 
 use super::{BlockBuilder, BlockTransactionError, BlockTransactionErrorForChainSpec};
 use crate::{
-    Block as _, BlockBuilderCreationError, EthLocalBlockForChainSpec, MineBlockResultAndState,
     blockchain::SyncBlockchain,
     config::CfgEnv,
     receipt::{ExecutionReceiptBuilder as _, ReceiptFactory},
@@ -26,6 +25,7 @@ use crate::{
     spec::{BlockEnvConstructor as _, ContextForChainSpec, RuntimeSpec, SyncRuntimeSpec},
     state::{AccountModifierFn, DatabaseComponents, StateDiff, SyncState, WrapDatabaseRef},
     transaction::TransactionError,
+    Block as _, BlockBuilderCreationError, EthLocalBlockForChainSpec, MineBlockResultAndState,
 };
 
 /// A builder for constructing Ethereum L1 blocks.
@@ -377,10 +377,10 @@ impl<'builder, BlockchainErrorT, ChainSpecT, StateErrorT> BlockBuilder<'builder,
 where
     BlockchainErrorT: Send + std::error::Error,
     ChainSpecT: SyncRuntimeSpec<
-            BlockReceiptFactory: Default,
-            Hardfork: Debug,
-            LocalBlock: From<EthLocalBlockForChainSpec<ChainSpecT>>,
-        >,
+        BlockReceiptFactory: Default,
+        Hardfork: Debug,
+        LocalBlock: From<EthLocalBlockForChainSpec<ChainSpecT>>,
+    >,
     StateErrorT: Send + std::error::Error,
 {
     type BlockchainError = BlockchainErrorT;
@@ -388,7 +388,11 @@ where
     type StateError = StateErrorT;
 
     fn new_block_builder(
-        blockchain: &'builder dyn SyncBlockchain<ChainSpecT, Self::BlockchainError, Self::StateError>,
+        blockchain: &'builder dyn SyncBlockchain<
+            ChainSpecT,
+            Self::BlockchainError,
+            Self::StateError,
+        >,
         state: Box<dyn SyncState<Self::StateError>>,
         cfg: CfgEnv<ChainSpecT::Hardfork>,
         options: BlockOptions,
@@ -478,10 +482,10 @@ pub struct EthBlockReceiptFactory<ExecutionReceiptT: ExecutionReceipt<Log = Filt
 }
 
 impl<
-    ExecutionReceiptT: ExecutionReceipt<Log = FilterLog>,
-    HardforkT: Into<l1::SpecId>,
-    SignedTransactionT,
-> ReceiptFactory<ExecutionReceiptT, HardforkT, SignedTransactionT>
+        ExecutionReceiptT: ExecutionReceipt<Log = FilterLog>,
+        HardforkT: Into<l1::SpecId>,
+        SignedTransactionT,
+    > ReceiptFactory<ExecutionReceiptT, HardforkT, SignedTransactionT>
     for EthBlockReceiptFactory<ExecutionReceiptT>
 {
     type Output = BlockReceipt<ExecutionReceiptT>;

--- a/crates/edr_evm/src/block/local.rs
+++ b/crates/edr_evm/src/block/local.rs
@@ -4,7 +4,6 @@ use std::{marker::PhantomData, sync::Arc};
 use alloy_rlp::Encodable as _;
 use derive_where::derive_where;
 use edr_eth::{
-    B256, KECCAK_EMPTY,
     block::{self, Header, PartialHeader},
     keccak256, l1,
     log::{ExecutionLog, FilterLog, FullBlockLog, ReceiptLog},
@@ -13,12 +12,12 @@ use edr_eth::{
     transaction::ExecutableTransaction,
     trie,
     withdrawal::Withdrawal,
+    B256, KECCAK_EMPTY,
 };
 use edr_utils::types::TypeConstructor;
 use itertools::izip;
 
 use crate::{
-    Block,
     block::{BlockReceipts, EmptyBlock, LocalBlock},
     blockchain::BlockchainError,
     receipt::ReceiptFactory,
@@ -27,6 +26,7 @@ use crate::{
         RuntimeSpec,
     },
     transaction::DetailedTransaction,
+    Block,
 };
 
 /// Helper type for a local Ethereum block for a given chain spec.
@@ -66,13 +66,13 @@ pub struct EthLocalBlock<
 }
 
 impl<
-    BlockConversionErrorT,
-    BlockReceiptT: ReceiptTrait,
-    HardforkT: Clone,
-    ExecutionReceiptTypeConstructorT: ExecutionReceiptTypeConstructorBounds,
-    ReceiptConversionErrorT,
-    SignedTransactionT: Debug + ExecutableTransaction,
->
+        BlockConversionErrorT,
+        BlockReceiptT: ReceiptTrait,
+        HardforkT: Clone,
+        ExecutionReceiptTypeConstructorT: ExecutionReceiptTypeConstructorBounds,
+        ReceiptConversionErrorT,
+        SignedTransactionT: Debug + ExecutableTransaction,
+    >
     EthLocalBlock<
         BlockConversionErrorT,
         BlockReceiptT,
@@ -162,13 +162,13 @@ impl<
 }
 
 impl<
-    BlockConversionErrorT,
-    BlockReceiptT: Debug + ReceiptTrait + alloy_rlp::Encodable,
-    ExecutionReceiptTypeConstructorT: ExecutionReceiptTypeConstructorBounds,
-    HardforkT,
-    ReceiptConversionErrorT,
-    SignedTransactionT: Debug + alloy_rlp::Encodable,
->
+        BlockConversionErrorT,
+        BlockReceiptT: Debug + ReceiptTrait + alloy_rlp::Encodable,
+        ExecutionReceiptTypeConstructorT: ExecutionReceiptTypeConstructorBounds,
+        HardforkT,
+        ReceiptConversionErrorT,
+        SignedTransactionT: Debug + alloy_rlp::Encodable,
+    >
     EthLocalBlock<
         BlockConversionErrorT,
         BlockReceiptT,
@@ -190,13 +190,13 @@ impl<
 }
 
 impl<
-    BlockConversionErrorT,
-    BlockReceiptT: Debug + ReceiptTrait + alloy_rlp::Encodable,
-    ExecutionReceiptTypeConstructorT: ExecutionReceiptTypeConstructorBounds,
-    HardforkT,
-    ReceiptConversionErrorT,
-    SignedTransactionT: Debug + alloy_rlp::Encodable,
-> Block<SignedTransactionT>
+        BlockConversionErrorT,
+        BlockReceiptT: Debug + ReceiptTrait + alloy_rlp::Encodable,
+        ExecutionReceiptTypeConstructorT: ExecutionReceiptTypeConstructorBounds,
+        HardforkT,
+        ReceiptConversionErrorT,
+        SignedTransactionT: Debug + alloy_rlp::Encodable,
+    > Block<SignedTransactionT>
     for EthLocalBlock<
         BlockConversionErrorT,
         BlockReceiptT,
@@ -235,13 +235,13 @@ impl<
 }
 
 impl<
-    BlockConversionErrorT,
-    BlockReceiptT: ReceiptTrait + Debug + alloy_rlp::Encodable,
-    ExecutionReceiptTypeConstructorT: ExecutionReceiptTypeConstructorBounds,
-    HardforkT: Debug,
-    ReceiptConversionErrorT,
-    SignedTransactionT: Debug + alloy_rlp::Encodable,
-> BlockReceipts<Arc<BlockReceiptT>>
+        BlockConversionErrorT,
+        BlockReceiptT: ReceiptTrait + Debug + alloy_rlp::Encodable,
+        ExecutionReceiptTypeConstructorT: ExecutionReceiptTypeConstructorBounds,
+        HardforkT: Debug,
+        ReceiptConversionErrorT,
+        SignedTransactionT: Debug + alloy_rlp::Encodable,
+    > BlockReceipts<Arc<BlockReceiptT>>
     for EthLocalBlock<
         BlockConversionErrorT,
         BlockReceiptT,
@@ -264,13 +264,13 @@ impl<
 }
 
 impl<
-    BlockConversionErrorT,
-    BlockReceiptT: ReceiptTrait,
-    ExecutionReceiptTypeConstructorT: ExecutionReceiptTypeConstructorBounds,
-    HardforkT: Into<l1::SpecId>,
-    ReceiptConversionErrorT,
-    SignedTransactionT: Debug + ExecutableTransaction + alloy_rlp::Encodable,
-> EmptyBlock<HardforkT>
+        BlockConversionErrorT,
+        BlockReceiptT: ReceiptTrait,
+        ExecutionReceiptTypeConstructorT: ExecutionReceiptTypeConstructorBounds,
+        HardforkT: Into<l1::SpecId>,
+        ReceiptConversionErrorT,
+        SignedTransactionT: Debug + ExecutableTransaction + alloy_rlp::Encodable,
+    > EmptyBlock<HardforkT>
     for EthLocalBlock<
         BlockConversionErrorT,
         BlockReceiptT,
@@ -305,13 +305,13 @@ impl<
 }
 
 impl<
-    BlockConversionErrorT,
-    BlockReceiptT: ReceiptTrait,
-    ExecutionReceiptTypeConstructorT: ExecutionReceiptTypeConstructorBounds,
-    HardforkT,
-    ReceiptConversionErrorT,
-    SignedTransactionT: Debug + ExecutableTransaction + alloy_rlp::Encodable,
-> LocalBlock<Arc<BlockReceiptT>>
+        BlockConversionErrorT,
+        BlockReceiptT: ReceiptTrait,
+        ExecutionReceiptTypeConstructorT: ExecutionReceiptTypeConstructorBounds,
+        HardforkT,
+        ReceiptConversionErrorT,
+        SignedTransactionT: Debug + ExecutableTransaction + alloy_rlp::Encodable,
+    > LocalBlock<Arc<BlockReceiptT>>
     for EthLocalBlock<
         BlockConversionErrorT,
         BlockReceiptT,
@@ -327,13 +327,13 @@ impl<
 }
 
 impl<
-    BlockConversionErrorT,
-    BlockReceiptT: Debug + ReceiptTrait + alloy_rlp::Encodable,
-    ExecutionReceiptTypeConstructorT: ExecutionReceiptTypeConstructorBounds,
-    HardforkT,
-    ReceiptConversionErrorT,
-    SignedTransactionT: Debug + alloy_rlp::Encodable,
-> alloy_rlp::Encodable
+        BlockConversionErrorT,
+        BlockReceiptT: Debug + ReceiptTrait + alloy_rlp::Encodable,
+        ExecutionReceiptTypeConstructorT: ExecutionReceiptTypeConstructorBounds,
+        HardforkT,
+        ReceiptConversionErrorT,
+        SignedTransactionT: Debug + alloy_rlp::Encodable,
+    > alloy_rlp::Encodable
     for EthLocalBlock<
         BlockConversionErrorT,
         BlockReceiptT,

--- a/crates/edr_evm/src/block/remote.rs
+++ b/crates/edr_evm/src/block/remote.rs
@@ -2,16 +2,16 @@ use std::sync::{Arc, OnceLock};
 
 use derive_where::derive_where;
 use edr_eth::{
-    B256, U256, block::Header, transaction::ExecutableTransaction as _, withdrawal::Withdrawal,
+    block::Header, transaction::ExecutableTransaction as _, withdrawal::Withdrawal, B256, U256,
 };
 use edr_rpc_eth::client::EthRpcClient;
 use tokio::runtime;
 
 use crate::{
-    Block, EthBlockData,
     block::BlockReceipts,
     blockchain::{BlockchainErrorForChainSpec, ForkedBlockchainError},
     spec::RuntimeSpec,
+    Block, EthBlockData,
 };
 
 /// Error that occurs when trying to convert the JSON-RPC `Block` type.

--- a/crates/edr_evm/src/blockchain.rs
+++ b/crates/edr_evm/src/blockchain.rs
@@ -8,7 +8,7 @@ use std::{collections::BTreeMap, fmt::Debug, ops::Bound::Included, sync::Arc};
 
 use auto_impl::auto_impl;
 use edr_eth::{
-    Address, B256, HashSet, U256, l1, log::FilterLog, receipt::ReceiptTrait, spec::ChainSpec,
+    l1, log::FilterLog, receipt::ReceiptTrait, spec::ChainSpec, Address, HashSet, B256, U256,
 };
 
 use self::storage::ReservableSparseBlockchainStorage;
@@ -17,10 +17,10 @@ pub use self::{
     local::{CreationError as LocalCreationError, GenesisBlockOptions, LocalBlockchain},
 };
 use crate::{
-    Block, BlockAndTotalDifficultyForChainSpec,
     hardfork::Activations,
     spec::{RuntimeSpec, SyncRuntimeSpec},
     state::{StateCommit, StateDiff, StateOverride, SyncState},
+    Block, BlockAndTotalDifficultyForChainSpec,
 };
 
 /// Helper type for a chain-specific [`BlockchainError`].

--- a/crates/edr_evm/src/blockchain/forked.rs
+++ b/crates/edr_evm/src/blockchain/forked.rs
@@ -2,11 +2,11 @@ use std::{collections::BTreeMap, fmt::Debug, num::NonZeroU64, sync::Arc};
 
 use derive_where::derive_where;
 use edr_eth::{
-    Address, B256, BlockSpec, ChainId, HashMap, HashSet, PreEip1898BlockSpec, U256,
     account::{Account, AccountStatus},
-    block::{LargestSafeBlockNumberArgs, largest_safe_block_number, safe_block_depth},
+    block::{largest_safe_block_number, safe_block_depth, LargestSafeBlockNumberArgs},
     l1,
     log::FilterLog,
+    Address, BlockSpec, ChainId, HashMap, HashSet, PreEip1898BlockSpec, B256, U256,
 };
 use edr_rpc_eth::{
     client::{EthRpcClient, RpcClientError},
@@ -16,30 +16,30 @@ use parking_lot::Mutex;
 use tokio::runtime;
 
 use super::{
-    BlockHash, Blockchain, BlockchainError, BlockchainErrorForChainSpec, BlockchainMut,
     compute_state_at_block,
     remote::RemoteBlockchain,
     storage::{
         self, ReservableSparseBlockchainStorage, ReservableSparseBlockchainStorageForChainSpec,
     },
-    validate_next_block,
+    validate_next_block, BlockHash, Blockchain, BlockchainError, BlockchainErrorForChainSpec,
+    BlockchainMut,
 };
 use crate::{
-    Block, BlockAndTotalDifficulty, BlockAndTotalDifficultyForChainSpec, BlockReceipts,
-    RandomHashGenerator, RemoteBlock,
     block::EthRpcBlock,
     eips::{
         eip2935::{
-            HISTORY_STORAGE_ADDRESS, add_history_storage_contract_to_state_diff,
-            history_storage_contract,
+            add_history_storage_contract_to_state_diff, history_storage_contract,
+            HISTORY_STORAGE_ADDRESS,
         },
         eip4788::{
-            BEACON_ROOTS_ADDRESS, add_beacon_roots_contract_to_state_diff, beacon_roots_contract,
+            add_beacon_roots_contract_to_state_diff, beacon_roots_contract, BEACON_ROOTS_ADDRESS,
         },
     },
     hardfork::{self, ChainOverride},
     spec::{RuntimeSpec, SyncRuntimeSpec},
     state::{ForkState, IrregularState, StateDiff, StateError, StateOverride, SyncState},
+    Block, BlockAndTotalDifficulty, BlockAndTotalDifficultyForChainSpec, BlockReceipts,
+    RandomHashGenerator, RemoteBlock,
 };
 
 /// An error that occurs upon creation of a [`ForkedBlockchain`].

--- a/crates/edr_evm/src/blockchain/local.rs
+++ b/crates/edr_evm/src/blockchain/local.rs
@@ -8,25 +8,25 @@ use std::{
 
 use derive_where::derive_where;
 use edr_eth::{
-    Address, B256, Bytes, HashSet, U256,
     block::{BlobGas, BlockOptions, PartialHeader},
     l1,
     log::FilterLog,
+    Address, Bytes, HashSet, B256, U256,
 };
 
 use super::{
-    BlockHash, Blockchain, BlockchainError, BlockchainErrorForChainSpec, BlockchainMut,
     compute_state_at_block,
     storage::{ReservableSparseBlockchainStorage, ReservableSparseBlockchainStorageForChainSpec},
-    validate_next_block,
+    validate_next_block, BlockHash, Blockchain, BlockchainError, BlockchainErrorForChainSpec,
+    BlockchainMut,
 };
 use crate::{
-    Block as _, BlockAndTotalDifficulty, BlockAndTotalDifficultyForChainSpec, BlockReceipts,
     block::EmptyBlock as _,
     spec::SyncRuntimeSpec,
     state::{
         StateCommit as _, StateDebug, StateDiff, StateError, StateOverride, SyncState, TrieState,
     },
+    Block as _, BlockAndTotalDifficulty, BlockAndTotalDifficultyForChainSpec, BlockReceipts,
 };
 
 /// An error that occurs upon creation of a [`LocalBlockchain`].
@@ -201,9 +201,9 @@ where
 impl<ChainSpecT: SyncRuntimeSpec> Blockchain<ChainSpecT> for LocalBlockchain<ChainSpecT>
 where
     ChainSpecT::LocalBlock: BlockReceipts<
-            Arc<ChainSpecT::BlockReceipt>,
-            Error = BlockchainErrorForChainSpec<ChainSpecT>,
-        >,
+        Arc<ChainSpecT::BlockReceipt>,
+        Error = BlockchainErrorForChainSpec<ChainSpecT>,
+    >,
 {
     type BlockchainError = BlockchainErrorForChainSpec<ChainSpecT>;
 
@@ -324,9 +324,9 @@ where
 impl<ChainSpecT: SyncRuntimeSpec> BlockchainMut<ChainSpecT> for LocalBlockchain<ChainSpecT>
 where
     ChainSpecT::LocalBlock: BlockReceipts<
-            Arc<ChainSpecT::BlockReceipt>,
-            Error = BlockchainErrorForChainSpec<ChainSpecT>,
-        >,
+        Arc<ChainSpecT::BlockReceipt>,
+        Error = BlockchainErrorForChainSpec<ChainSpecT>,
+    >,
 {
     type Error = BlockchainErrorForChainSpec<ChainSpecT>;
 
@@ -409,9 +409,9 @@ impl<ChainSpecT: SyncRuntimeSpec> BlockHash for LocalBlockchain<ChainSpecT> {
 #[cfg(test)]
 mod tests {
     use edr_eth::{
-        HashMap,
         account::{Account, AccountInfo, AccountStatus},
         l1::L1ChainSpec,
+        HashMap,
     };
 
     use super::*;

--- a/crates/edr_evm/src/blockchain/remote.rs
+++ b/crates/edr_evm/src/blockchain/remote.rs
@@ -3,15 +3,15 @@ use std::sync::Arc;
 use async_rwlock::{RwLock, RwLockUpgradableReadGuard};
 use derive_where::derive_where;
 use edr_eth::{
-    Address, B256, BlockSpec, HashSet, PreEip1898BlockSpec, U256, filter::OneOrMore, log::FilterLog,
+    filter::OneOrMore, log::FilterLog, Address, BlockSpec, HashSet, PreEip1898BlockSpec, B256, U256,
 };
 use edr_rpc_eth::client::EthRpcClient;
 use tokio::runtime;
 
 use super::{forked::ForkedBlockchainErrorForChainSpec, storage::SparseBlockchainStorage};
 use crate::{
-    Block, EthRpcBlock as _, RemoteBlock, blockchain::ForkedBlockchainError, spec::RuntimeSpec,
-    transaction::remote::EthRpcTransaction as _,
+    blockchain::ForkedBlockchainError, spec::RuntimeSpec,
+    transaction::remote::EthRpcTransaction as _, Block, EthRpcBlock as _, RemoteBlock,
 };
 
 #[derive_where(Debug; BlockT)]
@@ -313,13 +313,11 @@ mod tests {
         );
 
         let _ = remote.block_by_number(block_number).await.unwrap();
-        assert!(
-            remote
-                .cache
-                .read()
-                .await
-                .block_by_number(block_number)
-                .is_none()
-        );
+        assert!(remote
+            .cache
+            .read()
+            .await
+            .block_by_number(block_number)
+            .is_none());
     }
 }

--- a/crates/edr_evm/src/blockchain/storage/contiguous.rs
+++ b/crates/edr_evm/src/blockchain/storage/contiguous.rs
@@ -9,7 +9,7 @@
 use std::marker::PhantomData;
 
 use derive_where::derive_where;
-use edr_eth::{B256, HashMap, U256, receipt::ReceiptTrait, transaction::ExecutableTransaction};
+use edr_eth::{receipt::ReceiptTrait, transaction::ExecutableTransaction, HashMap, B256, U256};
 
 use super::InsertError;
 use crate::{Block, EmptyBlock, LocalBlock};
@@ -116,11 +116,11 @@ impl<BlockReceiptT, BlockT: Block<SignedTransactionT>, HardforkT, SignedTransact
 }
 
 impl<
-    BlockReceiptT: Clone + ReceiptTrait,
-    BlockT: Block<SignedTransactionT> + EmptyBlock<HardforkT> + LocalBlock<BlockReceiptT> + Clone,
-    HardforkT,
-    SignedTransactionT: ExecutableTransaction,
-> ContiguousBlockchainStorage<BlockReceiptT, BlockT, HardforkT, SignedTransactionT>
+        BlockReceiptT: Clone + ReceiptTrait,
+        BlockT: Block<SignedTransactionT> + EmptyBlock<HardforkT> + LocalBlock<BlockReceiptT> + Clone,
+        HardforkT,
+        SignedTransactionT: ExecutableTransaction,
+    > ContiguousBlockchainStorage<BlockReceiptT, BlockT, HardforkT, SignedTransactionT>
 {
     /// Constructs a new instance with the provided block.
     pub fn with_block(block: BlockT, total_difficulty: U256) -> Self {

--- a/crates/edr_evm/src/blockchain/storage/reservable.rs
+++ b/crates/edr_evm/src/blockchain/storage/reservable.rs
@@ -3,17 +3,17 @@ use std::{num::NonZeroU64, sync::Arc};
 
 use derive_where::derive_where;
 use edr_eth::{
-    Address, B256, HashMap, HashSet, U256,
     block::PartialHeader,
     log::FilterLog,
     receipt::{ExecutionReceipt, ReceiptTrait},
     spec::ChainSpec,
     transaction::ExecutableTransaction,
+    Address, HashMap, HashSet, B256, U256,
 };
 use parking_lot::{RwLock, RwLockUpgradableReadGuard, RwLockWriteGuard};
 
-use super::{InsertError, SparseBlockchainStorage, sparse};
-use crate::{Block, BlockReceipts, EmptyBlock, LocalBlock, spec::RuntimeSpec, state::StateDiff};
+use super::{sparse, InsertError, SparseBlockchainStorage};
+use crate::{spec::RuntimeSpec, state::StateDiff, Block, BlockReceipts, EmptyBlock, LocalBlock};
 
 /// A reservation for a sequence of blocks that have not yet been inserted into
 /// storage.
@@ -74,11 +74,11 @@ impl<BlockReceiptT: ReceiptTrait, BlockT, HardforkT, SignedTransactionT>
 }
 
 impl<
-    BlockReceiptT: ReceiptTrait,
-    BlockT: Block<SignedTransactionT> + Clone,
-    HardforkT,
-    SignedTransactionT: ExecutableTransaction,
-> ReservableSparseBlockchainStorage<BlockReceiptT, BlockT, HardforkT, SignedTransactionT>
+        BlockReceiptT: ReceiptTrait,
+        BlockT: Block<SignedTransactionT> + Clone,
+        HardforkT,
+        SignedTransactionT: ExecutableTransaction,
+    > ReservableSparseBlockchainStorage<BlockReceiptT, BlockT, HardforkT, SignedTransactionT>
 {
     /// Constructs a new instance with the provided block as genesis block.
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
@@ -151,11 +151,11 @@ impl<
 }
 
 impl<
-    BlockReceiptT: ExecutionReceipt<Log = FilterLog> + ReceiptTrait,
-    BlockT: BlockReceipts<BlockReceiptT>,
-    HardforkT,
-    SignedTransactionT,
-> ReservableSparseBlockchainStorage<BlockReceiptT, BlockT, HardforkT, SignedTransactionT>
+        BlockReceiptT: ExecutionReceipt<Log = FilterLog> + ReceiptTrait,
+        BlockT: BlockReceipts<BlockReceiptT>,
+        HardforkT,
+        SignedTransactionT,
+    > ReservableSparseBlockchainStorage<BlockReceiptT, BlockT, HardforkT, SignedTransactionT>
 {
     /// Retrieves the logs that match the provided filter.
     pub fn logs(
@@ -262,11 +262,11 @@ impl<BlockReceiptT: Clone + ReceiptTrait, BlockT: Clone, HardforkT, SignedTransa
 }
 
 impl<
-    BlockReceiptT: Clone + ReceiptTrait,
-    BlockT: Block<SignedTransactionT> + Clone + EmptyBlock<HardforkT> + LocalBlock<BlockReceiptT>,
-    HardforkT: Clone,
-    SignedTransactionT: ExecutableTransaction,
-> ReservableSparseBlockchainStorage<BlockReceiptT, BlockT, HardforkT, SignedTransactionT>
+        BlockReceiptT: Clone + ReceiptTrait,
+        BlockT: Block<SignedTransactionT> + Clone + EmptyBlock<HardforkT> + LocalBlock<BlockReceiptT>,
+        HardforkT: Clone,
+        SignedTransactionT: ExecutableTransaction,
+    > ReservableSparseBlockchainStorage<BlockReceiptT, BlockT, HardforkT, SignedTransactionT>
 {
     /// Retrieves the block by number, if it exists.
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]

--- a/crates/edr_evm/src/blockchain/storage/sparse.rs
+++ b/crates/edr_evm/src/blockchain/storage/sparse.rs
@@ -2,11 +2,11 @@ use std::marker::PhantomData;
 
 use derive_where::derive_where;
 use edr_eth::{
-    Address, B256, HashMap, HashSet, U256,
     hash_map::OccupiedError,
-    log::{FilterLog, matches_address_filter, matches_topics_filter},
+    log::{matches_address_filter, matches_topics_filter, FilterLog},
     receipt::{ExecutionReceipt, ReceiptTrait},
     transaction::ExecutableTransaction,
+    Address, HashMap, HashSet, B256, U256,
 };
 
 use super::InsertError;
@@ -25,10 +25,10 @@ pub struct SparseBlockchainStorage<BlockReceiptT: ReceiptTrait, BlockT, SignedTr
 }
 
 impl<
-    BlockReceiptT: ReceiptTrait,
-    BlockT: Block<SignedTransactionT> + Clone,
-    SignedTransactionT: ExecutableTransaction,
-> SparseBlockchainStorage<BlockReceiptT, BlockT, SignedTransactionT>
+        BlockReceiptT: ReceiptTrait,
+        BlockT: Block<SignedTransactionT> + Clone,
+        SignedTransactionT: ExecutableTransaction,
+    > SparseBlockchainStorage<BlockReceiptT, BlockT, SignedTransactionT>
 {
     /// Constructs a new instance with the provided block.
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]

--- a/crates/edr_evm/src/eips/eip2935.rs
+++ b/crates/edr_evm/src/eips/eip2935.rs
@@ -1,4 +1,4 @@
-use edr_eth::{Address, Bytecode, Bytes, account::AccountInfo, address, bytes};
+use edr_eth::{account::AccountInfo, address, bytes, Address, Bytecode, Bytes};
 
 use crate::state::StateDiff;
 

--- a/crates/edr_evm/src/eips/eip4788.rs
+++ b/crates/edr_evm/src/eips/eip4788.rs
@@ -1,4 +1,4 @@
-use edr_eth::{Address, Bytecode, Bytes, account::AccountInfo, address, bytes};
+use edr_eth::{account::AccountInfo, address, bytes, Address, Bytecode, Bytes};
 
 use crate::state::StateDiff;
 

--- a/crates/edr_evm/src/hardfork/l1.rs
+++ b/crates/edr_evm/src/hardfork/l1.rs
@@ -1,6 +1,6 @@
 use std::sync::OnceLock;
 
-use edr_eth::{HashMap, l1};
+use edr_eth::{l1, HashMap};
 
 use super::{Activation, Activations, ChainConfig, ForkCondition};
 

--- a/crates/edr_evm/src/inspector.rs
+++ b/crates/edr_evm/src/inspector.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Debug, marker::PhantomData};
 
-use edr_eth::{Address, U256, log::ExecutionLog};
+use edr_eth::{log::ExecutionLog, Address, U256};
 pub use revm::inspector::{Inspector, NoOpInspector};
 use revm_interpreter::{
     CallInputs, CallOutcome, CreateInputs, CreateOutcome, EOFCreateInputs, Interpreter,

--- a/crates/edr_evm/src/interpreter.rs
+++ b/crates/edr_evm/src/interpreter.rs
@@ -1,9 +1,8 @@
 pub use revm_handler::instructions::EthInstructions;
 pub use revm_interpreter::{
-    CallInputs, CallOutcome, CallValue, CreateInputs, CreateOutcome, EOFCreateInputs, FrameInput,
-    Gas, Host, InputsImpl, InstructionResult, Interpreter, InterpreterResult, InterpreterTypes,
-    MemoryGetter, SuccessOrHalt,
     interpreter::EthInterpreter,
     interpreter_types::{InputsTr, Jumps, LoopControl},
-    return_revert,
+    return_revert, CallInputs, CallOutcome, CallValue, CreateInputs, CreateOutcome,
+    EOFCreateInputs, FrameInput, Gas, Host, InputsImpl, InstructionResult, Interpreter,
+    InterpreterResult, InterpreterTypes, MemoryGetter, SuccessOrHalt,
 };

--- a/crates/edr_evm/src/mempool.rs
+++ b/crates/edr_evm/src/mempool.rs
@@ -1,11 +1,11 @@
 use std::{cmp::Ordering, fmt::Debug, num::NonZeroU64};
 
 use edr_eth::{
-    Address, B256, HashMap, U256,
     account::AccountInfo,
-    transaction::{ExecutableTransaction, upfront_cost},
+    transaction::{upfront_cost, ExecutableTransaction},
+    Address, HashMap, B256, U256,
 };
-use indexmap::{IndexMap, map::Entry};
+use indexmap::{map::Entry, IndexMap};
 
 use crate::state::State;
 

--- a/crates/edr_evm/src/miner.rs
+++ b/crates/edr_evm/src/miner.rs
@@ -1,7 +1,7 @@
 use std::{cmp::Ordering, fmt::Debug};
 
 use edr_eth::{
-    block::{BlockOptions, calculate_next_base_fee_per_blob_gas},
+    block::{calculate_next_base_fee_per_blob_gas, BlockOptions},
     l1,
     result::ExecutionResult,
     signature::SignatureError,
@@ -12,7 +12,6 @@ use revm::Inspector;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    Block as _, BlockBuilder, BlockTransactionError, MemPool,
     block::BlockBuilderCreationError,
     blockchain::SyncBlockchain,
     config::CfgEnv,
@@ -20,6 +19,7 @@ use crate::{
     spec::{ContextForChainSpec, RuntimeSpec, SyncRuntimeSpec},
     state::{DatabaseComponents, StateDiff, SyncState, WrapDatabaseRef},
     transaction::TransactionError,
+    Block as _, BlockBuilder, BlockTransactionError, MemPool,
 };
 
 /// The result of mining a block, including the state. This result needs to be
@@ -444,11 +444,11 @@ fn priority_comparator<SignedTransactionT: ExecutableTransaction>(
 
 #[cfg(test)]
 mod tests {
-    use edr_eth::{Address, U256, account::AccountInfo};
+    use edr_eth::{account::AccountInfo, Address, U256};
 
     use super::*;
     use crate::test_utils::{
-        MemPoolTestFixture, dummy_eip155_transaction_with_price, dummy_eip1559_transaction,
+        dummy_eip1559_transaction, dummy_eip155_transaction_with_price, MemPoolTestFixture,
     };
 
     #[test]

--- a/crates/edr_evm/src/precompile.rs
+++ b/crates/edr_evm/src/precompile.rs
@@ -4,8 +4,8 @@ use edr_eth::{Address, Bytes, HashMap, HashSet};
 pub use revm_handler::{EthPrecompiles, PrecompileProvider};
 use revm_interpreter::{Gas, InstructionResult, InterpreterResult};
 pub use revm_precompile::{
-    PrecompileError, PrecompileFn, PrecompileSpecId, PrecompileWithAddress, Precompiles, secp256r1,
-    u64_to_address,
+    secp256r1, u64_to_address, PrecompileError, PrecompileFn, PrecompileSpecId,
+    PrecompileWithAddress, Precompiles,
 };
 
 use crate::{config::Cfg, interpreter::InputsImpl, spec::ContextTrait};
@@ -26,9 +26,9 @@ pub struct OverriddenPrecompileProvider<
 }
 
 impl<
-    BaseProviderT: PrecompileProvider<ContextT, Output = InterpreterResult>,
-    ContextT: ContextTrait,
-> OverriddenPrecompileProvider<BaseProviderT, ContextT>
+        BaseProviderT: PrecompileProvider<ContextT, Output = InterpreterResult>,
+        ContextT: ContextTrait,
+    > OverriddenPrecompileProvider<BaseProviderT, ContextT>
 {
     /// Creates a new custom precompile provider.
     pub fn new(base: BaseProviderT) -> Self {
@@ -62,9 +62,9 @@ impl<
 }
 
 impl<
-    BaseProviderT: PrecompileProvider<ContextT, Output = InterpreterResult>,
-    ContextT: ContextTrait,
-> PrecompileProvider<ContextT> for OverriddenPrecompileProvider<BaseProviderT, ContextT>
+        BaseProviderT: PrecompileProvider<ContextT, Output = InterpreterResult>,
+        ContextT: ContextTrait,
+    > PrecompileProvider<ContextT> for OverriddenPrecompileProvider<BaseProviderT, ContextT>
 {
     type Output = InterpreterResult;
 

--- a/crates/edr_evm/src/random.rs
+++ b/crates/edr_evm/src/random.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use edr_eth::{B256, keccak256};
+use edr_eth::{keccak256, B256};
 
 /// A pseudorandom hash generator which allows overriding of the next generated
 /// hash.

--- a/crates/edr_evm/src/runtime.rs
+++ b/crates/edr_evm/src/runtime.rs
@@ -1,9 +1,10 @@
 use edr_eth::{
-    Address, HashMap, l1,
+    l1,
     result::{ExecutionResult, ExecutionResultAndState},
     transaction::TransactionValidation,
+    Address, HashMap,
 };
-use revm::{ExecuteEvm, InspectEvm, Inspector, Journal, precompile::PrecompileFn};
+use revm::{precompile::PrecompileFn, ExecuteEvm, InspectEvm, Inspector, Journal};
 use revm_context::JournalTr as _;
 
 use crate::{

--- a/crates/edr_evm/src/spec.rs
+++ b/crates/edr_evm/src/spec.rs
@@ -1,7 +1,6 @@
 use std::{fmt::Debug, marker::PhantomData, sync::Arc};
 
 use edr_eth::{
-    B256,
     block::{self, BlobGas, PartialHeader},
     eips::eip4844,
     l1::{self, BlockEnv, L1ChainSpec},
@@ -9,18 +8,16 @@ use edr_eth::{
     receipt::{BlockReceipt, ExecutionReceipt, MapReceiptLogs, ReceiptTrait},
     result::ResultAndState,
     spec::{ChainSpec, EthHeaderConstants},
+    B256,
 };
-use edr_rpc_eth::{RpcTypeFrom, TransactionConversionError, spec::RpcSpec};
+use edr_rpc_eth::{spec::RpcSpec, RpcTypeFrom, TransactionConversionError};
 use edr_utils::types::TypeConstructor;
-use revm::{ExecuteEvm, InspectEvm, Inspector, inspector::NoOpInspector};
+use revm::{inspector::NoOpInspector, ExecuteEvm, InspectEvm, Inspector};
 pub use revm_context_interface::ContextTr as ContextTrait;
-use revm_handler::{PrecompileProvider, instructions::EthInstructions};
-use revm_interpreter::{InterpreterResult, interpreter::EthInterpreter};
+use revm_handler::{instructions::EthInstructions, PrecompileProvider};
+use revm_interpreter::{interpreter::EthInterpreter, InterpreterResult};
 
 use crate::{
-    Block, BlockBuilder, BlockReceipts, EmptyBlock, EthBlockBuilder, EthBlockData,
-    EthBlockReceiptFactory, EthLocalBlock, EthRpcBlock, LocalBlock, RemoteBlock,
-    RemoteBlockConversionError, SyncBlock,
     block::transaction::TransactionAndBlockForChainSpec,
     config::CfgEnv,
     evm::{Evm, EvmData},
@@ -31,9 +28,12 @@ use crate::{
     result::EVMErrorForChain,
     state::{Database, DatabaseComponentError},
     transaction::{
-        ExecutableTransaction, TransactionError, TransactionErrorForChainSpec, TransactionType,
-        TransactionValidation, remote::EthRpcTransaction,
+        remote::EthRpcTransaction, ExecutableTransaction, TransactionError,
+        TransactionErrorForChainSpec, TransactionType, TransactionValidation,
     },
+    Block, BlockBuilder, BlockReceipts, EmptyBlock, EthBlockBuilder, EthBlockData,
+    EthBlockReceiptFactory, EthLocalBlock, EthRpcBlock, LocalBlock, RemoteBlock,
+    RemoteBlockConversionError, SyncBlock,
 };
 
 /// Helper type for a chain-specific [`revm::Context`].
@@ -358,10 +358,10 @@ impl<ChainSpecT> SyncRuntimeSpec for ChainSpecT where
 
 impl RuntimeSpec for L1ChainSpec {
     type Block = dyn SyncBlock<
-            Arc<Self::BlockReceipt>,
-            Self::SignedTransaction,
-            Error = <Self::LocalBlock as BlockReceipts<Arc<Self::BlockReceipt>>>::Error,
-        >;
+        Arc<Self::BlockReceipt>,
+        Self::SignedTransaction,
+        Error = <Self::LocalBlock as BlockReceipts<Arc<Self::BlockReceipt>>>::Error,
+    >;
 
     type BlockBuilder<
         'blockchain,

--- a/crates/edr_evm/src/state.rs
+++ b/crates/edr_evm/src/state.rs
@@ -13,12 +13,12 @@ use std::fmt::Debug;
 use auto_impl::auto_impl;
 use dyn_clone::DynClone;
 use edr_eth::{
-    Address, B256, Bytecode, HashMap, U256,
     account::{Account, AccountInfo},
+    Address, Bytecode, HashMap, B256, U256,
 };
 use edr_rpc_eth::client::RpcClientError;
 pub use revm::state::{EvmState, EvmStorage, EvmStorageSlot};
-use revm::{DatabaseRef, context_interface::DBErrorMarker};
+use revm::{context_interface::DBErrorMarker, DatabaseRef};
 pub use revm_database_interface::{Database, DatabaseCommit as StateCommit, WrapDatabaseRef};
 
 pub use self::{
@@ -26,8 +26,8 @@ pub use self::{
     diff::StateDiff,
     fork::ForkState,
     irregular::IrregularState,
-    r#override::StateOverride,
     overrides::*,
+    r#override::StateOverride,
     remote::RemoteState,
     trie::{AccountTrie, TrieState},
 };

--- a/crates/edr_evm/src/state/debug.rs
+++ b/crates/edr_evm/src/state/debug.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Debug, ops::Deref};
 
 use auto_impl::auto_impl;
-use edr_eth::{Address, B256, Bytecode, U256, account::AccountInfo};
+use edr_eth::{account::AccountInfo, Address, Bytecode, B256, U256};
 
 type BoxedAccountModifierFn = Box<dyn Fn(&mut U256, &mut u64, &mut Option<Bytecode>) + Send>;
 

--- a/crates/edr_evm/src/state/diff.rs
+++ b/crates/edr_evm/src/state/diff.rs
@@ -1,6 +1,6 @@
 use edr_eth::{
-    Address, HashMap, U256,
     account::{Account, AccountInfo, AccountStatus},
+    Address, HashMap, U256,
 };
 
 use crate::state::EvmStorageSlot;

--- a/crates/edr_evm/src/state/fork.rs
+++ b/crates/edr_evm/src/state/fork.rs
@@ -2,17 +2,17 @@ use std::sync::Arc;
 
 use derive_where::derive_where;
 use edr_eth::{
-    Address, B256, Bytecode, HashMap, HashSet, U256,
     account::{Account, AccountInfo},
     trie::KECCAK_NULL_RLP,
+    Address, Bytecode, HashMap, HashSet, B256, U256,
 };
 use edr_rpc_eth::{client::EthRpcClient, spec::RpcSpec};
 use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};
 use tokio::runtime;
 
 use super::{
-    RemoteState, State, StateCommit, StateDebug, StateError, StateMut as _, TrieState,
-    remote::CachedRemoteState,
+    remote::CachedRemoteState, RemoteState, State, StateCommit, StateDebug, StateError,
+    StateMut as _, TrieState,
 };
 use crate::random::RandomHashGenerator;
 
@@ -230,7 +230,7 @@ mod tests {
         str::FromStr,
     };
 
-    use edr_eth::{PreEip1898BlockSpec, l1::L1ChainSpec};
+    use edr_eth::{l1::L1ChainSpec, PreEip1898BlockSpec};
     use edr_test_utils::env::get_alchemy_url;
 
     use super::*;

--- a/crates/edr_evm/src/state/irregular.rs
+++ b/crates/edr_evm/src/state/irregular.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, btree_map},
+    collections::{btree_map, BTreeMap},
     fmt::Debug,
 };
 

--- a/crates/edr_evm/src/state/overrides.rs
+++ b/crates/edr_evm/src/state/overrides.rs
@@ -1,8 +1,8 @@
 use std::fmt::Debug;
 
 use edr_eth::{
-    Address, B256, Bytecode, HashMap, U256,
     account::{AccountInfo, KECCAK_EMPTY},
+    Address, Bytecode, HashMap, B256, U256,
 };
 use edr_rpc_eth::{AccountOverrideOptions, StateOverrideOptions};
 

--- a/crates/edr_evm/src/state/remote.rs
+++ b/crates/edr_evm/src/state/remote.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 pub use cached::CachedRemoteState;
 use derive_where::derive_where;
 use edr_eth::{
-    Address, B256, BlockSpec, Bytecode, PreEip1898BlockSpec, U256, account::AccountInfo,
+    account::AccountInfo, Address, BlockSpec, Bytecode, PreEip1898BlockSpec, B256, U256,
 };
 use edr_rpc_eth::{
     client::{EthRpcClient, RpcClientError},
@@ -14,7 +14,7 @@ use edr_rpc_eth::{
 use tokio::runtime;
 
 use super::{State, StateError};
-use crate::{EthRpcBlock as _, spec::RuntimeSpec};
+use crate::{spec::RuntimeSpec, EthRpcBlock as _};
 
 /// A state backed by a remote Ethereum node
 #[derive_where(Debug)]

--- a/crates/edr_evm/src/state/remote/cached.rs
+++ b/crates/edr_evm/src/state/remote/cached.rs
@@ -1,9 +1,9 @@
 use derive_where::derive_where;
-use edr_eth::{Address, B256, Bytecode, HashMap, U256, account::AccountInfo, hash_map::Entry};
+use edr_eth::{account::AccountInfo, hash_map::Entry, Address, Bytecode, HashMap, B256, U256};
 use edr_rpc_eth::spec::RpcSpec;
 
 use super::RemoteState;
-use crate::state::{State, StateError, StateMut, account::EdrAccount};
+use crate::state::{account::EdrAccount, State, StateError, StateMut};
 
 /// A cached version of [`RemoteState`].
 #[derive_where(Debug)]

--- a/crates/edr_evm/src/state/trie.rs
+++ b/crates/edr_evm/src/state/trie.rs
@@ -5,8 +5,8 @@ mod storage_trie;
 mod trie_query;
 
 use edr_eth::{
-    Address, B256, Bytecode, HashMap, U256,
     account::{Account, AccountInfo, KECCAK_EMPTY},
+    Address, Bytecode, HashMap, B256, U256,
 };
 
 pub use self::account::AccountTrie;

--- a/crates/edr_evm/src/state/trie/account.rs
+++ b/crates/edr_evm/src/state/trie/account.rs
@@ -1,8 +1,8 @@
 use std::{collections::BTreeMap, fmt::Debug};
 
 use edr_eth::{
-    Address, B256, HashMap, U256,
     account::{Account, AccountInfo, BasicAccount},
+    Address, HashMap, B256, U256,
 };
 use hasher::{Hasher, HasherKeccak};
 use rpds::HashTrieMapSync;

--- a/crates/edr_evm/src/state/trie/state_trie.rs
+++ b/crates/edr_evm/src/state/trie/state_trie.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use alloy_rlp::Decodable;
 use edr_eth::{
-    Address, B256,
     account::{AccountInfo, BasicAccount},
+    Address, B256,
 };
 
 use crate::state::trie::{persistent_memory_db::PersistentMemoryDB, trie_query::TrieQuery};

--- a/crates/edr_evm/src/test_utils.rs
+++ b/crates/edr_evm/src/test_utils.rs
@@ -2,25 +2,24 @@ use std::{fmt::Debug, num::NonZeroU64, sync::Arc};
 
 use anyhow::anyhow;
 use edr_eth::{
-    Address, Bytes, HashMap, PreEip1898BlockSpec, U256,
     account::AccountInfo,
-    block::{BlockOptions, miner_reward},
+    block::{miner_reward, BlockOptions},
     l1,
     log::FilterLog,
     receipt::{AsExecutionReceipt, ExecutionReceipt as _, ReceiptTrait as _},
     transaction::{TransactionValidation, TxKind},
     withdrawal::Withdrawal,
+    Address, Bytes, HashMap, PreEip1898BlockSpec, U256,
 };
 use edr_rpc_eth::client::EthRpcClient;
 
 use crate::{
-    Block, BlockBuilder, BlockReceipts, LocalBlock as _, MemPool, MemPoolAddTransactionError,
-    RandomHashGenerator, RemoteBlock,
     blockchain::{Blockchain as _, BlockchainErrorForChainSpec, ForkedBlockchain},
     config::CfgEnv,
     spec::SyncRuntimeSpec,
     state::{AccountTrie, IrregularState, StateError, TrieState},
-    transaction,
+    transaction, Block, BlockBuilder, BlockReceipts, LocalBlock as _, MemPool,
+    MemPoolAddTransactionError, RandomHashGenerator, RemoteBlock,
 };
 
 /// A test fixture for `MemPool`.

--- a/crates/edr_evm/src/trace.rs
+++ b/crates/edr_evm/src/trace.rs
@@ -2,18 +2,18 @@ use std::fmt::Debug;
 
 use derive_where::derive_where;
 use edr_eth::{
-    Address, Bytecode, Bytes, U256,
     bytecode::opcode,
     result::{ExecutionResult, Output},
     spec::HaltReasonTrait,
+    Address, Bytecode, Bytes, U256,
 };
 use revm::Inspector;
 
 use crate::{
     blockchain::BlockHash,
     interpreter::{
-        CallInputs, CallOutcome, CallValue, CreateInputs, CreateOutcome, EthInterpreter,
-        Interpreter, Jumps as _, MemoryGetter as _, SuccessOrHalt, return_revert,
+        return_revert, CallInputs, CallOutcome, CallValue, CreateInputs, CreateOutcome,
+        EthInterpreter, Interpreter, Jumps as _, MemoryGetter as _, SuccessOrHalt,
     },
     journal::{JournalExt, JournalTrait},
     spec::ContextTrait,
@@ -467,16 +467,16 @@ impl<HaltReasonT: HaltReasonTrait> TraceCollector<HaltReasonT> {
 }
 
 impl<
-    BlockchainT: BlockHash<Error: std::error::Error>,
-    ContextT: ContextTrait<
-        Journal: JournalExt
-                     + JournalTrait<
-            Database = WrapDatabaseRef<DatabaseComponents<BlockchainT, StateT>>,
+        BlockchainT: BlockHash<Error: std::error::Error>,
+        ContextT: ContextTrait<
+            Journal: JournalExt
+                         + JournalTrait<
+                Database = WrapDatabaseRef<DatabaseComponents<BlockchainT, StateT>>,
+            >,
         >,
-    >,
-    HaltReasonT: HaltReasonTrait,
-    StateT: State<Error: std::error::Error>,
-> Inspector<ContextT, EthInterpreter> for TraceCollector<HaltReasonT>
+        HaltReasonT: HaltReasonTrait,
+        StateT: State<Error: std::error::Error>,
+    > Inspector<ContextT, EthInterpreter> for TraceCollector<HaltReasonT>
 {
     fn call(&mut self, context: &mut ContextT, inputs: &mut CallInputs) -> Option<CallOutcome> {
         self.notify_call_start(context.journal(), inputs);

--- a/crates/edr_evm/src/transaction.rs
+++ b/crates/edr_evm/src/transaction.rs
@@ -6,7 +6,7 @@ use std::fmt::Debug;
 
 // Re-export the transaction types from `edr_eth`.
 pub use edr_eth::transaction::*;
-use edr_eth::{U256, l1, spec::ChainSpec};
+use edr_eth::{l1, spec::ChainSpec, U256};
 use revm_handler::validation::validate_initial_tx_gas;
 pub use revm_interpreter::gas::calculate_initial_tx_gas_for_tx;
 
@@ -139,7 +139,7 @@ pub fn validate<TransactionT: revm_context_interface::Transaction>(
 
 #[cfg(test)]
 mod tests {
-    use edr_eth::{Address, Bytes, transaction};
+    use edr_eth::{transaction, Address, Bytes};
 
     use super::*;
 

--- a/crates/edr_evm/tests/integration/blockchain.rs
+++ b/crates/edr_evm/tests/integration/blockchain.rs
@@ -3,7 +3,6 @@
 use std::{collections::BTreeMap, sync::Arc};
 
 use edr_eth::{
-    Address, B256, Bytes, HashSet, U256,
     block::PartialHeader,
     eips::eip2718::TypedEnvelope,
     l1::{self, L1ChainSpec},
@@ -11,10 +10,9 @@ use edr_eth::{
     receipt::{BlockReceipt, ExecutionReceipt as _, TransactionReceipt},
     result::{ExecutionResult, Output, SuccessReason},
     transaction::ExecutableTransaction as _,
+    Address, Bytes, HashSet, B256, U256,
 };
 use edr_evm::{
-    EmptyBlock as _, EthBlockReceiptFactory, EthLocalBlock, EthLocalBlockForChainSpec,
-    RemoteBlockConversionError,
     blockchain::{
         BlockchainError, BlockchainErrorForChainSpec, GenesisBlockOptions, LocalBlockchain,
         SyncBlockchain,
@@ -23,7 +21,8 @@ use edr_evm::{
     spec::{ExecutionReceiptTypeConstructorForChainSpec, RuntimeSpec},
     state::{StateDiff, StateError},
     test_utils::dummy_eip155_transaction,
-    transaction,
+    transaction, EmptyBlock as _, EthBlockReceiptFactory, EthLocalBlock, EthLocalBlockForChainSpec,
+    RemoteBlockConversionError,
 };
 use edr_rpc_eth::TransactionConversionError;
 use serial_test::serial;
@@ -47,8 +46,8 @@ const REMOTE_BLOCK_LAST_TRANSACTION_HASH: &str =
 async fn create_forked_dummy_blockchain(
     fork_block_number: Option<u64>,
 ) -> Box<dyn SyncBlockchain<L1ChainSpec, BlockchainErrorForChainSpec<L1ChainSpec>, StateError>> {
-    use edr_eth::{HashMap, l1};
-    use edr_evm::{RandomHashGenerator, blockchain::ForkedBlockchain, state::IrregularState};
+    use edr_eth::{l1, HashMap};
+    use edr_evm::{blockchain::ForkedBlockchain, state::IrregularState, RandomHashGenerator};
     use edr_rpc_eth::client::EthRpcClient;
     use edr_test_utils::env::get_alchemy_url;
     use parking_lot::Mutex;
@@ -78,8 +77,9 @@ async fn create_forked_dummy_blockchain(
 
 // The cache directory is only used when the `test-remote` feature is enabled
 #[allow(unused_variables)]
-async fn create_dummy_blockchains()
--> Vec<Box<dyn SyncBlockchain<L1ChainSpec, BlockchainErrorForChainSpec<L1ChainSpec>, StateError>>> {
+async fn create_dummy_blockchains(
+) -> Vec<Box<dyn SyncBlockchain<L1ChainSpec, BlockchainErrorForChainSpec<L1ChainSpec>, StateError>>>
+{
     const DEFAULT_GAS_LIMIT: u64 = 0xffffffffffffff;
     const DEFAULT_INITIAL_BASE_FEE: u128 = 1000000000;
 
@@ -104,7 +104,11 @@ async fn create_dummy_blockchains()
 }
 
 fn create_dummy_block(
-    blockchain: &dyn SyncBlockchain<L1ChainSpec, BlockchainErrorForChainSpec<L1ChainSpec>, StateError>,
+    blockchain: &dyn SyncBlockchain<
+        L1ChainSpec,
+        BlockchainErrorForChainSpec<L1ChainSpec>,
+        StateError,
+    >,
 ) -> EthLocalBlockForChainSpec<L1ChainSpec> {
     let block_number = blockchain.last_block_number() + 1;
 
@@ -112,7 +116,11 @@ fn create_dummy_block(
 }
 
 fn create_dummy_block_with_number(
-    blockchain: &dyn SyncBlockchain<L1ChainSpec, BlockchainErrorForChainSpec<L1ChainSpec>, StateError>,
+    blockchain: &dyn SyncBlockchain<
+        L1ChainSpec,
+        BlockchainErrorForChainSpec<L1ChainSpec>,
+        StateError,
+    >,
     number: u64,
 ) -> EthLocalBlockForChainSpec<L1ChainSpec> {
     let parent_hash = *blockchain
@@ -124,7 +132,11 @@ fn create_dummy_block_with_number(
 }
 
 fn create_dummy_block_with_difficulty(
-    blockchain: &dyn SyncBlockchain<L1ChainSpec, BlockchainErrorForChainSpec<L1ChainSpec>, StateError>,
+    blockchain: &dyn SyncBlockchain<
+        L1ChainSpec,
+        BlockchainErrorForChainSpec<L1ChainSpec>,
+        StateError,
+    >,
     number: u64,
     difficulty: u64,
 ) -> EthLocalBlockForChainSpec<L1ChainSpec> {
@@ -175,7 +187,11 @@ struct DummyBlockAndTransaction {
 
 /// Returns the transaction's hash.
 fn insert_dummy_block_with_transaction(
-    blockchain: &mut dyn SyncBlockchain<L1ChainSpec, BlockchainErrorForChainSpec<L1ChainSpec>, StateError>,
+    blockchain: &mut dyn SyncBlockchain<
+        L1ChainSpec,
+        BlockchainErrorForChainSpec<L1ChainSpec>,
+        StateError,
+    >,
 ) -> anyhow::Result<DummyBlockAndTransaction> {
     const GAS_USED: u64 = 100;
 
@@ -394,12 +410,10 @@ async fn block_by_number_none() {
 
     for blockchain in blockchains {
         let next_block_number = blockchain.last_block_number() + 1;
-        assert!(
-            blockchain
-                .block_by_number(next_block_number)
-                .unwrap()
-                .is_none()
-        );
+        assert!(blockchain
+            .block_by_number(next_block_number)
+            .unwrap()
+            .is_none());
     }
 }
 
@@ -683,17 +697,13 @@ async fn revert_to_block_local() -> anyhow::Result<()> {
         );
 
         // Blocks 1 and 2 are gone
-        assert!(
-            blockchain
-                .block_by_number(one.block.header().number)?
-                .is_none()
-        );
+        assert!(blockchain
+            .block_by_number(one.block.header().number)?
+            .is_none());
 
-        assert!(
-            blockchain
-                .block_by_number(two.block.header().number)?
-                .is_none()
-        );
+        assert!(blockchain
+            .block_by_number(two.block.header().number)?
+            .is_none());
 
         assert!(blockchain.block_by_hash(one.block.block_hash())?.is_none());
         assert!(blockchain.block_by_hash(two.block.block_hash())?.is_none());
@@ -808,12 +818,10 @@ async fn block_total_difficulty_by_hash() {
         );
 
         // Block 2 no longer stores a total difficulty
-        assert!(
-            blockchain
-                .total_difficulty_by_hash(two.block.block_hash())
-                .unwrap()
-                .is_none()
-        );
+        assert!(blockchain
+            .total_difficulty_by_hash(two.block.block_hash())
+            .unwrap()
+            .is_none());
     }
 }
 

--- a/crates/edr_evm/tests/integration/eip2935.rs
+++ b/crates/edr_evm/tests/integration/eip2935.rs
@@ -1,17 +1,17 @@
 use std::collections::BTreeMap;
 
 use edr_eth::{
-    Bytecode,
     l1::{self, L1ChainSpec},
+    Bytecode,
 };
 use edr_evm::{
-    RandomHashGenerator,
     blockchain::{Blockchain, GenesisBlockOptions, LocalBlockchain, LocalCreationError},
     eips::eip2935::{
-        HISTORY_STORAGE_ADDRESS, HISTORY_STORAGE_UNSUPPORTED_BYTECODE,
-        add_history_storage_contract_to_state_diff,
+        add_history_storage_contract_to_state_diff, HISTORY_STORAGE_ADDRESS,
+        HISTORY_STORAGE_UNSUPPORTED_BYTECODE,
     },
     state::StateDiff,
+    RandomHashGenerator,
 };
 
 fn local_blockchain(
@@ -72,7 +72,7 @@ fn local_blockchain_with_history() -> anyhow::Result<()> {
 mod remote {
     use std::sync::Arc;
 
-    use edr_eth::{Bytes, HashMap, bytes};
+    use edr_eth::{bytes, Bytes, HashMap};
     use edr_evm::{
         blockchain::{ForkedBlockchain, ForkedCreationError},
         state::IrregularState,

--- a/crates/edr_evm/tests/integration/issues.rs
+++ b/crates/edr_evm/tests/integration/issues.rs
@@ -4,14 +4,14 @@ use std::{str::FromStr, sync::Arc};
 
 use edr_defaults::CACHE_DIR;
 use edr_eth::{
-    Address, HashMap, U256,
     l1::{self, L1ChainSpec},
+    Address, HashMap, U256,
 };
 use edr_evm::{
-    RandomHashGenerator,
     blockchain::ForkedBlockchain,
     precompile::{self, Precompiles},
     state::{AccountModifierFn, ForkState, IrregularState, StateDebug},
+    RandomHashGenerator,
 };
 use edr_rpc_eth::client::EthRpcClient;
 use edr_test_utils::env::get_alchemy_url;

--- a/crates/edr_evm/tests/integration/mem_pool.rs
+++ b/crates/edr_evm/tests/integration/mem_pool.rs
@@ -2,15 +2,15 @@
 
 use std::num::NonZeroU64;
 
-use edr_eth::{Address, U256, account::AccountInfo, transaction::ExecutableTransaction};
+use edr_eth::{account::AccountInfo, transaction::ExecutableTransaction, Address, U256};
 use edr_evm::{
-    MemPoolAddTransactionError, OrderedTransaction,
     state::{AccountModifierFn, StateDebug},
     test_utils::{
-        MemPoolTestFixture, dummy_eip155_transaction, dummy_eip155_transaction_with_limit,
+        dummy_eip1559_transaction, dummy_eip155_transaction, dummy_eip155_transaction_with_limit,
         dummy_eip155_transaction_with_price, dummy_eip155_transaction_with_price_limit_and_value,
-        dummy_eip1559_transaction,
+        MemPoolTestFixture,
     },
+    MemPoolAddTransactionError, OrderedTransaction,
 };
 
 #[test]
@@ -417,12 +417,10 @@ fn add_transaction_insufficient_funds() -> anyhow::Result<()> {
         Err(MemPoolAddTransactionError::InsufficientFunds { max_upfront_cost, sender_balance }) if max_upfront_cost == U256::from(INITIAL_COST) && sender_balance == balance
     ));
 
-    assert!(
-        result
-            .unwrap_err()
-            .to_string()
-            .contains("Sender doesn't have enough funds to send tx")
-    );
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("Sender doesn't have enough funds to send tx"));
 
     Ok(())
 }

--- a/crates/edr_evm/tests/integration/op.rs
+++ b/crates/edr_evm/tests/integration/op.rs
@@ -3,11 +3,11 @@
 use std::sync::Arc;
 
 use edr_defaults::CACHE_DIR;
-use edr_eth::{HashMap, l1};
+use edr_eth::{l1, HashMap};
 use edr_evm::{
-    RandomHashGenerator,
     blockchain::{Blockchain, ForkedBlockchain},
     state::IrregularState,
+    RandomHashGenerator,
 };
 use edr_generic::GenericChainSpec;
 use edr_rpc_eth::client::EthRpcClient;

--- a/crates/edr_generic/src/eip2718.rs
+++ b/crates/edr_generic/src/eip2718.rs
@@ -1,8 +1,8 @@
 use alloy_rlp::Buf as _;
 use edr_eth::{
-    Bloom,
     receipt::{ExecutionReceipt, MapReceiptLogs, RootOrStatus},
     transaction::TransactionType,
+    Bloom,
 };
 
 use crate::transaction;

--- a/crates/edr_generic/src/rpc.rs
+++ b/crates/edr_generic/src/rpc.rs
@@ -1,7 +1,7 @@
 use edr_rpc_eth::RpcSpec;
-use serde::{Serialize, de::DeserializeOwned};
+use serde::{de::DeserializeOwned, Serialize};
 
-use crate::{GenericChainSpec, eip2718::TypedEnvelope};
+use crate::{eip2718::TypedEnvelope, GenericChainSpec};
 
 pub mod block;
 pub mod receipt;

--- a/crates/edr_generic/src/rpc/block.rs
+++ b/crates/edr_generic/src/rpc/block.rs
@@ -1,11 +1,11 @@
 use derive_where::derive_where;
 use edr_eth::{
-    Address, B64, B256, Bloom, Bytes, U256,
     block::{BlobGas, Header},
     transaction::ExecutableTransaction,
     withdrawal::Withdrawal,
+    Address, Bloom, Bytes, B256, B64, U256,
 };
-use edr_evm::{BlockAndTotalDifficulty, EthBlockData, EthRpcBlock, spec::RuntimeSpec};
+use edr_evm::{spec::RuntimeSpec, BlockAndTotalDifficulty, EthBlockData, EthRpcBlock};
 use edr_rpc_eth::spec::GetBlockNumber;
 use serde::{Deserialize, Serialize};
 
@@ -143,9 +143,9 @@ pub enum ConversionError<ChainSpecT: RuntimeSpec> {
 impl<TransactionT> TryFrom<Block<TransactionT>> for EthBlockData<GenericChainSpec>
 where
     TransactionT: TryInto<
-            crate::transaction::SignedWithFallbackToPostEip155,
-            Error = crate::rpc::transaction::ConversionError,
-        >,
+        crate::transaction::SignedWithFallbackToPostEip155,
+        Error = crate::rpc::transaction::ConversionError,
+    >,
 {
     type Error = ConversionError<GenericChainSpec>;
 
@@ -255,7 +255,7 @@ mod tests {
     use edr_rpc_client::jsonrpc;
     use edr_rpc_eth::client::EthRpcClient;
 
-    use crate::{GenericChainSpec, rpc::transaction::TransactionWithSignature};
+    use crate::{rpc::transaction::TransactionWithSignature, GenericChainSpec};
 
     #[tokio::test(flavor = "current_thread")]
     async fn test_allow_missing_nonce_or_mix_hash() {

--- a/crates/edr_generic/src/rpc/receipt.rs
+++ b/crates/edr_generic/src/rpc/receipt.rs
@@ -18,8 +18,8 @@ pub enum ConversionError {
 
 use edr_eth::{
     receipt::{
-        ExecutionReceipt, TransactionReceipt,
         execution::{Eip658, Legacy},
+        ExecutionReceipt, TransactionReceipt,
     },
     transaction::TransactionType,
 };

--- a/crates/edr_generic/src/rpc/transaction.rs
+++ b/crates/edr_generic/src/rpc/transaction.rs
@@ -6,7 +6,7 @@ use edr_evm::{
 use edr_rpc_eth::RpcTypeFrom;
 use serde::{Deserialize, Serialize};
 
-use crate::{GenericChainSpec, transaction};
+use crate::{transaction, GenericChainSpec};
 
 // We need to use a newtype here as `RpcTypeFrom` cannot be implemented here,
 // in an external crate, even though `TransactionAndBlock` is generic over

--- a/crates/edr_generic/src/spec.rs
+++ b/crates/edr_generic/src/spec.rs
@@ -9,7 +9,6 @@ use edr_eth::{
     transaction::TransactionValidation,
 };
 use edr_evm::{
-    BlockReceipts, EthBlockBuilder, EthBlockReceiptFactory, EthLocalBlock, RemoteBlock, SyncBlock,
     evm::{Evm, EvmData},
     hardfork::Activations,
     inspector::{Inspector, NoOpInspector},
@@ -18,8 +17,9 @@ use edr_evm::{
     spec::{ContextForChainSpec, ExecutionReceiptTypeConstructorForChainSpec, RuntimeSpec},
     state::{Database, DatabaseComponentError},
     transaction::{TransactionError, TransactionErrorForChainSpec},
+    BlockReceipts, EthBlockBuilder, EthBlockReceiptFactory, EthLocalBlock, RemoteBlock, SyncBlock,
 };
-use edr_provider::{ProviderSpec, TransactionFailureReason, time::TimeSinceEpoch};
+use edr_provider::{time::TimeSinceEpoch, ProviderSpec, TransactionFailureReason};
 
 use crate::GenericChainSpec;
 
@@ -39,10 +39,10 @@ impl EthHeaderConstants for GenericChainSpec {
 
 impl RuntimeSpec for GenericChainSpec {
     type Block = dyn SyncBlock<
-            Arc<Self::BlockReceipt>,
-            Self::SignedTransaction,
-            Error = <Self::LocalBlock as BlockReceipts<Arc<Self::BlockReceipt>>>::Error,
-        >;
+        Arc<Self::BlockReceipt>,
+        Self::SignedTransaction,
+        Error = <Self::LocalBlock as BlockReceipts<Arc<Self::BlockReceipt>>>::Error,
+    >;
 
     type BlockBuilder<
         'blockchain,

--- a/crates/edr_generic/src/transaction/request.rs
+++ b/crates/edr_generic/src/transaction/request.rs
@@ -1,20 +1,23 @@
 use edr_eth::{
-    Address, Bytes, U256, l1,
+    l1,
     signature::{SecretKey, SignatureError},
     transaction::{
-        self, TxKind,
+        self,
         signed::{FakeSign, Sign},
+        TxKind,
     },
+    Address, Bytes, U256,
 };
 use edr_provider::{
-    ProviderError, ProviderErrorForChainSpec, calculate_eip1559_fee_parameters,
+    calculate_eip1559_fee_parameters,
     requests::validation::{validate_call_request, validate_send_transaction_request},
     spec::{CallContext, FromRpcType, TransactionContext},
     time::TimeSinceEpoch,
+    ProviderError, ProviderErrorForChainSpec,
 };
 use edr_rpc_eth::{CallRequest, TransactionRequest};
 
-use crate::{GenericChainSpec, transaction::SignedWithFallbackToPostEip155};
+use crate::{transaction::SignedWithFallbackToPostEip155, GenericChainSpec};
 
 /// Container type for various Ethereum transaction requests.
 // NOTE: This is a newtype only because the default FromRpcType implementation

--- a/crates/edr_generic/src/transaction/signed.rs
+++ b/crates/edr_generic/src/transaction/signed.rs
@@ -1,5 +1,4 @@
 use edr_eth::{
-    Address, B256, Bytes, U256,
     eips::{eip2930, eip7702},
     impl_revm_transaction_trait,
     signature::Signature,
@@ -7,6 +6,7 @@ use edr_eth::{
         self, ExecutableTransaction, IsSupported, SignedTransaction, TransactionMut,
         TransactionType, TransactionValidation, TxKind,
     },
+    Address, Bytes, B256, U256,
 };
 
 /// The type of transaction.

--- a/crates/edr_generic/tests/integration/issue_570.rs
+++ b/crates/edr_generic/tests/integration/issue_570.rs
@@ -1,11 +1,11 @@
 use std::{str::FromStr as _, sync::Arc};
 
-use edr_eth::{B256, l1};
+use edr_eth::{l1, B256};
 use edr_evm::hardfork::{self, ChainOverride};
 use edr_generic::GenericChainSpec;
 use edr_provider::{
-    ForkConfig, MethodInvocation, NoopLogger, Provider, ProviderError, ProviderRequest,
-    test_utils::create_test_config_with_fork, time::CurrentTime,
+    test_utils::create_test_config_with_fork, time::CurrentTime, ForkConfig, MethodInvocation,
+    NoopLogger, Provider, ProviderError, ProviderRequest,
 };
 use edr_solidity::contract_decoder::ContractDecoder;
 use edr_test_utils::env::get_alchemy_url;

--- a/crates/edr_generic/tests/integration/unknown_transaction_type.rs
+++ b/crates/edr_generic/tests/integration/unknown_transaction_type.rs
@@ -3,11 +3,11 @@
 use std::sync::Arc;
 
 use edr_defaults::CACHE_DIR;
-use edr_eth::{HashMap, l1};
+use edr_eth::{l1, HashMap};
 use edr_evm::{
-    RandomHashGenerator,
     blockchain::{Blockchain, ForkedBlockchain},
     state::IrregularState,
+    RandomHashGenerator,
 };
 use edr_generic::GenericChainSpec;
 use edr_rpc_eth::client::EthRpcClient;

--- a/crates/edr_instrument/src/coverage.rs
+++ b/crates/edr_instrument/src/coverage.rs
@@ -264,11 +264,9 @@ mod tests {
         let result = instrument_code(FIXTURE, "instrumentation.sol", version, LIBRARY_PATH)
             .expect("Failed to instrument");
 
-        assert!(
-            result
-                .source
-                .contains(&format!("import \"{LIBRARY_PATH}\";"))
-        );
+        assert!(result
+            .source
+            .contains(&format!("import \"{LIBRARY_PATH}\";")));
     }
 
     #[test]

--- a/crates/edr_napi/src/call_override.rs
+++ b/crates/edr_napi/src/call_override.rs
@@ -2,12 +2,12 @@ use std::sync::mpsc::channel;
 
 use edr_eth::{Address, Bytes};
 use napi::{
-    Env, JsFunction, Status,
     bindgen_prelude::{Promise, Uint8Array},
     threadsafe_function::{
         ErrorStrategy, ThreadSafeCallContext, ThreadsafeFunction, ThreadsafeFunctionCallMode,
     },
     tokio::runtime,
+    Env, JsFunction, Status,
 };
 use napi_derive::napi;
 

--- a/crates/edr_napi/src/cast.rs
+++ b/crates/edr_napi/src/cast.rs
@@ -1,7 +1,7 @@
-use edr_eth::{Address, B64, B256, Bytecode, Bytes, U256};
+use edr_eth::{Address, Bytecode, Bytes, B256, B64, U256};
 use napi::{
-    Status,
     bindgen_prelude::{BigInt, Uint8Array},
+    Status,
 };
 
 /// An attempted conversion that consumes `self`, which may or may not be

--- a/crates/edr_napi/src/config.rs
+++ b/crates/edr_napi/src/config.rs
@@ -6,16 +6,16 @@ use std::{
 };
 
 use edr_eth::{
+    signature::{secret_key_from_str, SecretKey},
     Bytes, HashSet,
-    signature::{SecretKey, secret_key_from_str},
 };
 use edr_provider::coverage::SyncOnCollectedCoverageCallback;
 use napi::{
-    Either, JsFunction, JsString, JsStringUtf8,
     bindgen_prelude::{BigInt, Reference, Uint8Array},
     threadsafe_function::{
         ErrorStrategy, ThreadSafeCallContext, ThreadsafeFunction, ThreadsafeFunctionCallMode,
     },
+    Either, JsFunction, JsString, JsStringUtf8,
 };
 use napi_derive::napi;
 

--- a/crates/edr_napi/src/context.rs
+++ b/crates/edr_napi/src/context.rs
@@ -4,11 +4,11 @@ use edr_eth::HashMap;
 use edr_napi_core::provider::{self, SyncProviderFactory};
 use edr_solidity::contract_decoder::ContractDecoder;
 use napi::{
-    Env, JsObject,
     tokio::{runtime, sync::Mutex as AsyncMutex},
+    Env, JsObject,
 };
 use napi_derive::napi;
-use tracing_subscriber::{EnvFilter, Registry, prelude::*};
+use tracing_subscriber::{prelude::*, EnvFilter, Registry};
 
 use crate::{
     config::{ProviderConfig, TracingConfigWithBuffers},
@@ -69,8 +69,8 @@ impl EdrContext {
                 .map_err(|error| napi::Error::from_reason(error.to_string()))
         );
 
-        let contract_decoder =
-            try_or_reject_promise!(ContractDecoder::new(&build_info_config).map_or_else(
+        let contract_decoder = try_or_reject_promise!(ContractDecoder::new(&build_info_config)
+            .map_or_else(
                 |error| Err(napi::Error::from_reason(error.to_string())),
                 |contract_decoder| Ok(Arc::new(contract_decoder))
             ));

--- a/crates/edr_napi/src/logger.rs
+++ b/crates/edr_napi/src/logger.rs
@@ -1,12 +1,12 @@
-use std::sync::{Arc, mpsc::channel};
+use std::sync::{mpsc::channel, Arc};
 
 use edr_eth::Bytes;
 use edr_napi_core::logger::LoggerError;
 use napi::{
-    JsFunction, Status,
     threadsafe_function::{
         ErrorStrategy, ThreadSafeCallContext, ThreadsafeFunction, ThreadsafeFunctionCallMode,
     },
+    JsFunction, Status,
 };
 use napi_derive::napi;
 

--- a/crates/edr_napi/src/provider.rs
+++ b/crates/edr_napi/src/provider.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use edr_napi_core::provider::SyncProvider;
 use edr_solidity::contract_decoder::ContractDecoder;
-use napi::{Env, JsFunction, JsObject, Status, tokio::runtime};
+use napi::{tokio::runtime, Env, JsFunction, JsObject, Status};
 use napi_derive::napi;
 
 pub use self::factory::ProviderFactory;

--- a/crates/edr_napi/src/provider/response.rs
+++ b/crates/edr_napi/src/provider/response.rs
@@ -5,7 +5,7 @@ use napi_derive::napi;
 
 use crate::{
     cast::TryCast,
-    trace::{RawTrace, solidity_stack_trace::SolidityStackTrace},
+    trace::{solidity_stack_trace::SolidityStackTrace, RawTrace},
 };
 
 #[napi]

--- a/crates/edr_napi/src/result.rs
+++ b/crates/edr_napi/src/result.rs
@@ -1,7 +1,7 @@
 use edr_evm::trace::AfterMessage;
 use napi::{
-    Either,
     bindgen_prelude::{BigInt, Either3, Uint8Array},
+    Either,
 };
 use napi_derive::napi;
 

--- a/crates/edr_napi/src/scenarios.rs
+++ b/crates/edr_napi/src/scenarios.rs
@@ -2,7 +2,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use edr_scenarios::ScenarioConfig;
 use napi::tokio::{fs::File, io::AsyncWriteExt, sync::Mutex};
-use rand::{Rng, distributions::Alphanumeric};
+use rand::{distributions::Alphanumeric, Rng};
 
 const SCENARIO_FILE_PREFIX: &str = "EDR_SCENARIO_PREFIX";
 

--- a/crates/edr_napi/src/subscription.rs
+++ b/crates/edr_napi/src/subscription.rs
@@ -1,4 +1,4 @@
-use napi::{JsFunction, bindgen_prelude::BigInt};
+use napi::{bindgen_prelude::BigInt, JsFunction};
 use napi_derive::napi;
 
 /// Configuration for subscriptions.

--- a/crates/edr_napi/src/trace/solidity_stack_trace.rs
+++ b/crates/edr_napi/src/trace/solidity_stack_trace.rs
@@ -1,7 +1,7 @@
 //! Naive rewrite of `hardhat-network/stack-traces/solidity-stack-traces.ts`
 //! from Hardhat.
 
-use edr_eth::{U256, hex};
+use edr_eth::{hex, U256};
 use napi::bindgen_prelude::{BigInt, Either24, FromNapiValue, ToNapiValue, Uint8Array, Undefined};
 use napi_derive::napi;
 use serde::{Serialize, Serializer};

--- a/crates/edr_napi_core/src/logger.rs
+++ b/crates/edr_napi_core/src/logger.rs
@@ -3,16 +3,16 @@ use std::{fmt::Display, marker::PhantomData, sync::Arc};
 
 use ansi_term::{Color, Style};
 use derive_where::derive_where;
-use edr_eth::{B256, Bytes, U256, result::ExecutionResult, transaction::ExecutableTransaction};
+use edr_eth::{result::ExecutionResult, transaction::ExecutableTransaction, Bytes, B256, U256};
 use edr_evm::{
-    Block as _,
     blockchain::BlockchainErrorForChainSpec,
     precompile::{self, Precompiles},
     trace::{AfterMessage, Trace, TraceMessage},
+    Block as _,
 };
 use edr_provider::{
-    CallResult, DebugMineBlockResult, DebugMineBlockResultForChainSpec, EstimateGasFailure,
-    ProviderError, ProviderErrorForChainSpec, ProviderSpec, TransactionFailure, time::CurrentTime,
+    time::CurrentTime, CallResult, DebugMineBlockResult, DebugMineBlockResultForChainSpec,
+    EstimateGasFailure, ProviderError, ProviderErrorForChainSpec, ProviderSpec, TransactionFailure,
 };
 use edr_solidity::contract_decoder::{ContractAndFunctionName, ContractDecoder};
 use itertools::izip;

--- a/crates/edr_napi_core/src/provider/builder.rs
+++ b/crates/edr_napi_core/src/provider/builder.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use edr_evm::blockchain::BlockchainErrorForChainSpec;
-use edr_provider::{SyncLogger, time::CurrentTime};
+use edr_provider::{time::CurrentTime, SyncLogger};
 use edr_solidity::contract_decoder::ContractDecoder;
 use napi::tokio::runtime;
 

--- a/crates/edr_napi_core/src/provider/config.rs
+++ b/crates/edr_napi_core/src/provider/config.rs
@@ -2,16 +2,16 @@ use core::num::NonZeroU64;
 use std::{str::FromStr, time::SystemTime};
 
 use edr_eth::{
-    Address, B256, ChainId, HashMap,
     block::BlobGas,
     l1::{self, hardfork::UnknownHardfork},
     signature::SecretKey,
+    Address, ChainId, HashMap, B256,
 };
 use edr_evm::{
     hardfork::{self, ChainOverride},
     precompile::PrecompileFn,
 };
-use edr_provider::{AccountOverride, ForkConfig, config};
+use edr_provider::{config, AccountOverride, ForkConfig};
 
 /// Chain-agnostic configuration for a provider.
 #[derive(Clone, Debug)]

--- a/crates/edr_napi_core/src/spec.rs
+++ b/crates/edr_napi_core/src/spec.rs
@@ -8,7 +8,7 @@ use edr_eth::{
 use edr_evm::trace::Trace;
 use edr_generic::GenericChainSpec;
 use edr_provider::{
-    ProviderErrorForChainSpec, ResponseWithTraces, SyncProviderSpec, time::CurrentTime,
+    time::CurrentTime, ProviderErrorForChainSpec, ResponseWithTraces, SyncProviderSpec,
 };
 use edr_rpc_client::jsonrpc;
 use edr_solidity::contract_decoder::ContractDecoder;
@@ -51,16 +51,16 @@ pub struct SolidityTraceData<HaltReasonT: HaltReasonTrait> {
 /// Trait for a defining a chain's associated type in the N-API.
 pub trait SyncNapiSpec:
     SyncProviderSpec<
-        CurrentTime,
-        BlockEnv: Clone + Default,
-        PooledTransaction: IsEip155,
-        SignedTransaction: Default
-                               + TransactionMut
-                               + TransactionType<Type: IsEip4844>
-                               + TransactionValidation<
-            ValidationError: From<l1::InvalidTransaction> + PartialEq,
-        >,
-    >
+    CurrentTime,
+    BlockEnv: Clone + Default,
+    PooledTransaction: IsEip155,
+    SignedTransaction: Default
+                           + TransactionMut
+                           + TransactionType<Type: IsEip4844>
+                           + TransactionValidation<
+        ValidationError: From<l1::InvalidTransaction> + PartialEq,
+    >,
+>
 {
     /// The string type identifier of the chain.
     const CHAIN_TYPE: &'static str;

--- a/crates/edr_napi_core/src/subscription.rs
+++ b/crates/edr_napi_core/src/subscription.rs
@@ -1,11 +1,11 @@
 use derive_where::derive_where;
 use edr_eth::B256;
-use edr_provider::{ProviderSpec, SubscriptionEvent, time::CurrentTime};
+use edr_provider::{time::CurrentTime, ProviderSpec, SubscriptionEvent};
 use napi::{
-    JsFunction,
     threadsafe_function::{
         ErrorStrategy, ThreadSafeCallContext, ThreadsafeFunction, ThreadsafeFunctionCallMode,
     },
+    JsFunction,
 };
 
 #[derive_where(Clone)]

--- a/crates/edr_op/src/block/builder.rs
+++ b/crates/edr_op/src/block/builder.rs
@@ -1,15 +1,15 @@
-use edr_eth::{Address, block::PartialHeader};
+use edr_eth::{block::PartialHeader, Address};
 use edr_evm::{
-    BlockBuilder, BlockTransactionErrorForChainSpec, EthBlockBuilder, MineBlockResultAndState,
     blockchain::SyncBlockchain,
     config::CfgEnv,
     inspector::Inspector,
     spec::ContextForChainSpec,
     state::{DatabaseComponents, SyncState, WrapDatabaseRef},
+    BlockBuilder, BlockTransactionErrorForChainSpec, EthBlockBuilder, MineBlockResultAndState,
 };
 use op_revm::{L1BlockInfo, OpHaltReason};
 
-use crate::{OpChainSpec, OpSpecId, block::LocalBlock, receipt::BlockReceiptFactory, transaction};
+use crate::{block::LocalBlock, receipt::BlockReceiptFactory, transaction, OpChainSpec, OpSpecId};
 
 /// Block builder for OP.
 pub struct Builder<'blockchain, BlockchainErrorT, StateErrorT> {

--- a/crates/edr_op/src/eip2718.rs
+++ b/crates/edr_op/src/eip2718.rs
@@ -1,8 +1,8 @@
 use alloy_rlp::Buf as _;
 use edr_eth::{
-    Bloom,
     receipt::{ExecutionReceipt, MapReceiptLogs, RootOrStatus},
     transaction::TransactionType,
+    Bloom,
 };
 
 use crate::transaction;

--- a/crates/edr_op/src/receipt/block.rs
+++ b/crates/edr_op/src/receipt/block.rs
@@ -1,7 +1,7 @@
 use edr_eth::{
-    Address, B256, Bloom,
     log::FilterLog,
     receipt::{AsExecutionReceipt, ExecutionReceipt, ReceiptTrait, RootOrStatus},
+    Address, Bloom, B256,
 };
 use op_alloy_rpc_types::L1BlockInfo;
 

--- a/crates/edr_op/src/receipt/execution.rs
+++ b/crates/edr_op/src/receipt/execution.rs
@@ -2,17 +2,17 @@ mod deposit;
 
 pub use edr_eth::receipt::execution::{Eip658, Legacy};
 use edr_eth::{
-    Bloom,
     log::ExecutionLog,
     receipt::{ExecutionReceipt, MapReceiptLogs, RootOrStatus},
     result::ExecutionResult,
     transaction::{Transaction as _, TransactionType as _},
+    Bloom,
 };
 use edr_evm::{receipt::ExecutionReceiptBuilder, state::State};
 
 use self::deposit::Eip658OrDeposit;
 use super::Execution;
-use crate::{OpHaltReason, OpSpecId, eip2718::TypedEnvelope, transaction};
+use crate::{eip2718::TypedEnvelope, transaction, OpHaltReason, OpSpecId};
 
 /// Receipt for an OP deposit transaction with deposit nonce (since
 /// Regolith) and optionally deposit receipt version (since Canyon).
@@ -198,7 +198,7 @@ impl<LogT> ExecutionReceipt for Execution<LogT> {
 #[cfg(test)]
 mod tests {
     use alloy_rlp::Decodable as _;
-    use edr_eth::{Address, B256, Bytes, log::ExecutionLog};
+    use edr_eth::{log::ExecutionLog, Address, Bytes, B256};
 
     use super::*;
     use crate::eip2718::TypedEnvelope;

--- a/crates/edr_op/src/receipt/execution/deposit.rs
+++ b/crates/edr_op/src/receipt/execution/deposit.rs
@@ -1,5 +1,5 @@
 use alloy_rlp::{RlpDecodable, RlpEncodable};
-use edr_eth::{Bloom, receipt::MapReceiptLogs};
+use edr_eth::{receipt::MapReceiptLogs, Bloom};
 
 use super::{Deposit, Execution};
 

--- a/crates/edr_op/src/receipt/factory.rs
+++ b/crates/edr_op/src/receipt/factory.rs
@@ -1,12 +1,12 @@
 use edr_eth::{
-    B256,
     log::FilterLog,
     receipt::{ReceiptFactory, TransactionReceipt},
+    B256,
 };
 use edr_evm::EthBlockReceiptFactory;
 use op_revm::L1BlockInfo;
 
-use crate::{OpSpecId, eip2718::TypedEnvelope, receipt, transaction, transaction::OpTxTrait as _};
+use crate::{eip2718::TypedEnvelope, receipt, transaction, transaction::OpTxTrait as _, OpSpecId};
 
 /// Block receipt factory for OP.
 pub struct BlockReceiptFactory {

--- a/crates/edr_op/src/rpc.rs
+++ b/crates/edr_op/src/rpc.rs
@@ -3,7 +3,7 @@ pub mod receipt;
 /// Types for OP RPC transaction.
 pub mod transaction;
 
-use edr_eth::{Address, B256, Bloom, U256, eips::eip7702, log::FilterLog};
+use edr_eth::{eips::eip7702, log::FilterLog, Address, Bloom, B256, U256};
 use op_alloy_rpc_types::L1BlockInfo;
 use serde::{Deserialize, Serialize};
 

--- a/crates/edr_op/src/rpc/receipt.rs
+++ b/crates/edr_op/src/rpc/receipt.rs
@@ -4,7 +4,7 @@ use edr_eth::{
 };
 use edr_rpc_eth::RpcTypeFrom;
 
-use crate::{OpSpecId, eip2718::TypedEnvelope, receipt, rpc, transaction};
+use crate::{eip2718::TypedEnvelope, receipt, rpc, transaction, OpSpecId};
 
 impl RpcTypeFrom<receipt::Block> for rpc::BlockReceipt {
     type Hardfork = OpSpecId;
@@ -158,7 +158,7 @@ impl TryFrom<rpc::BlockReceipt> for receipt::Block {
 
 #[cfg(test)]
 mod tests {
-    use edr_eth::{Bloom, Bytes, U256, log::ExecutionLog};
+    use edr_eth::{log::ExecutionLog, Bloom, Bytes, U256};
     use edr_rpc_eth::impl_execution_receipt_tests;
     use receipt::BlockReceiptFactory;
 

--- a/crates/edr_op/src/rpc/transaction.rs
+++ b/crates/edr_op/src/rpc/transaction.rs
@@ -1,9 +1,9 @@
 use std::sync::OnceLock;
 
-use edr_eth::{B256, signature::Signature, transaction::MaybeSignedTransaction};
+use edr_eth::{signature::Signature, transaction::MaybeSignedTransaction, B256};
 use edr_evm::{
     block::transaction::{BlockDataForTransaction, TransactionAndBlockForChainSpec},
-    transaction::{TxKind, remote::EthRpcTransaction},
+    transaction::{remote::EthRpcTransaction, TxKind},
 };
 use edr_rpc_eth::{
     RpcTypeFrom, TransactionConversionError as L1ConversionError, TransactionWithSignature,
@@ -11,8 +11,8 @@ use edr_rpc_eth::{
 
 use super::Transaction;
 use crate::{
-    OpChainSpec, OpSpecId,
     transaction::{self, OpTxTrait as _},
+    OpChainSpec, OpSpecId,
 };
 
 impl EthRpcTransaction for Transaction {

--- a/crates/edr_op/src/spec.rs
+++ b/crates/edr_op/src/spec.rs
@@ -8,32 +8,32 @@ use edr_eth::{
     spec::{ChainSpec, EthHeaderConstants},
 };
 use edr_evm::{
-    BlockReceipts, RemoteBlock, RemoteBlockConversionError, SyncBlock,
     evm::{Evm, EvmData},
     interpreter::{EthInstructions, EthInterpreter, InterpreterResult},
     precompile::PrecompileProvider,
     spec::{ContextForChainSpec, RuntimeSpec},
     state::Database,
     transaction::{TransactionError, TransactionErrorForChainSpec, TransactionValidation},
+    BlockReceipts, RemoteBlock, RemoteBlockConversionError, SyncBlock,
 };
 use edr_napi_core::{
     napi,
-    spec::{Response, SyncNapiSpec, marshal_response_data},
+    spec::{marshal_response_data, Response, SyncNapiSpec},
 };
-use edr_provider::{ProviderSpec, TransactionFailureReason, time::TimeSinceEpoch};
+use edr_provider::{time::TimeSinceEpoch, ProviderSpec, TransactionFailureReason};
 use edr_rpc_eth::{jsonrpc, spec::RpcSpec};
 use edr_solidity::contract_decoder::ContractDecoder;
-use op_revm::{L1BlockInfo, OpEvm, precompiles::OpPrecompiles};
-use serde::{Serialize, de::DeserializeOwned};
+use op_revm::{precompiles::OpPrecompiles, L1BlockInfo, OpEvm};
+use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{
-    OpHaltReason, OpSpecId,
     block::{self, LocalBlock},
     eip2718::TypedEnvelope,
     hardfork,
     receipt::{self, BlockReceiptFactory},
     rpc,
     transaction::{self, InvalidTransaction},
+    OpHaltReason, OpSpecId,
 };
 
 /// Chain specification for the Ethereum JSON-RPC API.
@@ -62,10 +62,10 @@ impl ChainSpec for OpChainSpec {
 
 impl RuntimeSpec for OpChainSpec {
     type Block = dyn SyncBlock<
-            Arc<Self::BlockReceipt>,
-            Self::SignedTransaction,
-            Error = <Self::LocalBlock as BlockReceipts<Arc<Self::BlockReceipt>>>::Error,
-        >;
+        Arc<Self::BlockReceipt>,
+        Self::SignedTransaction,
+        Error = <Self::LocalBlock as BlockReceipts<Arc<Self::BlockReceipt>>>::Error,
+    >;
 
     type BlockBuilder<
         'blockchain,

--- a/crates/edr_op/src/transaction.rs
+++ b/crates/edr_op/src/transaction.rs
@@ -7,7 +7,7 @@ pub mod request;
 /// Types for signed transactions.
 pub mod signed;
 
-pub use op_revm::{OpTransactionError as InvalidTransaction, transaction::OpTxTr as OpTxTrait};
+pub use op_revm::{transaction::OpTxTr as OpTxTrait, OpTransactionError as InvalidTransaction};
 
 /// An OP pooled transaction, used to communicate between node pools.
 pub enum Pooled {

--- a/crates/edr_op/src/transaction/pooled.rs
+++ b/crates/edr_op/src/transaction/pooled.rs
@@ -1,11 +1,11 @@
 pub use edr_eth::transaction::pooled::{Eip155, Eip1559, Eip2930, Eip4844, Eip7702, Legacy};
 use edr_eth::{
-    Address, B256, Blob, Bytes, U256,
     eips::{eip2930, eip7702},
     transaction::{
-        ExecutableTransaction, INVALID_TX_TYPE_ERROR_MESSAGE, IsEip155, TxKind,
-        signed::PreOrPostEip155,
+        signed::PreOrPostEip155, ExecutableTransaction, IsEip155, TxKind,
+        INVALID_TX_TYPE_ERROR_MESSAGE,
     },
+    Address, Blob, Bytes, B256, U256,
 };
 use edr_provider::spec::HardforkValidationData;
 

--- a/crates/edr_op/src/transaction/request.rs
+++ b/crates/edr_op/src/transaction/request.rs
@@ -1,17 +1,19 @@
 pub use edr_eth::transaction::request::{Eip155, Eip1559, Eip2930, Eip4844, Eip7702, Legacy};
 use edr_eth::{
-    Address, Bytes, U256, l1,
+    l1,
     signature::{SecretKey, SignatureError},
     transaction::{
-        TxKind,
         signed::{FakeSign, Sign},
+        TxKind,
     },
+    Address, Bytes, U256,
 };
 use edr_provider::{
-    ProviderError, ProviderErrorForChainSpec, calculate_eip1559_fee_parameters,
+    calculate_eip1559_fee_parameters,
     requests::validation::{validate_call_request, validate_send_transaction_request},
     spec::{CallContext, FromRpcType, TransactionContext},
     time::TimeSinceEpoch,
+    ProviderError, ProviderErrorForChainSpec,
 };
 use edr_rpc_eth::{CallRequest, TransactionRequest};
 

--- a/crates/edr_op/src/transaction/signed.rs
+++ b/crates/edr_op/src/transaction/signed.rs
@@ -7,14 +7,15 @@ use std::sync::OnceLock;
 use alloy_rlp::{Buf, RlpDecodable, RlpEncodable};
 pub use edr_eth::transaction::signed::{Eip155, Eip1559, Eip2930, Eip4844, Eip7702, Legacy};
 use edr_eth::{
-    Address, B256, Bytes, U256,
     eips::{eip2930, eip7702},
     impl_revm_transaction_trait,
     signature::{Fakeable, Signature},
     transaction::{
-        ExecutableTransaction, INVALID_TX_TYPE_ERROR_MESSAGE, IsEip4844, IsLegacy, IsSupported,
-        MaybeSignedTransaction, TransactionMut, TransactionType, TransactionValidation, TxKind,
+        ExecutableTransaction, IsEip4844, IsLegacy, IsSupported, MaybeSignedTransaction,
+        TransactionMut, TransactionType, TransactionValidation, TxKind,
+        INVALID_TX_TYPE_ERROR_MESSAGE,
     },
+    Address, Bytes, B256, U256,
 };
 
 use super::Signed;

--- a/crates/edr_op/src/transaction/signed/deposit.rs
+++ b/crates/edr_op/src/transaction/signed/deposit.rs
@@ -1,10 +1,10 @@
 use alloy_rlp::Encodable;
 use edr_eth::{
-    Address, B256, Bytes, U256,
     eips::{eip2930, eip7702},
     keccak256,
     transaction::{ExecutableTransaction, TxKind},
     utils::enveloped,
+    Address, Bytes, B256, U256,
 };
 
 use super::Deposit;
@@ -118,8 +118,9 @@ mod tests {
     use std::{str::FromStr as _, sync::OnceLock};
 
     use edr_eth::{
-        Bytes, U256, address, b256,
+        address, b256,
         transaction::{ExecutableTransaction as _, TxKind},
+        Bytes, U256,
     };
 
     use super::*;

--- a/crates/edr_op/src/transaction/type.rs
+++ b/crates/edr_op/src/transaction/type.rs
@@ -1,11 +1,11 @@
 use std::str::FromStr;
 
 use edr_eth::{
-    U8,
     transaction::{IsEip4844, ParseError},
+    U8,
 };
 
-use super::{Type, signed};
+use super::{signed, Type};
 
 impl From<Type> for u8 {
     fn from(t: Type) -> u8 {

--- a/crates/edr_op/tests/integration/provider.rs
+++ b/crates/edr_op/tests/integration/provider.rs
@@ -2,12 +2,12 @@
 
 use std::sync::Arc;
 
-use edr_eth::{Address, BlockSpec, HashMap, U64, address, bytes};
+use edr_eth::{address, bytes, Address, BlockSpec, HashMap, U64};
 use edr_op::OpChainSpec;
 use edr_provider::{
-    ForkConfig, MethodInvocation, NoopLogger, Provider, ProviderRequest,
-    test_utils::{ProviderTestFixture, create_test_config_with_fork},
+    test_utils::{create_test_config_with_fork, ProviderTestFixture},
     time::CurrentTime,
+    ForkConfig, MethodInvocation, NoopLogger, Provider, ProviderRequest,
 };
 use edr_rpc_eth::CallRequest;
 use edr_solidity::contract_decoder::ContractDecoder;

--- a/crates/edr_op/tests/integration/rpc.rs
+++ b/crates/edr_op/tests/integration/rpc.rs
@@ -4,11 +4,11 @@ use std::sync::Arc;
 
 use anyhow::anyhow;
 use edr_defaults::CACHE_DIR;
-use edr_eth::{B256, HashMap, PreEip1898BlockSpec, b256, transaction::TransactionType as _};
+use edr_eth::{b256, transaction::TransactionType as _, HashMap, PreEip1898BlockSpec, B256};
 use edr_evm::{
-    Block, RandomHashGenerator, RemoteBlock, blockchain::ForkedBlockchain, state::IrregularState,
+    blockchain::ForkedBlockchain, state::IrregularState, Block, RandomHashGenerator, RemoteBlock,
 };
-use edr_op::{OpChainSpec, hardfork, transaction};
+use edr_op::{hardfork, transaction, OpChainSpec};
 use edr_rpc_eth::client::EthRpcClient;
 use edr_test_utils::env::get_alchemy_url;
 use op_alloy_rpc_types::L1BlockInfo;

--- a/crates/edr_provider/src/config.rs
+++ b/crates/edr_provider/src/config.rs
@@ -1,7 +1,7 @@
 use std::{num::NonZeroU64, path::PathBuf, time::SystemTime};
 
-use edr_eth::{Address, B256, Bytecode, ChainId, HashMap, U256, block::BlobGas};
-use edr_evm::{MineOrdering, hardfork::ChainOverride, precompile::PrecompileFn, state::EvmStorage};
+use edr_eth::{block::BlobGas, Address, Bytecode, ChainId, HashMap, B256, U256};
+use edr_evm::{hardfork::ChainOverride, precompile::PrecompileFn, state::EvmStorage, MineOrdering};
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 

--- a/crates/edr_provider/src/console_log.rs
+++ b/crates/edr_provider/src/console_log.rs
@@ -1,4 +1,4 @@
-use edr_eth::{Address, Bytes, address};
+use edr_eth::{address, Address, Bytes};
 use edr_evm::{
     inspector::Inspector,
     interpreter::{CallInputs, CallOutcome, EthInterpreter},
@@ -36,9 +36,10 @@ impl<ContextT> Inspector<ContextT, EthInterpreter> for ConsoleLogCollector {
 pub(crate) mod tests {
     use anyhow::Context;
     use edr_eth::{
-        Bytes, U256, hex,
+        hex,
         l1::L1ChainSpec,
-        transaction::{self, TxKind, request::TransactionRequestAndSender},
+        transaction::{self, request::TransactionRequestAndSender, TxKind},
+        Bytes, U256,
     };
 
     use crate::{data::ProviderData, time::TimeSinceEpoch};

--- a/crates/edr_provider/src/data.rs
+++ b/crates/edr_provider/src/data.rs
@@ -12,12 +12,10 @@ use std::{
 
 use alloy_dyn_abi::eip712::TypedData;
 use edr_eth::{
-    Address, B256, BlockSpec, BlockTag, Bytecode, Bytes, Eip1898BlockSpec, HashMap, HashSet,
-    KECCAK_EMPTY, U256,
     account::{Account, AccountInfo, AccountStatus},
     block::{
-        BlockOptions, calculate_next_base_fee_per_blob_gas, calculate_next_base_fee_per_gas,
-        miner_reward,
+        calculate_next_base_fee_per_blob_gas, calculate_next_base_fee_per_gas, miner_reward,
+        BlockOptions,
     },
     fee_history::FeeHistoryResult,
     filter::{FilteredEvents, LogOutput, SubscriptionType},
@@ -29,15 +27,15 @@ use edr_eth::{
     signature::{self, RecoveryMessage},
     spec::{ChainSpec, HaltReasonTrait},
     transaction::{
-        ExecutableTransaction, IsEip4844, IsSupported as _, TransactionMut, TransactionType,
-        TransactionValidation,
         request::TransactionRequestAndSender,
         signed::{FakeSign as _, Sign as _},
+        ExecutableTransaction, IsEip4844, IsSupported as _, TransactionMut, TransactionType,
+        TransactionValidation,
     },
+    Address, BlockSpec, BlockTag, Bytecode, Bytes, Eip1898BlockSpec, HashMap, HashSet, B256,
+    KECCAK_EMPTY, U256,
 };
 use edr_evm::{
-    Block, BlockAndTotalDifficulty, BlockReceipts as _, MemPool, MineBlockResultAndState,
-    OrderedTransaction, RandomHashGenerator,
     block::transaction::{
         BlockDataForTransaction, TransactionAndBlock, TransactionAndBlockForChainSpec,
     },
@@ -54,7 +52,8 @@ use edr_evm::{
         StateOverrides, StateRefOverrider, SyncState,
     },
     trace::Trace,
-    transaction,
+    transaction, Block, BlockAndTotalDifficulty, BlockReceipts as _, MemPool,
+    MineBlockResultAndState, OrderedTransaction, RandomHashGenerator,
 };
 use edr_rpc_eth::client::{EthRpcClient, HeaderMap};
 use edr_solidity::contract_decoder::ContractDecoder;
@@ -66,21 +65,19 @@ use rpds::HashTrieMapSync;
 use tokio::runtime;
 
 use crate::{
-    MiningConfig, ProviderConfig, ProviderError, SubscriptionEvent, SubscriptionEventData,
-    SyncSubscriberCallback,
-    data::gas::{BinarySearchEstimationArgs, CheckGasLimitArgs, compute_rewards},
+    data::gas::{compute_rewards, BinarySearchEstimationArgs, CheckGasLimitArgs},
     debug_mine::{
         DebugMineBlockResult, DebugMineBlockResultAndState, DebugMineBlockResultForChainSpec,
     },
     debug_trace::{
-        DebugTraceConfig, DebugTraceResultWithTraces, TracerEip3155, debug_trace_transaction,
-        execution_result_to_debug_result,
+        debug_trace_transaction, execution_result_to_debug_result, DebugTraceConfig,
+        DebugTraceResultWithTraces, TracerEip3155,
     },
     error::{
         CreationError, CreationErrorForChainSpec, EstimateGasFailure, ProviderErrorForChainSpec,
         TransactionFailure, TransactionFailureWithTraces,
     },
-    filter::{Filter, FilterData, LogFilter, bloom_contains_log_filter, filter_logs},
+    filter::{bloom_contains_log_filter, filter_logs, Filter, FilterData, LogFilter},
     logger::SyncLogger,
     mock::SyncCallOverride,
     observability::{self, RuntimeObserver},
@@ -89,6 +86,8 @@ use crate::{
     snapshot::Snapshot,
     spec::{ProviderSpec, SyncProviderSpec},
     time::{CurrentTime, TimeSinceEpoch},
+    MiningConfig, ProviderConfig, ProviderError, SubscriptionEvent, SubscriptionEventData,
+    SyncSubscriberCallback,
 };
 
 const DEFAULT_INITIAL_BASE_FEE_PER_GAS: u128 = 1_000_000_000;
@@ -126,10 +125,10 @@ pub struct SendTransactionResult<BlockT, HaltReasonT: HaltReasonTrait, SignedTra
 }
 
 impl<
-    BlockT: Block<SignedTransactionT>,
-    HaltReasonT: HaltReasonTrait,
-    SignedTransactionT: ExecutableTransaction,
-> SendTransactionResult<BlockT, HaltReasonT, SignedTransactionT>
+        BlockT: Block<SignedTransactionT>,
+        HaltReasonT: HaltReasonTrait,
+        SignedTransactionT: ExecutableTransaction,
+    > SendTransactionResult<BlockT, HaltReasonT, SignedTransactionT>
 {
     /// Present if the transaction was auto-mined.
     pub fn transaction_result_and_trace(&self) -> Option<ExecutionResultAndTrace<'_, HaltReasonT>> {
@@ -1694,13 +1693,13 @@ where
 impl<ChainSpecT, TimerT> ProviderData<ChainSpecT, TimerT>
 where
     ChainSpecT: SyncProviderSpec<
-            TimerT,
-            BlockEnv: Default,
-            SignedTransaction: Default
-                                   + TransactionValidation<
-                ValidationError: From<l1::InvalidTransaction> + PartialEq,
-            >,
+        TimerT,
+        BlockEnv: Default,
+        SignedTransaction: Default
+                               + TransactionValidation<
+            ValidationError: From<l1::InvalidTransaction> + PartialEq,
         >,
+    >,
     TimerT: Clone + TimeSinceEpoch,
 {
     /// Returns the balance of the account corresponding to the provided address
@@ -2291,14 +2290,14 @@ where
 impl<ChainSpecT, TimerT> ProviderData<ChainSpecT, TimerT>
 where
     ChainSpecT: SyncProviderSpec<
-            TimerT,
-            BlockEnv: Default,
-            SignedTransaction: Default
-                                   + TransactionType<Type: IsEip4844>
-                                   + TransactionValidation<
-                ValidationError: From<l1::InvalidTransaction> + PartialEq,
-            >,
+        TimerT,
+        BlockEnv: Default,
+        SignedTransaction: Default
+                               + TransactionType<Type: IsEip4844>
+                               + TransactionValidation<
+            ValidationError: From<l1::InvalidTransaction> + PartialEq,
         >,
+    >,
     TimerT: Clone + TimeSinceEpoch,
 {
     pub fn send_transaction(
@@ -2398,13 +2397,13 @@ where
 impl<ChainSpecT, TimerT> ProviderData<ChainSpecT, TimerT>
 where
     ChainSpecT: SyncProviderSpec<
-            TimerT,
-            BlockEnv: Clone + Default,
-            SignedTransaction: Default
-                                   + TransactionValidation<
-                ValidationError: From<l1::InvalidTransaction> + PartialEq,
-            >,
+        TimerT,
+        BlockEnv: Clone + Default,
+        SignedTransaction: Default
+                               + TransactionValidation<
+            ValidationError: From<l1::InvalidTransaction> + PartialEq,
         >,
+    >,
     TimerT: Clone + TimeSinceEpoch,
 {
     #[cfg_attr(feature = "tracing", tracing::instrument(level = "trace", skip(self)))]
@@ -2492,14 +2491,14 @@ where
 impl<ChainSpecT, TimerT> ProviderData<ChainSpecT, TimerT>
 where
     ChainSpecT: SyncProviderSpec<
-            TimerT,
-            BlockEnv: Default,
-            SignedTransaction: Default
-                                   + TransactionMut
-                                   + TransactionValidation<
-                ValidationError: From<l1::InvalidTransaction> + PartialEq,
-            >,
+        TimerT,
+        BlockEnv: Default,
+        SignedTransaction: Default
+                               + TransactionMut
+                               + TransactionValidation<
+            ValidationError: From<l1::InvalidTransaction> + PartialEq,
         >,
+    >,
     TimerT: Clone + TimeSinceEpoch,
 {
     /// Estimate the gas cost of a transaction. Matches Hardhat behavior.
@@ -2917,8 +2916,8 @@ fn get_skip_unsupported_transaction_types_from_env() -> bool {
         .map_or(DEFAULT_SKIP_UNSUPPORTED_TRANSACTION_TYPES, |s| s == "true")
 }
 
-fn get_max_cached_states_from_env<ChainSpecT: RuntimeSpec>()
--> Result<NonZeroUsize, CreationErrorForChainSpec<ChainSpecT>> {
+fn get_max_cached_states_from_env<ChainSpecT: RuntimeSpec>(
+) -> Result<NonZeroUsize, CreationErrorForChainSpec<ChainSpecT>> {
     std::env::var(EDR_MAX_CACHED_STATES_ENV_VAR).map_or_else(
         |err| match err {
             std::env::VarError::NotPresent => {
@@ -2942,9 +2941,9 @@ mod tests {
 
     use super::*;
     use crate::{
+        console_log::tests::{deploy_console_log_contract, ConsoleLogTransaction},
+        test_utils::{create_test_config, one_ether, ProviderTestFixture},
         MemPoolConfig, MiningConfig, ProviderConfig,
-        console_log::tests::{ConsoleLogTransaction, deploy_console_log_contract},
-        test_utils::{ProviderTestFixture, create_test_config, one_ether},
     };
 
     #[test]
@@ -2997,12 +2996,10 @@ mod tests {
         let transaction = fixture.signed_dummy_transaction(0, None)?;
         let recovered_address = transaction.caller();
 
-        assert!(
-            fixture
-                .provider_data
-                .local_accounts
-                .contains_key(recovered_address)
-        );
+        assert!(fixture
+            .provider_data
+            .local_accounts
+            .contains_key(recovered_address));
 
         Ok(())
     }
@@ -3028,13 +3025,11 @@ mod tests {
 
         let transaction_hash = fixture.provider_data.add_pending_transaction(transaction)?;
 
-        assert!(
-            fixture
-                .provider_data
-                .mem_pool
-                .transaction_by_hash(&transaction_hash)
-                .is_some()
-        );
+        assert!(fixture
+            .provider_data
+            .mem_pool
+            .transaction_by_hash(&transaction_hash)
+            .is_some());
 
         match fixture
             .provider_data
@@ -3465,18 +3460,14 @@ mod tests {
 
         // Check that only the first and third transactions were mined
         assert_eq!(result.block.transactions().len(), 2);
-        assert!(
-            fixture
-                .provider_data
-                .transaction_receipt(transaction1.transaction_hash())?
-                .is_some()
-        );
-        assert!(
-            fixture
-                .provider_data
-                .transaction_receipt(transaction3.transaction_hash())?
-                .is_some()
-        );
+        assert!(fixture
+            .provider_data
+            .transaction_receipt(transaction1.transaction_hash())?
+            .is_some());
+        assert!(fixture
+            .provider_data
+            .transaction_receipt(transaction3.transaction_hash())?
+            .is_some());
 
         // Check that the second transaction is still pending
         let pending_transactions = fixture
@@ -3763,25 +3754,21 @@ mod tests {
         let transaction = fixture.impersonated_dummy_transaction()?;
         let transaction_hash = fixture.provider_data.add_pending_transaction(transaction)?;
 
-        assert!(
-            fixture
-                .provider_data
-                .mem_pool
-                .transaction_by_hash(&transaction_hash)
-                .is_some()
-        );
+        assert!(fixture
+            .provider_data
+            .mem_pool
+            .transaction_by_hash(&transaction_hash)
+            .is_some());
 
         fixture
             .provider_data
             .set_balance(fixture.impersonated_account, U256::from(100))?;
 
-        assert!(
-            fixture
-                .provider_data
-                .mem_pool
-                .transaction_by_hash(&transaction_hash)
-                .is_none()
-        );
+        assert!(fixture
+            .provider_data
+            .mem_pool
+            .transaction_by_hash(&transaction_hash)
+            .is_none());
 
         Ok(())
     }
@@ -3833,13 +3820,11 @@ mod tests {
             .mine_and_commit_block(BlockOptions::default())?;
 
         // Make sure transaction was mined successfully.
-        assert!(
-            results
-                .transaction_results
-                .first()
-                .context("failed to mine transaction")?
-                .is_success()
-        );
+        assert!(results
+            .transaction_results
+            .first()
+            .context("failed to mine transaction")?
+            .is_success());
         // Sanity check that the mempool is empty.
         assert_eq!(fixture.provider_data.mem_pool.transactions().count(), 0);
 
@@ -3922,7 +3907,7 @@ mod tests {
         use edr_test_utils::env::get_alchemy_url;
 
         use super::*;
-        use crate::{ForkConfig, test_utils::FORK_BLOCK_NUMBER};
+        use crate::{test_utils::FORK_BLOCK_NUMBER, ForkConfig};
 
         #[test]
         fn reset_local_to_forking() -> anyhow::Result<()> {
@@ -3944,12 +3929,10 @@ mod tests {
             // We're fetching a specific block instead of the last block number for the
             // forked blockchain, because the last block number query cannot be
             // cached.
-            assert!(
-                fixture
-                    .provider_data
-                    .block_by_block_spec(&block_spec)?
-                    .is_some()
-            );
+            assert!(fixture
+                .provider_data
+                .block_by_block_spec(&block_spec)?
+                .is_some());
 
             Ok(())
         }
@@ -3961,12 +3944,10 @@ mod tests {
             // We're fetching a specific block instead of the last block number for the
             // forked blockchain, because the last block number query cannot be
             // cached.
-            assert!(
-                fixture
-                    .provider_data
-                    .block_by_block_spec(&BlockSpec::Number(FORK_BLOCK_NUMBER))?
-                    .is_some()
-            );
+            assert!(fixture
+                .provider_data
+                .block_by_block_spec(&BlockSpec::Number(FORK_BLOCK_NUMBER))?
+                .is_some());
 
             fixture.provider_data.reset(None)?;
 
@@ -3977,7 +3958,7 @@ mod tests {
 
         #[test]
         fn run_call_in_hardfork_context() -> anyhow::Result<()> {
-            use alloy_sol_types::{SolCall, sol};
+            use alloy_sol_types::{sol, SolCall};
             use edr_evm::transaction::TransactionError;
             use edr_rpc_eth::CallRequest;
 

--- a/crates/edr_provider/src/data/call.rs
+++ b/crates/edr_provider/src/data/call.rs
@@ -1,6 +1,6 @@
 use edr_eth::{
-    Address, HashMap, block::Header, l1, result::ExecutionResult,
-    transaction::TransactionValidation,
+    block::Header, l1, result::ExecutionResult, transaction::TransactionValidation, Address,
+    HashMap,
 };
 use edr_evm::{
     blockchain::{BlockHash, BlockchainErrorForChainSpec},
@@ -12,7 +12,7 @@ use edr_evm::{
     state::{DatabaseComponents, State, StateError, WrapDatabaseRef},
 };
 
-use crate::{ProviderError, error::ProviderErrorForChainSpec};
+use crate::{error::ProviderErrorForChainSpec, ProviderError};
 
 /// Execute a transaction as a call. Returns the gas used and the output.
 pub(super) fn run_call<BlockchainT, ChainSpecT, InspectorT, StateT>(
@@ -27,12 +27,10 @@ pub(super) fn run_call<BlockchainT, ChainSpecT, InspectorT, StateT>(
 where
     BlockchainT: BlockHash<Error = BlockchainErrorForChainSpec<ChainSpecT>>,
     ChainSpecT: SyncRuntimeSpec<
-            BlockEnv: Default,
-            SignedTransaction: Default
-                                   + TransactionValidation<
-                ValidationError: From<l1::InvalidTransaction>,
-            >,
-        >,
+        BlockEnv: Default,
+        SignedTransaction: Default
+                               + TransactionValidation<ValidationError: From<l1::InvalidTransaction>>,
+    >,
     InspectorT: Inspector<
         ContextForChainSpec<ChainSpecT, WrapDatabaseRef<DatabaseComponents<BlockchainT, StateT>>>,
     >,

--- a/crates/edr_provider/src/data/gas.rs
+++ b/crates/edr_provider/src/data/gas.rs
@@ -2,29 +2,30 @@ use core::cmp;
 use std::sync::Arc;
 
 use edr_eth::{
-    Address, HashMap, U256,
     block::Header,
     l1,
     receipt::ReceiptTrait as _,
     result::ExecutionResult,
     reward_percentile::RewardPercentile,
     transaction::{ExecutableTransaction as _, TransactionMut, TransactionValidation},
+    Address, HashMap, U256,
 };
 use edr_evm::{
-    Block as _, BlockReceipts,
     blockchain::{BlockchainErrorForChainSpec, SyncBlockchain},
     config::CfgEnv,
     precompile::PrecompileFn,
     spec::SyncRuntimeSpec,
     state::{StateError, SyncState},
     trace::TraceCollector,
+    Block as _, BlockReceipts,
 };
 use itertools::Itertools;
 
 use crate::{data::call, error::ProviderErrorForChainSpec};
 
 pub(super) struct CheckGasLimitArgs<'a, ChainSpecT: SyncRuntimeSpec> {
-    pub blockchain: &'a dyn SyncBlockchain<ChainSpecT, BlockchainErrorForChainSpec<ChainSpecT>, StateError>,
+    pub blockchain:
+        &'a dyn SyncBlockchain<ChainSpecT, BlockchainErrorForChainSpec<ChainSpecT>, StateError>,
     pub header: &'a Header,
     pub state: &'a dyn SyncState<StateError>,
     pub cfg_env: CfgEnv<ChainSpecT::Hardfork>,
@@ -42,13 +43,11 @@ pub(super) fn check_gas_limit<ChainSpecT>(
 ) -> Result<bool, ProviderErrorForChainSpec<ChainSpecT>>
 where
     ChainSpecT: SyncRuntimeSpec<
-            BlockEnv: Default,
-            SignedTransaction: Default
-                                   + TransactionMut
-                                   + TransactionValidation<
-                ValidationError: From<l1::InvalidTransaction>,
-            >,
-        >,
+        BlockEnv: Default,
+        SignedTransaction: Default
+                               + TransactionMut
+                               + TransactionValidation<ValidationError: From<l1::InvalidTransaction>>,
+    >,
 {
     let CheckGasLimitArgs {
         blockchain,
@@ -77,7 +76,8 @@ where
 }
 
 pub(super) struct BinarySearchEstimationArgs<'a, ChainSpecT: SyncRuntimeSpec> {
-    pub blockchain: &'a dyn SyncBlockchain<ChainSpecT, BlockchainErrorForChainSpec<ChainSpecT>, StateError>,
+    pub blockchain:
+        &'a dyn SyncBlockchain<ChainSpecT, BlockchainErrorForChainSpec<ChainSpecT>, StateError>,
     pub header: &'a Header,
     pub state: &'a dyn SyncState<StateError>,
     pub cfg_env: CfgEnv<ChainSpecT::Hardfork>,
@@ -96,13 +96,11 @@ pub(super) fn binary_search_estimation<ChainSpecT>(
 ) -> Result<u64, ProviderErrorForChainSpec<ChainSpecT>>
 where
     ChainSpecT: SyncRuntimeSpec<
-            BlockEnv: Default,
-            SignedTransaction: Default
-                                   + TransactionMut
-                                   + TransactionValidation<
-                ValidationError: From<l1::InvalidTransaction>,
-            >,
-        >,
+        BlockEnv: Default,
+        SignedTransaction: Default
+                               + TransactionMut
+                               + TransactionValidation<ValidationError: From<l1::InvalidTransaction>>,
+    >,
 {
     const MAX_ITERATIONS: usize = 20;
 

--- a/crates/edr_provider/src/debug_mine.rs
+++ b/crates/edr_provider/src/debug_mine.rs
@@ -2,16 +2,16 @@ use core::fmt::Debug;
 use std::{marker::PhantomData, sync::Arc};
 
 use edr_eth::{
-    B256, Bytes,
     result::ExecutionResult,
     spec::{ChainSpec, HaltReasonTrait},
     transaction::ExecutableTransaction,
+    Bytes, B256,
 };
 use edr_evm::{
-    Block, MineBlockResultAndState,
     spec::RuntimeSpec,
     state::{StateDiff, SyncState},
     trace::Trace,
+    Block, MineBlockResultAndState,
 };
 
 /// The result of mining a block, including the state, in debug mode. This
@@ -95,10 +95,10 @@ impl<BlockT, HaltReasonT: HaltReasonTrait, SignedTransactionT>
 }
 
 impl<
-    BlockT: Block<SignedTransactionT>,
-    HaltReasonT: HaltReasonTrait,
-    SignedTransactionT: ExecutableTransaction,
-> DebugMineBlockResult<BlockT, HaltReasonT, SignedTransactionT>
+        BlockT: Block<SignedTransactionT>,
+        HaltReasonT: HaltReasonTrait,
+        SignedTransactionT: ExecutableTransaction,
+    > DebugMineBlockResult<BlockT, HaltReasonT, SignedTransactionT>
 {
     /// Whether the block contains a transaction with the given hash.
     pub fn has_transaction(&self, transaction_hash: &B256) -> bool {

--- a/crates/edr_provider/src/debug_trace.rs
+++ b/crates/edr_provider/src/debug_trace.rs
@@ -1,7 +1,6 @@
 use std::{collections::HashMap, fmt::Debug};
 
 use edr_eth::{
-    Address, B256, Bytes, U256,
     block::Block as _,
     bytecode::opcode::{self, OpCode},
     hex, l1,
@@ -9,6 +8,7 @@ use edr_eth::{
     spec::{ChainSpec, HaltReasonTrait},
     transaction::{ExecutableTransaction as _, TransactionValidation},
     utils::u256_to_padded_hex,
+    Address, Bytes, B256, U256,
 };
 use edr_evm::{
     blockchain::SyncBlockchain,
@@ -47,12 +47,10 @@ pub fn debug_trace_transaction<ChainSpecT, BlockchainErrorT, StateErrorT>(
 >
 where
     ChainSpecT: RuntimeSpec<
-            BlockEnv: Clone,
-            SignedTransaction: Default
-                                   + TransactionValidation<
-                ValidationError: From<l1::InvalidTransaction>,
-            >,
-        >,
+        BlockEnv: Clone,
+        SignedTransaction: Default
+                               + TransactionValidation<ValidationError: From<l1::InvalidTransaction>>,
+    >,
     BlockchainErrorT: Send + std::error::Error,
     StateErrorT: Send + std::error::Error,
 {

--- a/crates/edr_provider/src/error.rs
+++ b/crates/edr_provider/src/error.rs
@@ -7,28 +7,28 @@ use std::{ffi::OsString, num::TryFromIntError, time::SystemTime};
 
 use alloy_sol_types::{ContractError, SolInterface};
 use edr_eth::{
-    Address, B256, BlockSpec, BlockTag, Bytes, U256,
     filter::SubscriptionType,
     hex, l1,
     result::ExecutionResult,
     spec::{ChainSpec, HaltReasonTrait},
     transaction::TransactionValidation,
+    Address, BlockSpec, BlockTag, Bytes, B256, U256,
 };
 use edr_evm::{
-    MemPoolAddTransactionError, MineBlockError, MineTransactionError,
     blockchain::{BlockchainError, ForkedCreationError, LocalCreationError},
     spec::RuntimeSpec,
     state::{AccountOverrideConversionError, StateError},
     trace::Trace,
     transaction::{self, TransactionError},
+    MemPoolAddTransactionError, MineBlockError, MineTransactionError,
 };
 use edr_rpc_eth::{client::RpcClientError, error::HttpError, jsonrpc};
 use edr_solidity::contract_decoder::ContractDecoderError;
 use serde::Serialize;
 
 use crate::{
-    ProviderSpec, config::IntervalConfigConversionError, debug_trace::DebugTraceError,
-    time::TimeSinceEpoch,
+    config::IntervalConfigConversionError, debug_trace::DebugTraceError, time::TimeSinceEpoch,
+    ProviderSpec,
 };
 
 /// Helper type for a chain-specific [`CreationError`].
@@ -366,12 +366,12 @@ pub enum ProviderError<
 }
 
 impl<
-    BlockConversionErrorT,
-    HaltReasonT: HaltReasonTrait,
-    HardforkT: Debug,
-    ReceiptConversionErrorT,
-    TransactionValidationErrorT,
->
+        BlockConversionErrorT,
+        HaltReasonT: HaltReasonTrait,
+        HardforkT: Debug,
+        ReceiptConversionErrorT,
+        TransactionValidationErrorT,
+    >
     ProviderError<
         BlockConversionErrorT,
         HaltReasonT,
@@ -393,12 +393,12 @@ impl<
 }
 
 impl<
-    BlockConversionErrorT: std::error::Error,
-    HaltReasonT: HaltReasonTrait + Serialize,
-    HardforkT: Debug,
-    ReceiptConversionErrorT: std::error::Error,
-    TransactionValidationErrorT: std::error::Error,
->
+        BlockConversionErrorT: std::error::Error,
+        HaltReasonT: HaltReasonTrait + Serialize,
+        HardforkT: Debug,
+        ReceiptConversionErrorT: std::error::Error,
+        TransactionValidationErrorT: std::error::Error,
+    >
     From<
         ProviderError<
             BlockConversionErrorT,

--- a/crates/edr_provider/src/filter.rs
+++ b/crates/edr_provider/src/filter.rs
@@ -6,8 +6,8 @@ use std::{
 };
 
 use edr_eth::{
-    B256,
     filter::{FilteredEvents, LogOutput, SubscriptionType},
+    B256,
 };
 
 pub use self::criteria::*;

--- a/crates/edr_provider/src/filter/criteria.rs
+++ b/crates/edr_provider/src/filter/criteria.rs
@@ -1,7 +1,7 @@
 use edr_eth::{
-    Address, B256, Bloom, BloomInput, HashSet,
     filter::LogOutput,
-    log::{FilterLog, matches_address_filter, matches_topics_filter},
+    log::{matches_address_filter, matches_topics_filter, FilterLog},
+    Address, Bloom, BloomInput, HashSet, B256,
 };
 
 #[derive(Clone, Debug, PartialEq)]

--- a/crates/edr_provider/src/interval.rs
+++ b/crates/edr_provider/src/interval.rs
@@ -4,14 +4,14 @@ use edr_eth::{l1, transaction::TransactionValidation};
 use edr_evm::spec::RuntimeSpec;
 use tokio::{
     runtime,
-    sync::{Mutex, oneshot},
+    sync::{oneshot, Mutex},
     task::JoinHandle,
     time::Instant,
 };
 
 use crate::{
-    IntervalConfig, data::ProviderData, error::ProviderErrorForChainSpec, spec::SyncProviderSpec,
-    time::TimeSinceEpoch,
+    data::ProviderData, error::ProviderErrorForChainSpec, spec::SyncProviderSpec,
+    time::TimeSinceEpoch, IntervalConfig,
 };
 
 /// Type for interval mining on a separate thread.
@@ -29,7 +29,7 @@ struct Inner<ChainSpecT: RuntimeSpec> {
 }
 
 impl<
-    ChainSpecT: SyncProviderSpec<
+        ChainSpecT: SyncProviderSpec<
             TimerT,
             BlockEnv: Default,
             SignedTransaction: Default
@@ -37,8 +37,8 @@ impl<
                 ValidationError: From<l1::InvalidTransaction> + PartialEq,
             >,
         >,
-    TimerT: Clone + TimeSinceEpoch,
-> IntervalMiner<ChainSpecT, TimerT>
+        TimerT: Clone + TimeSinceEpoch,
+    > IntervalMiner<ChainSpecT, TimerT>
 {
     pub fn new(
         runtime: runtime::Handle,
@@ -63,13 +63,13 @@ impl<
 #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
 async fn interval_mining_loop<
     ChainSpecT: SyncProviderSpec<
-            TimerT,
-            BlockEnv: Default,
-            SignedTransaction: Default
-                                   + TransactionValidation<
-                ValidationError: From<l1::InvalidTransaction> + PartialEq,
-            >,
+        TimerT,
+        BlockEnv: Default,
+        SignedTransaction: Default
+                               + TransactionValidation<
+            ValidationError: From<l1::InvalidTransaction> + PartialEq,
         >,
+    >,
     TimerT: Clone + TimeSinceEpoch,
 >(
     config: IntervalConfig,

--- a/crates/edr_provider/src/lib.rs
+++ b/crates/edr_provider/src/lib.rs
@@ -30,8 +30,8 @@ pub mod time;
 use core::fmt::Debug;
 
 use edr_eth::{
-    HashSet,
     spec::{ChainSpec, HaltReasonTrait},
+    HashSet,
 };
 // Re-export parts of `edr_evm`
 pub use edr_evm::hardfork;
@@ -53,9 +53,9 @@ pub use self::{
     mock::{CallOverrideResult, SyncCallOverride},
     provider::Provider,
     requests::{
+        eth::calculate_eip1559_fee_parameters, hardhat::rpc_types as hardhat_rpc_types,
         IntervalConfig as IntervalConfigRequest, InvalidRequestReason, MethodInvocation,
-        ProviderRequest, Timestamp, eth::calculate_eip1559_fee_parameters,
-        hardhat::rpc_types as hardhat_rpc_types,
+        ProviderRequest, Timestamp,
     },
     spec::{ProviderSpec, SyncProviderSpec},
     subscribe::*,

--- a/crates/edr_provider/src/logger.rs
+++ b/crates/edr_provider/src/logger.rs
@@ -5,8 +5,8 @@ use dyn_clone::DynClone;
 use edr_evm::{blockchain::BlockchainErrorForChainSpec, spec::RuntimeSpec};
 
 use crate::{
-    ProviderErrorForChainSpec, data::CallResult, debug_mine::DebugMineBlockResultForChainSpec,
-    error::EstimateGasFailure,
+    data::CallResult, debug_mine::DebugMineBlockResultForChainSpec, error::EstimateGasFailure,
+    ProviderErrorForChainSpec,
 };
 
 pub trait Logger<ChainSpecT: RuntimeSpec> {

--- a/crates/edr_provider/src/observability.rs
+++ b/crates/edr_provider/src/observability.rs
@@ -16,10 +16,10 @@ use edr_evm::{
 };
 
 use crate::{
-    SyncCallOverride,
     console_log::ConsoleLogCollector,
     coverage::{CodeCoverageReporter, SyncOnCollectedCoverageCallback},
     mock::Mocker,
+    SyncCallOverride,
 };
 
 /// Configuration for a [`RuntimeObserver`].
@@ -69,16 +69,16 @@ impl<HaltReasonT: HaltReasonTrait> RuntimeObserver<HaltReasonT> {
 }
 
 impl<
-    BlockchainT: BlockHash<Error: std::error::Error>,
-    ContextT: ContextTrait<
-        Journal: JournalExt
-                     + JournalTrait<
-            Database = WrapDatabaseRef<DatabaseComponents<BlockchainT, StateT>>,
+        BlockchainT: BlockHash<Error: std::error::Error>,
+        ContextT: ContextTrait<
+            Journal: JournalExt
+                         + JournalTrait<
+                Database = WrapDatabaseRef<DatabaseComponents<BlockchainT, StateT>>,
+            >,
         >,
-    >,
-    HaltReasonT: HaltReasonTrait,
-    StateT: State<Error: std::error::Error>,
-> Inspector<ContextT, EthInterpreter> for RuntimeObserver<HaltReasonT>
+        HaltReasonT: HaltReasonTrait,
+        StateT: State<Error: std::error::Error>,
+    > Inspector<ContextT, EthInterpreter> for RuntimeObserver<HaltReasonT>
 {
     fn call(&mut self, context: &mut ContextT, inputs: &mut CallInputs) -> Option<CallOutcome> {
         self.console_logger.call(context, inputs);

--- a/crates/edr_provider/src/pending.rs
+++ b/crates/edr_provider/src/pending.rs
@@ -2,15 +2,15 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use derive_where::derive_where;
 use edr_eth::{
-    B256, HashSet, U256, receipt::ReceiptTrait as _, transaction::ExecutableTransaction as _,
+    receipt::ReceiptTrait as _, transaction::ExecutableTransaction as _, HashSet, B256, U256,
 };
 use edr_evm::{
-    Block as _, BlockAndTotalDifficulty, BlockReceipts,
     blockchain::{
         BlockHash, Blockchain, BlockchainErrorForChainSpec, BlockchainMut, SyncBlockchain,
     },
     spec::SyncRuntimeSpec,
     state::{StateDiff, StateError, StateOverride, SyncState},
+    Block as _, BlockAndTotalDifficulty, BlockReceipts,
 };
 
 /// A blockchain with a pending block.
@@ -25,7 +25,11 @@ use edr_evm::{
 /// <https://github.com/NomicFoundation/edr/issues/284>
 #[derive_where(Debug)]
 pub(crate) struct BlockchainWithPending<'blockchain, ChainSpecT: SyncRuntimeSpec> {
-    blockchain: &'blockchain dyn SyncBlockchain<ChainSpecT, BlockchainErrorForChainSpec<ChainSpecT>, StateError>,
+    blockchain: &'blockchain dyn SyncBlockchain<
+        ChainSpecT,
+        BlockchainErrorForChainSpec<ChainSpecT>,
+        StateError,
+    >,
     pending_block: Arc<ChainSpecT::LocalBlock>,
     pending_state_diff: StateDiff,
 }

--- a/crates/edr_provider/src/provider.rs
+++ b/crates/edr_provider/src/provider.rs
@@ -10,20 +10,21 @@ use parking_lot::Mutex;
 use tokio::{runtime, sync::Mutex as AsyncMutex, task};
 
 use crate::{
-    PRIVATE_RPC_METHODS, ProviderConfig, ResponseWithTraces, SyncSubscriberCallback,
     data::ProviderData,
     error::{CreationErrorForChainSpec, ProviderError, ProviderErrorForChainSpec},
     interval::IntervalMiner,
     logger::SyncLogger,
     mock::SyncCallOverride,
     requests::{
-        MethodInvocation, ProviderRequest, debug,
+        debug,
         eth::{self, handle_set_interval_mining},
         hardhat::{self, rpc_types::ResetProviderConfig},
+        MethodInvocation, ProviderRequest,
     },
     spec::{ProviderSpec, SyncProviderSpec},
     time::{CurrentTime, TimeSinceEpoch},
-    to_json, to_json_with_trace, to_json_with_traces,
+    to_json, to_json_with_trace, to_json_with_traces, ProviderConfig, ResponseWithTraces,
+    SyncSubscriberCallback, PRIVATE_RPC_METHODS,
 };
 
 /// A JSON-RPC provider for Ethereum.
@@ -83,7 +84,7 @@ impl<ChainSpecT: SyncProviderSpec<TimerT>, TimerT: Clone + TimeSinceEpoch>
 }
 
 impl<
-    ChainSpecT: SyncProviderSpec<
+        ChainSpecT: SyncProviderSpec<
             TimerT,
             BlockEnv: Default,
             SignedTransaction: Default
@@ -91,8 +92,8 @@ impl<
                 ValidationError: From<l1::InvalidTransaction> + PartialEq,
             >,
         >,
-    TimerT: Clone + TimeSinceEpoch,
-> Provider<ChainSpecT, TimerT>
+        TimerT: Clone + TimeSinceEpoch,
+    > Provider<ChainSpecT, TimerT>
 {
     /// Constructs a new instance.
     pub fn new(
@@ -149,7 +150,7 @@ impl<
 }
 
 impl<
-    ChainSpecT: SyncProviderSpec<
+        ChainSpecT: SyncProviderSpec<
             TimerT,
             BlockEnv: Clone + Default,
             PooledTransaction: IsEip155,
@@ -160,8 +161,8 @@ impl<
                 ValidationError: From<l1::InvalidTransaction> + PartialEq,
             >,
         >,
-    TimerT: Clone + TimeSinceEpoch,
-> Provider<ChainSpecT, TimerT>
+        TimerT: Clone + TimeSinceEpoch,
+    > Provider<ChainSpecT, TimerT>
 {
     /// Blocking method to handle a request.
     pub fn handle_request(

--- a/crates/edr_provider/src/requests.rs
+++ b/crates/edr_provider/src/requests.rs
@@ -12,8 +12,8 @@ pub mod validation;
 use std::{fmt, marker::PhantomData};
 
 use ::serde::{
-    Deserialize, Deserializer, Serialize,
     de::{self, MapAccess, SeqAccess, Visitor},
+    Deserialize, Deserializer, Serialize,
 };
 use derive_where::derive_where;
 use edr_rpc_eth::spec::RpcSpec;

--- a/crates/edr_provider/src/requests/debug.rs
+++ b/crates/edr_provider/src/requests/debug.rs
@@ -1,25 +1,25 @@
-use edr_eth::{B256, BlockSpec, l1, transaction::TransactionValidation};
+use edr_eth::{l1, transaction::TransactionValidation, BlockSpec, B256};
 use edr_evm::state::StateOverrides;
 use serde::{Deserialize, Deserializer};
 
 use crate::{
-    ProviderError, ProviderResultWithTraces,
     data::ProviderData,
     debug_trace::{DebugTraceResult, DebugTraceResultWithTraces},
     requests::eth::{resolve_block_spec_for_call_request, resolve_call_request},
     spec::SyncProviderSpec,
     time::TimeSinceEpoch,
+    ProviderError, ProviderResultWithTraces,
 };
 
 pub fn handle_debug_trace_transaction<
     ChainSpecT: SyncProviderSpec<
-            TimerT,
-            BlockEnv: Clone + Default,
-            SignedTransaction: Default
-                                   + TransactionValidation<
-                ValidationError: From<l1::InvalidTransaction> + PartialEq,
-            >,
+        TimerT,
+        BlockEnv: Clone + Default,
+        SignedTransaction: Default
+                               + TransactionValidation<
+            ValidationError: From<l1::InvalidTransaction> + PartialEq,
         >,
+    >,
     TimerT: Clone + TimeSinceEpoch,
 >(
     data: &mut ProviderData<ChainSpecT, TimerT>,
@@ -49,13 +49,13 @@ pub fn handle_debug_trace_call<ChainSpecT, TimerT>(
 ) -> ProviderResultWithTraces<DebugTraceResult, ChainSpecT>
 where
     ChainSpecT: SyncProviderSpec<
-            TimerT,
-            BlockEnv: Default,
-            SignedTransaction: Default
-                                   + TransactionValidation<
-                ValidationError: From<l1::InvalidTransaction> + PartialEq,
-            >,
+        TimerT,
+        BlockEnv: Default,
+        SignedTransaction: Default
+                               + TransactionValidation<
+            ValidationError: From<l1::InvalidTransaction> + PartialEq,
         >,
+    >,
     TimerT: Clone + TimeSinceEpoch,
 {
     let block_spec = resolve_block_spec_for_call_request(block_spec);

--- a/crates/edr_provider/src/requests/eth/blockchain.rs
+++ b/crates/edr_provider/src/requests/eth/blockchain.rs
@@ -1,9 +1,8 @@
-use edr_eth::{Address, BlockSpec, U64, U256, l1, transaction::TransactionValidation};
+use edr_eth::{l1, transaction::TransactionValidation, Address, BlockSpec, U256, U64};
 
 use crate::{
-    ProviderErrorForChainSpec, data::ProviderData,
-    requests::validation::validate_post_merge_block_tags, spec::SyncProviderSpec,
-    time::TimeSinceEpoch,
+    data::ProviderData, requests::validation::validate_post_merge_block_tags,
+    spec::SyncProviderSpec, time::TimeSinceEpoch, ProviderErrorForChainSpec,
 };
 
 pub fn handle_block_number_request<
@@ -26,13 +25,13 @@ pub fn handle_chain_id_request<
 
 pub fn handle_get_transaction_count_request<
     ChainSpecT: SyncProviderSpec<
-            TimerT,
-            BlockEnv: Default,
-            SignedTransaction: Default
-                                   + TransactionValidation<
-                ValidationError: From<l1::InvalidTransaction> + PartialEq,
-            >,
+        TimerT,
+        BlockEnv: Default,
+        SignedTransaction: Default
+                               + TransactionValidation<
+            ValidationError: From<l1::InvalidTransaction> + PartialEq,
         >,
+    >,
     TimerT: Clone + TimeSinceEpoch,
 >(
     data: &mut ProviderData<ChainSpecT, TimerT>,

--- a/crates/edr_provider/src/requests/eth/blocks.rs
+++ b/crates/edr_provider/src/requests/eth/blocks.rs
@@ -2,20 +2,21 @@ use core::fmt::Debug;
 use std::sync::Arc;
 
 use edr_eth::{
-    B256, BlockSpec, PreEip1898BlockSpec, U64, U256, l1,
+    l1,
     transaction::{ExecutableTransaction as _, TransactionValidation},
+    BlockSpec, PreEip1898BlockSpec, B256, U256, U64,
 };
 use edr_evm::{
-    Block as _,
     block::transaction::{BlockDataForTransaction, TransactionAndBlock},
     spec::RuntimeSpec,
+    Block as _,
 };
 use edr_rpc_eth::RpcTypeFrom as _;
 
 use crate::{
-    ProviderError, data::ProviderData, error::ProviderErrorForChainSpec,
+    data::ProviderData, error::ProviderErrorForChainSpec,
     requests::validation::validate_post_merge_block_tags, spec::SyncProviderSpec,
-    time::TimeSinceEpoch,
+    time::TimeSinceEpoch, ProviderError,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
@@ -53,13 +54,13 @@ pub fn handle_get_block_by_hash_request<
 
 pub fn handle_get_block_by_number_request<
     ChainSpecT: SyncProviderSpec<
-            TimerT,
-            BlockEnv: Default,
-            SignedTransaction: Default
-                                   + TransactionValidation<
-                ValidationError: From<l1::InvalidTransaction> + PartialEq,
-            >,
+        TimerT,
+        BlockEnv: Default,
+        SignedTransaction: Default
+                               + TransactionValidation<
+            ValidationError: From<l1::InvalidTransaction> + PartialEq,
         >,
+    >,
     TimerT: Clone + TimeSinceEpoch,
 >(
     data: &mut ProviderData<ChainSpecT, TimerT>,
@@ -102,13 +103,13 @@ pub fn handle_get_block_transaction_count_by_hash_request<
 
 pub fn handle_get_block_transaction_count_by_block_number<
     ChainSpecT: SyncProviderSpec<
-            TimerT,
-            BlockEnv: Default,
-            SignedTransaction: Default
-                                   + TransactionValidation<
-                ValidationError: From<l1::InvalidTransaction> + PartialEq,
-            >,
+        TimerT,
+        BlockEnv: Default,
+        SignedTransaction: Default
+                               + TransactionValidation<
+            ValidationError: From<l1::InvalidTransaction> + PartialEq,
         >,
+    >,
     TimerT: Clone + TimeSinceEpoch,
 >(
     data: &mut ProviderData<ChainSpecT, TimerT>,
@@ -135,13 +136,13 @@ struct BlockByNumberResult<BlockT> {
 
 fn block_by_number<
     ChainSpecT: SyncProviderSpec<
-            TimerT,
-            BlockEnv: Default,
-            SignedTransaction: Default
-                                   + TransactionValidation<
-                ValidationError: From<l1::InvalidTransaction> + PartialEq,
-            >,
+        TimerT,
+        BlockEnv: Default,
+        SignedTransaction: Default
+                               + TransactionValidation<
+            ValidationError: From<l1::InvalidTransaction> + PartialEq,
         >,
+    >,
     TimerT: Clone + TimeSinceEpoch,
 >(
     data: &mut ProviderData<ChainSpecT, TimerT>,

--- a/crates/edr_provider/src/requests/eth/call.rs
+++ b/crates/edr_provider/src/requests/eth/call.rs
@@ -1,28 +1,29 @@
 use edr_eth::{
-    BlockSpec, Bytes, l1,
-    transaction::{TransactionValidation, signed::FakeSign as _},
+    l1,
+    transaction::{signed::FakeSign as _, TransactionValidation},
+    BlockSpec, Bytes,
 };
 use edr_evm::{state::StateOverrides, trace::Trace, transaction};
 use edr_rpc_eth::StateOverrideOptions;
 
 use crate::{
-    ProviderError, TransactionFailure,
     data::ProviderData,
     error::{ProviderErrorForChainSpec, TransactionFailureWithTraces},
     spec::{CallContext, FromRpcType, MaybeSender as _, SyncProviderSpec},
     time::TimeSinceEpoch,
+    ProviderError, TransactionFailure,
 };
 
 pub fn handle_call_request<
     ChainSpecT: SyncProviderSpec<
-            TimerT,
-            BlockEnv: Default,
-            SignedTransaction: Clone
-                                   + Default
-                                   + TransactionValidation<
-                ValidationError: From<l1::InvalidTransaction> + PartialEq,
-            >,
+        TimerT,
+        BlockEnv: Default,
+        SignedTransaction: Clone
+                               + Default
+                               + TransactionValidation<
+            ValidationError: From<l1::InvalidTransaction> + PartialEq,
         >,
+    >,
     TimerT: Clone + TimeSinceEpoch,
 >(
     data: &mut ProviderData<ChainSpecT, TimerT>,
@@ -68,13 +69,13 @@ pub(crate) fn resolve_block_spec_for_call_request(block_spec: Option<BlockSpec>)
 
 pub(crate) fn resolve_call_request<
     ChainSpecT: SyncProviderSpec<
-            TimerT,
-            BlockEnv: Default,
-            SignedTransaction: Default
-                                   + TransactionValidation<
-                ValidationError: From<l1::InvalidTransaction> + PartialEq,
-            >,
+        TimerT,
+        BlockEnv: Default,
+        SignedTransaction: Default
+                               + TransactionValidation<
+            ValidationError: From<l1::InvalidTransaction> + PartialEq,
         >,
+    >,
     TimerT: Clone + TimeSinceEpoch,
 >(
     data: &mut ProviderData<ChainSpecT, TimerT>,

--- a/crates/edr_provider/src/requests/eth/config.rs
+++ b/crates/edr_provider/src/requests/eth/config.rs
@@ -1,11 +1,11 @@
-use edr_eth::{Address, U64, U256};
+use edr_eth::{Address, U256, U64};
 use edr_evm::spec::RuntimeSpec;
 
 use crate::{
-    ProviderErrorForChainSpec,
     data::ProviderData,
     spec::{ProviderSpec, SyncProviderSpec},
     time::TimeSinceEpoch,
+    ProviderErrorForChainSpec,
 };
 
 pub fn handle_blob_base_fee<
@@ -31,24 +31,24 @@ pub fn handle_coinbase_request<ChainSpecT: ProviderSpec<TimerT>, TimerT: Clone +
     Ok(data.coinbase())
 }
 
-pub fn handle_max_priority_fee_per_gas<ChainSpecT: RuntimeSpec>()
--> Result<U256, ProviderErrorForChainSpec<ChainSpecT>> {
+pub fn handle_max_priority_fee_per_gas<ChainSpecT: RuntimeSpec>(
+) -> Result<U256, ProviderErrorForChainSpec<ChainSpecT>> {
     // 1 gwei
     Ok(U256::from(1_000_000_000))
 }
 
-pub fn handle_mining<ChainSpecT: RuntimeSpec>()
--> Result<bool, ProviderErrorForChainSpec<ChainSpecT>> {
+pub fn handle_mining<ChainSpecT: RuntimeSpec>(
+) -> Result<bool, ProviderErrorForChainSpec<ChainSpecT>> {
     Ok(false)
 }
 
-pub fn handle_net_listening_request<ChainSpecT: RuntimeSpec>()
--> Result<bool, ProviderErrorForChainSpec<ChainSpecT>> {
+pub fn handle_net_listening_request<ChainSpecT: RuntimeSpec>(
+) -> Result<bool, ProviderErrorForChainSpec<ChainSpecT>> {
     Ok(true)
 }
 
-pub fn handle_net_peer_count_request<ChainSpecT: RuntimeSpec>()
--> Result<U64, ProviderErrorForChainSpec<ChainSpecT>> {
+pub fn handle_net_peer_count_request<ChainSpecT: RuntimeSpec>(
+) -> Result<U64, ProviderErrorForChainSpec<ChainSpecT>> {
     Ok(U64::from(0))
 }
 
@@ -61,7 +61,7 @@ pub fn handle_net_version_request<
     Ok(data.network_id())
 }
 
-pub fn handle_syncing<ChainSpecT: RuntimeSpec>()
--> Result<bool, ProviderErrorForChainSpec<ChainSpecT>> {
+pub fn handle_syncing<ChainSpecT: RuntimeSpec>(
+) -> Result<bool, ProviderErrorForChainSpec<ChainSpecT>> {
     Ok(false)
 }

--- a/crates/edr_provider/src/requests/eth/evm.rs
+++ b/crates/edr_provider/src/requests/eth/evm.rs
@@ -1,13 +1,13 @@
 use std::num::NonZeroU64;
 
-use edr_eth::{U64, block::BlockOptions, l1, transaction::TransactionValidation};
+use edr_eth::{block::BlockOptions, l1, transaction::TransactionValidation, U64};
 
 use crate::{
-    ProviderError, ProviderResultWithTraces, Timestamp,
     data::ProviderData,
     error::ProviderErrorForChainSpec,
     spec::{ProviderSpec, SyncProviderSpec},
     time::TimeSinceEpoch,
+    ProviderError, ProviderResultWithTraces, Timestamp,
 };
 
 pub fn handle_increase_time_request<
@@ -25,13 +25,13 @@ pub fn handle_increase_time_request<
 
 pub fn handle_mine_request<
     ChainSpecT: SyncProviderSpec<
-            TimerT,
-            BlockEnv: Default,
-            SignedTransaction: Default
-                                   + TransactionValidation<
-                ValidationError: From<l1::InvalidTransaction> + PartialEq,
-            >,
+        TimerT,
+        BlockEnv: Default,
+        SignedTransaction: Default
+                               + TransactionValidation<
+            ValidationError: From<l1::InvalidTransaction> + PartialEq,
         >,
+    >,
     TimerT: Clone + TimeSinceEpoch,
 >(
     data: &mut ProviderData<ChainSpecT, TimerT>,

--- a/crates/edr_provider/src/requests/eth/filter.rs
+++ b/crates/edr_provider/src/requests/eth/filter.rs
@@ -1,19 +1,19 @@
 use core::iter;
 
 use edr_eth::{
-    BlockSpec, BlockTag, Eip1898BlockSpec, HashSet, U256,
     filter::{FilteredEvents, LogFilterOptions, LogOutput, OneOrMore, SubscriptionType},
+    BlockSpec, BlockTag, Eip1898BlockSpec, HashSet, U256,
 };
 use edr_evm::Block as _;
 
 use crate::{
-    ProviderError,
     data::ProviderData,
     error::ProviderErrorForChainSpec,
     filter::LogFilter,
     requests::validation::validate_post_merge_block_tags,
     spec::{ProviderSpec, SyncProviderSpec},
     time::TimeSinceEpoch,
+    ProviderError,
 };
 
 pub fn handle_get_filter_changes_request<

--- a/crates/edr_provider/src/requests/eth/gas.rs
+++ b/crates/edr_provider/src/requests/eth/gas.rs
@@ -1,31 +1,31 @@
 use edr_eth::{
-    BlockSpec, U64, U256,
     fee_history::FeeHistoryResult,
     l1,
     reward_percentile::RewardPercentile,
-    transaction::{TransactionMut, TransactionValidation, signed::FakeSign as _},
+    transaction::{signed::FakeSign as _, TransactionMut, TransactionValidation},
+    BlockSpec, U256, U64,
 };
-use edr_evm::{Block as _, state::StateOverrides, transaction};
+use edr_evm::{state::StateOverrides, transaction, Block as _};
 
 use crate::{
-    ProviderError, ProviderResultWithTraces,
     data::ProviderData,
     error::ProviderErrorForChainSpec,
     requests::validation::validate_post_merge_block_tags,
     spec::{CallContext, FromRpcType as _, MaybeSender as _, SyncProviderSpec},
     time::TimeSinceEpoch,
+    ProviderError, ProviderResultWithTraces,
 };
 
 pub fn handle_estimate_gas<
     ChainSpecT: SyncProviderSpec<
-            TimerT,
-            BlockEnv: Default,
-            SignedTransaction: Default
-                                   + TransactionMut
-                                   + TransactionValidation<
-                ValidationError: From<l1::InvalidTransaction> + PartialEq,
-            >,
+        TimerT,
+        BlockEnv: Default,
+        SignedTransaction: Default
+                               + TransactionMut
+                               + TransactionValidation<
+            ValidationError: From<l1::InvalidTransaction> + PartialEq,
         >,
+    >,
     TimerT: Clone + TimeSinceEpoch,
 >(
     data: &mut ProviderData<ChainSpecT, TimerT>,
@@ -58,13 +58,13 @@ pub fn handle_estimate_gas<
 
 pub fn handle_fee_history<
     ChainSpecT: SyncProviderSpec<
-            TimerT,
-            BlockEnv: Default,
-            SignedTransaction: Default
-                                   + TransactionValidation<
-                ValidationError: From<l1::InvalidTransaction> + PartialEq,
-            >,
+        TimerT,
+        BlockEnv: Default,
+        SignedTransaction: Default
+                               + TransactionValidation<
+            ValidationError: From<l1::InvalidTransaction> + PartialEq,
         >,
+    >,
     TimerT: Clone + TimeSinceEpoch,
 >(
     data: &mut ProviderData<ChainSpecT, TimerT>,
@@ -121,13 +121,13 @@ The reward percentiles should be in non-decreasing order, but the percentile num
 
 fn resolve_estimate_gas_request<
     ChainSpecT: SyncProviderSpec<
-            TimerT,
-            BlockEnv: Default,
-            SignedTransaction: Default
-                                   + TransactionValidation<
-                ValidationError: From<l1::InvalidTransaction> + PartialEq,
-            >,
+        TimerT,
+        BlockEnv: Default,
+        SignedTransaction: Default
+                               + TransactionValidation<
+            ValidationError: From<l1::InvalidTransaction> + PartialEq,
         >,
+    >,
     TimerT: Clone + TimeSinceEpoch,
 >(
     data: &mut ProviderData<ChainSpecT, TimerT>,
@@ -188,12 +188,12 @@ fn resolve_estimate_gas_request<
 
 #[cfg(test)]
 mod tests {
-    use edr_eth::{BlockTag, transaction::ExecutableTransaction as _};
+    use edr_eth::{transaction::ExecutableTransaction as _, BlockTag};
     use edr_rpc_eth::CallRequest;
     use l1::L1ChainSpec;
 
     use super::*;
-    use crate::test_utils::{ProviderTestFixture, pending_base_fee};
+    use crate::test_utils::{pending_base_fee, ProviderTestFixture};
 
     #[test]
     fn resolve_estimate_gas_request_with_default_max_priority_fee() -> anyhow::Result<()> {

--- a/crates/edr_provider/src/requests/eth/mine.rs
+++ b/crates/edr_provider/src/requests/eth/mine.rs
@@ -4,19 +4,19 @@ use edr_eth::{l1, transaction::TransactionValidation};
 use tokio::{runtime, sync::Mutex};
 
 use crate::{
-    IntervalConfig, data::ProviderData, error::ProviderErrorForChainSpec, interval::IntervalMiner,
-    requests, spec::SyncProviderSpec, time::TimeSinceEpoch,
+    data::ProviderData, error::ProviderErrorForChainSpec, interval::IntervalMiner, requests,
+    spec::SyncProviderSpec, time::TimeSinceEpoch, IntervalConfig,
 };
 
 pub fn handle_set_interval_mining<
     ChainSpecT: SyncProviderSpec<
-            TimerT,
-            BlockEnv: Default,
-            SignedTransaction: Default
-                                   + TransactionValidation<
-                ValidationError: From<l1::InvalidTransaction> + PartialEq,
-            >,
+        TimerT,
+        BlockEnv: Default,
+        SignedTransaction: Default
+                               + TransactionValidation<
+            ValidationError: From<l1::InvalidTransaction> + PartialEq,
         >,
+    >,
     TimerT: Clone + TimeSinceEpoch,
 >(
     data: Arc<Mutex<ProviderData<ChainSpecT, TimerT>>>,

--- a/crates/edr_provider/src/requests/eth/sign.rs
+++ b/crates/edr_provider/src/requests/eth/sign.rs
@@ -2,7 +2,7 @@ use alloy_dyn_abi::eip712::TypedData;
 use edr_eth::{Address, Bytes};
 
 use crate::{
-    ProviderErrorForChainSpec, data::ProviderData, spec::ProviderSpec, time::TimeSinceEpoch,
+    data::ProviderData, spec::ProviderSpec, time::TimeSinceEpoch, ProviderErrorForChainSpec,
 };
 
 pub fn handle_sign_request<ChainSpecT: ProviderSpec<TimerT>, TimerT: Clone + TimeSinceEpoch>(

--- a/crates/edr_provider/src/requests/eth/state.rs
+++ b/crates/edr_provider/src/requests/eth/state.rs
@@ -1,23 +1,22 @@
 use edr_eth::{
-    Address, BlockSpec, Bytes, U256, l1, transaction::TransactionValidation,
-    utils::u256_to_padded_hex,
+    l1, transaction::TransactionValidation, utils::u256_to_padded_hex, Address, BlockSpec, Bytes,
+    U256,
 };
 
 use crate::{
-    ProviderErrorForChainSpec, data::ProviderData,
-    requests::validation::validate_post_merge_block_tags, spec::SyncProviderSpec,
-    time::TimeSinceEpoch,
+    data::ProviderData, requests::validation::validate_post_merge_block_tags,
+    spec::SyncProviderSpec, time::TimeSinceEpoch, ProviderErrorForChainSpec,
 };
 
 pub fn handle_get_balance_request<
     ChainSpecT: SyncProviderSpec<
-            TimerT,
-            BlockEnv: Default,
-            SignedTransaction: Default
-                                   + TransactionValidation<
-                ValidationError: From<l1::InvalidTransaction> + PartialEq,
-            >,
+        TimerT,
+        BlockEnv: Default,
+        SignedTransaction: Default
+                               + TransactionValidation<
+            ValidationError: From<l1::InvalidTransaction> + PartialEq,
         >,
+    >,
     TimerT: Clone + TimeSinceEpoch,
 >(
     data: &mut ProviderData<ChainSpecT, TimerT>,
@@ -33,13 +32,13 @@ pub fn handle_get_balance_request<
 
 pub fn handle_get_code_request<
     ChainSpecT: SyncProviderSpec<
-            TimerT,
-            BlockEnv: Default,
-            SignedTransaction: Default
-                                   + TransactionValidation<
-                ValidationError: From<l1::InvalidTransaction> + PartialEq,
-            >,
+        TimerT,
+        BlockEnv: Default,
+        SignedTransaction: Default
+                               + TransactionValidation<
+            ValidationError: From<l1::InvalidTransaction> + PartialEq,
         >,
+    >,
     TimerT: Clone + TimeSinceEpoch,
 >(
     data: &mut ProviderData<ChainSpecT, TimerT>,
@@ -55,13 +54,13 @@ pub fn handle_get_code_request<
 
 pub fn handle_get_storage_at_request<
     ChainSpecT: SyncProviderSpec<
-            TimerT,
-            BlockEnv: Default,
-            SignedTransaction: Default
-                                   + TransactionValidation<
-                ValidationError: From<l1::InvalidTransaction> + PartialEq,
-            >,
+        TimerT,
+        BlockEnv: Default,
+        SignedTransaction: Default
+                               + TransactionValidation<
+            ValidationError: From<l1::InvalidTransaction> + PartialEq,
         >,
+    >,
     TimerT: Clone + TimeSinceEpoch,
 >(
     data: &mut ProviderData<ChainSpecT, TimerT>,

--- a/crates/edr_provider/src/requests/eth/transactions.rs
+++ b/crates/edr_provider/src/requests/eth/transactions.rs
@@ -1,24 +1,23 @@
 use std::sync::Arc;
 
 use edr_eth::{
-    B256, Bytes, PreEip1898BlockSpec, U256, l1,
+    l1,
     rlp::Decodable,
     transaction::{
-        ExecutableTransaction as _, INVALID_TX_TYPE_ERROR_MESSAGE, IsEip155, IsEip4844,
-        TransactionType, TransactionValidation, request::TransactionRequestAndSender,
+        request::TransactionRequestAndSender, ExecutableTransaction as _, IsEip155, IsEip4844,
+        TransactionType, TransactionValidation, INVALID_TX_TYPE_ERROR_MESSAGE,
     },
+    Bytes, PreEip1898BlockSpec, B256, U256,
 };
 use edr_evm::{
-    Block,
     block::transaction::{BlockDataForTransaction, TransactionAndBlock},
     blockchain::BlockchainErrorForChainSpec,
     spec::RuntimeSpec,
-    transaction,
+    transaction, Block,
 };
 use edr_rpc_eth::RpcTypeFrom as _;
 
 use crate::{
-    ProviderError, ProviderResultWithTraces, TransactionFailure,
     data::ProviderData,
     error::{ProviderErrorForChainSpec, TransactionFailureWithTraces},
     requests::validation::{
@@ -27,6 +26,7 @@ use crate::{
     },
     spec::{FromRpcType, Sender as _, SyncProviderSpec, TransactionContext},
     time::TimeSinceEpoch,
+    ProviderError, ProviderResultWithTraces, TransactionFailure,
 };
 
 pub fn handle_get_transaction_by_block_hash_and_index<
@@ -51,13 +51,13 @@ pub fn handle_get_transaction_by_block_hash_and_index<
 
 pub fn handle_get_transaction_by_block_spec_and_index<
     ChainSpecT: SyncProviderSpec<
-            TimerT,
-            BlockEnv: Default,
-            SignedTransaction: Default
-                                   + TransactionValidation<
-                ValidationError: From<l1::InvalidTransaction> + PartialEq,
-            >,
+        TimerT,
+        BlockEnv: Default,
+        SignedTransaction: Default
+                               + TransactionValidation<
+            ValidationError: From<l1::InvalidTransaction> + PartialEq,
         >,
+    >,
     TimerT: Clone + TimeSinceEpoch,
 >(
     data: &mut ProviderData<ChainSpecT, TimerT>,
@@ -168,14 +168,14 @@ fn transaction_from_block<BlockT: Block<SignedTransactionT> + Clone, SignedTrans
 
 pub fn handle_send_transaction_request<
     ChainSpecT: SyncProviderSpec<
-            TimerT,
-            BlockEnv: Default,
-            SignedTransaction: Default
-                                   + TransactionType<Type: IsEip4844>
-                                   + TransactionValidation<
-                ValidationError: From<l1::InvalidTransaction> + PartialEq,
-            >,
+        TimerT,
+        BlockEnv: Default,
+        SignedTransaction: Default
+                               + TransactionType<Type: IsEip4844>
+                               + TransactionValidation<
+            ValidationError: From<l1::InvalidTransaction> + PartialEq,
         >,
+    >,
     TimerT: Clone + TimeSinceEpoch,
 >(
     data: &mut ProviderData<ChainSpecT, TimerT>,
@@ -194,15 +194,15 @@ pub fn handle_send_transaction_request<
 
 pub fn handle_send_raw_transaction_request<
     ChainSpecT: SyncProviderSpec<
-            TimerT,
-            BlockEnv: Default,
-            SignedTransaction: Default
-                                   + TransactionType<Type: IsEip4844>
-                                   + TransactionValidation<
-                ValidationError: From<l1::InvalidTransaction> + PartialEq,
-            >,
-            PooledTransaction: IsEip155,
+        TimerT,
+        BlockEnv: Default,
+        SignedTransaction: Default
+                               + TransactionType<Type: IsEip4844>
+                               + TransactionValidation<
+            ValidationError: From<l1::InvalidTransaction> + PartialEq,
         >,
+        PooledTransaction: IsEip155,
+    >,
     TimerT: Clone + TimeSinceEpoch,
 >(
     data: &mut ProviderData<ChainSpecT, TimerT>,
@@ -229,14 +229,14 @@ pub fn handle_send_raw_transaction_request<
 
 pub fn calculate_eip1559_fee_parameters<
     ChainSpecT: SyncProviderSpec<
-            TimerT,
-            BlockEnv: Default,
-            SignedTransaction: Default
-                                   + TransactionType<Type: IsEip4844>
-                                   + TransactionValidation<
-                ValidationError: From<l1::InvalidTransaction> + PartialEq,
-            >,
+        TimerT,
+        BlockEnv: Default,
+        SignedTransaction: Default
+                               + TransactionType<Type: IsEip4844>
+                               + TransactionValidation<
+            ValidationError: From<l1::InvalidTransaction> + PartialEq,
         >,
+    >,
     TimerT: Clone + TimeSinceEpoch,
 >(
     data: &mut ProviderData<ChainSpecT, TimerT>,
@@ -250,14 +250,14 @@ pub fn calculate_eip1559_fee_parameters<
     /// Panics if `data.evm_spec_id()` is less than `SpecId::LONDON`.
     fn calculate_max_fee_per_gas<
         ChainSpecT: SyncProviderSpec<
-                TimerT,
-                BlockEnv: Default,
-                SignedTransaction: Default
-                                       + TransactionType<Type: IsEip4844>
-                                       + TransactionValidation<
-                    ValidationError: From<l1::InvalidTransaction> + PartialEq,
-                >,
+            TimerT,
+            BlockEnv: Default,
+            SignedTransaction: Default
+                                   + TransactionType<Type: IsEip4844>
+                                   + TransactionValidation<
+                ValidationError: From<l1::InvalidTransaction> + PartialEq,
             >,
+        >,
         TimerT: Clone + TimeSinceEpoch,
     >(
         data: &ProviderData<ChainSpecT, TimerT>,
@@ -293,14 +293,14 @@ pub fn calculate_eip1559_fee_parameters<
 
 fn send_raw_transaction_and_log<
     ChainSpecT: SyncProviderSpec<
-            TimerT,
-            BlockEnv: Default,
-            SignedTransaction: Default
-                                   + TransactionType<Type: IsEip4844>
-                                   + TransactionValidation<
-                ValidationError: From<l1::InvalidTransaction> + PartialEq,
-            >,
+        TimerT,
+        BlockEnv: Default,
+        SignedTransaction: Default
+                               + TransactionType<Type: IsEip4844>
+                               + TransactionValidation<
+            ValidationError: From<l1::InvalidTransaction> + PartialEq,
         >,
+    >,
     TimerT: Clone + TimeSinceEpoch,
 >(
     data: &mut ProviderData<ChainSpecT, TimerT>,
@@ -382,11 +382,11 @@ You can use them by running Hardhat Network with 'hardfork' {minimum_hardfork:?}
 #[cfg(test)]
 mod tests {
     use anyhow::Context;
-    use edr_eth::{Address, Bytes, U256, l1::L1ChainSpec};
-    use transaction::{TxKind, signed::FakeSign as _};
+    use edr_eth::{l1::L1ChainSpec, Address, Bytes, U256};
+    use transaction::{signed::FakeSign as _, TxKind};
 
     use super::*;
-    use crate::test_utils::{ProviderTestFixture, one_ether};
+    use crate::test_utils::{one_ether, ProviderTestFixture};
 
     #[test]
     fn transaction_by_hash_for_impersonated_account() -> anyhow::Result<()> {

--- a/crates/edr_provider/src/requests/eth/web3.rs
+++ b/crates/edr_provider/src/requests/eth/web3.rs
@@ -1,4 +1,4 @@
-use edr_eth::{B256, Bytes};
+use edr_eth::{Bytes, B256};
 use edr_evm::spec::RuntimeSpec;
 use sha3::{Digest, Keccak256};
 
@@ -12,8 +12,8 @@ pub fn client_version() -> String {
     )
 }
 
-pub fn handle_web3_client_version_request<ChainSpecT: RuntimeSpec>()
--> Result<String, ProviderErrorForChainSpec<ChainSpecT>> {
+pub fn handle_web3_client_version_request<ChainSpecT: RuntimeSpec>(
+) -> Result<String, ProviderErrorForChainSpec<ChainSpecT>> {
     Ok(client_version())
 }
 

--- a/crates/edr_provider/src/requests/hardhat/accounts.rs
+++ b/crates/edr_provider/src/requests/hardhat/accounts.rs
@@ -1,7 +1,7 @@
 use edr_eth::Address;
 
 use crate::{
-    ProviderErrorForChainSpec, data::ProviderData, spec::ProviderSpec, time::TimeSinceEpoch,
+    data::ProviderData, spec::ProviderSpec, time::TimeSinceEpoch, ProviderErrorForChainSpec,
 };
 
 pub fn handle_impersonate_account_request<

--- a/crates/edr_provider/src/requests/hardhat/compiler.rs
+++ b/crates/edr_provider/src/requests/hardhat/compiler.rs
@@ -4,8 +4,8 @@ use edr_solidity::{
 };
 
 use crate::{
-    ProviderError, ProviderErrorForChainSpec, ProviderSpec, data::ProviderData,
-    time::TimeSinceEpoch,
+    data::ProviderData, time::TimeSinceEpoch, ProviderError, ProviderErrorForChainSpec,
+    ProviderSpec,
 };
 
 pub fn handle_add_compilation_result<

--- a/crates/edr_provider/src/requests/hardhat/config.rs
+++ b/crates/edr_provider/src/requests/hardhat/config.rs
@@ -2,11 +2,11 @@ use edr_eth::{Address, B256};
 use edr_evm::Block as _;
 
 use crate::{
-    ProviderErrorForChainSpec,
     data::ProviderData,
     requests::{eth::client_version, hardhat::rpc_types::Metadata},
     spec::{ProviderSpec, SyncProviderSpec},
     time::TimeSinceEpoch,
+    ProviderErrorForChainSpec,
 };
 
 pub fn handle_get_automine_request<

--- a/crates/edr_provider/src/requests/hardhat/log.rs
+++ b/crates/edr_provider/src/requests/hardhat/log.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ProviderErrorForChainSpec, data::ProviderData, spec::ProviderSpec, time::TimeSinceEpoch,
+    data::ProviderData, spec::ProviderSpec, time::TimeSinceEpoch, ProviderErrorForChainSpec,
 };
 
 pub fn handle_set_logging_enabled_request<

--- a/crates/edr_provider/src/requests/hardhat/miner.rs
+++ b/crates/edr_provider/src/requests/hardhat/miner.rs
@@ -1,19 +1,19 @@
 use edr_eth::{l1, transaction::TransactionValidation};
 
 use crate::{
-    ProviderError, ProviderResultWithTraces, data::ProviderData, error::ProviderErrorForChainSpec,
-    spec::SyncProviderSpec, time::TimeSinceEpoch,
+    data::ProviderData, error::ProviderErrorForChainSpec, spec::SyncProviderSpec,
+    time::TimeSinceEpoch, ProviderError, ProviderResultWithTraces,
 };
 
 pub fn handle_interval_mine_request<
     ChainSpecT: SyncProviderSpec<
-            TimerT,
-            BlockEnv: Default,
-            SignedTransaction: Default
-                                   + TransactionValidation<
-                ValidationError: From<l1::InvalidTransaction> + PartialEq,
-            >,
+        TimerT,
+        BlockEnv: Default,
+        SignedTransaction: Default
+                               + TransactionValidation<
+            ValidationError: From<l1::InvalidTransaction> + PartialEq,
         >,
+    >,
     TimerT: Clone + TimeSinceEpoch,
 >(
     data: &mut ProviderData<ChainSpecT, TimerT>,
@@ -23,13 +23,13 @@ pub fn handle_interval_mine_request<
 
 pub fn handle_mine<
     ChainSpecT: SyncProviderSpec<
-            TimerT,
-            BlockEnv: Default,
-            SignedTransaction: Default
-                                   + TransactionValidation<
-                ValidationError: From<l1::InvalidTransaction> + PartialEq,
-            >,
+        TimerT,
+        BlockEnv: Default,
+        SignedTransaction: Default
+                               + TransactionValidation<
+            ValidationError: From<l1::InvalidTransaction> + PartialEq,
         >,
+    >,
     TimerT: Clone + TimeSinceEpoch,
 >(
     data: &mut ProviderData<ChainSpecT, TimerT>,

--- a/crates/edr_provider/src/requests/hardhat/state.rs
+++ b/crates/edr_provider/src/requests/hardhat/state.rs
@@ -1,7 +1,7 @@
 use edr_eth::{Address, Bytes, U256};
 
 use crate::{
-    ProviderErrorForChainSpec, data::ProviderData, spec::SyncProviderSpec, time::TimeSinceEpoch,
+    data::ProviderData, spec::SyncProviderSpec, time::TimeSinceEpoch, ProviderErrorForChainSpec,
 };
 
 pub fn handle_set_balance<ChainSpecT: SyncProviderSpec<TimerT>, TimerT: Clone + TimeSinceEpoch>(

--- a/crates/edr_provider/src/requests/hardhat/transactions.rs
+++ b/crates/edr_provider/src/requests/hardhat/transactions.rs
@@ -1,8 +1,8 @@
 use edr_eth::B256;
 
 use crate::{
-    ProviderError, data::ProviderData, error::ProviderErrorForChainSpec, spec::SyncProviderSpec,
-    time::TimeSinceEpoch,
+    data::ProviderData, error::ProviderErrorForChainSpec, spec::SyncProviderSpec,
+    time::TimeSinceEpoch, ProviderError,
 };
 
 pub fn handle_drop_transaction<

--- a/crates/edr_provider/src/requests/methods.rs
+++ b/crates/edr_provider/src/requests/methods.rs
@@ -1,11 +1,11 @@
 use alloy_dyn_abi::eip712::TypedData;
 use derive_where::derive_where;
 use edr_eth::{
-    Address, B256, BlockSpec, Bytes, PreEip1898BlockSpec, U64, U128, U256,
     filter::{LogFilterOptions, SubscriptionType},
     serde::{optional_single_to_sequence, sequence_to_optional_single},
+    Address, BlockSpec, Bytes, PreEip1898BlockSpec, B256, U128, U256, U64,
 };
-use edr_rpc_eth::{StateOverrideOptions, spec::RpcSpec};
+use edr_rpc_eth::{spec::RpcSpec, StateOverrideOptions};
 use edr_solidity::artifacts::{CompilerInput, CompilerOutput};
 use serde::{Deserialize, Serialize};
 

--- a/crates/edr_provider/src/requests/resolve.rs
+++ b/crates/edr_provider/src/requests/resolve.rs
@@ -1,18 +1,19 @@
 use edr_eth::{
-    Bytes, U256,
     l1::{self, L1ChainSpec},
     transaction::TxKind,
+    Bytes, U256,
 };
 use edr_evm::transaction;
 use edr_rpc_eth::{CallRequest, TransactionRequest};
 
 use super::validation::validate_call_request;
 use crate::{
-    ProviderError, calculate_eip1559_fee_parameters,
+    calculate_eip1559_fee_parameters,
     error::ProviderErrorForChainSpec,
     requests::validation::validate_send_transaction_request,
     spec::{CallContext, FromRpcType, TransactionContext},
     time::TimeSinceEpoch,
+    ProviderError,
 };
 
 impl<TimerT: Clone + TimeSinceEpoch> FromRpcType<CallRequest, TimerT> for transaction::Request {
@@ -234,12 +235,12 @@ impl<TimerT: Clone + TimeSinceEpoch> FromRpcType<TransactionRequest, TimerT>
 
 #[cfg(test)]
 mod tests {
-    use edr_eth::{Address, BlockSpec, eips::eip7702};
+    use edr_eth::{eips::eip7702, Address, BlockSpec};
     use edr_evm::state::StateOverrides;
     use edr_rpc_eth::CallRequest;
 
     use super::*;
-    use crate::test_utils::{ProviderTestFixture, pending_base_fee};
+    use crate::test_utils::{pending_base_fee, ProviderTestFixture};
 
     #[test]
     fn resolve_call_request_with_gas_price() -> anyhow::Result<()> {

--- a/crates/edr_provider/src/requests/serde.rs
+++ b/crates/edr_provider/src/requests/serde.rs
@@ -5,11 +5,11 @@ use std::{
 };
 
 use alloy_dyn_abi::TypedData;
-use edr_eth::{Address, Bytes, U64, U256};
+use edr_eth::{Address, Bytes, U256, U64};
 use edr_evm::spec::RuntimeSpec;
 use serde::{Deserialize, Deserializer, Serialize};
 
-use crate::{ProviderError, error::ProviderErrorForChainSpec};
+use crate::{error::ProviderErrorForChainSpec, ProviderError};
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 #[repr(transparent)]
@@ -388,8 +388,8 @@ pub(crate) mod storage_value {
     use serde::Serializer;
 
     use super::{
-        Deserialize, Deserializer, FromStr, STORAGE_VALUE_INVALID_LENGTH_ERROR_MESSAGE, U256,
-        extract_value_from_serde_json_error,
+        extract_value_from_serde_json_error, Deserialize, Deserializer, FromStr,
+        STORAGE_VALUE_INVALID_LENGTH_ERROR_MESSAGE, U256,
     };
 
     /// Helper function for deserializing the JSON-RPC data type, specialized
@@ -529,9 +529,7 @@ mod tests {
         let test = Test { n };
 
         let json = serde_json::to_string(&test).unwrap();
-        assert!(
-            json.contains("0x000000000000000000000000313f922be1649cec058ec0f076664500c78bdc0b")
-        );
+        assert!(json.contains("0x000000000000000000000000313f922be1649cec058ec0f076664500c78bdc0b"));
 
         let parsed = serde_json::from_str::<Test>(&json).unwrap();
 

--- a/crates/edr_provider/src/requests/validation.rs
+++ b/crates/edr_provider/src/requests/validation.rs
@@ -1,15 +1,15 @@
 use edr_eth::{
-    Address, B256, Blob, BlockSpec, BlockTag, Bytes, MAX_INITCODE_SIZE, PreEip1898BlockSpec,
     eips::{eip2930, eip7702},
     l1,
-    transaction::{ExecutableTransaction, pooled::PooledTransaction},
+    transaction::{pooled::PooledTransaction, ExecutableTransaction},
+    Address, Blob, BlockSpec, BlockTag, Bytes, PreEip1898BlockSpec, B256, MAX_INITCODE_SIZE,
 };
 use edr_evm::{spec::RuntimeSpec, transaction};
 use edr_rpc_eth::{CallRequest, TransactionRequest};
 
 use crate::{
-    ProviderError, SyncProviderSpec, data::ProviderData, error::ProviderErrorForChainSpec,
-    spec::HardforkValidationData, time::TimeSinceEpoch,
+    data::ProviderData, error::ProviderErrorForChainSpec, spec::HardforkValidationData,
+    time::TimeSinceEpoch, ProviderError, SyncProviderSpec,
 };
 
 impl HardforkValidationData for TransactionRequest {
@@ -402,7 +402,7 @@ pub(crate) fn validate_post_merge_block_tags<'a, ChainSpecT: RuntimeSpec>(
 
 #[cfg(test)]
 mod tests {
-    use edr_eth::{U256, l1::L1ChainSpec};
+    use edr_eth::{l1::L1ChainSpec, U256};
 
     use super::*;
 

--- a/crates/edr_provider/src/snapshot.rs
+++ b/crates/edr_provider/src/snapshot.rs
@@ -1,7 +1,7 @@
 use std::time::Instant;
 
-use edr_eth::{Address, transaction::ExecutableTransaction};
-use edr_evm::{MemPool, RandomHashGenerator, state::IrregularState};
+use edr_eth::{transaction::ExecutableTransaction, Address};
+use edr_evm::{state::IrregularState, MemPool, RandomHashGenerator};
 use rpds::HashTrieMapSync;
 
 use crate::data::StateId;

--- a/crates/edr_provider/src/spec.rs
+++ b/crates/edr_provider/src/spec.rs
@@ -3,39 +3,36 @@ use std::sync::Arc;
 
 pub use edr_eth::spec::EthHeaderConstants;
 use edr_eth::{
-    Address, B256, Blob, BlockSpec,
     eips::{eip2930, eip7702},
     l1::L1ChainSpec,
     rlp,
     transaction::{
-        ExecutableTransaction, IsSupported,
         signed::{FakeSign, Sign},
+        ExecutableTransaction, IsSupported,
     },
+    Address, Blob, BlockSpec, B256,
 };
 pub use edr_evm::spec::{RuntimeSpec, SyncRuntimeSpec};
 use edr_evm::{
-    BlockAndTotalDifficulty, BlockReceipts, blockchain::BlockchainErrorForChainSpec,
-    state::StateOverrides, transaction,
+    blockchain::BlockchainErrorForChainSpec, state::StateOverrides, transaction,
+    BlockAndTotalDifficulty, BlockReceipts,
 };
 use edr_rpc_eth::{CallRequest, TransactionRequest};
 
 use crate::{
-    TransactionFailureReason, data::ProviderData, error::ProviderErrorForChainSpec,
-    time::TimeSinceEpoch,
+    data::ProviderData, error::ProviderErrorForChainSpec, time::TimeSinceEpoch,
+    TransactionFailureReason,
 };
 
 pub trait ProviderSpec<TimerT: Clone + TimeSinceEpoch>:
     RuntimeSpec<
-        Block: BlockReceipts<Arc<Self::BlockReceipt>, Error = BlockchainErrorForChainSpec<Self>>,
-        LocalBlock: BlockReceipts<
-            Arc<Self::BlockReceipt>,
-            Error = BlockchainErrorForChainSpec<Self>,
-        >,
-        RpcBlock<B256>: From<BlockAndTotalDifficulty<Arc<Self::Block>, Self::SignedTransaction>>,
-        RpcCallRequest: MaybeSender,
-        RpcTransactionRequest: Sender,
-        SignedTransaction: IsSupported,
-    >
+    Block: BlockReceipts<Arc<Self::BlockReceipt>, Error = BlockchainErrorForChainSpec<Self>>,
+    LocalBlock: BlockReceipts<Arc<Self::BlockReceipt>, Error = BlockchainErrorForChainSpec<Self>>,
+    RpcBlock<B256>: From<BlockAndTotalDifficulty<Arc<Self::Block>, Self::SignedTransaction>>,
+    RpcCallRequest: MaybeSender,
+    RpcTransactionRequest: Sender,
+    SignedTransaction: IsSupported,
+>
 {
     type PooledTransaction: HardforkValidationData
         + Into<Self::SignedTransaction>

--- a/crates/edr_provider/src/subscribe.rs
+++ b/crates/edr_provider/src/subscribe.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use derive_where::derive_where;
 use dyn_clone::DynClone;
-use edr_eth::{B256, U256, filter::LogOutput};
-use edr_evm::{BlockAndTotalDifficulty, spec::RuntimeSpec};
+use edr_eth::{filter::LogOutput, B256, U256};
+use edr_evm::{spec::RuntimeSpec, BlockAndTotalDifficulty};
 
 /// Subscription event.
 #[derive_where(Clone, Debug)]

--- a/crates/edr_provider/src/test_utils.rs
+++ b/crates/edr_provider/src/test_utils.rs
@@ -3,13 +3,13 @@ use std::{num::NonZeroU64, sync::Arc, time::SystemTime};
 
 use anyhow::anyhow;
 use edr_eth::{
-    Address, B256, Bytes, HashMap, U160, U256,
     block::BlobGas,
     eips::eip7702,
     l1::{self, L1ChainSpec},
-    signature::{SignatureWithYParity, public_key_to_address, secret_key_from_str},
-    transaction::{self, TransactionValidation, TxKind, request::TransactionRequestAndSender},
+    signature::{public_key_to_address, secret_key_from_str, SignatureWithYParity},
+    transaction::{self, request::TransactionRequestAndSender, TransactionValidation, TxKind},
     trie::KECCAK_NULL_RLP,
+    Address, Bytes, HashMap, B256, U160, U256,
 };
 use edr_evm::Block as _;
 use edr_rpc_eth::TransactionRequest;
@@ -18,11 +18,12 @@ use k256::SecretKey;
 use tokio::runtime;
 
 use crate::{
-    AccountOverride, ForkConfig, MethodInvocation, NoopLogger, Provider, ProviderConfig,
-    ProviderData, ProviderRequest, ProviderSpec, SyncProviderSpec, config,
+    config,
     error::ProviderErrorForChainSpec,
     observability,
     time::{CurrentTime, TimeSinceEpoch},
+    AccountOverride, ForkConfig, MethodInvocation, NoopLogger, Provider, ProviderConfig,
+    ProviderData, ProviderRequest, ProviderSpec, SyncProviderSpec,
 };
 
 pub const TEST_SECRET_KEY: &str =
@@ -104,13 +105,13 @@ pub fn create_test_config_with_fork<HardforkT: Default>(
 /// Retrieves the pending base fee per gas from the provider data.
 pub fn pending_base_fee<
     ChainSpecT: SyncProviderSpec<
-            TimerT,
-            BlockEnv: Default,
-            SignedTransaction: Default
-                                   + TransactionValidation<
-                ValidationError: From<l1::InvalidTransaction> + PartialEq,
-            >,
+        TimerT,
+        BlockEnv: Default,
+        SignedTransaction: Default
+                               + TransactionValidation<
+            ValidationError: From<l1::InvalidTransaction> + PartialEq,
         >,
+    >,
     TimerT: Clone + TimeSinceEpoch,
 >(
     data: &mut ProviderData<ChainSpecT, TimerT>,

--- a/crates/edr_provider/tests/common/blob.rs
+++ b/crates/edr_provider/tests/common/blob.rs
@@ -1,10 +1,10 @@
 use std::str::FromStr as _;
 
 use edr_eth::{
-    Address, B256, Blob, Bytes, Bytes48,
     eips::eip4844::ethereum_kzg_settings,
     rlp::{self, Decodable as _},
     transaction::{self, pooled::PooledTransaction},
+    Address, Blob, Bytes, Bytes48, B256,
 };
 use edr_test_utils::secret_key::secret_key_from_str;
 

--- a/crates/edr_provider/tests/integration/coverage.rs
+++ b/crates/edr_provider/tests/integration/coverage.rs
@@ -3,11 +3,11 @@
 use std::{str::FromStr as _, sync::Arc};
 
 use edr_eth::{
-    Address, B256, Bytes, HashSet, bytes, l1::L1ChainSpec, signature::public_key_to_address,
+    bytes, l1::L1ChainSpec, signature::public_key_to_address, Address, Bytes, HashSet, B256,
 };
 use edr_provider::{
-    MethodInvocation, NoopLogger, Provider, ProviderRequest, test_utils::create_test_config,
-    time::CurrentTime,
+    test_utils::create_test_config, time::CurrentTime, MethodInvocation, NoopLogger, Provider,
+    ProviderRequest,
 };
 use edr_rpc_eth::{CallRequest, TransactionRequest};
 use edr_solidity::contract_decoder::ContractDecoder;

--- a/crates/edr_provider/tests/integration/disable_balance_check.rs
+++ b/crates/edr_provider/tests/integration/disable_balance_check.rs
@@ -2,10 +2,10 @@
 
 use std::sync::Arc;
 
-use edr_eth::{U256, address, bytes, l1::L1ChainSpec, signature::public_key_to_address};
+use edr_eth::{address, bytes, l1::L1ChainSpec, signature::public_key_to_address, U256};
 use edr_provider::{
-    MethodInvocation, NoopLogger, Provider, ProviderRequest, test_utils::create_test_config,
-    time::CurrentTime,
+    test_utils::create_test_config, time::CurrentTime, MethodInvocation, NoopLogger, Provider,
+    ProviderRequest,
 };
 use edr_rpc_eth::CallRequest;
 use edr_solidity::contract_decoder::ContractDecoder;

--- a/crates/edr_provider/tests/integration/eip2537.rs
+++ b/crates/edr_provider/tests/integration/eip2537.rs
@@ -4,12 +4,13 @@ use core::str::FromStr as _;
 use std::sync::Arc;
 
 use edr_eth::{
-    Bytes, address,
+    address,
     l1::{self, L1ChainSpec},
+    Bytes,
 };
 use edr_provider::{
-    MethodInvocation, NoopLogger, Provider, ProviderRequest, test_utils::create_test_config,
-    time::CurrentTime,
+    test_utils::create_test_config, time::CurrentTime, MethodInvocation, NoopLogger, Provider,
+    ProviderRequest,
 };
 use edr_rpc_eth::CallRequest;
 use edr_solidity::contract_decoder::ContractDecoder;

--- a/crates/edr_provider/tests/integration/eip4844.rs
+++ b/crates/edr_provider/tests/integration/eip4844.rs
@@ -4,15 +4,15 @@ use std::{str::FromStr, sync::Arc};
 
 use edr_defaults::SECRET_KEYS;
 use edr_eth::{
-    Address, B256, Blob, Bytes, PreEip1898BlockSpec, U256,
     eips::eip4844::{self, GAS_PER_BLOB},
     l1::{self, L1ChainSpec},
     transaction::{self, ExecutableTransaction as _, TransactionType as _},
+    Address, Blob, Bytes, PreEip1898BlockSpec, B256, U256,
 };
 use edr_provider::{
-    AccountOverride, MethodInvocation, NoopLogger, Provider, ProviderError, ProviderRequest,
     test_utils::{create_test_config, deploy_contract, one_ether},
     time::CurrentTime,
+    AccountOverride, MethodInvocation, NoopLogger, Provider, ProviderError, ProviderRequest,
 };
 use edr_rpc_eth::{CallRequest, TransactionRequest};
 use edr_solidity::contract_decoder::ContractDecoder;
@@ -20,7 +20,7 @@ use edr_test_utils::secret_key::secret_key_to_address;
 use tokio::runtime;
 
 use crate::common::blob::{
-    BlobTransactionBuilder, fake_pooled_transaction, fake_raw_transaction, fake_transaction,
+    fake_pooled_transaction, fake_raw_transaction, fake_transaction, BlobTransactionBuilder,
 };
 
 fn fake_call_request() -> CallRequest {

--- a/crates/edr_provider/tests/integration/eip7623.rs
+++ b/crates/edr_provider/tests/integration/eip7623.rs
@@ -6,13 +6,13 @@ mod send_data_to_eoa;
 use std::sync::Arc;
 
 use edr_eth::{
-    B256, U64,
     l1::{self, L1ChainSpec},
+    B256, U64,
 };
 use edr_provider::{
-    MethodInvocation, NoopLogger, Provider, ProviderRequest,
     test_utils::{create_test_config, one_ether, set_genesis_state_with_owned_accounts},
     time::CurrentTime,
+    MethodInvocation, NoopLogger, Provider, ProviderRequest,
 };
 use edr_rpc_eth::{CallRequest, TransactionRequest};
 use edr_solidity::contract_decoder::ContractDecoder;

--- a/crates/edr_provider/tests/integration/eip7691.rs
+++ b/crates/edr_provider/tests/integration/eip7691.rs
@@ -3,19 +3,19 @@
 use std::sync::Arc;
 
 use edr_eth::{
-    B256, PreEip1898BlockSpec,
     eips::eip4844::GAS_PER_BLOB,
     l1::{self, L1ChainSpec},
     transaction::ExecutableTransaction as _,
+    PreEip1898BlockSpec, B256,
 };
 use edr_provider::{
-    MethodInvocation, NoopLogger, Provider, ProviderRequest, test_utils::create_test_config,
-    time::CurrentTime,
+    test_utils::create_test_config, time::CurrentTime, MethodInvocation, NoopLogger, Provider,
+    ProviderRequest,
 };
 use edr_solidity::contract_decoder::ContractDecoder;
 use tokio::runtime;
 
-use crate::common::blob::{BlobTransactionBuilder, fake_raw_transaction, fake_transaction};
+use crate::common::blob::{fake_raw_transaction, fake_transaction, BlobTransactionBuilder};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn block_header() -> anyhow::Result<()> {

--- a/crates/edr_provider/tests/integration/eip7702.rs
+++ b/crates/edr_provider/tests/integration/eip7702.rs
@@ -11,18 +11,19 @@ mod zeroed_chain_id;
 use std::sync::Arc;
 
 use edr_eth::{
-    Address, B256, Bytes, U256, address,
+    address,
     eips::eip7702,
     l1::{self, L1ChainSpec},
     signature::public_key_to_address,
     transaction::{self, ExecutableTransaction as _},
+    Address, Bytes, B256, U256,
 };
 use edr_provider::{
-    MethodInvocation, NoopLogger, Provider, ProviderConfig, ProviderRequest,
     test_utils::{
         create_test_config, one_ether, set_genesis_state_with_owned_accounts, sign_authorization,
     },
     time::CurrentTime,
+    MethodInvocation, NoopLogger, Provider, ProviderConfig, ProviderRequest,
 };
 use edr_rpc_eth::TransactionRequest;
 use edr_solidity::contract_decoder::ContractDecoder;

--- a/crates/edr_provider/tests/integration/eip7702/different_sender_and_authorizer.rs
+++ b/crates/edr_provider/tests/integration/eip7702/different_sender_and_authorizer.rs
@@ -1,14 +1,15 @@
 use edr_eth::{
-    Bytes, U256, address, bytes,
+    address, bytes,
     eips::eip7702,
     l1::{self, L1ChainSpec},
     signature::public_key_to_address,
+    Bytes, U256,
 };
-use edr_provider::{MethodInvocation, Provider, ProviderRequest, test_utils::create_test_config};
+use edr_provider::{test_utils::create_test_config, MethodInvocation, Provider, ProviderRequest};
 use edr_rpc_eth::{CallRequest, TransactionRequest};
-use edr_test_utils::secret_key::{SecretKey, secret_key_from_str};
+use edr_test_utils::secret_key::{secret_key_from_str, SecretKey};
 
-use super::{CHAIN_ID, assert_code_at, sign_authorization};
+use super::{assert_code_at, sign_authorization, CHAIN_ID};
 
 static EXPECTED_CODE: Bytes = bytes!("ef01001234567890123456789012345678901234567890");
 

--- a/crates/edr_provider/tests/integration/eip7702/invalid_chain_id.rs
+++ b/crates/edr_provider/tests/integration/eip7702/invalid_chain_id.rs
@@ -1,14 +1,15 @@
 use edr_eth::{
-    Bytes, U256, address, bytes,
+    address, bytes,
     eips::eip7702,
     l1::{self, L1ChainSpec},
     signature::public_key_to_address,
+    Bytes, U256,
 };
-use edr_provider::{MethodInvocation, Provider, ProviderRequest, test_utils::create_test_config};
+use edr_provider::{test_utils::create_test_config, MethodInvocation, Provider, ProviderRequest};
 use edr_rpc_eth::TransactionRequest;
-use edr_test_utils::secret_key::{SecretKey, secret_key_from_str};
+use edr_test_utils::secret_key::{secret_key_from_str, SecretKey};
 
-use super::{CHAIN_ID, assert_code_at, sign_authorization};
+use super::{assert_code_at, sign_authorization, CHAIN_ID};
 
 fn new_provider(sender_secret_key: SecretKey) -> anyhow::Result<Provider<L1ChainSpec>> {
     let mut config = create_test_config();

--- a/crates/edr_provider/tests/integration/eip7702/invalid_nonce.rs
+++ b/crates/edr_provider/tests/integration/eip7702/invalid_nonce.rs
@@ -1,14 +1,15 @@
 use edr_eth::{
-    Bytes, U256, address, bytes,
+    address, bytes,
     eips::eip7702,
     l1::{self, L1ChainSpec},
     signature::public_key_to_address,
+    Bytes, U256,
 };
-use edr_provider::{MethodInvocation, Provider, ProviderRequest, test_utils::create_test_config};
+use edr_provider::{test_utils::create_test_config, MethodInvocation, Provider, ProviderRequest};
 use edr_rpc_eth::TransactionRequest;
-use edr_test_utils::secret_key::{SecretKey, secret_key_from_str};
+use edr_test_utils::secret_key::{secret_key_from_str, SecretKey};
 
-use super::{CHAIN_ID, assert_code_at, sign_authorization};
+use super::{assert_code_at, sign_authorization, CHAIN_ID};
 
 fn new_provider(sender_secret_key: SecretKey) -> anyhow::Result<Provider<L1ChainSpec>> {
     let mut config = create_test_config();

--- a/crates/edr_provider/tests/integration/eip7702/multiple_authorizers.rs
+++ b/crates/edr_provider/tests/integration/eip7702/multiple_authorizers.rs
@@ -1,14 +1,15 @@
 use edr_eth::{
-    Address, Bytes, U256, address, bytes,
+    address, bytes,
     eips::eip7702,
     l1::{self, L1ChainSpec},
     signature::public_key_to_address,
+    Address, Bytes, U256,
 };
-use edr_provider::{MethodInvocation, Provider, ProviderRequest, test_utils::create_test_config};
+use edr_provider::{test_utils::create_test_config, MethodInvocation, Provider, ProviderRequest};
 use edr_rpc_eth::{CallRequest, TransactionRequest};
-use edr_test_utils::secret_key::{SecretKey, secret_key_from_str};
+use edr_test_utils::secret_key::{secret_key_from_str, SecretKey};
 
-use super::{CHAIN_ID, assert_code_at, sign_authorization};
+use super::{assert_code_at, sign_authorization, CHAIN_ID};
 
 static EXPECTED_CODE1: Bytes = bytes!("ef01001234567890123456789012345678901234567890");
 static EXPECTED_CODE2: Bytes = bytes!("ef01001111222233334444555566667777888899990000");

--- a/crates/edr_provider/tests/integration/eip7702/reset.rs
+++ b/crates/edr_provider/tests/integration/eip7702/reset.rs
@@ -1,14 +1,15 @@
 use edr_eth::{
-    Address, Bytes, U256, address, bytes,
+    address, bytes,
     eips::eip7702,
     l1::{self, L1ChainSpec},
     signature::public_key_to_address,
+    Address, Bytes, U256,
 };
-use edr_provider::{MethodInvocation, Provider, ProviderRequest, test_utils::create_test_config};
+use edr_provider::{test_utils::create_test_config, MethodInvocation, Provider, ProviderRequest};
 use edr_rpc_eth::TransactionRequest;
-use edr_test_utils::secret_key::{SecretKey, secret_key_from_str};
+use edr_test_utils::secret_key::{secret_key_from_str, SecretKey};
 
-use super::{CHAIN_ID, assert_code_at, sign_authorization};
+use super::{assert_code_at, sign_authorization, CHAIN_ID};
 
 static EXPECTED_CODE: Bytes = bytes!("ef01001234567890123456789012345678901234567890");
 

--- a/crates/edr_provider/tests/integration/eip7702/same_sender_and_authorizer.rs
+++ b/crates/edr_provider/tests/integration/eip7702/same_sender_and_authorizer.rs
@@ -1,14 +1,15 @@
 use edr_eth::{
-    Bytes, U256, address, bytes,
+    address, bytes,
     eips::eip7702,
     l1::{self, L1ChainSpec},
     signature::public_key_to_address,
+    Bytes, U256,
 };
-use edr_provider::{MethodInvocation, Provider, ProviderRequest, test_utils::create_test_config};
+use edr_provider::{test_utils::create_test_config, MethodInvocation, Provider, ProviderRequest};
 use edr_rpc_eth::{CallRequest, TransactionRequest};
-use edr_test_utils::secret_key::{SecretKey, secret_key_from_str};
+use edr_test_utils::secret_key::{secret_key_from_str, SecretKey};
 
-use super::{CHAIN_ID, assert_code_at, sign_authorization};
+use super::{assert_code_at, sign_authorization, CHAIN_ID};
 
 static EXPECTED_CODE: Bytes = bytes!("ef01001234567890123456789012345678901234567890");
 

--- a/crates/edr_provider/tests/integration/eip7702/zeroed_chain_id.rs
+++ b/crates/edr_provider/tests/integration/eip7702/zeroed_chain_id.rs
@@ -1,14 +1,15 @@
 use edr_eth::{
-    Bytes, U256, address, bytes,
+    address, bytes,
     eips::eip7702,
     l1::{self, L1ChainSpec},
     signature::public_key_to_address,
+    Bytes, U256,
 };
-use edr_provider::{MethodInvocation, Provider, ProviderRequest, test_utils::create_test_config};
+use edr_provider::{test_utils::create_test_config, MethodInvocation, Provider, ProviderRequest};
 use edr_rpc_eth::{CallRequest, TransactionRequest};
-use edr_test_utils::secret_key::{SecretKey, secret_key_from_str};
+use edr_test_utils::secret_key::{secret_key_from_str, SecretKey};
 
-use super::{CHAIN_ID, assert_code_at, sign_authorization};
+use super::{assert_code_at, sign_authorization, CHAIN_ID};
 
 static EXPECTED_CODE: Bytes = bytes!("ef01001234567890123456789012345678901234567890");
 

--- a/crates/edr_provider/tests/integration/eth_max_priority_fee_per_gas.rs
+++ b/crates/edr_provider/tests/integration/eth_max_priority_fee_per_gas.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 
 use edr_eth::l1::L1ChainSpec;
 use edr_provider::{
-    MethodInvocation, NoopLogger, Provider, ProviderRequest, test_utils::create_test_config,
-    time::CurrentTime,
+    test_utils::create_test_config, time::CurrentTime, MethodInvocation, NoopLogger, Provider,
+    ProviderRequest,
 };
 use edr_solidity::contract_decoder::ContractDecoder;
 use tokio::runtime;

--- a/crates/edr_provider/tests/integration/eth_request_serialization.rs
+++ b/crates/edr_provider/tests/integration/eth_request_serialization.rs
@@ -1,8 +1,8 @@
 use edr_eth::{
-    Address, B256, Blob, BlockSpec, BlockTag, Bytes, PreEip1898BlockSpec, U160, U256,
     eips::{eip4844::GAS_PER_BLOB, eip7702},
     filter::{LogFilterOptions, LogOutput, OneOrMore},
     l1::L1ChainSpec,
+    Address, Blob, BlockSpec, BlockTag, Bytes, PreEip1898BlockSpec, B256, U160, U256,
 };
 use edr_provider::{IntervalConfigRequest, MethodInvocation, Timestamp};
 use edr_rpc_eth::{CallRequest, TransactionRequest};

--- a/crates/edr_provider/tests/integration/hardhat_request_serialization.rs
+++ b/crates/edr_provider/tests/integration/hardhat_request_serialization.rs
@@ -1,7 +1,7 @@
-use edr_eth::{Address, B256, Bytes, U128, U160, U256, l1::L1ChainSpec};
+use edr_eth::{l1::L1ChainSpec, Address, Bytes, B256, U128, U160, U256};
 use edr_provider::{
-    MethodInvocation,
     hardhat_rpc_types::{ResetForkConfig, ResetProviderConfig},
+    MethodInvocation,
 };
 use edr_solidity::artifacts::{CompilerInput, CompilerOutput};
 

--- a/crates/edr_provider/tests/integration/issues/issue_324.rs
+++ b/crates/edr_provider/tests/integration/issues/issue_324.rs
@@ -1,12 +1,12 @@
 use std::{str::FromStr, sync::Arc};
 
 use edr_eth::{
-    Address, Bytes, HashMap, U256,
     l1::{self, L1ChainSpec},
+    Address, Bytes, HashMap, U256,
 };
 use edr_provider::{
-    ForkConfig, MethodInvocation, NoopLogger, Provider, ProviderRequest,
-    test_utils::create_test_config_with_fork, time::CurrentTime,
+    test_utils::create_test_config_with_fork, time::CurrentTime, ForkConfig, MethodInvocation,
+    NoopLogger, Provider, ProviderRequest,
 };
 use edr_rpc_eth::CallRequest;
 use edr_solidity::contract_decoder::ContractDecoder;

--- a/crates/edr_provider/tests/integration/issues/issue_325.rs
+++ b/crates/edr_provider/tests/integration/issues/issue_325.rs
@@ -1,13 +1,13 @@
 use std::sync::Arc;
 
 use edr_eth::{
-    Address, B256, PreEip1898BlockSpec,
     l1::{self, L1ChainSpec},
+    Address, PreEip1898BlockSpec, B256,
 };
 use edr_provider::{
-    AccountOverride, MethodInvocation, MiningConfig, NoopLogger, Provider, ProviderRequest,
     test_utils::{create_test_config_with_fork, one_ether},
     time::CurrentTime,
+    AccountOverride, MethodInvocation, MiningConfig, NoopLogger, Provider, ProviderRequest,
 };
 use edr_rpc_eth::TransactionRequest;
 use edr_solidity::contract_decoder::ContractDecoder;

--- a/crates/edr_provider/tests/integration/issues/issue_326.rs
+++ b/crates/edr_provider/tests/integration/issues/issue_326.rs
@@ -1,13 +1,13 @@
 use std::sync::Arc;
 
 use edr_eth::{
-    Address,
     l1::{self, L1ChainSpec},
+    Address,
 };
 use edr_provider::{
-    AccountOverride, MethodInvocation, MiningConfig, NoopLogger, Provider, ProviderRequest,
     test_utils::{create_test_config_with_fork, one_ether},
     time::CurrentTime,
+    AccountOverride, MethodInvocation, MiningConfig, NoopLogger, Provider, ProviderRequest,
 };
 use edr_rpc_eth::{CallRequest, TransactionRequest};
 use edr_solidity::contract_decoder::ContractDecoder;

--- a/crates/edr_provider/tests/integration/issues/issue_346.rs
+++ b/crates/edr_provider/tests/integration/issues/issue_346.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use edr_eth::l1::L1ChainSpec;
-use edr_provider::{NoopLogger, Provider, test_utils::create_test_config, time::CurrentTime};
+use edr_provider::{test_utils::create_test_config, time::CurrentTime, NoopLogger, Provider};
 use edr_solidity::contract_decoder::ContractDecoder;
 use serde_json::json;
 use tokio::runtime;
@@ -78,11 +78,9 @@ async fn issue_346() -> anyhow::Result<()> {
       ]
     });
 
-    assert!(
-        provider
-            .handle_request(serde_json::from_value(request_hex_salt)?)
-            .is_ok()
-    );
+    assert!(provider
+        .handle_request(serde_json::from_value(request_hex_salt)?)
+        .is_ok());
 
     #[allow(clippy::zero_prefixed_literal)]
     let request_array_salt = json!({
@@ -140,11 +138,9 @@ async fn issue_346() -> anyhow::Result<()> {
       ]
     });
 
-    assert!(
-        provider
-            .handle_request(serde_json::from_value(request_array_salt)?)
-            .is_ok()
-    );
+    assert!(provider
+        .handle_request(serde_json::from_value(request_array_salt)?)
+        .is_ok());
 
     Ok(())
 }

--- a/crates/edr_provider/tests/integration/issues/issue_356.rs
+++ b/crates/edr_provider/tests/integration/issues/issue_356.rs
@@ -2,12 +2,12 @@ use std::{str::FromStr, sync::Arc};
 
 use anyhow::Context;
 use edr_eth::{
-    Address, Bytes, HashMap,
     l1::{self, L1ChainSpec},
+    Address, Bytes, HashMap,
 };
 use edr_provider::{
-    ForkConfig, MethodInvocation, NoopLogger, Provider, ProviderRequest,
-    test_utils::create_test_config_with_fork, time::CurrentTime,
+    test_utils::create_test_config_with_fork, time::CurrentTime, ForkConfig, MethodInvocation,
+    NoopLogger, Provider, ProviderRequest,
 };
 use edr_rpc_eth::CallRequest;
 use edr_solidity::contract_decoder::ContractDecoder;

--- a/crates/edr_provider/tests/integration/issues/issue_361.rs
+++ b/crates/edr_provider/tests/integration/issues/issue_361.rs
@@ -1,14 +1,14 @@
 use std::sync::Arc;
 
 use edr_eth::{
-    Address, BlockSpec,
     filter::LogFilterOptions,
     l1::{self, L1ChainSpec},
+    Address, BlockSpec,
 };
 use edr_provider::{
-    AccountOverride, MethodInvocation, NoopLogger, Provider, ProviderRequest,
     test_utils::{create_test_config_with_fork, one_ether},
     time::CurrentTime,
+    AccountOverride, MethodInvocation, NoopLogger, Provider, ProviderRequest,
 };
 use edr_rpc_eth::TransactionRequest;
 use edr_solidity::contract_decoder::ContractDecoder;

--- a/crates/edr_provider/tests/integration/issues/issue_384.rs
+++ b/crates/edr_provider/tests/integration/issues/issue_384.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
-use edr_eth::{HashMap, l1::L1ChainSpec};
+use edr_eth::{l1::L1ChainSpec, HashMap};
 use edr_provider::{
-    ForkConfig, MethodInvocation, NoopLogger, Provider, ProviderRequest,
-    test_utils::create_test_config_with_fork, time::CurrentTime,
+    test_utils::create_test_config_with_fork, time::CurrentTime, ForkConfig, MethodInvocation,
+    NoopLogger, Provider, ProviderRequest,
 };
 use edr_solidity::contract_decoder::ContractDecoder;
 use edr_test_utils::env::get_infura_url;

--- a/crates/edr_provider/tests/integration/issues/issue_407.rs
+++ b/crates/edr_provider/tests/integration/issues/issue_407.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use edr_eth::l1::L1ChainSpec;
-use edr_provider::{NoopLogger, Provider, test_utils::create_test_config, time::CurrentTime};
+use edr_provider::{test_utils::create_test_config, time::CurrentTime, NoopLogger, Provider};
 use edr_solidity::contract_decoder::ContractDecoder;
 use serde_json::json;
 use tokio::runtime;

--- a/crates/edr_provider/tests/integration/issues/issue_503.rs
+++ b/crates/edr_provider/tests/integration/issues/issue_503.rs
@@ -1,12 +1,12 @@
 use std::{str::FromStr as _, sync::Arc};
 
 use edr_eth::{
-    Address, HashMap, U256,
     l1::{self, L1ChainSpec},
+    Address, HashMap, U256,
 };
 use edr_provider::{
-    ForkConfig, MethodInvocation, NoopLogger, Provider, ProviderRequest,
-    test_utils::create_test_config_with_fork, time::CurrentTime,
+    test_utils::create_test_config_with_fork, time::CurrentTime, ForkConfig, MethodInvocation,
+    NoopLogger, Provider, ProviderRequest,
 };
 use edr_solidity::contract_decoder::ContractDecoder;
 use edr_test_utils::env::get_alchemy_url;

--- a/crates/edr_provider/tests/integration/issues/issue_533.rs
+++ b/crates/edr_provider/tests/integration/issues/issue_533.rs
@@ -1,9 +1,9 @@
 use std::{str::FromStr as _, sync::Arc};
 
-use edr_eth::{B256, HashMap, l1::L1ChainSpec};
+use edr_eth::{l1::L1ChainSpec, HashMap, B256};
 use edr_provider::{
-    ForkConfig, MethodInvocation, NoopLogger, Provider, ProviderRequest,
-    test_utils::create_test_config_with_fork, time::CurrentTime,
+    test_utils::create_test_config_with_fork, time::CurrentTime, ForkConfig, MethodInvocation,
+    NoopLogger, Provider, ProviderRequest,
 };
 use edr_solidity::contract_decoder::ContractDecoder;
 use edr_test_utils::env::get_alchemy_url;

--- a/crates/edr_provider/tests/integration/issues/issue_588.rs
+++ b/crates/edr_provider/tests/integration/issues/issue_588.rs
@@ -4,9 +4,9 @@
 
 use std::sync::Arc;
 
-use edr_eth::{HashMap, l1::L1ChainSpec};
+use edr_eth::{l1::L1ChainSpec, HashMap};
 use edr_provider::{
-    ForkConfig, NoopLogger, Provider, test_utils::create_test_config_with_fork, time::MockTime,
+    test_utils::create_test_config_with_fork, time::MockTime, ForkConfig, NoopLogger, Provider,
 };
 use edr_solidity::contract_decoder::ContractDecoder;
 use edr_test_utils::env::get_alchemy_url;

--- a/crates/edr_provider/tests/integration/timestamp.rs
+++ b/crates/edr_provider/tests/integration/timestamp.rs
@@ -2,11 +2,11 @@
 
 use std::sync::Arc;
 
-use edr_eth::{B256, PreEip1898BlockSpec, l1::L1ChainSpec};
+use edr_eth::{l1::L1ChainSpec, PreEip1898BlockSpec, B256};
 use edr_provider::{
-    MethodInvocation, NoopLogger, Provider, ProviderRequest, Timestamp,
     test_utils::create_test_config,
     time::{MockTime, TimeSinceEpoch},
+    MethodInvocation, NoopLogger, Provider, ProviderRequest, Timestamp,
 };
 use edr_solidity::contract_decoder::ContractDecoder;
 use tokio::runtime;

--- a/crates/edr_rpc_client/src/cache/block_spec.rs
+++ b/crates/edr_rpc_client/src/cache/block_spec.rs
@@ -1,4 +1,4 @@
-use edr_eth::{B256, BlockSpec, BlockTag, Eip1898BlockSpec, PreEip1898BlockSpec};
+use edr_eth::{BlockSpec, BlockTag, Eip1898BlockSpec, PreEip1898BlockSpec, B256};
 
 use super::key::CacheKeyVariant;
 

--- a/crates/edr_rpc_client/src/cache/filter.rs
+++ b/crates/edr_rpc_client/src/cache/filter.rs
@@ -1,6 +1,6 @@
 use edr_eth::{
-    Address, B256,
     filter::{LogFilterOptions, OneOrMore},
+    Address, B256,
 };
 
 use super::{block_spec::CacheableBlockSpec, key::CacheKeyVariant};

--- a/crates/edr_rpc_client/src/cache/hasher.rs
+++ b/crates/edr_rpc_client/src/cache/hasher.rs
@@ -1,5 +1,5 @@
-use edr_eth::{Address, B256, U256, reward_percentile::RewardPercentile};
-use sha3::{Digest, Sha3_256, digest::FixedOutput};
+use edr_eth::{reward_percentile::RewardPercentile, Address, B256, U256};
+use sha3::{digest::FixedOutput, Digest, Sha3_256};
 
 use super::{
     block_spec::{CacheableBlockSpec, UnresolvedBlockTagError},

--- a/crates/edr_rpc_client/src/cache/key.rs
+++ b/crates/edr_rpc_client/src/cache/key.rs
@@ -1,8 +1,8 @@
-use edr_eth::block::{IsSafeBlockNumberArgs, is_safe_block_number};
+use edr_eth::block::{is_safe_block_number, IsSafeBlockNumberArgs};
 
 use super::{
-    CacheableMethod, block_spec::CacheableBlockSpec, filter::CacheableLogFilterRange,
-    hasher::KeyHasher,
+    block_spec::CacheableBlockSpec, filter::CacheableLogFilterRange, hasher::KeyHasher,
+    CacheableMethod,
 };
 
 /// Trait for retrieving the unique id of an enum variant.

--- a/crates/edr_rpc_client/src/client.rs
+++ b/crates/edr_rpc_client/src/client.rs
@@ -8,30 +8,30 @@ use std::{
 };
 
 use edr_eth::{
+    block::{block_time, is_safe_block_number, IsSafeBlockNumberArgs},
     U64,
-    block::{IsSafeBlockNumberArgs, block_time, is_safe_block_number},
 };
-use futures::{TryFutureExt, future};
+use futures::{future, TryFutureExt};
 use hyper::header::HeaderValue;
-pub use hyper::{HeaderMap, header};
+pub use hyper::{header, HeaderMap};
 use reqwest::Client as HttpClient;
 use reqwest_middleware::{ClientBuilder as HttpClientBuilder, ClientWithMiddleware};
-use reqwest_retry::{RetryTransientMiddleware, policies::ExponentialBackoff};
+use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware};
 #[cfg(feature = "tracing")]
 use reqwest_tracing::TracingMiddleware;
-use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use tokio::sync::{OnceCell, RwLock};
 use uuid::Uuid;
 
 use crate::{
     cache::{
-        self, CacheableMethod, CachedBlockNumber,
+        self,
         chain_id::chain_id_from_url,
         key::{
             CacheKeyForUncheckedBlockNumber, CacheKeyForUnresolvedBlockTag, ReadCacheKey,
             ResolvedSymbolicTag, WriteCacheKey,
         },
-        remove_from_cache,
+        remove_from_cache, CacheableMethod, CachedBlockNumber,
     },
     error::{MiddlewareError, ReqwestError},
     jsonrpc,
@@ -672,11 +672,11 @@ mod tests {
     use edr_eth::PreEip1898BlockSpec;
 
     use self::cache::{
-        KeyHasher,
         block_spec::{
             CacheableBlockSpec, PreEip1898BlockSpecNotCacheableError, UnresolvedBlockTagError,
         },
         key::CacheKeyVariant,
+        KeyHasher,
     };
     use super::*;
 
@@ -991,12 +991,10 @@ mod tests {
             }
 
             // Latest block number is never cacheable
-            assert!(
-                !client
-                    .is_cacheable_block_number(latest_block_number)
-                    .await
-                    .unwrap()
-            );
+            assert!(!client
+                .is_cacheable_block_number(latest_block_number)
+                .await
+                .unwrap());
 
             assert!(client.is_cacheable_block_number(16220843).await.unwrap());
         }

--- a/crates/edr_rpc_eth/src/block.rs
+++ b/crates/edr_rpc_eth/src/block.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use edr_eth::{Address, B64, B256, Bloom, Bytes, U256, block::BlobGas, withdrawal::Withdrawal};
+use edr_eth::{block::BlobGas, withdrawal::Withdrawal, Address, Bloom, Bytes, B256, B64, U256};
 use serde::{Deserialize, Serialize};
 
 use crate::spec::GetBlockNumber;

--- a/crates/edr_rpc_eth/src/cacheable_method_invocation.rs
+++ b/crates/edr_rpc_eth/src/cacheable_method_invocation.rs
@@ -1,15 +1,16 @@
-use edr_eth::{Address, B256, U256, reward_percentile::RewardPercentile};
+use edr_eth::{reward_percentile::RewardPercentile, Address, B256, U256};
 use edr_rpc_client::{
-    RpcMethod,
     cache::{
-        self, CacheableMethod,
+        self,
         block_spec::{
             BlockSpecNotCacheableError, CacheableBlockSpec, PreEip1898BlockSpecNotCacheableError,
             UnresolvedBlockTagError,
         },
         filter::{CacheableLogFilterOptions, LogFilterOptionsNotCacheableError},
         key::{CacheKeyVariant, ReadCacheKey, WriteCacheKey},
+        CacheableMethod,
     },
+    RpcMethod,
 };
 
 use crate::request_methods::RequestMethod;

--- a/crates/edr_rpc_eth/src/call_request.rs
+++ b/crates/edr_rpc_eth/src/call_request.rs
@@ -1,6 +1,6 @@
 use edr_eth::{
-    Address, B256, Blob, Bytes, U256,
     eips::{eip2930, eip7702},
+    Address, Blob, Bytes, B256, U256,
 };
 
 /// For specifying input to methods requiring a transaction object, like

--- a/crates/edr_rpc_eth/src/client.rs
+++ b/crates/edr_rpc_eth/src/client.rs
@@ -2,15 +2,15 @@ use std::{fmt::Debug, path::PathBuf};
 
 use derive_where::derive_where;
 use edr_eth::{
-    Address, B256, BlockSpec, Bytecode, Bytes, PreEip1898BlockSpec, U64, U256,
     account::{AccountInfo, KECCAK_EMPTY},
     fee_history::FeeHistoryResult,
     filter::{LogFilterOptions, OneOrMore},
     log::FilterLog,
     reward_percentile::RewardPercentile,
+    Address, BlockSpec, Bytecode, Bytes, PreEip1898BlockSpec, B256, U256, U64,
 };
 use edr_rpc_client::RpcClient;
-pub use edr_rpc_client::{HeaderMap, RpcClientError, header};
+pub use edr_rpc_client::{header, HeaderMap, RpcClientError};
 use futures::StreamExt;
 
 use crate::{
@@ -393,7 +393,7 @@ mod tests {
     mod alchemy {
         use std::{fs::File, path::PathBuf};
 
-        use edr_eth::{Address, BlockSpec, Bytes, PreEip1898BlockSpec, U256, filter::OneOrMore};
+        use edr_eth::{filter::OneOrMore, Address, BlockSpec, Bytes, PreEip1898BlockSpec, U256};
         use edr_test_utils::env::get_alchemy_url;
         use walkdir::WalkDir;
 

--- a/crates/edr_rpc_eth/src/lib.rs
+++ b/crates/edr_rpc_eth/src/lib.rs
@@ -17,7 +17,7 @@ pub mod spec;
 mod test_utils;
 mod transaction;
 
-pub use edr_rpc_client::{HeaderMap, error, header, jsonrpc};
+pub use edr_rpc_client::{error, header, jsonrpc, HeaderMap};
 
 pub use self::{
     block::Block,

--- a/crates/edr_rpc_eth/src/override.rs
+++ b/crates/edr_rpc_eth/src/override.rs
@@ -1,4 +1,4 @@
-use edr_eth::{Address, B256, Bytes, HashMap, U256};
+use edr_eth::{Address, Bytes, HashMap, B256, U256};
 
 /// Type representing a set of overrides for storage information.
 pub type StorageOverride = HashMap<B256, U256>;

--- a/crates/edr_rpc_eth/src/receipt.rs
+++ b/crates/edr_rpc_eth/src/receipt.rs
@@ -1,5 +1,4 @@
 use edr_eth::{
-    Address, B256, Bloom,
     eips::{eip2718::TypedEnvelope, eip7702},
     l1,
     log::FilterLog,
@@ -7,6 +6,7 @@ use edr_eth::{
         self, AsExecutionReceipt as _, Execution, ExecutionReceipt as _, TransactionReceipt,
     },
     transaction::{self, TransactionType as _},
+    Address, Bloom, B256,
 };
 use serde::{Deserialize, Serialize};
 
@@ -284,10 +284,10 @@ impl TryFrom<Block>
 mod test {
     use assert_json_diff::assert_json_eq;
     use edr_eth::{
-        Bloom, Bytes,
         eips::eip2718::TypedEnvelope,
         l1::{self, L1ChainSpec},
         log::ExecutionLog,
+        Bloom, Bytes,
     };
     use edr_evm::block::EthBlockReceiptFactory;
     use serde_json::json;

--- a/crates/edr_rpc_eth/src/request_methods.rs
+++ b/crates/edr_rpc_eth/src/request_methods.rs
@@ -1,6 +1,6 @@
 use edr_eth::{
-    Address, B256, BlockSpec, PreEip1898BlockSpec, U256, filter::LogFilterOptions,
-    reward_percentile::RewardPercentile,
+    filter::LogFilterOptions, reward_percentile::RewardPercentile, Address, BlockSpec,
+    PreEip1898BlockSpec, B256, U256,
 };
 
 /// Methods for requests to a remote Ethereum node. Only contains methods

--- a/crates/edr_rpc_eth/src/spec.rs
+++ b/crates/edr_rpc_eth/src/spec.rs
@@ -1,7 +1,7 @@
 use edr_eth::{eips::eip2718::TypedEnvelope, l1::L1ChainSpec, receipt::ExecutionReceipt};
-use serde::{Serialize, de::DeserializeOwned};
+use serde::{de::DeserializeOwned, Serialize};
 
-use crate::{CallRequest, receipt::Block};
+use crate::{receipt::Block, CallRequest};
 
 /// Trait for specifying Ethereum-based JSON-RPC method types.
 pub trait RpcSpec {

--- a/crates/edr_rpc_eth/src/transaction.rs
+++ b/crates/edr_rpc_eth/src/transaction.rs
@@ -3,11 +3,12 @@ mod request;
 use std::{ops::Deref, sync::OnceLock};
 
 use edr_eth::{
-    Address, B256, Bytes, U256, block,
+    block,
     eips::{eip2930, eip7702},
     l1,
     signature::{self, SignatureWithYParity, SignatureWithYParityArgs},
     transaction::{self, ExecutableTransaction, IsEip4844, IsLegacy, TransactionType, TxKind},
+    Address, Bytes, B256, U256,
 };
 
 pub use self::request::TransactionRequest;

--- a/crates/edr_rpc_eth/src/transaction/request.rs
+++ b/crates/edr_rpc_eth/src/transaction/request.rs
@@ -1,6 +1,6 @@
 use edr_eth::{
-    Address, B256, Blob, Bytes, U256,
     eips::{eip2930, eip7702},
+    Address, Blob, Bytes, B256, U256,
 };
 
 /// Represents _all_ transaction requests received from RPC

--- a/crates/edr_scenarios/src/lib.rs
+++ b/crates/edr_scenarios/src/lib.rs
@@ -8,7 +8,7 @@ pub mod old;
 use std::{num::NonZeroU64, path::PathBuf, time::SystemTime};
 
 use chrono::{DateTime, Utc};
-use edr_eth::{Address, B256, ChainId, HashMap, block::BlobGas};
+use edr_eth::{block::BlobGas, Address, ChainId, HashMap, B256};
 use edr_evm::hardfork::ChainOverride;
 use edr_napi_core::provider::Config as ProviderConfig;
 use edr_provider::{AccountOverride, ForkConfig, MiningConfig};

--- a/crates/edr_solidity/benches/contracts_identifier.rs
+++ b/crates/edr_solidity/benches/contracts_identifier.rs
@@ -15,7 +15,7 @@
 //!    3.2. `cargo bench contracts_identifier`
 use std::{fs, path::PathBuf, time::Duration};
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use edr_solidity::{
     artifacts::{BuildInfoConfig, BuildInfoWithOutput},
     contract_decoder::ContractDecoder,

--- a/crates/edr_solidity/src/bytecode_trie.rs
+++ b/crates/edr_solidity/src/bytecode_trie.rs
@@ -1,6 +1,6 @@
 use std::{
     cmp::Ordering,
-    collections::{HashMap, hash_map::Entry},
+    collections::{hash_map::Entry, HashMap},
     fmt::Debug,
     sync::Arc,
 };

--- a/crates/edr_solidity/src/contract_decoder.rs
+++ b/crates/edr_solidity/src/contract_decoder.rs
@@ -1,7 +1,7 @@
 //! Enriches the [`NestedTrace`] with the resolved [`ContractMetadata`].
 use std::sync::Arc;
 
-use edr_eth::{Bytes, spec::HaltReasonTrait};
+use edr_eth::{spec::HaltReasonTrait, Bytes};
 use parking_lot::RwLock;
 
 use super::{

--- a/crates/edr_solidity/src/contracts_identifier.rs
+++ b/crates/edr_solidity/src/contracts_identifier.rs
@@ -7,7 +7,7 @@
 
 use std::{borrow::Cow, collections::HashMap, sync::Arc};
 
-use edr_eth::{Address, bytecode::opcode::OpCode};
+use edr_eth::{bytecode::opcode::OpCode, Address};
 
 use crate::{
     build_model::ContractMetadata,

--- a/crates/edr_solidity/src/error_inferrer.rs
+++ b/crates/edr_solidity/src/error_inferrer.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, collections::HashSet, mem};
 
 use alloy_dyn_abi::{DynSolValue, JsonAbiExt};
-use edr_eth::{U256, bytecode::opcode::OpCode, hex, spec::HaltReasonTrait};
+use edr_eth::{bytecode::opcode::OpCode, hex, spec::HaltReasonTrait, U256};
 use semver::{Version, VersionReq};
 
 use crate::{
@@ -14,8 +14,8 @@ use crate::{
     },
     return_data::ReturnData,
     solidity_stack_trace::{
-        CONSTRUCTOR_FUNCTION_NAME, FALLBACK_FUNCTION_NAME, RECEIVE_FUNCTION_NAME, SourceReference,
-        StackTraceEntry,
+        SourceReference, StackTraceEntry, CONSTRUCTOR_FUNCTION_NAME, FALLBACK_FUNCTION_NAME,
+        RECEIVE_FUNCTION_NAME,
     },
 };
 

--- a/crates/edr_solidity/src/nested_trace.rs
+++ b/crates/edr_solidity/src/nested_trace.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use derive_where::derive_where;
-use edr_eth::{Address, Bytes, U256, spec::HaltReasonTrait};
+use edr_eth::{spec::HaltReasonTrait, Address, Bytes, U256};
 
 use crate::{build_model::ContractMetadata, exit_code::ExitCode};
 

--- a/crates/edr_solidity/src/nested_tracer.rs
+++ b/crates/edr_solidity/src/nested_tracer.rs
@@ -2,7 +2,7 @@
 
 use std::{cell::RefCell, rc::Rc};
 
-use edr_eth::{Address, Bytes, U160, U256, result::ExecutionResult, spec::HaltReasonTrait};
+use edr_eth::{result::ExecutionResult, spec::HaltReasonTrait, Address, Bytes, U160, U256};
 use edr_evm::trace::{BeforeMessage, Step};
 
 use crate::{

--- a/crates/edr_solidity/src/solidity_tracer.rs
+++ b/crates/edr_solidity/src/solidity_tracer.rs
@@ -7,7 +7,7 @@ use crate::{
     error_inferrer,
     error_inferrer::{InferrerError, SubmessageData},
     mapped_inline_internal_functions_heuristics::{
-        HeuristicsError, adjust_stack_trace, stack_trace_may_require_adjustments,
+        adjust_stack_trace, stack_trace_may_require_adjustments, HeuristicsError,
     },
     nested_trace::{
         CallMessage, CreateMessage, CreateOrCallMessage, CreateOrCallMessageRef, EvmStep,

--- a/crates/edr_test_utils/src/secret_key.rs
+++ b/crates/edr_test_utils/src/secret_key.rs
@@ -2,8 +2,8 @@ pub use edr_eth::signature::{SecretKey, SignatureError};
 #[allow(deprecated)]
 // This is test code, it's ok to use `DangerousSecretKeyStr`
 use edr_eth::{
+    signature::{public_key_to_address, DangerousSecretKeyStr},
     Address,
-    signature::{DangerousSecretKeyStr, public_key_to_address},
 };
 
 /// Converts a hex string to a secret key.

--- a/crates/tools/src/execution_api.rs
+++ b/crates/tools/src/execution_api.rs
@@ -8,7 +8,7 @@ use std::{
 use anyhow::{anyhow, bail};
 use cfg_if::cfg_if;
 
-use crate::update::{Mode, project_root};
+use crate::update::{project_root, Mode};
 
 const EXECUTION_API_DIR: &str = "crates/eth_execution_api";
 const EXECUTION_API_RAW_REPO: &str = "https://raw.githubusercontent.com/ethereum/execution-apis";

--- a/crates/tools/src/remote_block.rs
+++ b/crates/tools/src/remote_block.rs
@@ -8,7 +8,7 @@ use edr_eth::{
     receipt::AsExecutionReceipt,
     transaction::TransactionValidation,
 };
-use edr_evm::{BlockReceipts, blockchain::BlockchainErrorForChainSpec, test_utils::run_full_block};
+use edr_evm::{blockchain::BlockchainErrorForChainSpec, test_utils::run_full_block, BlockReceipts};
 use edr_op::OpChainSpec;
 use edr_provider::spec::SyncRuntimeSpec;
 use edr_rpc_eth::client::EthRpcClient;

--- a/crates/tools/src/scenario.rs
+++ b/crates/tools/src/scenario.rs
@@ -11,18 +11,18 @@ use edr_eth::l1;
 use edr_evm::{blockchain::BlockchainErrorForChainSpec, spec::RuntimeSpec};
 use edr_generic::GenericChainSpec;
 use edr_napi_core::spec::SyncNapiSpec;
-use edr_provider::{Logger, ProviderErrorForChainSpec, ProviderRequest, time::CurrentTime};
+use edr_provider::{time::CurrentTime, Logger, ProviderErrorForChainSpec, ProviderRequest};
 use edr_rpc_eth::jsonrpc;
 use edr_scenarios::ScenarioConfig;
 use edr_solidity::contract_decoder::ContractDecoder;
-use flate2::{Compression, bufread::GzDecoder, write::GzEncoder};
+use flate2::{bufread::GzDecoder, write::GzEncoder, Compression};
 use indicatif::ProgressBar;
 use tokio::{
     io::{AsyncBufReadExt, AsyncWriteExt as _},
     runtime, task,
 };
 #[cfg(feature = "tracing")]
-use tracing_subscriber::{Registry, prelude::*};
+use tracing_subscriber::{prelude::*, Registry};
 
 fn convert_gzipped_json(path: PathBuf) -> anyhow::Result<()> {
     use std::{


### PR DESCRIPTION
Downgrade to Rust edition 2021 for compatibility with `feat/solidity-tests. We [originally](https://github.com/NomicFoundation/edr/pull/856) bumped the Rust edition to 2024 in main for compatibility with REVM 21, but that doesn't seem necessary anymore.

This PR contains two types of changes:
- Changes the edition to 2021 in the root Cargo.toml
- Runs rustfmt that reorders the imports as they're sorted differently between the editions