### PR TITLE
test: add test for hh2 local edr version

### DIFF
--- a/crates/tools/js/benchmark/test/test-local-edr.ts
+++ b/crates/tools/js/benchmark/test/test-local-edr.ts
@@ -4,13 +4,12 @@ import { test } from "node:test";
 import path from "path";
 import { dirName } from "@nomicfoundation/edr-helpers";
 
-// The benchmarks assume that the EDR version used by
+// The provider scenario benchmarks assume that the EDR version used by
 // Hardhat is the one in the workspace, instead of the one installed
 // from npm. This test checks that this is the case.
-// eslint-disable-next-line @typescript-eslint/no-floating-promises
-test("uses the workspace version of EDR", function () {
+function checkHardhatEdrVersion(hardhatPackageName: string) {
   const require = createRequire(import.meta.url);
-  const hardhatPath = require.resolve("hardhat");
+  const hardhatPath = require.resolve(hardhatPackageName);
 
   const edrPath = require.resolve("@nomicfoundation/edr", {
     paths: [hardhatPath],
@@ -29,4 +28,16 @@ test("uses the workspace version of EDR", function () {
   );
 
   assert.equal(edrPath, expectedPath);
+}
+
+// False positive
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
+test("Hardhat 2 uses the workspace version of EDR", function () {
+  checkHardhatEdrVersion("hardhat2");
+});
+
+// False positive
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
+test("Hardhat 3 uses the workspace version of EDR", function () {
+  checkHardhatEdrVersion("hardhat");
 });


### PR DESCRIPTION
This test checks that we're using the local EDR as a transitive dependency of Hardhat 2 when importing `createHardhatNetworkProvider` here: https://github.com/NomicFoundation/edr/blob/25e5d83c375b3f219b30832d7423577a07d425b6/crates/tools/js/benchmark/src/index.ts#L22-L24

While debugging a related problem, I noticed that the test imports the `hardhat` package instead of `hardhat2`. This is not a big problem, because the override applies to both:

https://github.com/NomicFoundation/edr/blob/25e5d83c375b3f219b30832d7423577a07d425b6/package.json#L15-L17

But I thought it best to add an explicit test for Hardhat 2 as well.

More context on why we're still using Hardhat 2 for the provider scenario benchmarks for here: https://github.com/NomicFoundation/edr/issues/960

