### PR TITLE
edr-0.11.2

### DIFF
--- a/.changeset/neat-rocks-prove.md
+++ b/.changeset/neat-rocks-prove.md
@@ -1,5 +1,0 @@
----
-"@nomicfoundation/edr": patch
----
-
-Removed copying of account code for provider accounts in forked networks. Code was previously ignored for default accounts only, now also for user accounts.

--- a/crates/edr_napi/CHANGELOG.md
+++ b/crates/edr_napi/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @nomicfoundation/edr
 
+## 0.11.2
+
+### Patch Changes
+
+- 56a4266: Removed copying of account code for provider accounts in forked networks. Code was previously ignored for default accounts only, now also for user accounts.
+
 ## 0.11.1
 
 ### Patch Changes

--- a/crates/edr_napi/package.json
+++ b/crates/edr_napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomicfoundation/edr",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "devDependencies": {
     "@napi-rs/cli": "^2.18.4",
     "@types/chai": "^4.2.0",


### PR DESCRIPTION
> ⚠️ This branch is intended to test the upcoming release and should be merged manually, to trigger the release

This release contains the following changes:

- Removed copying of account code for provider accounts in forked networks. Code was previously ignored for default accounts only, now also for user accounts.