### PR TITLE
fix: add custom precompiles support for eth_sendTransaction

### DIFF
--- a/crates/edr_coverage/tests/integration/e2e.rs
+++ b/crates/edr_coverage/tests/integration/e2e.rs
@@ -51,7 +51,14 @@ fn deploy_contract(
         ..l1::BlockEnv::default()
     };
 
-    let result = run::<_, L1ChainSpec, _>(blockchain, state, cfg, signed.into(), block)?;
+    let result = run::<_, L1ChainSpec, _>(
+        blockchain,
+        state,
+        cfg,
+        signed.into(),
+        block,
+        &HashMap::new(),
+    )?;
     let address = if let ExecutionResult::Success {
         output: Output::Create(_, Some(address)),
         ..

--- a/crates/edr_evm/src/block/builder.rs
+++ b/crates/edr_evm/src/block/builder.rs
@@ -6,9 +6,9 @@ use edr_eth::{
     block::{BlockOptions, PartialHeader},
     spec::ChainSpec,
     transaction::TransactionValidation,
-    Address,
+    Address, HashMap,
 };
-use revm::Inspector;
+use revm::{precompile::PrecompileFn, Inspector};
 
 pub use self::l1::{EthBlockBuilder, EthBlockReceiptFactory};
 use crate::{
@@ -110,6 +110,7 @@ where
     fn add_transaction(
         &mut self,
         transaction: ChainSpecT::SignedTransaction,
+        custom_precompiles: &HashMap<Address, PrecompileFn>,
     ) -> Result<
         (),
         BlockTransactionErrorForChainSpec<Self::BlockchainError, ChainSpecT, Self::StateError>,
@@ -120,6 +121,7 @@ where
         &mut self,
         transaction: ChainSpecT::SignedTransaction,
         inspector: &mut InspectorT,
+        custom_precompiles: &HashMap<Address, PrecompileFn>,
     ) -> Result<
         (),
         BlockTransactionErrorForChainSpec<Self::BlockchainError, ChainSpecT, Self::StateError>,

--- a/crates/edr_evm/src/spec.rs
+++ b/crates/edr_evm/src/spec.rs
@@ -226,20 +226,25 @@ pub trait RuntimeSpec:
     fn evm<
         BlockchainErrorT,
         DatabaseT: Database<Error = DatabaseComponentError<BlockchainErrorT, StateErrorT>>,
+        PrecompileProviderT: PrecompileProvider<
+            ContextForChainSpec<Self, DatabaseT>,
+            Output = InterpreterResult
+        >,
         StateErrorT,
     >(
         context: ContextForChainSpec<Self, DatabaseT>,
+        precompile_provider: PrecompileProviderT,
     ) -> Self::Evm<
         BlockchainErrorT,
         DatabaseT,
         NoOpInspector,
-        Self::PrecompileProvider<BlockchainErrorT, DatabaseT, StateErrorT>,
+        PrecompileProviderT,
         StateErrorT,
     > {
         Self::evm_with_inspector(
             context,
             NoOpInspector {},
-            Self::PrecompileProvider::<BlockchainErrorT, DatabaseT, StateErrorT>::default(),
+            precompile_provider,
         )
     }
 

--- a/crates/edr_evm/src/test_utils.rs
+++ b/crates/edr_evm/src/test_utils.rs
@@ -244,7 +244,7 @@ pub async fn run_full_block<
     assert_eq!(replay_header.base_fee_per_gas, builder.header().base_fee);
 
     for transaction in replay_block.transactions() {
-        builder.add_transaction(transaction.clone())?;
+        builder.add_transaction(transaction.clone(), &HashMap::new())?;
     }
 
     let rewards = vec![(

--- a/crates/edr_generic/src/spec.rs
+++ b/crates/edr_generic/src/spec.rs
@@ -120,21 +120,14 @@ impl RuntimeSpec for GenericChainSpec {
     fn evm<
         BlockchainErrorT,
         DatabaseT: Database<Error = DatabaseComponentError<BlockchainErrorT, StateErrorT>>,
+        PrecompileProviderT: PrecompileProvider<ContextForChainSpec<Self, DatabaseT>, Output = InterpreterResult>,
         StateErrorT,
     >(
         context: ContextForChainSpec<Self, DatabaseT>,
-    ) -> Self::Evm<
-        BlockchainErrorT,
-        DatabaseT,
-        NoOpInspector,
-        Self::PrecompileProvider<BlockchainErrorT, DatabaseT, StateErrorT>,
-        StateErrorT,
-    > {
-        Self::evm_with_inspector(
-            context,
-            NoOpInspector {},
-            Self::PrecompileProvider::<BlockchainErrorT, DatabaseT, StateErrorT>::default(),
-        )
+        precompile_provider: PrecompileProviderT,
+    ) -> Self::Evm<BlockchainErrorT, DatabaseT, NoOpInspector, PrecompileProviderT, StateErrorT>
+    {
+        Self::evm_with_inspector(context, NoOpInspector {}, precompile_provider)
     }
 
     fn evm_with_inspector<

--- a/crates/edr_op/src/block/builder.rs
+++ b/crates/edr_op/src/block/builder.rs
@@ -1,8 +1,9 @@
-use edr_eth::{block::PartialHeader, Address};
+use edr_eth::{block::PartialHeader, Address, HashMap};
 use edr_evm::{
     blockchain::SyncBlockchain,
     config::CfgEnv,
     inspector::Inspector,
+    precompile::PrecompileFn,
     spec::ContextForChainSpec,
     state::{DatabaseComponents, SyncState, WrapDatabaseRef},
     BlockBuilder, BlockTransactionErrorForChainSpec, EthBlockBuilder, MineBlockResultAndState,
@@ -67,17 +68,19 @@ where
     fn add_transaction(
         &mut self,
         transaction: transaction::Signed,
+        custom_precompiles: &HashMap<Address, PrecompileFn>,
     ) -> Result<
         (),
         BlockTransactionErrorForChainSpec<Self::BlockchainError, OpChainSpec, Self::StateError>,
     > {
-        self.eth.add_transaction(transaction)
+        self.eth.add_transaction(transaction, custom_precompiles)
     }
 
     fn add_transaction_with_inspector<InspectorT>(
         &mut self,
         transaction: transaction::Signed,
         inspector: &mut InspectorT,
+        custom_precompiles: &HashMap<Address, PrecompileFn>,
     ) -> Result<
         (),
         BlockTransactionErrorForChainSpec<Self::BlockchainError, OpChainSpec, Self::StateError>,
@@ -100,7 +103,7 @@ where
         >,
     {
         self.eth
-            .add_transaction_with_inspector(transaction, inspector)
+            .add_transaction_with_inspector(transaction, inspector, custom_precompiles)
     }
 
     fn finalize(

--- a/crates/edr_provider/src/data.rs
+++ b/crates/edr_provider/src/data.rs
@@ -2244,6 +2244,7 @@ where
     > {
         let reward = miner_reward(config.spec.into()).unwrap_or(0);
         let state_to_be_modified = (*self.current_state()?).clone();
+        let custom_precompiles = self.initial_config.precompile_overrides.clone();
 
         let result = mine_block(
             self.blockchain.as_ref(),
@@ -2255,6 +2256,7 @@ where
             self.initial_config.mining.mem_pool.order,
             reward,
             Some(runtime_observer),
+            &custom_precompiles,
         )?;
 
         Ok(result)
@@ -2273,6 +2275,7 @@ where
     > {
         let reward = miner_reward(config.spec.into()).unwrap_or(0);
         let state_to_be_modified = (*self.current_state()?).clone();
+        let custom_precompiles = self.initial_config.precompile_overrides.clone();
 
         let result = mine_block_with_single_transaction(
             self.blockchain.as_ref(),
@@ -2283,6 +2286,7 @@ where
             self.min_gas_price,
             reward,
             Some(runtime_observer),
+            &custom_precompiles,
         )?;
 
         Ok(result)

--- a/crates/edr_provider/src/debug_trace.rs
+++ b/crates/edr_provider/src/debug_trace.rs
@@ -102,6 +102,7 @@ where
                 evm_config.clone(),
                 transaction,
                 block.clone(),
+                &edr_eth::HashMap::new(),
             )?;
         }
     }

--- a/crates/edr_provider/tests/integration/mod.rs
+++ b/crates/edr_provider/tests/integration/mod.rs
@@ -9,4 +9,5 @@ mod eth_max_priority_fee_per_gas;
 mod eth_request_serialization;
 mod hardhat_request_serialization;
 mod issues;
+mod rip7212;
 mod timestamp;

--- a/crates/edr_provider/tests/integration/rip7212.rs
+++ b/crates/edr_provider/tests/integration/rip7212.rs
@@ -1,0 +1,126 @@
+#![cfg(feature = "test-utils")]
+
+use std::sync::Arc;
+
+use edr_eth::{bytes, l1::L1ChainSpec, signature::public_key_to_address, Bytes, HashMap};
+use edr_provider::{
+    test_utils::create_test_config, time::CurrentTime, MethodInvocation, NoopLogger, Provider,
+    ProviderRequest,
+};
+use edr_rpc_eth::{CallRequest, TransactionRequest};
+use edr_solidity::contract_decoder::ContractDecoder;
+use edr_test_utils::secret_key::secret_key_from_str;
+use revm_precompile::secp256r1;
+use tokio::runtime;
+
+// Example adapted from
+// <https://github.com/maticnetwork/bor/blob/bade7f57df5c09ae060c15fc66aed488c526149e/core/vm/testdata/precompiles/p256Verify.json>
+static CALLDATA: Bytes = bytes!(
+    "4cee90eb86eaa050036147a12d49004b6b9c72bd725d39d4785011fe190f0b4da73bd4903f0ce3b639bbbf6e8e80d16931ff4bcf5993d58468e8fb19086e8cac36dbcd03009df8c59286b162af3bd7fcc0450c9aa81be5d10d312af6c66b1d604aebd3099c618202fcfe16ae7770b0c49ab5eadf74b754204a3bb6060e44eff37618b065f9832de4ca6ca971a7a1adc826d0f7c00181a5fb2ddf79ae00b4e10e"
+);
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rip7212_disabled() -> anyhow::Result<()> {
+    let config = create_test_config(); // default config, no custom precompiles
+
+    let logger = Box::new(NoopLogger::<L1ChainSpec>::default());
+    let subscriber = Box::new(|_event| {});
+    let provider = Provider::new(
+        runtime::Handle::current(),
+        logger,
+        subscriber,
+        config,
+        Arc::<ContractDecoder>::default(),
+        CurrentTime,
+    )?;
+
+    let response =
+        provider.handle_request(ProviderRequest::with_single(MethodInvocation::Call(
+            CallRequest {
+                to: Some(*secp256r1::P256VERIFY.address()),
+                data: Some(CALLDATA.clone()),
+                ..CallRequest::default()
+            },
+            None,
+            None,
+        )))?;
+
+    assert_eq!(response.result, "0x");
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rip7212_enabled() -> anyhow::Result<()> {
+    let mut config = create_test_config();
+    config.precompile_overrides = HashMap::from([(
+        *secp256r1::P256VERIFY.address(),
+        *secp256r1::P256VERIFY.precompile(),
+    )]);
+
+    let logger = Box::new(NoopLogger::<L1ChainSpec>::default());
+    let subscriber = Box::new(|_event| {});
+    let provider = Provider::new(
+        runtime::Handle::current(),
+        logger,
+        subscriber,
+        config,
+        Arc::<ContractDecoder>::default(),
+        CurrentTime,
+    )?;
+
+    let response =
+        provider.handle_request(ProviderRequest::with_single(MethodInvocation::Call(
+            CallRequest {
+                to: Some(*secp256r1::P256VERIFY.address()),
+                data: Some(CALLDATA.clone()),
+                ..CallRequest::default()
+            },
+            None,
+            None,
+        )))?;
+
+    // 1 gwei in hex
+    assert_eq!(
+        response.result,
+        "0x0000000000000000000000000000000000000000000000000000000000000001"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rip7212_enabled_send_transaction() -> anyhow::Result<()> {
+    let mut config = create_test_config();
+    config.precompile_overrides = HashMap::from([(
+        *secp256r1::P256VERIFY.address(),
+        *secp256r1::P256VERIFY.precompile(),
+    )]);
+
+    let secret_key = secret_key_from_str(edr_defaults::SECRET_KEYS[0])?;
+    let sender = public_key_to_address(secret_key.public_key());
+
+    let logger = Box::new(NoopLogger::<L1ChainSpec>::default());
+    let subscriber = Box::new(|_event| {});
+    let provider = Provider::new(
+        runtime::Handle::current(),
+        logger,
+        subscriber,
+        config,
+        Arc::<ContractDecoder>::default(),
+        CurrentTime,
+    )?;
+
+    let response = provider.handle_request(ProviderRequest::with_single(
+        MethodInvocation::SendTransaction(TransactionRequest {
+            from: sender,
+            to: Some(*secp256r1::P256VERIFY.address()),
+            data: Some(CALLDATA.clone()),
+            ..TransactionRequest::default()
+        }),
+    ))?;
+
+    assert_eq!(response.result, "0x");
+
+    Ok(())
+}

--- a/js/integration-tests/solidity-tests/contracts/CustomPrecompile.sol
+++ b/js/integration-tests/solidity-tests/contracts/CustomPrecompile.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.24;
+
+// Test vector from: https://github.com/C2SP/wycheproof/blob/4a6c2bf5dc4c0b67c770233ad33961ee653996a0/testvectors/ecdsa_secp256r1_sha256_test.json#L17
+contract CustomPrecompile {
+    bytes32 h =
+        0xbb5a52f42f9c9261ed4361f59422a1e30036e7c32b270c8807a419feca605023;
+    bytes32 r =
+        0x2ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18;
+    bytes32 s =
+        0x4cd60b855d442f5b3c7b11eb6c4e0ae7525fe710fab9aa7c77a67f79e6fadd76;
+    bytes32 x =
+        0x2927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838;
+    bytes32 y =
+        0xc7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e;
+
+    function rip2712Precompile() public view {
+        bytes
+            memory expected = hex"0000000000000000000000000000000000000000000000000000000000000001";
+        (bool success, bytes memory returndata) = address(0x100).staticcall(
+            abi.encode(h, r, s, x, y)
+        );
+        if (!success) {
+            revert("precompile returned success = false");
+        }
+        if (keccak256(returndata) != keccak256(expected)) {
+            revert("precompile returned wrong return data");
+        }
+    }
+}

--- a/js/integration-tests/solidity-tests/contracts/CustomPrecompile.sol
+++ b/js/integration-tests/solidity-tests/contracts/CustomPrecompile.sol
@@ -14,7 +14,7 @@ contract CustomPrecompile {
     bytes32 y =
         0xc7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e;
 
-    function rip2712Precompile() public view {
+    function rip7212Precompile() public view {
         bytes
             memory expected = hex"0000000000000000000000000000000000000000000000000000000000000001";
         (bool success, bytes memory returndata) = address(0x100).staticcall(

--- a/js/integration-tests/solidity-tests/package.json
+++ b/js/integration-tests/solidity-tests/package.json
@@ -6,8 +6,10 @@
   "devDependencies": {
     "@nomicfoundation/edr": "workspace:*",
     "@nomicfoundation/edr-helpers": "workspace:*",
+    "@nomicfoundation/ethereumjs-util": "^9.0.4",
     "@tsconfig/node20": "^20.1.4",
     "@types/node": "^20.0.0",
+    "ethers": "^6.14.4",
     "forge-std": "github:foundry-rs/forge-std#v1.9.5",
     "hardhat": "3.0.0-next.4",
     "prettier": "^3.2.5",

--- a/js/integration-tests/solidity-tests/test/provider.ts
+++ b/js/integration-tests/solidity-tests/test/provider.ts
@@ -1,0 +1,303 @@
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+import { Interface } from "ethers";
+import { toBytes } from "@nomicfoundation/ethereumjs-util";
+import edr from "@nomicfoundation/edr";
+
+import { TestContext } from "./testContext.js";
+import {
+    L1_CHAIN_TYPE,
+    l1GenesisState,
+    l1HardforkLatest,
+    l1HardforkToString,
+    MineOrdering,
+    SubscriptionEvent,
+} from "@nomicfoundation/edr";
+
+describe("Provider tests", () => {
+    let testContext: TestContext;
+
+    before(async () => {
+        testContext = await TestContext.setup();
+    });
+
+    it("CustomPrecompileEnabled", async function () {
+        const customPrecompileArtifact = testContext.artifacts.find(
+            (artifact) => artifact.id.name === "CustomPrecompile"
+        );
+
+        assert.notStrictEqual(customPrecompileArtifact, undefined);
+
+        const counterInterface = new Interface(customPrecompileArtifact!.contract.abi);
+
+        const hardfork = l1HardforkLatest();
+
+        const providerConfig = {
+            allowBlocksWithSameTimestamp: false,
+            allowUnlimitedContractSize: true,
+            bailOnCallFailure: false,
+            bailOnTransactionFailure: false,
+            blockGasLimit: 300_000_000n,
+            chainId: 123n,
+            chainOverrides: [],
+            coinbase: Buffer.from("0000000000000000000000000000000000000000", "hex"),
+            genesisState: [
+                {
+                    address: toBytes("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"),
+                    balance: 1000n * 10n ** 18n,
+                },
+                ...l1GenesisState(hardfork),
+            ],
+            hardfork: l1HardforkToString(hardfork),
+            initialBlobGas: {
+                gasUsed: 0n,
+                excessGas: 0n,
+            },
+            initialParentBeaconBlockRoot: Buffer.from(
+                "0000000000000000000000000000000000000000000000000000000000000000",
+                "hex"
+            ),
+            minGasPrice: 0n,
+            mining: {
+                autoMine: true,
+                memPool: {
+                    order: MineOrdering.Priority,
+                },
+            },
+            networkId: 123n,
+            observability: {
+                codeCoverage: {
+                    onCollectedCoverageCallback: (coverage: Uint8Array[]) => { },
+                },
+            },
+            ownedAccounts: [
+                "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+            ],
+            precompileOverrides: [(0, edr.precompileP256Verify)()],
+        };
+
+        const loggerConfig = {
+            enable: false,
+            decodeConsoleLogInputsCallback: (_inputs: ArrayBuffer[]): string[] => {
+                return [];
+            },
+            printLineCallback: (_message: string, _replace: boolean) => { },
+        };
+
+        const provider = await testContext.edrContext.createProvider(
+            L1_CHAIN_TYPE,
+            providerConfig,
+            loggerConfig,
+            {
+                subscriptionCallback: (_event: SubscriptionEvent) => { },
+            },
+            {}
+        );
+
+        const sender = "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266";
+
+        const deploymentTransactionResponse = await provider.handleRequest(
+            JSON.stringify({
+                id: 1,
+                jsonrpc: "2.0",
+                method: "eth_sendTransaction",
+                params: [
+                    {
+                        from: sender,
+                        data: customPrecompileArtifact!.contract.bytecode,
+                    },
+                ],
+            })
+        );
+
+        const deploymentTransactionHash = JSON.parse(
+            deploymentTransactionResponse.data
+        ).result;
+
+        const deploymentTransactionReceiptResponse = await provider.handleRequest(
+            JSON.stringify({
+                id: 1,
+                jsonrpc: "2.0",
+                method: "eth_getTransactionReceipt",
+                params: [deploymentTransactionHash],
+            })
+        );
+
+        const deployedAddress = JSON.parse(
+            deploymentTransactionReceiptResponse.data
+        ).result.contractAddress;
+
+        const precompileTransactionResponse = await provider.handleRequest(
+            JSON.stringify({
+                id: 1,
+                jsonrpc: "2.0",
+                method: "eth_sendTransaction",
+                params: [
+                    {
+                        from: sender,
+                        to: deployedAddress,
+                        data: counterInterface.encodeFunctionData("rip2712Precompile"),
+                    },
+                ],
+            })
+        );
+
+        const precompileTransactionHash = JSON.parse(
+            precompileTransactionResponse.data
+        ).result;
+
+        const precompileTransactionReceiptResponse = await provider.handleRequest(
+            JSON.stringify({
+                id: 1,
+                jsonrpc: "2.0",
+                method: "eth_getTransactionReceipt",
+                params: [precompileTransactionHash],
+            })
+        );
+
+        const precompileReceipt = JSON.parse(
+            precompileTransactionReceiptResponse.data
+        ).result;
+        assert.strictEqual(precompileReceipt.status, "0x1");
+    });
+
+    it("CustomPrecompileDisabled", async function () {
+        const customPrecompileArtifact = testContext.artifacts.find(
+            (artifact) => artifact.id.name === "CustomPrecompile"
+        );
+
+        assert.notStrictEqual(customPrecompileArtifact, undefined);
+
+        const counterInterface = new Interface(customPrecompileArtifact!.contract.abi);
+
+        const hardfork = l1HardforkLatest();
+
+        const providerConfig = {
+            allowBlocksWithSameTimestamp: false,
+            allowUnlimitedContractSize: true,
+            bailOnCallFailure: false,
+            bailOnTransactionFailure: false,
+            blockGasLimit: 300_000_000n,
+            chainId: 123n,
+            chainOverrides: [],
+            coinbase: Buffer.from("0000000000000000000000000000000000000000", "hex"),
+            genesisState: [
+                {
+                    address: toBytes("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"),
+                    balance: 1000n * 10n ** 18n,
+                },
+                ...l1GenesisState(hardfork),
+            ],
+            hardfork: l1HardforkToString(hardfork),
+            initialBlobGas: {
+                gasUsed: 0n,
+                excessGas: 0n,
+            },
+            initialParentBeaconBlockRoot: Buffer.from(
+                "0000000000000000000000000000000000000000000000000000000000000000",
+                "hex"
+            ),
+            minGasPrice: 0n,
+            mining: {
+                autoMine: true,
+                memPool: {
+                    order: MineOrdering.Priority,
+                },
+            },
+            networkId: 123n,
+            observability: {
+                codeCoverage: {
+                    onCollectedCoverageCallback: (coverage: Uint8Array[]) => { },
+                },
+            },
+            ownedAccounts: [
+                "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+            ],
+            precompileOverrides: [],
+        };
+
+        const loggerConfig = {
+            enable: false,
+            decodeConsoleLogInputsCallback: (_inputs: ArrayBuffer[]): string[] => {
+                return [];
+            },
+            printLineCallback: (_message: string, _replace: boolean) => { },
+        };
+
+        const provider = await testContext.edrContext.createProvider(
+            L1_CHAIN_TYPE,
+            providerConfig,
+            loggerConfig,
+            {
+                subscriptionCallback: (_event: SubscriptionEvent) => { },
+            },
+            {}
+        );
+
+        const sender = "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266";
+
+        const deploymentTransactionResponse = await provider.handleRequest(
+            JSON.stringify({
+                id: 1,
+                jsonrpc: "2.0",
+                method: "eth_sendTransaction",
+                params: [
+                    {
+                        from: sender,
+                        data: customPrecompileArtifact!.contract.bytecode,
+                    },
+                ],
+            })
+        );
+
+        const deploymentTransactionHash = JSON.parse(
+            deploymentTransactionResponse.data
+        ).result;
+
+        const deploymentTransactionReceiptResponse = await provider.handleRequest(
+            JSON.stringify({
+                id: 1,
+                jsonrpc: "2.0",
+                method: "eth_getTransactionReceipt",
+                params: [deploymentTransactionHash],
+            })
+        );
+
+        const deployedAddress = JSON.parse(
+            deploymentTransactionReceiptResponse.data
+        ).result.contractAddress;
+
+        const precompileTransactionResponse = await provider.handleRequest(
+            JSON.stringify({
+                id: 1,
+                jsonrpc: "2.0",
+                method: "eth_sendTransaction",
+                params: [
+                    {
+                        from: sender,
+                        to: deployedAddress,
+                        data: counterInterface.encodeFunctionData("rip2712Precompile"),
+                    },
+                ],
+            })
+        );
+
+        const precompileTransactionHash = JSON.parse(
+            precompileTransactionResponse.data
+        ).result;
+
+        const precompileTransactionReceiptResponse = await provider.handleRequest(
+            JSON.stringify({
+                id: 1,
+                jsonrpc: "2.0",
+                method: "eth_getTransactionReceipt",
+                params: [precompileTransactionHash],
+            })
+        );
+
+        const precompileReceipt = JSON.parse(
+            precompileTransactionReceiptResponse.data
+        ).result;
+        assert.strictEqual(precompileReceipt.status, "0x0");
+    });
+});

--- a/js/integration-tests/solidity-tests/test/provider.ts
+++ b/js/integration-tests/solidity-tests/test/provider.ts
@@ -136,7 +136,7 @@ describe("Provider tests", () => {
                     {
                         from: sender,
                         to: deployedAddress,
-                        data: counterInterface.encodeFunctionData("rip2712Precompile"),
+                        data: counterInterface.encodeFunctionData("rip7212Precompile"),
                     },
                 ],
             })
@@ -276,7 +276,7 @@ describe("Provider tests", () => {
                     {
                         from: sender,
                         to: deployedAddress,
-                        data: counterInterface.encodeFunctionData("rip2712Precompile"),
+                        data: counterInterface.encodeFunctionData("rip7212Precompile"),
                     },
                 ],
             })

--- a/js/integration-tests/solidity-tests/test/testContext.ts
+++ b/js/integration-tests/solidity-tests/test/testContext.ts
@@ -4,6 +4,7 @@ import {
   CallTrace,
   EdrContext,
   HeuristicFailed,
+  l1ProviderFactory,
   L1_CHAIN_TYPE,
   l1SolidityTestRunnerFactory,
   type SolidityTestRunnerConfigArgs,
@@ -53,6 +54,11 @@ export class TestContext {
       results.artifacts,
       results.testSuiteIds,
       results.tracingConfig
+    );
+
+    await context.edrContext.registerProviderFactory(
+      L1_CHAIN_TYPE,
+      l1ProviderFactory()
     );
 
     await context.edrContext.registerSolidityTestRunnerFactory(


### PR DESCRIPTION
This PR adds support for custom precompiles for `eth_sendTransaction`, which are controlled via `precompileOverrides`. Previously, custom precompiles only worked for `eth_call` with the addition of RIP-7212 support.