### PR TITLE
Fix Alchemy errors in CI

### DIFF
--- a/crates/edr_rpc_eth/src/client.rs
+++ b/crates/edr_rpc_eth/src/client.rs
@@ -431,8 +431,16 @@ mod tests {
                 .expect_err("should have failed");
 
             if let RpcClientError::JsonRpcError { error, .. } = error {
-                assert!(error.message.to_lowercase().contains("block"));
-                assert!(error.code <= -32000);
+                assert!(
+                    error.message.to_lowercase().contains("block"),
+                    "unexpected error: {}",
+                    error.message
+                );
+                assert!(
+                    error.code <= -32000,
+                    "unexpected error code: {}",
+                    error.code
+                );
                 assert!(error.data.is_none());
             } else {
                 unreachable!("Invalid error: {error}");
@@ -660,8 +668,16 @@ mod tests {
                 }
                 Err(error) => {
                     if let RpcClientError::JsonRpcError { error, .. } = error {
-                        assert!(error.message.to_lowercase().contains("block"));
-                        assert!(error.code <= -32000);
+                        assert!(
+                            error.message.to_lowercase().contains("block"),
+                            "unexpected error: {}",
+                            error.message
+                        );
+                        assert!(
+                            error.code <= -32000,
+                            "unexpected error code: {}",
+                            error.code
+                        );
                         assert!(error.data.is_none());
                     } else {
                         unreachable!("Invalid error: {error}");
@@ -803,8 +819,16 @@ mod tests {
                 .expect_err("should have failed");
 
             if let RpcClientError::JsonRpcError { error, .. } = error {
-                assert!(error.message.to_lowercase().contains("block"));
-                assert!(error.code <= -32000);
+                assert!(
+                    error.message.to_lowercase().contains("block"),
+                    "unexpected error: {}",
+                    error.message
+                );
+                assert!(
+                    error.code <= -32000,
+                    "unexpected error code: {}",
+                    error.code
+                );
                 assert!(error.data.is_none());
             } else {
                 unreachable!("Invalid error: {error}");
@@ -929,8 +953,16 @@ mod tests {
                 .expect_err("should have failed");
 
             if let RpcClientError::JsonRpcError { error, .. } = error {
-                assert!(error.message.to_lowercase().contains("block"));
-                assert!(error.code <= -32000);
+                assert!(
+                    error.message.to_lowercase().contains("block"),
+                    "unexpected error: {}",
+                    error.message
+                );
+                assert!(
+                    error.code <= -32000,
+                    "unexpected error code: {}",
+                    error.code
+                );
                 assert!(error.data.is_none());
             } else {
                 unreachable!("Invalid error: {error}");

--- a/crates/edr_rpc_eth/src/client.rs
+++ b/crates/edr_rpc_eth/src/client.rs
@@ -432,11 +432,6 @@ mod tests {
 
             if let RpcClientError::JsonRpcError { error, .. } = error {
                 assert!(
-                    error.message.to_lowercase().contains("block"),
-                    "unexpected error: {}",
-                    error.message
-                );
-                assert!(
                     error.code <= -32000,
                     "unexpected error code: {}",
                     error.code
@@ -669,11 +664,6 @@ mod tests {
                 Err(error) => {
                     if let RpcClientError::JsonRpcError { error, .. } = error {
                         assert!(
-                            error.message.to_lowercase().contains("block"),
-                            "unexpected error: {}",
-                            error.message
-                        );
-                        assert!(
                             error.code <= -32000,
                             "unexpected error code: {}",
                             error.code
@@ -820,11 +810,6 @@ mod tests {
 
             if let RpcClientError::JsonRpcError { error, .. } = error {
                 assert!(
-                    error.message.to_lowercase().contains("block"),
-                    "unexpected error: {}",
-                    error.message
-                );
-                assert!(
                     error.code <= -32000,
                     "unexpected error code: {}",
                     error.code
@@ -953,11 +938,6 @@ mod tests {
                 .expect_err("should have failed");
 
             if let RpcClientError::JsonRpcError { error, .. } = error {
-                assert!(
-                    error.message.to_lowercase().contains("block"),
-                    "unexpected error: {}",
-                    error.message
-                );
                 assert!(
                     error.code <= -32000,
                     "unexpected error code: {}",

--- a/crates/edr_rpc_eth/src/client.rs
+++ b/crates/edr_rpc_eth/src/client.rs
@@ -431,8 +431,8 @@ mod tests {
                 .expect_err("should have failed");
 
             if let RpcClientError::JsonRpcError { error, .. } = error {
-                assert_eq!(error.message, "block not found: 0x7fffffffffffffff");
-                assert_eq!(error.code, -32001);
+                assert!(error.message.to_lowercase().contains("block"));
+                assert!(error.code <= -32000);
                 assert!(error.data.is_none());
             } else {
                 unreachable!("Invalid error: {error}");
@@ -660,11 +660,8 @@ mod tests {
                 }
                 Err(error) => {
                     if let RpcClientError::JsonRpcError { error, .. } = error {
-                        assert_eq!(
-                            error.message,
-                            "One of the blocks specified in filter (fromBlock, toBlock or blockHash) cannot be found."
-                        );
-                        assert_eq!(error.code, -32000);
+                        assert!(error.message.to_lowercase().contains("block"));
+                        assert!(error.code <= -32000);
                         assert!(error.data.is_none());
                     } else {
                         unreachable!("Invalid error: {error}");
@@ -806,8 +803,8 @@ mod tests {
                 .expect_err("should have failed");
 
             if let RpcClientError::JsonRpcError { error, .. } = error {
-                assert_eq!(error.message, "block not found: 0x7fffffffffffffff");
-                assert_eq!(error.code, -32001);
+                assert!(error.message.to_lowercase().contains("block"));
+                assert!(error.code <= -32000);
                 assert!(error.data.is_none());
             } else {
                 unreachable!("Invalid error: {error}");
@@ -932,8 +929,8 @@ mod tests {
                 .expect_err("should have failed");
 
             if let RpcClientError::JsonRpcError { error, .. } = error {
-                assert_eq!(error.message, "block not found: 0x7fffffffffffffff");
-                assert_eq!(error.code, -32001);
+                assert!(error.message.to_lowercase().contains("block"));
+                assert!(error.code <= -32000);
                 assert!(error.data.is_none());
             } else {
                 unreachable!("Invalid error: {error}");

--- a/crates/edr_rpc_eth/src/client.rs
+++ b/crates/edr_rpc_eth/src/client.rs
@@ -431,8 +431,8 @@ mod tests {
                 .expect_err("should have failed");
 
             if let RpcClientError::JsonRpcError { error, .. } = error {
-                assert_eq!(error.message, "Unknown block number");
-                assert_eq!(error.code, -32602);
+                assert_eq!(error.message, "block not found: 0x7fffffffffffffff");
+                assert_eq!(error.code, -32001);
                 assert!(error.data.is_none());
             } else {
                 unreachable!("Invalid error: {error}");
@@ -806,8 +806,8 @@ mod tests {
                 .expect_err("should have failed");
 
             if let RpcClientError::JsonRpcError { error, .. } = error {
-                assert_eq!(error.message, "Unknown block number");
-                assert_eq!(error.code, -32602);
+                assert_eq!(error.message, "block not found: 0x7fffffffffffffff");
+                assert_eq!(error.code, -32001);
                 assert!(error.data.is_none());
             } else {
                 unreachable!("Invalid error: {error}");
@@ -922,16 +922,22 @@ mod tests {
             let dai_address = Address::from_str("0x6b175474e89094c44da98b954eedeac495271d0f")
                 .expect("failed to parse address");
 
-            let storage_slot = TestRpcClient::new(&alchemy_url)
+            let error = TestRpcClient::new(&alchemy_url)
                 .get_storage_at(
                     dai_address,
                     U256::from(1),
                     Some(BlockSpec::Number(MAX_BLOCK_NUMBER)),
                 )
                 .await
-                .expect("should have succeeded");
+                .expect_err("should have failed");
 
-            assert!(storage_slot.is_none());
+            if let RpcClientError::JsonRpcError { error, .. } = error {
+                assert_eq!(error.message, "block not found: 0x7fffffffffffffff");
+                assert_eq!(error.code, -32001);
+                assert!(error.data.is_none());
+            } else {
+                unreachable!("Invalid error: {error}");
+            }
         }
 
         #[tokio::test]

--- a/crates/edr_rpc_eth/src/client.rs
+++ b/crates/edr_rpc_eth/src/client.rs
@@ -431,8 +431,8 @@ mod tests {
                 .expect_err("should have failed");
 
             if let RpcClientError::JsonRpcError { error, .. } = error {
-                assert_eq!(error.code, -32602);
                 assert_eq!(error.message, "Unknown block number");
+                assert_eq!(error.code, -32602);
                 assert!(error.data.is_none());
             } else {
                 unreachable!("Invalid error: {error}");
@@ -660,11 +660,11 @@ mod tests {
                 }
                 Err(error) => {
                     if let RpcClientError::JsonRpcError { error, .. } = error {
-                        assert_eq!(error.code, -32000);
                         assert_eq!(
                             error.message,
                             "One of the blocks specified in filter (fromBlock, toBlock or blockHash) cannot be found."
                         );
+                        assert_eq!(error.code, -32000);
                         assert!(error.data.is_none());
                     } else {
                         unreachable!("Invalid error: {error}");
@@ -806,8 +806,8 @@ mod tests {
                 .expect_err("should have failed");
 
             if let RpcClientError::JsonRpcError { error, .. } = error {
-                assert_eq!(error.code, -32602);
                 assert_eq!(error.message, "Unknown block number");
+                assert_eq!(error.code, -32602);
                 assert!(error.data.is_none());
             } else {
                 unreachable!("Invalid error: {error}");


### PR DESCRIPTION
Some requests now go directly to the nodes (instead of being rejected by Alchemy) and return a different error message than what our test suite expects.

Since we're not sure what exact error we will get and it's not central to these tests, this PR relaxes the assertions for errors.