### PR TITLE
chore: move custom precompiles to BlockBuilder

### DIFF
--- a/crates/edr_evm/src/block/builder.rs
+++ b/crates/edr_evm/src/block/builder.rs
@@ -130,7 +130,7 @@ where
         cfg: CfgEnv<ChainSpecT::Hardfork>,
         inputs: BlockInputs,
         overrides: HeaderOverrides,
-        custom_precompiles: HashMap<Address, PrecompileFn>,
+        custom_precompiles: &'builder HashMap<Address, PrecompileFn>,
     ) -> Result<
         Self,
         BlockBuilderCreationErrorForChainSpec<Self::BlockchainError, ChainSpecT, Self::StateError>,

--- a/crates/edr_evm/src/block/builder/l1.rs
+++ b/crates/edr_evm/src/block/builder/l1.rs
@@ -44,7 +44,7 @@ where
     transactions: Vec<ChainSpecT::SignedTransaction>,
     transaction_results: Vec<ExecutionResult<ChainSpecT::HaltReason>>,
     withdrawals: Option<Vec<Withdrawal>>,
-    custom_precompiles: HashMap<Address, PrecompileFn>,
+    custom_precompiles: &'builder HashMap<Address, PrecompileFn>,
 }
 
 impl<BlockchainErrorT, ChainSpecT, StateErrorT>
@@ -129,7 +129,7 @@ where
         cfg: CfgEnv<ChainSpecT::Hardfork>,
         inputs: BlockInputs,
         mut overrides: HeaderOverrides,
-        custom_precompiles: HashMap<Address, PrecompileFn>,
+        custom_precompiles: &'builder HashMap<Address, PrecompileFn>,
     ) -> Result<Self, BlockBuilderCreationError<BlockchainErrorT, ChainSpecT::Hardfork, StateErrorT>>
     {
         let parent_block = blockchain
@@ -195,7 +195,7 @@ where
             self.cfg.clone(),
             transaction.clone(),
             block,
-            &self.custom_precompiles,
+            self.custom_precompiles,
         )?;
 
         self.add_transaction_result(receipt_builder, transaction, transaction_result);
@@ -236,7 +236,7 @@ where
             self.cfg.clone(),
             transaction.clone(),
             block,
-            &self.custom_precompiles,
+            self.custom_precompiles,
             extension,
         )
         .map_err(BlockTransactionError::from)?;
@@ -403,7 +403,7 @@ where
         cfg: CfgEnv<ChainSpecT::Hardfork>,
         inputs: BlockInputs,
         overrides: HeaderOverrides,
-        custom_precompiles: HashMap<Address, PrecompileFn>,
+        custom_precompiles: &'builder HashMap<Address, PrecompileFn>,
     ) -> Result<
         Self,
         BlockBuilderCreationError<Self::BlockchainError, ChainSpecT::Hardfork, Self::StateError>,

--- a/crates/edr_evm/src/miner.rs
+++ b/crates/edr_evm/src/miner.rs
@@ -132,7 +132,7 @@ where
         cfg.clone(),
         BlockInputs::new(cfg.spec),
         overrides,
-        custom_precompiles.clone(),
+        custom_precompiles,
     )?;
 
     let mut pending_transactions = {
@@ -402,7 +402,7 @@ where
         cfg.clone(),
         BlockInputs::new(cfg.spec),
         overrides,
-        custom_precompiles.clone(),
+        custom_precompiles,
     )?;
 
     let beneficiary = block_builder.header().beneficiary;

--- a/crates/edr_evm/src/spec.rs
+++ b/crates/edr_evm/src/spec.rs
@@ -134,11 +134,11 @@ pub trait RuntimeSpec:
 
     /// Type representing a block builder.
     type BlockBuilder<
-        'blockchain,
-        BlockchainErrorT: 'blockchain + std::error::Error + Send,
-        StateErrorT: 'blockchain + std::error::Error + Send
+        'builder,
+        BlockchainErrorT: 'builder + std::error::Error + Send,
+        StateErrorT: 'builder + std::error::Error + Send
     >: BlockBuilder<
-        'blockchain,
+        'builder,
         Self,
         BlockchainError = BlockchainErrorT,
         StateError = StateErrorT>;
@@ -369,10 +369,10 @@ impl RuntimeSpec for L1ChainSpec {
     >;
 
     type BlockBuilder<
-        'blockchain,
-        BlockchainErrorT: 'blockchain + Send + std::error::Error,
-        StateErrorT: 'blockchain + Send + std::error::Error,
-    > = EthBlockBuilder<'blockchain, BlockchainErrorT, Self, StateErrorT>;
+        'builder,
+        BlockchainErrorT: 'builder + Send + std::error::Error,
+        StateErrorT: 'builder + Send + std::error::Error,
+    > = EthBlockBuilder<'builder, BlockchainErrorT, Self, StateErrorT>;
 
     type BlockReceipt = BlockReceipt<Self::ExecutionReceipt<FilterLog>>;
     type BlockReceiptFactory = EthBlockReceiptFactory<Self::ExecutionReceipt<FilterLog>>;

--- a/crates/edr_evm/src/test_utils.rs
+++ b/crates/edr_evm/src/test_utils.rs
@@ -235,7 +235,7 @@ pub async fn run_full_block<
             withdrawals: replay_block.withdrawals().map(<[Withdrawal]>::to_vec),
         },
         header_overrides_constructor(replay_header),
-        custom_precompiles,
+        &custom_precompiles,
     )?;
 
     assert_eq!(replay_header.base_fee_per_gas, builder.header().base_fee);

--- a/crates/edr_generic/src/spec.rs
+++ b/crates/edr_generic/src/spec.rs
@@ -45,10 +45,10 @@ impl RuntimeSpec for GenericChainSpec {
     >;
 
     type BlockBuilder<
-        'blockchain,
-        BlockchainErrorT: 'blockchain + std::error::Error + Send,
-        StateErrorT: 'blockchain + std::error::Error + Send,
-    > = EthBlockBuilder<'blockchain, BlockchainErrorT, Self, StateErrorT>;
+        'builder,
+        BlockchainErrorT: 'builder + std::error::Error + Send,
+        StateErrorT: 'builder + std::error::Error + Send,
+    > = EthBlockBuilder<'builder, BlockchainErrorT, Self, StateErrorT>;
 
     type BlockReceipt = BlockReceipt<Self::ExecutionReceipt<FilterLog>>;
 

--- a/crates/edr_op/src/block/builder.rs
+++ b/crates/edr_op/src/block/builder.rs
@@ -19,13 +19,13 @@ use crate::{
 };
 
 /// Block builder for OP.
-pub struct Builder<'blockchain, BlockchainErrorT, StateErrorT> {
-    eth: EthBlockBuilder<'blockchain, BlockchainErrorT, OpChainSpec, StateErrorT>,
+pub struct Builder<'builder, BlockchainErrorT, StateErrorT> {
+    eth: EthBlockBuilder<'builder, BlockchainErrorT, OpChainSpec, StateErrorT>,
     l1_block_info: L1BlockInfo,
 }
 
-impl<'blockchain, BlockchainErrorT, StateErrorT> BlockBuilder<'blockchain, OpChainSpec>
-    for Builder<'blockchain, BlockchainErrorT, StateErrorT>
+impl<'builder, BlockchainErrorT, StateErrorT> BlockBuilder<'builder, OpChainSpec>
+    for Builder<'builder, BlockchainErrorT, StateErrorT>
 where
     BlockchainErrorT: Send + std::error::Error,
     StateErrorT: Send + std::error::Error,
@@ -34,7 +34,7 @@ where
     type StateError = StateErrorT;
 
     fn new_block_builder(
-        blockchain: &'blockchain dyn edr_evm::blockchain::SyncBlockchain<
+        blockchain: &'builder dyn edr_evm::blockchain::SyncBlockchain<
             OpChainSpec,
             Self::BlockchainError,
             Self::StateError,
@@ -43,7 +43,7 @@ where
         cfg: CfgEnv<OpSpecId>,
         mut inputs: BlockInputs,
         mut overrides: edr_eth::block::HeaderOverrides,
-        custom_precompiles: HashMap<Address, PrecompileFn>,
+        custom_precompiles: &'builder HashMap<Address, PrecompileFn>,
     ) -> Result<Self, BlockBuilderCreationError<Self::BlockchainError, OpSpecId, Self::StateError>>
     {
         // TODO: https://github.com/NomicFoundation/edr/issues/990

--- a/crates/edr_op/src/spec.rs
+++ b/crates/edr_op/src/spec.rs
@@ -68,10 +68,10 @@ impl RuntimeSpec for OpChainSpec {
     >;
 
     type BlockBuilder<
-        'blockchain,
-        BlockchainErrorT: 'blockchain + Send + std::error::Error,
-        StateErrorT: 'blockchain + Send + std::error::Error,
-    > = block::Builder<'blockchain, BlockchainErrorT, StateErrorT>;
+        'builder,
+        BlockchainErrorT: 'builder + Send + std::error::Error,
+        StateErrorT: 'builder + Send + std::error::Error,
+    > = block::Builder<'builder, BlockchainErrorT, StateErrorT>;
 
     type BlockReceipt = receipt::Block;
     type BlockReceiptFactory = BlockReceiptFactory;


### PR DESCRIPTION
This PR improves #974 by moving custom precompiles to the `BlockBuilder`, which removes the possibility of using different precompiles for different transactions.