### PR TITLE
chore: disable Codecov statuses

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,1 +1,7 @@
+coverage:
+  status:
+    project: false
+    patch: false
+    changes: false
+
 github_checks: false


### PR DESCRIPTION
#982 did not disable the right thing: [status checks](https://docs.codecov.com/docs/commit-status) are not the same as [GitHub checks](https://docs.codecov.com/docs/github-checks).

Note Codecov should continue to post a comment in PRs.