### PR TITLE
edr-0.11.3

### DIFF
--- a/.changeset/flat-books-retire.md
+++ b/.changeset/flat-books-retire.md
@@ -1,5 +1,0 @@
----
-"@nomicfoundation/edr": patch
----
-
-Fixed custom precompiles not being applied in `eth_sendTransaction`. This enables RIP-7212 support in transactions.

--- a/.changeset/slow-houses-call.md
+++ b/.changeset/slow-houses-call.md
@@ -1,5 +1,0 @@
----
-"@nomicfoundation/edr": patch
----
-
-Turned panics during stack trace generation due to invalid assumptions into errors.

--- a/.changeset/spicy-cameras-fix.md
+++ b/.changeset/spicy-cameras-fix.md
@@ -1,5 +1,0 @@
----
-"@nomicfoundation/edr": minor
----
-
-Fixed panic on stack trace generation for receive function with modifier that calls another method. https://github.com/NomicFoundation/edr/issues/894

--- a/crates/edr_napi/CHANGELOG.md
+++ b/crates/edr_napi/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @nomicfoundation/edr
 
+## 0.11.3
+
+### Patch Changes
+
+- 1ac9b2e4: Fixed custom precompiles not being applied in `eth_sendTransaction`. This enables RIP-7212 support in transactions.
+- 7e12f64: Fixed panic on stack trace generation for receive function with modifier that calls another method. https://github.com/NomicFoundation/edr/issues/894
+- 5861ad6: Turned panics during stack trace generation due to invalid assumptions into errors.
+
 ## 0.11.2
 
 ### Patch Changes

--- a/crates/edr_napi/npm/darwin-arm64/package.json
+++ b/crates/edr_napi/npm/darwin-arm64/package.json
@@ -4,7 +4,7 @@
     "url": "https://github.com/NomicFoundation/edr.git",
     "type": "git"
   },
-  "version": "0.2.0-alpha.1",
+  "version": "0.11.3",
   "main": "edr.darwin-arm64.node",
   "files": [
     "edr.darwin-arm64.node"

--- a/crates/edr_napi/npm/darwin-x64/package.json
+++ b/crates/edr_napi/npm/darwin-x64/package.json
@@ -4,7 +4,7 @@
     "url": "https://github.com/NomicFoundation/edr.git",
     "type": "git"
   },
-  "version": "0.2.0-alpha.1",
+  "version": "0.11.3",
   "main": "edr.darwin-x64.node",
   "files": [
     "edr.darwin-x64.node"

--- a/crates/edr_napi/npm/linux-arm64-gnu/package.json
+++ b/crates/edr_napi/npm/linux-arm64-gnu/package.json
@@ -4,7 +4,7 @@
     "url": "https://github.com/NomicFoundation/edr.git",
     "type": "git"
   },
-  "version": "0.2.0-alpha.1",
+  "version": "0.11.3",
   "main": "edr.linux-arm64-gnu.node",
   "files": [
     "edr.linux-arm64-gnu.node"

--- a/crates/edr_napi/npm/linux-arm64-musl/package.json
+++ b/crates/edr_napi/npm/linux-arm64-musl/package.json
@@ -4,7 +4,7 @@
     "url": "https://github.com/NomicFoundation/edr.git",
     "type": "git"
   },
-  "version": "0.2.0-alpha.1",
+  "version": "0.11.3",
   "main": "edr.linux-arm64-musl.node",
   "files": [
     "edr.linux-arm64-musl.node"

--- a/crates/edr_napi/npm/linux-x64-gnu/package.json
+++ b/crates/edr_napi/npm/linux-x64-gnu/package.json
@@ -4,7 +4,7 @@
     "url": "https://github.com/NomicFoundation/edr.git",
     "type": "git"
   },
-  "version": "0.2.0-alpha.1",
+  "version": "0.11.3",
   "main": "edr.linux-x64-gnu.node",
   "files": [
     "edr.linux-x64-gnu.node"

--- a/crates/edr_napi/npm/linux-x64-musl/package.json
+++ b/crates/edr_napi/npm/linux-x64-musl/package.json
@@ -4,7 +4,7 @@
     "url": "https://github.com/NomicFoundation/edr.git",
     "type": "git"
   },
-  "version": "0.2.0-alpha.1",
+  "version": "0.11.3",
   "main": "edr.linux-x64-musl.node",
   "files": [
     "edr.linux-x64-musl.node"

--- a/crates/edr_napi/npm/win32-x64-msvc/package.json
+++ b/crates/edr_napi/npm/win32-x64-msvc/package.json
@@ -4,7 +4,7 @@
     "url": "https://github.com/NomicFoundation/edr.git",
     "type": "git"
   },
-  "version": "0.2.0-alpha.1",
+  "version": "0.11.3",
   "main": "edr.win32-x64-msvc.node",
   "files": [
     "edr.win32-x64-msvc.node"

--- a/crates/edr_napi/package.json
+++ b/crates/edr_napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomicfoundation/edr",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "devDependencies": {
     "@napi-rs/cli": "^2.18.4",
     "@types/chai": "^4.2.0",


### PR DESCRIPTION
# @nomicfoundation/edr release

## 0.11.3

### Patch Changes

- 1ac9b2e4: Fixed custom precompiles not being applied in `eth_sendTransaction`. This enables RIP-7212 support in transactions.
- 7e12f64: Fixed panic on stack trace generation for receive function with modifier that calls another method. https://github.com/NomicFoundation/edr/issues/894
- 5861ad6: Turned panics during stack trace generation due to invalid assumptions into errors.