### PR TITLE
ci: fix hh2 benchmark

### DIFF
--- a/.github/workflows/edr-benchmark.yml
+++ b/.github/workflows/edr-benchmark.yml
@@ -3,7 +3,7 @@ name: EDR Benchmark
 on:
   push:
     branches:
-      - main
+      - hh2
   pull_request:
     branches:
       - "**"
@@ -16,7 +16,7 @@ defaults:
 concurrency:
   group: ${{github.workflow}}-${{github.ref}}
   # Don't cancel in progress jobs in main
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/hh2' }}
 
 jobs:
   js-benchmark:
@@ -24,7 +24,7 @@ jobs:
     environment: github-action-benchmark
     runs-on: self-hosted
     # Only run for trusted collaborators since third-parties could run malicious code on the self-hosted benchmark runner.
-    if: github.ref == 'refs/heads/main' || github.repository == github.event.pull_request.head.repo.full_name
+    if: github.ref == 'refs/heads/hh2' || github.repository == github.event.pull_request.head.repo.full_name
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node
@@ -51,13 +51,13 @@ jobs:
           tool: customSmallerIsBetter
           output-file-path: crates/tools/js/benchmark/report.json
           gh-repository: github.com/nomic-foundation-automation/edr-benchmark-results
-          gh-pages-branch: main
+          gh-pages-branch: hh2
           benchmark-data-dir-path: bench
           github-token: ${{ secrets.BENCHMARK_GITHUB_TOKEN }}
-          # Only save the data for main branch pushes. For PRs we only compare
-          auto-push: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' }}
+          # Only save the data for hh2 branch pushes. For PRs we only compare
+          auto-push: ${{ github.ref == 'refs/heads/hh2' && github.event_name != 'pull_request' }}
           alert-threshold: "110%"
-          # Only fail on pull requests, don't break CI in main
+          # Only fail on pull requests, don't break CI in hh2
           fail-on-alert: ${{ github.event_name == 'pull_request' }}
           # Enable Job Summary for PRs
           summary-always: true


### PR DESCRIPTION
We noticed that the `hh2` branch uses the `main` branch as baseline for scenario benchmarks. This creates false positives, because the REVM version used in `main` is faster than the one in the `hh2`.

This PR does two things:

1. Record baseline on every push for the `hh2` branch. It uses the `hh2` branch of the https://github.com/nomic-foundation-automation/edr-benchmark-results repo to store the recordings. I created the `hh2` branch in the automation repo by forking from the latest `main` and removing the recordings in https://github.com/nomic-foundation-automation/edr-benchmark-results/commit/4da2d50f4769c9dad5f1febc8ea301426aa9f0eb for new commits in `main`.
2. In PRs targeting the `hh2` branch, use the latest recording from the `hh2` branch as the baseline.