### PR TITLE
test: fix trying to get a compiler before downloaded

### DIFF
--- a/hardhat-tests/test/internal/hardhat-network/stack-traces/compilation.ts
+++ b/hardhat-tests/test/internal/hardhat-network/stack-traces/compilation.ts
@@ -137,6 +137,7 @@ export async function compileFiles(
       longVersion: compilerOptions.solidityVersion,
     };
   } else {
+    await downloadCompiler(compilerOptions.solidityVersion);
     compiler = await getCompilerForVersion(compilerOptions.solidityVersion);
   }
 


### PR DESCRIPTION
Fixes the occasional 

```
HardhatError: HH11: An internal invariant was violated: Trying to get a compiler before it was downloaded
```

error when running stack trace tests.