### PR TITLE
chore: backport latest Foundry expectRevert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3010,6 +3010,7 @@ dependencies = [
  "itertools 0.12.1",
  "jsonpath_lib",
  "k256",
+ "memchr",
  "p256",
  "regex",
  "revm",

--- a/crates/edr_solidity_tests/tests/testdata/cheats/Vm.sol
+++ b/crates/edr_solidity_tests/tests/testdata/cheats/Vm.sol
@@ -23,6 +23,7 @@ interface Vm {
     function _expectCheatcodeRevert() external;
     function _expectCheatcodeRevert(bytes4 revertData) external;
     function _expectCheatcodeRevert(bytes calldata revertData) external;
+    function _expectInternalRevert() external;
     function accesses(address target) external returns (bytes32[] memory readSlots, bytes32[] memory writeSlots);
     function activeFork() external view returns (uint256 forkId);
     function addr(uint256 privateKey) external pure returns (address keyAddr);
@@ -214,9 +215,20 @@ interface Vm {
     function expectEmit(bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData, address emitter) external;
     function expectEmit() external;
     function expectEmit(address emitter) external;
+    function expectPartialRevert(bytes4 revertData) external;
+    function expectPartialRevert(bytes4 revertData, address reverter) external;
     function expectRevert() external;
     function expectRevert(bytes4 revertData) external;
+    function expectRevert(bytes4 revertData, address reverter, uint64 count) external;
+    function expectRevert(bytes calldata revertData, address reverter, uint64 count) external;
     function expectRevert(bytes calldata revertData) external;
+    function expectRevert(address reverter) external;
+    function expectRevert(bytes4 revertData, address reverter) external;
+    function expectRevert(bytes calldata revertData, address reverter) external;
+    function expectRevert(uint64 count) external;
+    function expectRevert(bytes4 revertData, uint64 count) external;
+    function expectRevert(bytes calldata revertData, uint64 count) external;
+    function expectRevert(address reverter, uint64 count) external;
     function expectSafeMemory(uint64 min, uint64 max) external;
     function expectSafeMemoryCall(uint64 min, uint64 max) external;
     function fee(uint256 newBasefee) external;

--- a/crates/edr_solidity_tests/tests/testdata/default/cheats/ExpectRevert.t.sol
+++ b/crates/edr_solidity_tests/tests/testdata/default/cheats/ExpectRevert.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity 0.8.18;
+pragma solidity ^0.8.18;
 
 import "ds-test/test.sol";
 import "cheats/Vm.sol";
@@ -28,6 +28,10 @@ contract Reverter {
     function callThenRevert(Dummy dummy, string memory message) public pure {
         dummy.callMe();
         revert(message);
+    }
+
+    function callThenNoRevert(Dummy dummy) public pure {
+        dummy.callMe();
     }
 
     function revertWithoutReason() public pure {
@@ -80,20 +84,10 @@ contract ExpectRevertTest is DSTest {
         reverter.revertWithMessage("revert");
     }
 
-    function testFailExpectRevertWrongString() public {
+    function testShouldFailIfExpectRevertWrongString() public {
         Reverter reverter = new Reverter();
-        vm.expectRevert("my not so cool error");
+        vm.expectRevert("my not so cool error", 0);
         reverter.revertWithMessage("my cool error");
-    }
-
-    function testFailRevertNotOnImmediateNextCall() public {
-        Reverter reverter = new Reverter();
-        // expectRevert should only work for the next call. However,
-        // we do not immediately revert, so,
-        // we fail.
-        vm.expectRevert("revert");
-        reverter.doNotRevert();
-        reverter.revertWithMessage("revert");
     }
 
     function testExpectRevertConstructor() public {
@@ -133,18 +127,6 @@ contract ExpectRevertTest is DSTest {
         dummy.largeReturnType();
     }
 
-    function testFailExpectRevertErrorDoesNotMatch() public {
-        Reverter reverter = new Reverter();
-        vm.expectRevert("should revert with this message");
-        reverter.revertWithMessage("but reverts with this message");
-    }
-
-    function testFailExpectRevertDidNotRevert() public {
-        Reverter reverter = new Reverter();
-        vm.expectRevert("does not revert, but we think it should");
-        reverter.doNotRevert();
-    }
-
     function testExpectRevertNoReason() public {
         Reverter reverter = new Reverter();
         vm.expectRevert(bytes(""));
@@ -177,29 +159,284 @@ contract ExpectRevertTest is DSTest {
         reverter.revertWithoutReason();
     }
 
-    function testFailExpectRevertAnyRevertDidNotRevert() public {
-        Reverter reverter = new Reverter();
-        vm.expectRevert();
-        reverter.doNotRevert();
-    }
-
-    function testFailExpectRevertDangling() public {
-        vm.expectRevert("dangling");
-    }
-
     function testexpectCheatcodeRevert() public {
-        vm._expectCheatcodeRevert("JSON value at \".a\" is not an object");
+        vm._expectCheatcodeRevert('JSON value at ".a" is not an object');
         vm.parseJsonKeys('{"a": "b"}', ".a");
     }
+}
 
-    function testFailexpectCheatcodeRevertForExtCall() public {
+contract AContract {
+    BContract bContract;
+    CContract cContract;
+
+    constructor(BContract _bContract, CContract _cContract) {
+        bContract = _bContract;
+        cContract = _cContract;
+    }
+
+    function callAndRevert() public pure {
+        require(1 > 2, "Reverted by AContract");
+    }
+
+    function callAndRevertInBContract() public {
+        bContract.callAndRevert();
+    }
+
+    function callAndRevertInCContract() public {
+        cContract.callAndRevert();
+    }
+
+    function callAndRevertInCContractThroughBContract() public {
+        bContract.callAndRevertInCContract();
+    }
+
+    function createDContract() public {
+        new DContract();
+    }
+
+    function createDContractThroughBContract() public {
+        bContract.createDContract();
+    }
+
+    function createDContractThroughCContract() public {
+        cContract.createDContract();
+    }
+
+    function doNotRevert() public {}
+}
+
+contract BContract {
+    CContract cContract;
+
+    constructor(CContract _cContract) {
+        cContract = _cContract;
+    }
+
+    function callAndRevert() public pure {
+        require(1 > 2, "Reverted by BContract");
+    }
+
+    function callAndRevertInCContract() public {
+        this.doNotRevert();
+        cContract.doNotRevert();
+        cContract.callAndRevert();
+    }
+
+    function createDContract() public {
+        this.doNotRevert();
+        cContract.doNotRevert();
+        new DContract();
+    }
+
+    function createDContractThroughCContract() public {
+        this.doNotRevert();
+        cContract.doNotRevert();
+        cContract.createDContract();
+    }
+
+    function doNotRevert() public {}
+}
+
+contract CContract {
+    error CContractError(string reason);
+
+    function callAndRevert() public pure {
+        revert CContractError("Reverted by CContract");
+    }
+
+    function createDContract() public {
+        new DContract();
+    }
+
+    function doNotRevert() public {}
+}
+
+contract DContract {
+    constructor() {
+        require(1 > 2, "Reverted by DContract");
+    }
+}
+
+contract ExpectRevertWithReverterTest is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+
+    error CContractError(string reason);
+
+    AContract aContract;
+    BContract bContract;
+    CContract cContract;
+
+    function setUp() public {
+        cContract = new CContract();
+        bContract = new BContract(cContract);
+        aContract = new AContract(bContract, cContract);
+    }
+
+    function testExpectRevertsWithReverter() public {
+        // Test expect revert with reverter at first call.
+        vm.expectRevert(address(aContract));
+        aContract.callAndRevert();
+        // Test expect revert with reverter at second subcall.
+        vm.expectRevert(address(bContract));
+        aContract.callAndRevertInBContract();
+        // Test expect revert with partial data match and reverter at third subcall.
+        vm.expectPartialRevert(CContractError.selector, address(cContract));
+        aContract.callAndRevertInCContractThroughBContract();
+        // Test expect revert with exact data match and reverter at second subcall.
+        vm.expectRevert(abi.encodeWithSelector(CContractError.selector, "Reverted by CContract"), address(cContract));
+        aContract.callAndRevertInCContract();
+    }
+
+    function testExpectRevertsWithReverterInConstructor() public {
+        // Test expect revert with reverter when constructor reverts.
+        vm.expectRevert(abi.encodePacked("Reverted by DContract"), address(cContract));
+        cContract.createDContract();
+
+        vm.expectRevert(address(bContract));
+        bContract.createDContract();
+        vm.expectRevert(address(cContract));
+        bContract.createDContractThroughCContract();
+
+        vm.expectRevert(address(aContract));
+        aContract.createDContract();
+        vm.expectRevert(address(bContract));
+        aContract.createDContractThroughBContract();
+        vm.expectRevert(address(cContract));
+        aContract.createDContractThroughCContract();
+    }
+}
+
+contract ExpectRevertCount is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+
+    function testRevertCountAny() public {
+        uint64 count = 3;
         Reverter reverter = new Reverter();
-        vm._expectCheatcodeRevert();
+        vm.expectRevert(count);
+        reverter.revertWithMessage("revert");
+        reverter.revertWithMessage("revert2");
+        reverter.revertWithMessage("revert3");
+
+        vm.expectRevert("revert");
         reverter.revertWithMessage("revert");
     }
 
-    function testFailexpectCheatcodeRevertForCreate() public {
-        vm._expectCheatcodeRevert();
-        new ConstructorReverter("some message");
+    function testNoRevert() public {
+        uint64 count = 0;
+        Reverter reverter = new Reverter();
+        vm.expectRevert(count);
+        reverter.doNotRevert();
+    }
+
+    function testRevertCountSpecific() public {
+        uint64 count = 2;
+        Reverter reverter = new Reverter();
+        vm.expectRevert("revert", count);
+        reverter.revertWithMessage("revert");
+        reverter.revertWithMessage("revert");
+    }
+
+    function testNoRevertSpecific() public {
+        uint64 count = 0;
+        Reverter reverter = new Reverter();
+        vm.expectRevert("revert", count);
+        reverter.doNotRevert();
+    }
+
+    function testNoRevertSpecificButDiffRevert() public {
+        uint64 count = 0;
+        Reverter reverter = new Reverter();
+        vm.expectRevert("revert", count);
+        reverter.revertWithMessage("revert2");
+    }
+
+    function testRevertCountWithConstructor() public {
+        uint64 count = 1;
+        vm.expectRevert("constructor revert", count);
+        new ConstructorReverter("constructor revert");
+    }
+
+    function testNoRevertWithConstructor() public {
+        uint64 count = 0;
+        vm.expectRevert("constructor revert", count);
+        new CContract();
+    }
+
+    function testRevertCountNestedSpecific() public {
+        uint64 count = 2;
+        Reverter reverter = new Reverter();
+        Reverter inner = new Reverter();
+
+        vm.expectRevert("nested revert", count);
+        reverter.revertWithMessage("nested revert");
+        reverter.nestedRevert(inner, "nested revert");
+
+        vm.expectRevert("nested revert", count);
+        reverter.nestedRevert(inner, "nested revert");
+        reverter.nestedRevert(inner, "nested revert");
+    }
+
+    function testRevertCountCallsThenReverts() public {
+        uint64 count = 2;
+        Reverter reverter = new Reverter();
+        Dummy dummy = new Dummy();
+
+        vm.expectRevert("called a function and then reverted", count);
+        reverter.callThenRevert(dummy, "called a function and then reverted");
+        reverter.callThenRevert(dummy, "called a function and then reverted");
+    }
+
+    function testNoRevertCall() public {
+        uint64 count = 0;
+        Reverter reverter = new Reverter();
+        Dummy dummy = new Dummy();
+
+        vm.expectRevert("called a function and then reverted", count);
+        reverter.callThenNoRevert(dummy);
+    }
+}
+
+contract ExpectRevertCountWithReverter is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+
+    function testRevertCountWithReverter() public {
+        uint64 count = 2;
+        Reverter reverter = new Reverter();
+        vm.expectRevert(address(reverter), count);
+        reverter.revertWithMessage("revert");
+        reverter.revertWithMessage("revert");
+    }
+
+    function testNoRevertWithReverter() public {
+        uint64 count = 0;
+        Reverter reverter = new Reverter();
+        vm.expectRevert(address(reverter), count);
+        reverter.doNotRevert();
+    }
+
+    function testNoRevertWithWrongReverter() public {
+        uint64 count = 0;
+        Reverter reverter = new Reverter();
+        Reverter reverter2 = new Reverter();
+        vm.expectRevert(address(reverter), count);
+        reverter2.revertWithMessage("revert"); // revert from wrong reverter
+    }
+
+    function testReverterCountWithData() public {
+        uint64 count = 2;
+        Reverter reverter = new Reverter();
+        vm.expectRevert("revert", address(reverter), count);
+        reverter.revertWithMessage("revert");
+        reverter.revertWithMessage("revert");
+    }
+
+    function testNoReverterCountWithData() public {
+        uint64 count = 0;
+        Reverter reverter = new Reverter();
+        vm.expectRevert("revert", address(reverter), count);
+        reverter.doNotRevert();
+
+        vm.expectRevert("revert", address(reverter), count);
+        reverter.revertWithMessage("revert2");
     }
 }

--- a/crates/edr_solidity_tests/tests/testdata/default/cheats/LastCallGas.t.sol
+++ b/crates/edr_solidity_tests/tests/testdata/default/cheats/LastCallGas.t.sol
@@ -39,7 +39,7 @@ abstract contract LastCallGasFixture is DSTest {
     }
 
     function testRevertNoCachedLastCallGas() public {
-        vm.expectRevert();
+        vm._expectCheatcodeRevert();
         vm.lastCallGas();
     }
 

--- a/crates/edr_solidity_tests/tests/testdata/default/cheats/MemSafety.t.sol
+++ b/crates/edr_solidity_tests/tests/testdata/default/cheats/MemSafety.t.sol
@@ -416,7 +416,7 @@ contract MemSafetyTest is DSTest {
     function testExpectSafeMemory_MLOAD_REVERT() public {
         vm.expectSafeMemory(0x80, 0x100);
 
-        vm.expectRevert();
+        vm._expectInternalRevert();
 
         // This should revert. Ugly hack to make sure the mload isn't optimized
         // out.
@@ -506,7 +506,7 @@ contract MemSafetyTest is DSTest {
     ///      will cause the test to fail while using the `LOG0` opcode.
     function testExpectSafeMemory_LOG0_REVERT() public {
         vm.expectSafeMemory(0x80, 0x100);
-        vm.expectRevert();
+        vm._expectInternalRevert();
         // This should revert.
         assembly {
             log0(0x100, 0x20)

--- a/crates/edr_solidity_tests/tests/testdata/default/cheats/MockCall.t.sol
+++ b/crates/edr_solidity_tests/tests/testdata/default/cheats/MockCall.t.sol
@@ -175,8 +175,11 @@ contract MockCallRevertTest is DSTest {
 
         // post-mock
         assertEq(target.numberA(), 1);
-        vm.expectRevert();
-        target.numberB();
+        try target.numberB() {
+            revert();
+        } catch (bytes memory err) {
+            require(keccak256(err) == keccak256(ERROR_MESSAGE));
+        }
     }
 
     function testMockRevertWithCustomError() public {
@@ -190,8 +193,11 @@ contract MockCallRevertTest is DSTest {
         vm.mockCallRevert(address(target), abi.encodeWithSelector(target.numberB.selector), customError);
 
         assertEq(target.numberA(), 1);
-        vm.expectRevert(customError);
-        target.numberB();
+        try target.numberB() {
+            revert();
+        } catch (bytes memory err) {
+            require(keccak256(err) == keccak256(customError));
+        }
     }
 
     function testMockNestedRevert() public {
@@ -202,8 +208,11 @@ contract MockCallRevertTest is DSTest {
 
         vm.mockCallRevert(address(inner), abi.encodeWithSelector(inner.numberB.selector), ERROR_MESSAGE);
 
-        vm.expectRevert(ERROR_MESSAGE);
-        target.sum();
+        try target.sum() {
+            revert();
+        } catch (bytes memory err) {
+            require(keccak256(err) == keccak256(ERROR_MESSAGE));
+        }
     }
 
     function testMockCalldataRevert() public {
@@ -215,8 +224,11 @@ contract MockCallRevertTest is DSTest {
 
         assertEq(target.add(6, 4), 10);
 
-        vm.expectRevert(ERROR_MESSAGE);
-        target.add(5, 5);
+        try target.add(5, 5) {
+            revert();
+        } catch (bytes memory err) {
+            require(keccak256(err) == keccak256(ERROR_MESSAGE));
+        }
     }
 
     function testClearMockRevertedCalls() public {
@@ -237,8 +249,11 @@ contract MockCallRevertTest is DSTest {
 
         assertEq(mock.add(1, 2), 3);
 
-        vm.expectRevert(ERROR_MESSAGE);
-        mock.add(2, 3);
+        try mock.add(2, 3) {
+            revert();
+        } catch (bytes memory err) {
+            require(keccak256(err) == keccak256(ERROR_MESSAGE));
+        }
     }
 
     function testMockCallRevertWithValue() public {
@@ -249,8 +264,11 @@ contract MockCallRevertTest is DSTest {
         assertEq(mock.pay(1), 1);
         assertEq(mock.pay(2), 2);
 
-        vm.expectRevert(ERROR_MESSAGE);
-        mock.pay{value: 10}(1);
+        try mock.pay{value: 10}(1) {
+            revert();
+        } catch (bytes memory err) {
+            require(keccak256(err) == keccak256(ERROR_MESSAGE));
+        }
     }
 
     function testMockCallResetsMockCallRevert() public {
@@ -270,8 +288,11 @@ contract MockCallRevertTest is DSTest {
 
         vm.mockCallRevert(address(mock), abi.encodeWithSelector(mock.add.selector), ERROR_MESSAGE);
 
-        vm.expectRevert(ERROR_MESSAGE);
-        mock.add(2, 3);
+        try mock.add(2, 3) {
+            revert();
+        } catch (bytes memory err) {
+            require(keccak256(err) == keccak256(ERROR_MESSAGE));
+        }
     }
 
     function testMockCallRevertWithCall() public {
@@ -291,7 +312,10 @@ contract MockCallRevertTest is DSTest {
 
         vm.mockCallRevert(address(mock), abi.encodeWithSelector(mock.add.selector), ERROR_MESSAGE);
 
-        vm.expectRevert(ERROR_MESSAGE);
-        mock.add(1, 2);
+        try mock.add(2, 3) {
+            revert();
+        } catch (bytes memory err) {
+            require(keccak256(err) == keccak256(ERROR_MESSAGE));
+        }
     }
 }

--- a/crates/foundry/cheatcodes/Cargo.toml
+++ b/crates/foundry/cheatcodes/Cargo.toml
@@ -38,6 +38,7 @@ rustc-hash.workspace = true
 toml = { workspace = true, features = ["preserve_order"] }
 tracing.workspace = true
 k256.workspace = true
+memchr = "2.7"
 
 dialoguer = "0.11.0"
 p256 = "0.13.2"

--- a/crates/foundry/cheatcodes/assets/cheatcodes.json
+++ b/crates/foundry/cheatcodes/assets/cheatcodes.json
@@ -537,6 +537,26 @@
     },
     {
       "func": {
+        "id": "_expectInternalRevert",
+        "description": "Expects a `count` number of reverts from the upcoming calls from the reverter address that exactly match the revert data.",
+        "declaration": "function _expectInternalRevert() external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "_expectInternalRevert()",
+        "selector": "0x2ae06891",
+        "selectorBytes": [
+          42,
+          224,
+          104,
+          145
+        ]
+      },
+      "group": "testing",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
         "id": "accesses",
         "description": "Gets all accessed reads and write slot from a `vm.record` session, for a given address.",
         "declaration": "function accesses(address target) external returns (bytes32[] memory readSlots, bytes32[] memory writeSlots);",
@@ -4361,6 +4381,46 @@
     },
     {
       "func": {
+        "id": "expectPartialRevert_0",
+        "description": "Expects an error on next call that starts with the revert data.",
+        "declaration": "function expectPartialRevert(bytes4 revertData) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "expectPartialRevert(bytes4)",
+        "selector": "0x11fb5b9c",
+        "selectorBytes": [
+          17,
+          251,
+          91,
+          156
+        ]
+      },
+      "group": "testing",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
+        "id": "expectPartialRevert_1",
+        "description": "Expects an error on next call to reverter address, that starts with the revert data.",
+        "declaration": "function expectPartialRevert(bytes4 revertData, address reverter) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "expectPartialRevert(bytes4,address)",
+        "selector": "0x51aa008a",
+        "selectorBytes": [
+          81,
+          170,
+          0,
+          138
+        ]
+      },
+      "group": "testing",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
         "id": "expectRevert_0",
         "description": "Expects an error on next call with any revert data.",
         "declaration": "function expectRevert() external;",
@@ -4382,7 +4442,7 @@
     {
       "func": {
         "id": "expectRevert_1",
-        "description": "Expects an error on next call that starts with the revert data.",
+        "description": "Expects an error on next call that exactly matches the revert data.",
         "declaration": "function expectRevert(bytes4 revertData) external;",
         "visibility": "external",
         "mutability": "",
@@ -4393,6 +4453,46 @@
           30,
           176,
           224
+        ]
+      },
+      "group": "testing",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
+        "id": "expectRevert_10",
+        "description": "Expects a `count` number of reverts from the upcoming calls from the reverter address that match the revert data.",
+        "declaration": "function expectRevert(bytes4 revertData, address reverter, uint64 count) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "expectRevert(bytes4,address,uint64)",
+        "selector": "0xb0762d73",
+        "selectorBytes": [
+          176,
+          118,
+          45,
+          115
+        ]
+      },
+      "group": "testing",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
+        "id": "expectRevert_11",
+        "description": "Expects a `count` number of reverts from the upcoming calls from the reverter address that exactly match the revert data.",
+        "declaration": "function expectRevert(bytes calldata revertData, address reverter, uint64 count) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "expectRevert(bytes,address,uint64)",
+        "selector": "0xd345fb1f",
+        "selectorBytes": [
+          211,
+          69,
+          251,
+          31
         ]
       },
       "group": "testing",
@@ -4413,6 +4513,146 @@
           141,
           206,
           179
+        ]
+      },
+      "group": "testing",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
+        "id": "expectRevert_3",
+        "description": "Expects an error with any revert data on next call to reverter address.",
+        "declaration": "function expectRevert(address reverter) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "expectRevert(address)",
+        "selector": "0xd814f38a",
+        "selectorBytes": [
+          216,
+          20,
+          243,
+          138
+        ]
+      },
+      "group": "testing",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
+        "id": "expectRevert_4",
+        "description": "Expects an error from reverter address on next call, with any revert data.",
+        "declaration": "function expectRevert(bytes4 revertData, address reverter) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "expectRevert(bytes4,address)",
+        "selector": "0x260bc5de",
+        "selectorBytes": [
+          38,
+          11,
+          197,
+          222
+        ]
+      },
+      "group": "testing",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
+        "id": "expectRevert_5",
+        "description": "Expects an error from reverter address on next call, that exactly matches the revert data.",
+        "declaration": "function expectRevert(bytes calldata revertData, address reverter) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "expectRevert(bytes,address)",
+        "selector": "0x61ebcf12",
+        "selectorBytes": [
+          97,
+          235,
+          207,
+          18
+        ]
+      },
+      "group": "testing",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
+        "id": "expectRevert_6",
+        "description": "Expects a `count` number of reverts from the upcoming calls with any revert data or reverter.",
+        "declaration": "function expectRevert(uint64 count) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "expectRevert(uint64)",
+        "selector": "0x4ee38244",
+        "selectorBytes": [
+          78,
+          227,
+          130,
+          68
+        ]
+      },
+      "group": "testing",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
+        "id": "expectRevert_7",
+        "description": "Expects a `count` number of reverts from the upcoming calls that match the revert data.",
+        "declaration": "function expectRevert(bytes4 revertData, uint64 count) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "expectRevert(bytes4,uint64)",
+        "selector": "0xe45ca72d",
+        "selectorBytes": [
+          228,
+          92,
+          167,
+          45
+        ]
+      },
+      "group": "testing",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
+        "id": "expectRevert_8",
+        "description": "Expects a `count` number of reverts from the upcoming calls that exactly match the revert data.",
+        "declaration": "function expectRevert(bytes calldata revertData, uint64 count) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "expectRevert(bytes,uint64)",
+        "selector": "0x4994c273",
+        "selectorBytes": [
+          73,
+          148,
+          194,
+          115
+        ]
+      },
+      "group": "testing",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
+        "id": "expectRevert_9",
+        "description": "Expects a `count` number of reverts from the upcoming calls from the reverter address.",
+        "declaration": "function expectRevert(address reverter, uint64 count) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "expectRevert(address,uint64)",
+        "selector": "0x1ff5f952",
+        "selectorBytes": [
+          31,
+          245,
+          249,
+          82
         ]
       },
       "group": "testing",

--- a/crates/foundry/cheatcodes/spec/src/vm.rs
+++ b/crates/foundry/cheatcodes/spec/src/vm.rs
@@ -758,13 +758,61 @@ interface Vm {
     #[cheatcode(group = Testing, safety = Unsafe)]
     function expectRevert() external;
 
-    /// Expects an error on next call that starts with the revert data.
+    /// Expects an error on next call that exactly matches the revert data.
     #[cheatcode(group = Testing, safety = Unsafe)]
     function expectRevert(bytes4 revertData) external;
 
     /// Expects an error on next call that exactly matches the revert data.
     #[cheatcode(group = Testing, safety = Unsafe)]
     function expectRevert(bytes calldata revertData) external;
+
+    /// Expects an error with any revert data on next call to reverter address.
+    #[cheatcode(group = Testing, safety = Unsafe)]
+    function expectRevert(address reverter) external;
+
+    /// Expects an error from reverter address on next call, with any revert data.
+    #[cheatcode(group = Testing, safety = Unsafe)]
+    function expectRevert(bytes4 revertData, address reverter) external;
+
+    /// Expects an error from reverter address on next call, that exactly matches the revert data.
+    #[cheatcode(group = Testing, safety = Unsafe)]
+    function expectRevert(bytes calldata revertData, address reverter) external;
+
+    /// Expects a `count` number of reverts from the upcoming calls with any revert data or reverter.
+    #[cheatcode(group = Testing, safety = Unsafe)]
+    function expectRevert(uint64 count) external;
+
+    /// Expects a `count` number of reverts from the upcoming calls that match the revert data.
+    #[cheatcode(group = Testing, safety = Unsafe)]
+    function expectRevert(bytes4 revertData, uint64 count) external;
+
+    /// Expects a `count` number of reverts from the upcoming calls that exactly match the revert data.
+    #[cheatcode(group = Testing, safety = Unsafe)]
+    function expectRevert(bytes calldata revertData, uint64 count) external;
+
+    /// Expects a `count` number of reverts from the upcoming calls from the reverter address.
+    #[cheatcode(group = Testing, safety = Unsafe)]
+    function expectRevert(address reverter, uint64 count) external;
+
+    /// Expects a `count` number of reverts from the upcoming calls from the reverter address that match the revert data.
+    #[cheatcode(group = Testing, safety = Unsafe)]
+    function expectRevert(bytes4 revertData, address reverter, uint64 count) external;
+
+    /// Expects a `count` number of reverts from the upcoming calls from the reverter address that exactly match the revert data.
+    #[cheatcode(group = Testing, safety = Unsafe)]
+    function expectRevert(bytes calldata revertData, address reverter, uint64 count) external;
+
+    /// Expects a `count` number of reverts from the upcoming calls from the reverter address that exactly match the revert data.
+    #[cheatcode(group = Testing, safety = Unsafe)]
+    function _expectInternalRevert() external;
+
+    /// Expects an error on next call that starts with the revert data.
+    #[cheatcode(group = Testing, safety = Unsafe)]
+    function expectPartialRevert(bytes4 revertData) external;
+
+    /// Expects an error on next call to reverter address, that starts with the revert data.
+    #[cheatcode(group = Testing, safety = Unsafe)]
+    function expectPartialRevert(bytes4 revertData, address reverter) external;
 
     /// Expects an error on next cheatcode call with any revert data.
     #[cheatcode(group = Testing, safety = Unsafe, status = Internal)]

--- a/crates/foundry/cheatcodes/src/test.rs
+++ b/crates/foundry/cheatcodes/src/test.rs
@@ -14,6 +14,7 @@ use crate::{
 
 pub(crate) mod assert;
 pub(crate) mod expect;
+pub(crate) mod revert_handlers;
 
 use crate::impl_is_pure_true;
 

--- a/crates/foundry/cheatcodes/src/test/revert_handlers.rs
+++ b/crates/foundry/cheatcodes/src/test/revert_handlers.rs
@@ -1,0 +1,201 @@
+use crate::{Error, Result};
+use alloy_primitives::{address, hex, Address, Bytes};
+use alloy_sol_types::{SolError, SolValue};
+use foundry_evm_core::{contracts::ContractsByArtifact, decode::RevertDecoder};
+use revm::interpreter::{return_ok, InstructionResult};
+use spec::Vm;
+
+use super::expect::ExpectedRevert;
+
+/// For some cheatcodes we may internally change the status of the call, i.e. in `expectRevert`.
+/// Solidity will see a successful call and attempt to decode the return data. Therefore, we need
+/// to populate the return with dummy bytes so the decode doesn't fail.
+///
+/// 8192 bytes was arbitrarily chosen because it is long enough for return values up to 256 words in
+/// size.
+static DUMMY_CALL_OUTPUT: Bytes = Bytes::from_static(&[0u8; 8192]);
+
+/// Same reasoning as [DUMMY_CALL_OUTPUT], but for creates.
+const DUMMY_CREATE_ADDRESS: Address = address!("0x0000000000000000000000000000000000000001");
+
+fn stringify(data: &[u8]) -> String {
+    if let Ok(s) = String::abi_decode(data, true) {
+        return s;
+    }
+    if data.is_ascii() {
+        return std::str::from_utf8(data).unwrap().to_owned();
+    }
+    hex::encode_prefixed(data)
+}
+
+/// Common parameters for expected or assumed reverts. Allows for code reuse.
+pub(crate) trait RevertParameters {
+    fn reverter(&self) -> Option<Address>;
+    fn reason(&self) -> Option<&[u8]>;
+    fn partial_match(&self) -> bool;
+}
+
+/// Core logic for handling reverts that may or may not be expected (or assumed).
+fn handle_revert(
+    is_cheatcode: bool,
+    revert_params: &impl RevertParameters,
+    status: InstructionResult,
+    retdata: &Bytes,
+    known_contracts: Option<&ContractsByArtifact>,
+    reverter: Option<&Address>,
+) -> Result<(), Error> {
+    // If expected reverter address is set then check it matches the actual reverter.
+    if let (Some(expected_reverter), Some(&actual_reverter)) = (revert_params.reverter(), reverter)
+    {
+        if expected_reverter != actual_reverter {
+            return Err(fmt_err!(
+                "Reverter != expected reverter: {} != {}",
+                actual_reverter,
+                expected_reverter
+            ));
+        }
+    }
+
+    let expected_reason = revert_params.reason();
+    // If None, accept any revert.
+    let Some(expected_reason) = expected_reason else {
+        return Ok(());
+    };
+
+    if !expected_reason.is_empty() && retdata.is_empty() {
+        bail!("call reverted as expected, but without data");
+    }
+
+    let mut actual_revert: Vec<u8> = retdata.to_vec();
+
+    // Compare only the first 4 bytes if partial match.
+    if revert_params.partial_match() && actual_revert.get(..4) == expected_reason.get(..4) {
+        return Ok(());
+    }
+
+    // Try decoding as known errors.
+    actual_revert = decode_revert(actual_revert);
+
+    if actual_revert == expected_reason ||
+        (is_cheatcode && memchr::memmem::find(&actual_revert, expected_reason).is_some())
+    {
+        Ok(())
+    } else {
+        let (actual, expected) = if let Some(contracts) = known_contracts {
+            let decoder = RevertDecoder::new().with_abis(contracts.values().map(|c| &c.abi));
+            (
+                &decoder.decode(actual_revert.as_slice(), Some(status)),
+                &decoder.decode(expected_reason, Some(status)),
+            )
+        } else {
+            (&stringify(&actual_revert), &stringify(expected_reason))
+        };
+
+        if expected == actual {
+            return Ok(());
+        }
+
+        Err(fmt_err!("Error != expected error: {} != {}", actual, expected))
+    }
+}
+
+pub(crate) fn handle_expect_revert(
+    is_cheatcode: bool,
+    is_create: bool,
+    internal_expect_revert: bool,
+    expected_revert: &ExpectedRevert,
+    status: InstructionResult,
+    retdata: Bytes,
+    known_contracts: Option<&ContractsByArtifact>,
+) -> Result<(Option<Address>, Bytes)> {
+    let success_return = || {
+        if is_create {
+            (Some(DUMMY_CREATE_ADDRESS), Bytes::new())
+        } else {
+            (None, DUMMY_CALL_OUTPUT.clone())
+        }
+    };
+
+    // Check depths if it's not an expect cheatcode call and if internal expect reverts not enabled.
+    if !is_cheatcode && !internal_expect_revert {
+        ensure!(
+            expected_revert.max_depth > expected_revert.depth,
+            "call didn't revert at a lower depth than cheatcode call depth"
+        );
+    }
+
+    if expected_revert.count == 0 {
+        if expected_revert.reverter.is_none() && expected_revert.reason.is_none() {
+            ensure!(
+                matches!(status, return_ok!()),
+                "call reverted when it was expected not to revert"
+            );
+            return Ok(success_return());
+        }
+
+        // Flags to track if the reason and reverter match.
+        let mut reason_match = expected_revert.reason.as_ref().map(|_| false);
+        let mut reverter_match = expected_revert.reverter.as_ref().map(|_| false);
+
+        // Reverter check
+        if let (Some(expected_reverter), Some(actual_reverter)) =
+            (expected_revert.reverter, expected_revert.reverted_by)
+        {
+            if expected_reverter == actual_reverter {
+                reverter_match = Some(true);
+            }
+        }
+
+        // Reason check
+        let expected_reason = expected_revert.reason.as_deref();
+        if let Some(expected_reason) = expected_reason {
+            let mut actual_revert: Vec<u8> = retdata.into();
+            actual_revert = decode_revert(actual_revert);
+
+            if actual_revert == expected_reason {
+                reason_match = Some(true);
+            }
+        };
+
+        match (reason_match, reverter_match) {
+            (Some(true), Some(true)) => Err(fmt_err!(
+                "expected 0 reverts with reason: {}, from address: {}, but got one",
+                &stringify(expected_reason.unwrap_or_default()),
+                expected_revert.reverter.unwrap()
+            )),
+            (Some(true), None) => Err(fmt_err!(
+                "expected 0 reverts with reason: {}, but got one",
+                &stringify(expected_reason.unwrap_or_default())
+            )),
+            (None, Some(true)) => Err(fmt_err!(
+                "expected 0 reverts from address: {}, but got one",
+                expected_revert.reverter.unwrap()
+            )),
+            _ => Ok(success_return()),
+        }
+    } else {
+        ensure!(!matches!(status, return_ok!()), "next call did not revert as expected");
+
+        handle_revert(
+            is_cheatcode,
+            expected_revert,
+            status,
+            &retdata,
+            known_contracts,
+            expected_revert.reverted_by.as_ref(),
+        )?;
+        Ok(success_return())
+    }
+}
+
+fn decode_revert(revert: Vec<u8>) -> Vec<u8> {
+    if matches!(
+        revert.get(..4).map(|s| s.try_into().unwrap()),
+        Some(Vm::CheatcodeError::SELECTOR | alloy_sol_types::Revert::SELECTOR)
+    ) {
+        if let Ok(decoded) = Vec::<u8>::abi_decode(&revert[4..], false) {
+            return decoded;
+        }
+    }
+    revert
+}


### PR DESCRIPTION
This was backported from the latest Foundry commit with matching revm and alloy versions (foundry-rs/foundry@066e0ce0).

The starting point was to copy over `ExpectRevert.t.sol` as is. All `expectRevert` cheatcode impls and `expect_revert` helper were copied over (overwriting the existing ones), then adjusted to compile (generics, `apply_full`, `IsPure`). `depth` values were kept `u64` to minimize impact in the rest of the code (they're `usize` upstream now). `handle_expect_revert` was moved into a new module like upstream and updated to the latest version. Finally, `inspector.rs` aspects related to expected reverts were selectively copied over. This left some errors in the rest of the tests that I tried to address with updates from upstream or minimal custom adjustments where necessary, the largest one being a custom cheatcode `_expectInternalRevert` (with underscore prefix as it's for internal use) to replace the inline config that EDR doesn't support.