### PR TITLE
fix: ignore remote code of all provider accounts

### DIFF
--- a/.changeset/neat-rocks-prove.md
+++ b/.changeset/neat-rocks-prove.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Removed copying of account code for provider accounts in forked networks. Code was previously ignored for default accounts only, now also for user accounts.


### PR DESCRIPTION
Follow up to #933. Instead of ignoring code of known leaked accounts only, we've decided that Hardhat v2 and v3 will both ignore the code in the forked network (see https://github.com/NomicFoundation/hardhat/pull/6842#discussion_r2142794489).