### PR TITLE
refactor: use errors instead of panics for invariant violations (#983)

### DIFF
--- a/.changeset/slow-houses-call.md
+++ b/.changeset/slow-houses-call.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Turned panics during stack trace generation due to invalid assumptions into errors.

--- a/crates/edr_napi/src/trace/library_utils.rs
+++ b/crates/edr_napi/src/trace/library_utils.rs
@@ -1,6 +1,11 @@
 use napi_derive::napi;
 
 #[napi]
-pub fn link_hex_string_bytecode(code: String, address: String, position: u32) -> String {
+pub fn link_hex_string_bytecode(
+    code: String,
+    address: String,
+    position: u32,
+) -> napi::Result<String> {
     edr_solidity::library_utils::link_hex_string_bytecode(code, &address, position)
+        .map_err(|err| napi::Error::from_reason(err.to_string()))
 }

--- a/crates/edr_solidity/src/bytecode_trie.rs
+++ b/crates/edr_solidity/src/bytecode_trie.rs
@@ -184,7 +184,7 @@ impl<T: Clone + TrieKeyTrait> BytecodeTrie<T> {
     /// Fill the split node from the node with the node
     /// and the new key as children. If the new key is shorter than the
     /// node's prefix, the new split node will be a match for the new
-    /// key. Panics if `split_index > new_key.key().len()`
+    /// key. Panics if `self.prefix.range_end > new_key.key().len()`
     fn fill_split_node(&mut self, node_to_split: BytecodeTrie<T>, new_item: T) {
         // We use the descendants to keep track of insertion order, so it's
         // important to preserve that order here
@@ -214,8 +214,12 @@ impl<T: Clone + TrieKeyTrait> BytecodeTrie<T> {
             }
             Ordering::Greater => {
                 // If the split index is greater than the length of the key, this function was
-                // called with the wrong arguments due to a bug.
-                panic!("split index is greater than new key length")
+                // called with the wrong arguments due to a bug. Such a bug would be local to
+                // the bytecode trie insertion logic, so while in other parts of `edr_solidity`
+                // we prefer to propagate an error in case of invariant violations due to
+                // possibly unforeseen dependencies between components, we panic
+                // here.
+                unreachable!("split index is greater than new key length")
             }
         }
     }

--- a/crates/edr_solidity/src/library_utils.rs
+++ b/crates/edr_solidity/src/library_utils.rs
@@ -1,6 +1,7 @@
 //! Utility functions for working with libraries in Solidity.
 //! Ported from `hardhat-network/stack-traces/library-utils.ts`.
 
+use anyhow::Context;
 use edr_evm::hex;
 
 use crate::artifacts::CompilerOutputBytecode;
@@ -10,15 +11,15 @@ use crate::artifacts::CompilerOutputBytecode;
 pub fn normalize_compiler_output_bytecode(
     mut compiler_output_bytecode_object: String,
     addresses_positions: &[u32],
-) -> Result<Vec<u8>, hex::FromHexError> {
+) -> Result<Vec<u8>, anyhow::Error> {
     const ZERO_ADDRESS: &str = "0000000000000000000000000000000000000000";
 
     for &pos in addresses_positions {
         compiler_output_bytecode_object =
-            link_hex_string_bytecode(compiler_output_bytecode_object, ZERO_ADDRESS, pos);
+            link_hex_string_bytecode(compiler_output_bytecode_object, ZERO_ADDRESS, pos)?;
     }
 
-    hex::decode(compiler_output_bytecode_object)
+    Ok(hex::decode(compiler_output_bytecode_object)?)
 }
 
 /// Retrieves the positions of the library addresses in the bytecode.
@@ -37,11 +38,17 @@ pub fn get_library_address_positions(bytecode_output: &CompilerOutputBytecode) -
 /// given address. # Panics
 /// This function panics if replacing the address would result in an invalid
 /// UTF-8 string.
-pub fn link_hex_string_bytecode(code: String, address: &str, position: u32) -> String {
+pub fn link_hex_string_bytecode(
+    code: String,
+    address: &str,
+    position: u32,
+) -> Result<String, anyhow::Error> {
     let address = address.strip_prefix("0x").unwrap_or(address);
     let pos = position as usize;
 
     let mut bytes = code.into_bytes();
     bytes[pos * 2..pos * 2 + address.len()].copy_from_slice(address.as_bytes());
-    String::from_utf8(bytes).expect("ASCII string to be valid UTF-8")
+    String::from_utf8(bytes).with_context(|| {
+        format!("Invalid UTF-8 in hex strings for code or address. The address is '{address}'")
+    })
 }

--- a/crates/edr_solidity/src/mapped_inline_internal_functions_heuristics.rs
+++ b/crates/edr_solidity/src/mapped_inline_internal_functions_heuristics.rs
@@ -31,6 +31,8 @@ const FIRST_SOLC_VERSION_WITH_MAPPED_SMALL_INTERNAL_FUNCTIONS: Version = Version
 pub enum HeuristicsError {
     #[error(transparent)]
     BytecodeError(#[from] ContractMetadataError),
+    #[error("Invariant violation: {0}")]
+    InvariantViolation(String),
     #[error("Missing contract")]
     MissingContract,
 }
@@ -72,7 +74,7 @@ pub fn adjust_stack_trace(
         source_reference, ..
     }) = stacktrace.last()
     else {
-        unreachable!("This should be only used immediately after we check with `stack_trace_may_require_adjustments` that the last frame is a revert frame");
+        return Err(HeuristicsError::InvariantViolation("This should be only used immediately after we check with `stack_trace_may_require_adjustments` that the last frame is a revert frame".to_string()));
     };
 
     // Replace the last revert frame with an adjusted frame if needed

--- a/crates/edr_solidity/src/nested_tracer.rs
+++ b/crates/edr_solidity/src/nested_tracer.rs
@@ -19,6 +19,9 @@ use crate::{
 /// Errors that can occur during the generation of the nested trace.
 #[derive(Debug, thiserror::Error)]
 pub enum NestedTracerError {
+    /// Invalid precompile address
+    #[error("Invalid precompile address: {0}")]
+    InvalidPrecompileAddress(U160),
     /// Invalid input: The created address should be defined in the successful
     #[error("Created address should be defined in successful create trace")]
     MissingAddressInExecutionResult,
@@ -114,7 +117,7 @@ impl NestedTracer {
             if to_as_u160 <= U160::from(MAX_PRECOMPILE_NUMBER) {
                 let precompile: u32 = to_as_u160
                     .try_into()
-                    .expect("MAX_PRECOMPILE_NUMBER is of type u16 so it fits");
+                    .map_err(|_err| NestedTracerError::InvalidPrecompileAddress(to_as_u160))?;
 
                 let precompile_trace = PrecompileMessage {
                     value: message.value,


### PR DESCRIPTION
Cherry-picked https://github.com/NomicFoundation/edr/pull/983 for release in HH2

There were some merge conflicts related to the generic halt reason in `main` that I resolved mechanically.

Stacked on top https://github.com/NomicFoundation/edr/pull/987