### PR TITLE
docs: add setup notes to improve VS Code experience

### DIFF
--- a/book/src/01_getting_started/01_setup.md
+++ b/book/src/01_getting_started/01_setup.md
@@ -4,6 +4,18 @@
 
 To make the developer experience as seamless and consistent as possible, we recommend using the VS Code [devcontainer](https://github.com/NomicFoundation/slang/tree/main/.devcontainer) included in this repository. It is a light image that uses a script to install the minimum required tools to build this project. If you are not familiar with containerized development, we recommend taking a look at [the official VS Code guide](https://code.visualstudio.com/docs/remote/containers). Using a devcontainer allows us to quickly setup the environment and install different dependencies for different projects, without polluting the local environment. In the future, it will enable us to include Windows and Mac OS specific images for cross-platform testing.
 
+If you're using rust-analyzer in VS Code and find that the analysis takes too much time, adding the following to your `settings.json` file will help speed things up significantly:
+
+```json
+"rust-analyzer.procMacro.ignored": {
+    "napi-derive": [
+        "napi"
+    ],
+},
+```
+
+Note: To prevent crashes in rust-analyzer, make sure that the container has enough memory. 16GB should be enough for most use cases.
+
 ## Automated
 
 If you would like to develop outside a container, you can use the automated setup method provided for your platform.


### PR DESCRIPTION
Adds a note to the book to make sure the dev container has enough memory. Increasing from the default 8GB on macOS to 16GB solved most of the Rust language server crashes for me. Also adds a setting that speeds up rust-analyzer checks significantly by ignoring expanding on napi proc-macro.