### PR TITLE
chore: fix workflow caching of rpc requests

### DIFF
--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -58,8 +58,7 @@ jobs:
         with:
           path: |
             **/edr-cache
-          key: edr-rs-rpc-cache-v1
-          enableCrossOsArchive: true
+          key: edr-rs-rpc-cache-v1-${{ matrix.os }}
 
       - name: Run cargo tests (with coverage)
         env:
@@ -83,8 +82,7 @@ jobs:
         with:
           path: |
             **/edr-cache
-          key: edr-rs-rpc-cache-v1-${{ hashFiles('**/edr-cache/**/*') }}
-          enableCrossOsArchive: true
+          key: edr-rs-rpc-cache-v1-${{ matrix.os }}-${{ hashFiles('**/edr-cache/**/*') }}
 
       # disable until:
       # 1) https://github.com/napi-rs/napi-rs/issues/1405 is resolved (Windows-only)
@@ -124,8 +122,7 @@ jobs:
         with:
           path: |
             **/edr-cache
-          key: edr-ts-rpc-cache-v1
-          enableCrossOsArchive: true
+          key: edr-ts-rpc-cache-v1-${{ matrix.os }}
 
       - name: Install package
         run: pnpm install --frozen-lockfile --prefer-offline
@@ -140,8 +137,7 @@ jobs:
         with:
           path: |
             **/edr-cache
-          key: edr-ts-rpc-cache-v1-${{ hashFiles('**/edr-cache/**/*') }}
-          enableCrossOsArchive: true
+          key: edr-ts-rpc-cache-v1-${{ matrix.os }}-${{ hashFiles('**/edr-cache/**/*') }}
 
   edr-style:
     name: Check EDR Style

--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -58,7 +58,9 @@ jobs:
         with:
           path: |
             **/edr-cache
-          key: edr-rs-rpc-cache-v1
+          key: edr-rs-rpc-cache-v1-${{ hashFiles('**/edr-cache/**/*') }}
+          restore-keys: edr-rs-rpc-cache-v1
+          enableCrossOsArchive: true
 
       - name: Run cargo tests (with coverage)
         env:
@@ -115,7 +117,9 @@ jobs:
         with:
           path: |
             **/edr-cache
-          key: edr-ts-rpc-cache-v1
+          key: edr-ts-rpc-cache-v1-${{ hashFiles('**/edr-cache/**/*') }}
+          restore-keys: edr-ts-rpc-cache-v1
+          enableCrossOsArchive: true
 
       - name: Install package
         run: pnpm install --frozen-lockfile --prefer-offline

--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -53,13 +53,12 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 
-      - name: Cache EDR RPC cache
-        uses: actions/cache@v4
+      - name: Restore EDR RPC cache
+        uses: actions/cache/restore@v4
         with:
           path: |
             **/edr-cache
-          key: edr-rs-rpc-cache-v1-${{ hashFiles('**/edr-cache/**/*') }}
-          restore-keys: edr-rs-rpc-cache-v1
+          key: edr-rs-rpc-cache-v1
           enableCrossOsArchive: true
 
       - name: Run cargo tests (with coverage)
@@ -78,6 +77,14 @@ jobs:
 
       - name: Doctests
         run: cargo test --doc --workspace --features tracing
+
+      - name: Save EDR RPC cache
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            **/edr-cache
+          key: edr-rs-rpc-cache-v1-${{ hashFiles('**/edr-cache/**/*') }}
+          enableCrossOsArchive: true
 
       # disable until:
       # 1) https://github.com/napi-rs/napi-rs/issues/1405 is resolved (Windows-only)
@@ -112,13 +119,12 @@ jobs:
 
       - uses: ./.github/actions/setup-rust
 
-      - name: Cache EDR RPC cache
-        uses: actions/cache@v4
+      - name: Restore EDR RPC cache
+        uses: actions/cache/restore@v4
         with:
           path: |
             **/edr-cache
-          key: edr-ts-rpc-cache-v1-${{ hashFiles('**/edr-cache/**/*') }}
-          restore-keys: edr-ts-rpc-cache-v1
+          key: edr-ts-rpc-cache-v1
           enableCrossOsArchive: true
 
       - name: Install package
@@ -128,6 +134,14 @@ jobs:
         env:
           ALCHEMY_URL: ${{ secrets.ALCHEMY_URL }}
         run: cd crates/edr_napi && pnpm test
+
+      - name: Save EDR RPC cache
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            **/edr-cache
+          key: edr-ts-rpc-cache-v1-${{ hashFiles('**/edr-cache/**/*') }}
+          enableCrossOsArchive: true
 
   edr-style:
     name: Check EDR Style


### PR DESCRIPTION
We've identified potential issues with the use of GitHub Actions cache for RPC requests.

The cache at a key is immutable (except for evictions), once a cache key is written to it won't be updated. This is an issue for the RPC requests cache because the set of RPC requests can change as tests are added or depend on the OS (some tests are OS-specific). This PR fixes that by hashing the cache contents and using that in the key. Since the contents aren't known until the end of the run we always restore from the most recently created cache via `restore-keys`.

~Another issue is that caches are by default not shared across OSs. So the Windows run is not sharing a cache with the Ubuntu and macOS runs. This PR enables cross-OS caching.~ &rarr; Disabling this since some tests are OS-specific.