### PR TITLE
fix: avoid panic on stack trace for receive with modifier

### DIFF
--- a/.changeset/spicy-cameras-fix.md
+++ b/.changeset/spicy-cameras-fix.md
@@ -2,5 +2,4 @@
 "@nomicfoundation/edr": minor
 ---
 
-Fixed panic on stack trace generation for receive function with modifier that calls another
-method. https://github.com/NomicFoundation/edr/issues/894
+Fixed panic on stack trace generation for receive function with modifier that calls another method. https://github.com/NomicFoundation/edr/issues/894

--- a/.changeset/spicy-cameras-fix.md
+++ b/.changeset/spicy-cameras-fix.md
@@ -1,0 +1,6 @@
+---
+"@nomicfoundation/edr": minor
+---
+
+Fixed panic on stack trace generation for receive function with modifier that calls another
+method. https://github.com/NomicFoundation/edr/issues/894

--- a/crates/edr_solidity/src/error_inferrer.rs
+++ b/crates/edr_solidity/src/error_inferrer.rs
@@ -1123,6 +1123,7 @@ fn get_entry_before_initial_modifier_callstack_entry<HaltReasonT: HaltReasonTrai
         // If there is no selector, it must be a transfer.
         contract.receive.as_ref()
     } else {
+        // TODO https://github.com/NomicFoundation/edr/issues/963
         // Defaulting to shorter slice doesn't make much sense at first glance, but we
         // keep it after fixing the receive fallback, as this pattern is consistently
         // used in the codebase.

--- a/crates/edr_solidity/src/error_inferrer.rs
+++ b/crates/edr_solidity/src/error_inferrer.rs
@@ -1119,8 +1119,12 @@ fn get_entry_before_initial_modifier_callstack_entry<HaltReasonT: HaltReasonTrai
         .ok_or(InferrerError::MissingContract)?;
     let contract = contract_meta.contract.read();
 
-    let called_function =
-        contract.get_function_from_selector(trace.calldata.get(..4).unwrap_or(&trace.calldata[..]));
+    let called_function = if let Some(selector) = trace.calldata.get(..4) {
+        contract.get_function_from_selector(selector)
+    } else {
+        // If there is no selector, it must be a transfer.
+        contract.receive.as_ref()
+    };
 
     let source_reference = match called_function {
         Some(called_function) => get_function_start_source_reference(

--- a/hardhat-tests/test/internal/hardhat-network/stack-traces/compilation.ts
+++ b/hardhat-tests/test/internal/hardhat-network/stack-traces/compilation.ts
@@ -137,6 +137,7 @@ export async function compileFiles(
       longVersion: compilerOptions.solidityVersion,
     };
   } else {
+    await downloadCompiler(compilerOptions.solidityVersion);
     compiler = await getCompilerForVersion(compilerOptions.solidityVersion);
   }
 

--- a/hardhat-tests/test/internal/hardhat-network/stack-traces/test-files/0_8/revert-without-message/modifiers/call-message/modifier-private-method/c.sol
+++ b/hardhat-tests/test/internal/hardhat-network/stack-traces/test-files/0_8/revert-without-message/modifiers/call-message/modifier-private-method/c.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+// Repro for https://github.com/NomicFoundation/edr/issues/894
+contract C {
+    bool public isReverted;
+
+    modifier revertIf() {
+        checkReverted();
+        _;
+    }
+
+    function setIsReverted(bool _isReverted) external {
+        isReverted = _isReverted;
+    }
+
+    receive() external payable revertIf {}
+
+    function checkReverted() private view {
+        require(!isReverted, "I'm reverted");
+    }
+}

--- a/hardhat-tests/test/internal/hardhat-network/stack-traces/test-files/0_8/revert-without-message/modifiers/call-message/modifier-private-method/test.json
+++ b/hardhat-tests/test/internal/hardhat-network/stack-traces/test-files/0_8/revert-without-message/modifiers/call-message/modifier-private-method/test.json
@@ -1,5 +1,4 @@
 {
-  "only": true,
   "transactions": [
     {
       "file": "c.sol",

--- a/hardhat-tests/test/internal/hardhat-network/stack-traces/test-files/0_8/revert-without-message/modifiers/call-message/modifier-private-method/test.json
+++ b/hardhat-tests/test/internal/hardhat-network/stack-traces/test-files/0_8/revert-without-message/modifiers/call-message/modifier-private-method/test.json
@@ -1,0 +1,48 @@
+{
+  "only": true,
+  "transactions": [
+    {
+      "file": "c.sol",
+      "contract": "C"
+    },
+    {
+      "to": 0,
+      "params": [true],
+      "function": "setIsReverted"
+    },
+    {
+      "to": 0,
+      "value": 100,
+      "stackTrace": [
+        {
+          "type": "CALLSTACK_ENTRY",
+          "sourceReference": {
+            "contract": "C",
+            "file": "c.sol",
+            "function": "",
+            "line": 17
+          }
+        },
+        {
+          "type": "CALLSTACK_ENTRY",
+          "sourceReference": {
+            "contract": "C",
+            "file": "c.sol",
+            "function": "revertIf",
+            "line": 9
+          }
+        },
+        {
+          "type": "REVERT_ERROR",
+          "message": "I'm reverted",
+          "sourceReference": {
+            "contract": "C",
+            "file": "c.sol",
+            "function": "checkReverted",
+            "line": 20
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes a panic on stack trace generation for a receive function with a modifier that calls another method.

Fixes https://github.com/NomicFoundation/edr/issues/894