### PR TITLE
fix: use previous block's dynamic base fee parameters

### DIFF
--- a/crates/edr_op/src/block/builder.rs
+++ b/crates/edr_op/src/block/builder.rs
@@ -1,5 +1,6 @@
 use edr_eth::{
-    block::PartialHeader, spec::EthHeaderConstants, trie::KECCAK_NULL_RLP, Address, Bytes, HashMap,
+    block::PartialHeader, eips::eip1559::ConstantBaseFeeParams, spec::EthHeaderConstants,
+    trie::KECCAK_NULL_RLP, Address, Bytes, HashMap,
 };
 use edr_evm::{
     blockchain::SyncBlockchain,
@@ -74,15 +75,57 @@ where
         if cfg.spec >= OpSpecId::HOLOCENE {
             const DYNAMIC_BASE_FEE_PARAM_VERSION: u8 = 0x0;
 
-            overrides.extra_data = Some(overrides.extra_data.unwrap_or_else(|| {
-                // Ensure that the same base fee parameters are used in the EthBlockBuilder
-                // and in the extra data.
-                let base_fee_params = overrides.base_fee_params.get_or_insert_with(|| {
-                    *OpChainSpec::BASE_FEE_PARAMS
-                        .at_hardfork(cfg.spec)
-                        .expect("Chain spec must have base fee params for post-London hardforks")
-                });
+            let base_fee_params = overrides.base_fee_params.map_or_else(|| -> Result<ConstantBaseFeeParams, BlockBuilderCreationError<Self::BlockchainError, OpSpecId, Self::StateError>> {
+                let parent_block_number = blockchain.last_block_number();
+                let parent_hardfork = blockchain
+                    .spec_at_block_number(parent_block_number)
+                    .map_err(BlockBuilderCreationError::Blockchain)?;
 
+                if parent_hardfork >= OpSpecId::HOLOCENE {
+                    // Take parameters from parent block's extra data
+                    let parent_block = blockchain
+                        .last_block()
+                        .map_err(BlockBuilderCreationError::Blockchain)?;
+
+                    let parent_header = parent_block.header();
+                    let extra_data = &parent_header.extra_data;
+
+                    let version = *extra_data.first()
+                        .expect("Extra data should have at least 1 byte for version");
+
+                    let base_fee_params = match version {
+                        DYNAMIC_BASE_FEE_PARAM_VERSION => {
+                            let denominator_bytes: [u8; 4] = extra_data[1..=4]
+                                .try_into()
+                                .expect("The slice should be exactly 4 bytes");
+
+                            let elasticity_bytes: [u8; 4] = extra_data[5..=8]
+                                .try_into()
+                                .expect("The slice should be exactly 4 bytes");
+
+                            ConstantBaseFeeParams {
+                                max_change_denominator: u32::from_be_bytes(denominator_bytes)
+                                    .into(),
+                                elasticity_multiplier: u32::from_be_bytes(elasticity_bytes).into(),
+                            }
+                        }
+                        _ => panic!(
+                            "Unsupported base fee params version: {version}. Expected {DYNAMIC_BASE_FEE_PARAM_VERSION}."
+                        )
+                    };
+
+                    Ok(base_fee_params)
+                } else {
+                    // Use the prior EIP-1559 constants.
+                    let base_fee_params = *OpChainSpec::BASE_FEE_PARAMS
+                        .at_hardfork(cfg.spec)
+                        .expect("Chain spec must have base fee params for post-London hardforks");
+
+                    Ok(base_fee_params)
+                }
+            }, Ok)?;
+
+            let extra_data = overrides.extra_data.unwrap_or_else(|| {
                 let denominator: [u8; 4] = u32::try_from(base_fee_params.max_change_denominator)
                     .expect("Base fee denominators can only be up to u32::MAX")
                     .to_be_bytes();
@@ -97,7 +140,10 @@ where
 
                 let bytes: Box<[u8]> = Box::new(extra_data);
                 Bytes::from(bytes)
-            }));
+            });
+
+            overrides.base_fee_params = Some(base_fee_params);
+            overrides.extra_data = Some(extra_data);
         }
 
         let eth = EthBlockBuilder::new(blockchain, state, cfg, inputs, overrides)?;


### PR DESCRIPTION
The implementation in https://github.com/NomicFoundation/edr/pull/977 was part of the [spec](https://specs.optimism.io/protocol/holocene/exec-engine.html#dynamic-eip-1559-parameters). In particular, we were not reading the dynamic base fee parameters from the previous block header's `extra_data`:

> Prior to the Holocene upgrade, the EIP-1559 denominator and elasticity parameters used to compute the block base fee were [constants](https://specs.optimism.io/protocol/exec-engine.html#1559-parameters).
> 
> With the Holocene upgrade, these parameters are instead determined as follows:
> 
>     if Holocene is not active in parent_header.timestamp, the [prior EIP-1559 constants](https://specs.optimism.io/protocol/exec-engine.html#1559-parameters) are used. Note that parent_header.extraData is empty prior to Holocene, except possibly for the genesis block.
>     if Holocene is active at parent_header.timestamp, then the parameters from parent_header.extraData are used.

This PR fixes that oversight and tests it.