### PR TITLE
ci: disable test that times out

### DIFF
--- a/crates/edr_napi/test/issues.ts
+++ b/crates/edr_napi/test/issues.ts
@@ -79,6 +79,7 @@ describe("Provider", () => {
     }
 
     // GitHub Actions time out for this task on Ubuntu and MacOS.
+    // TODO https://github.com/NomicFoundation/edr/issues/952
     if (
       isCI() &&
       (process.platform === "linux" || process.platform === "darwin")


### PR DESCRIPTION
Disable "issue 543" `edr_napi` test on Ubuntu and MacOS that regularly times out in CI on these platforms. Locally the test passes for me on Ubuntu.