### PR TITLE
chore: replace Buffer with Uint8Array in Solidity tests interface

### DIFF
--- a/.changeset/rotten-vans-divide.md
+++ b/.changeset/rotten-vans-divide.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": minor
+---
+
+Replaced `Buffer` with `Uint8Array` in Solidity tests interface

--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -524,12 +524,12 @@ export interface SolidityTestRunnerConfigArgs {
    * The value of `msg.sender` in tests as hex string.
    * Defaults to `0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38`.
    */
-  sender?: Buffer
+  sender?: Uint8Array
   /**
    * The value of `tx.origin` in tests as hex string.
    * Defaults to `0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38`.
    */
-  txOrigin?: Buffer
+  txOrigin?: Uint8Array
   /**
    * The initial balance of the sender in tests.
    * Defaults to `0xffffffffffffffffffffffff`.
@@ -564,7 +564,7 @@ export interface SolidityTestRunnerConfigArgs {
    * The value of `block.coinbase` in tests.
    * Defaults to `0x0000000000000000000000000000000000000000`.
    */
-  blockCoinbase?: Buffer
+  blockCoinbase?: Uint8Array
   /**
    * The value of `block.timestamp` in tests.
    * Defaults to 1.
@@ -772,7 +772,7 @@ export enum FsAccessPermission {
 }
 export interface AddressLabel {
   /** The address to label */
-  address: Buffer
+  address: Uint8Array
   /** The label to assign to the address */
   label: string
 }
@@ -860,7 +860,7 @@ export interface FuzzTestKind {
 /** See [edr_solidity_tests::fuzz::FuzzCase] */
 export interface FuzzCase {
   /** The calldata used for this fuzz test */
-  readonly calldata: Buffer
+  readonly calldata: Uint8Array
   /** Consumed gas */
   readonly gas: bigint
   /** The initial gas stipend for the transaction */
@@ -888,11 +888,11 @@ export interface CounterExampleSequence {
 /** See [edr_solidity_tests::fuzz::BaseCounterExample] */
 export interface BaseCounterExample {
   /** See [edr_solidity_tests::fuzz::BaseCounterExample::sender] */
-  readonly sender?: Buffer
+  readonly sender?: Uint8Array
   /** See [edr_solidity_tests::fuzz::BaseCounterExample::addr] */
-  readonly address?: Buffer
+  readonly address?: Uint8Array
   /** See [edr_solidity_tests::fuzz::BaseCounterExample::calldata] */
-  readonly calldata: Buffer
+  readonly calldata: Uint8Array
   /** See [edr_solidity_tests::fuzz::BaseCounterExample::contract_name] */
   readonly contractName?: string
   /** See [edr_solidity_tests::fuzz::BaseCounterExample::signature] */

--- a/crates/edr_napi/src/cast.rs
+++ b/crates/edr_napi/src/cast.rs
@@ -1,6 +1,6 @@
 use edr_eth::{Address, Bytecode, Bytes, B256, B64, U256};
 use napi::{
-    bindgen_prelude::{BigInt, Buffer, Uint8Array},
+    bindgen_prelude::{BigInt, Uint8Array},
     Status,
 };
 
@@ -13,20 +13,6 @@ pub trait TryCast<T>: Sized {
 
     /// Performs the conversion.
     fn try_cast(self) -> Result<T, Self::Error>;
-}
-
-impl TryCast<Address> for Buffer {
-    type Error = napi::Error;
-
-    fn try_cast(self) -> std::result::Result<Address, Self::Error> {
-        if self.len() != 20 {
-            return Err(napi::Error::new(
-                Status::InvalidArg,
-                "Buffer was expected to be 20 bytes.".to_string(),
-            ));
-        }
-        Ok(Address::from_slice(&self))
-    }
 }
 
 impl TryCast<Address> for Uint8Array {

--- a/crates/edr_napi/src/serde.rs
+++ b/crates/edr_napi/src/serde.rs
@@ -1,9 +1,9 @@
 use edr_eth::hex;
-use napi::bindgen_prelude::{BigInt, Buffer};
+use napi::bindgen_prelude::{BigInt, Uint8Array};
 use serde::Serializer;
 
-/// Serialize a Buffer as a 0x-prefixed hex string
-pub fn serialize_buffer_as_hex<S>(buffer: &Buffer, serializer: S) -> Result<S::Ok, S::Error>
+/// Serialize a Uint8Array as a 0x-prefixed hex string
+pub fn serialize_uint8array_as_hex<S>(buffer: &Uint8Array, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
@@ -11,9 +11,9 @@ where
     serializer.serialize_str(&hex_string)
 }
 
-/// Serialize an Option<Buffer> as a 0x-prefixed hex string or None
-pub fn serialize_optional_buffer_as_hex<S>(
-    buffer: &Option<Buffer>,
+/// Serialize an Option<Uint8Array> as a 0x-prefixed hex string or None
+pub fn serialize_optional_uint8array_as_hex<S>(
+    buffer: &Option<Uint8Array>,
     serializer: S,
 ) -> Result<S::Ok, S::Error>
 where

--- a/crates/edr_napi/src/serde.rs
+++ b/crates/edr_napi/src/serde.rs
@@ -2,7 +2,7 @@ use edr_eth::hex;
 use napi::bindgen_prelude::{BigInt, Uint8Array};
 use serde::Serializer;
 
-/// Serialize a Uint8Array as a 0x-prefixed hex string
+/// Serialize a `Uint8Array` as a 0x-prefixed hex string
 pub fn serialize_uint8array_as_hex<S>(buffer: &Uint8Array, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,

--- a/crates/edr_napi/src/solidity_tests/config.rs
+++ b/crates/edr_napi/src/solidity_tests/config.rs
@@ -9,7 +9,7 @@ use edr_solidity_tests::{
 };
 use foundry_cheatcodes::{FsPermissions, RpcEndpoint, RpcEndpoints};
 use napi::{
-    bindgen_prelude::{BigInt, Buffer},
+    bindgen_prelude::{BigInt, Uint8Array},
     Either, Status,
 };
 use napi_derive::napi;
@@ -17,8 +17,8 @@ use napi_derive::napi;
 use crate::{
     cast::TryCast,
     serde::{
-        serialize_buffer_as_hex, serialize_optional_bigint_as_struct,
-        serialize_optional_buffer_as_hex,
+        serialize_uint8array_as_hex, serialize_optional_bigint_as_struct,
+        serialize_optional_uint8array_as_hex,
     },
 };
 
@@ -49,12 +49,12 @@ pub struct SolidityTestRunnerConfigArgs {
     pub ffi: Option<bool>,
     /// The value of `msg.sender` in tests as hex string.
     /// Defaults to `0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38`.
-    #[serde(serialize_with = "serialize_optional_buffer_as_hex")]
-    pub sender: Option<Buffer>,
+    #[serde(serialize_with = "serialize_optional_uint8array_as_hex")]
+    pub sender: Option<Uint8Array>,
     /// The value of `tx.origin` in tests as hex string.
     /// Defaults to `0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38`.
-    #[serde(serialize_with = "serialize_optional_buffer_as_hex")]
-    pub tx_origin: Option<Buffer>,
+    #[serde(serialize_with = "serialize_optional_uint8array_as_hex")]
+    pub tx_origin: Option<Uint8Array>,
     /// The initial balance of the sender in tests.
     /// Defaults to `0xffffffffffffffffffffffff`.
     #[serde(serialize_with = "serialize_optional_bigint_as_struct")]
@@ -81,8 +81,8 @@ pub struct SolidityTestRunnerConfigArgs {
     pub block_base_fee_per_gas: Option<BigInt>,
     /// The value of `block.coinbase` in tests.
     /// Defaults to `0x0000000000000000000000000000000000000000`.
-    #[serde(serialize_with = "serialize_optional_buffer_as_hex")]
-    pub block_coinbase: Option<Buffer>,
+    #[serde(serialize_with = "serialize_optional_uint8array_as_hex")]
+    pub block_coinbase: Option<Uint8Array>,
     /// The value of `block.timestamp` in tests.
     /// Defaults to 1.
     #[serde(serialize_with = "serialize_optional_bigint_as_struct")]
@@ -707,8 +707,8 @@ impl From<FsAccessPermission> for foundry_cheatcodes::FsAccessPermission {
 #[derive(Clone, serde::Serialize)]
 pub struct AddressLabel {
     /// The address to label
-    #[serde(serialize_with = "serialize_buffer_as_hex")]
-    pub address: Buffer,
+    #[serde(serialize_with = "serialize_uint8array_as_hex")]
+    pub address: Uint8Array,
     /// The label to assign to the address
     pub label: String,
 }

--- a/crates/edr_napi/src/solidity_tests/config.rs
+++ b/crates/edr_napi/src/solidity_tests/config.rs
@@ -17,8 +17,8 @@ use napi_derive::napi;
 use crate::{
     cast::TryCast,
     serde::{
-        serialize_uint8array_as_hex, serialize_optional_bigint_as_struct,
-        serialize_optional_uint8array_as_hex,
+        serialize_optional_bigint_as_struct, serialize_optional_uint8array_as_hex,
+        serialize_uint8array_as_hex,
     },
 };
 

--- a/crates/edr_napi/src/solidity_tests/test_results.rs
+++ b/crates/edr_napi/src/solidity_tests/test_results.rs
@@ -407,8 +407,12 @@ impl Debug for BaseCounterExample {
 impl From<edr_solidity_tests::fuzz::BaseCounterExample> for BaseCounterExample {
     fn from(value: edr_solidity_tests::fuzz::BaseCounterExample) -> Self {
         Self {
-            sender: value.sender.map(|sender| Uint8Array::from(sender.as_slice())),
-            address: value.addr.map(|address| Uint8Array::from(address.as_slice())),
+            sender: value
+                .sender
+                .map(|sender| Uint8Array::from(sender.as_slice())),
+            address: value
+                .addr
+                .map(|address| Uint8Array::from(address.as_slice())),
             calldata: Uint8Array::from(value.calldata.as_ref()),
             contract_name: value.contract_name,
             signature: value.signature,

--- a/crates/edr_napi/src/solidity_tests/test_results.rs
+++ b/crates/edr_napi/src/solidity_tests/test_results.rs
@@ -409,11 +409,11 @@ impl From<edr_solidity_tests::fuzz::BaseCounterExample> for BaseCounterExample {
         Self {
             sender: value
                 .sender
-                .map(|sender| Uint8Array::with_data_copied(sender.as_slice())),
+                .map(|sender| Uint8Array::with_data_copied(sender)),
             address: value
                 .addr
-                .map(|address| Uint8Array::with_data_copied(address.as_slice())),
-            calldata: Uint8Array::with_data_copied(value.calldata.as_ref()),
+                .map(|address| Uint8Array::with_data_copied(address)),
+            calldata: Uint8Array::with_data_copied(value.calldata),
             contract_name: value.contract_name,
             signature: value.signature,
             args: value.args,

--- a/crates/edr_napi/src/solidity_tests/test_results.rs
+++ b/crates/edr_napi/src/solidity_tests/test_results.rs
@@ -409,11 +409,11 @@ impl From<edr_solidity_tests::fuzz::BaseCounterExample> for BaseCounterExample {
         Self {
             sender: value
                 .sender
-                .map(|sender| Uint8Array::from(sender.as_slice())),
+                .map(|sender| Uint8Array::with_data_copied(sender.as_slice())),
             address: value
                 .addr
-                .map(|address| Uint8Array::from(address.as_slice())),
-            calldata: Uint8Array::from(value.calldata.as_ref()),
+                .map(|address| Uint8Array::with_data_copied(address.as_slice())),
+            calldata: Uint8Array::with_data_copied(value.calldata.as_ref()),
             contract_name: value.contract_name,
             signature: value.signature,
             args: value.args,

--- a/crates/edr_napi/src/solidity_tests/test_results.rs
+++ b/crates/edr_napi/src/solidity_tests/test_results.rs
@@ -409,10 +409,10 @@ impl From<edr_solidity_tests::fuzz::BaseCounterExample> for BaseCounterExample {
         Self {
             sender: value
                 .sender
-                .map(|sender| Uint8Array::with_data_copied(sender)),
+                .map(Uint8Array::with_data_copied),
             address: value
                 .addr
-                .map(|address| Uint8Array::with_data_copied(address)),
+                .map(Uint8Array::with_data_copied),
             calldata: Uint8Array::with_data_copied(value.calldata),
             contract_name: value.contract_name,
             signature: value.signature,

--- a/crates/edr_napi/src/solidity_tests/test_results.rs
+++ b/crates/edr_napi/src/solidity_tests/test_results.rs
@@ -11,7 +11,7 @@ use edr_solidity_tests::{
     traces::{self, CallTraceArena, SparsedTraceArena},
 };
 use napi::{
-    bindgen_prelude::{BigInt, Buffer, Either3, Either4, Uint8Array},
+    bindgen_prelude::{BigInt, Either3, Either4, Uint8Array},
     Either,
 };
 use napi_derive::napi;
@@ -326,7 +326,7 @@ pub struct FuzzTestKind {
 pub struct FuzzCase {
     /// The calldata used for this fuzz test
     #[napi(readonly)]
-    pub calldata: Buffer,
+    pub calldata: Uint8Array,
     /// Consumed gas
     #[napi(readonly)]
     pub gas: BigInt,
@@ -376,13 +376,13 @@ pub struct CounterExampleSequence {
 pub struct BaseCounterExample {
     /// See [edr_solidity_tests::fuzz::BaseCounterExample::sender]
     #[napi(readonly)]
-    pub sender: Option<Buffer>,
+    pub sender: Option<Uint8Array>,
     /// See [edr_solidity_tests::fuzz::BaseCounterExample::addr]
     #[napi(readonly)]
-    pub address: Option<Buffer>,
+    pub address: Option<Uint8Array>,
     /// See [edr_solidity_tests::fuzz::BaseCounterExample::calldata]
     #[napi(readonly)]
-    pub calldata: Buffer,
+    pub calldata: Uint8Array,
     /// See [edr_solidity_tests::fuzz::BaseCounterExample::contract_name]
     #[napi(readonly)]
     pub contract_name: Option<String>,
@@ -407,9 +407,9 @@ impl Debug for BaseCounterExample {
 impl From<edr_solidity_tests::fuzz::BaseCounterExample> for BaseCounterExample {
     fn from(value: edr_solidity_tests::fuzz::BaseCounterExample) -> Self {
         Self {
-            sender: value.sender.map(|sender| Buffer::from(sender.as_slice())),
-            address: value.addr.map(|address| Buffer::from(address.as_slice())),
-            calldata: Buffer::from(value.calldata.as_ref()),
+            sender: value.sender.map(|sender| Uint8Array::from(sender.as_slice())),
+            address: value.addr.map(|address| Uint8Array::from(address.as_slice())),
+            calldata: Uint8Array::from(value.calldata.as_ref()),
             contract_name: value.contract_name,
             signature: value.signature,
             args: value.args,


### PR DESCRIPTION
This PR replaces all occurrences of `Buffer` with `Uint8Array` in Solidity tests interface.

I have also bumped up the minor version since this is a breaking change.

closes #946 