### PR TITLE
chore: move custom precompiles to BlockBuilder

### DIFF
--- a/crates/edr_evm/src/miner.rs
+++ b/crates/edr_evm/src/miner.rs
@@ -131,6 +131,7 @@ where
         &parent_block,
         options,
         dao_hardfork_activation_block,
+        custom_precompiles.clone(),
     )?;
 
     let mut pending_transactions = {
@@ -160,13 +161,7 @@ where
         let ExecutionResultWithContext {
             result,
             evm_context,
-        } = block_builder.add_transaction(
-            blockchain,
-            state,
-            transaction,
-            custom_precompiles,
-            debug_context,
-        );
+        } = block_builder.add_transaction(blockchain, state, transaction, debug_context);
 
         match result {
             Err(
@@ -392,18 +387,13 @@ where
         parent_block.as_ref(),
         options,
         dao_hardfork_activation_block,
+        custom_precompiles.clone(),
     )?;
 
     let ExecutionResultWithContext {
         result,
         evm_context,
-    } = block_builder.add_transaction(
-        blockchain,
-        state,
-        transaction,
-        custom_precompiles,
-        debug_context,
-    );
+    } = block_builder.add_transaction(blockchain, state, transaction, debug_context);
 
     let result = result?;
     let mut state = evm_context.state;

--- a/crates/edr_provider/src/test_utils.rs
+++ b/crates/edr_provider/src/test_utils.rs
@@ -200,6 +200,8 @@ pub async fn run_full_block(url: String, block_number: u64, chain_id: u64) -> an
     let parent = blockchain.last_block()?;
     let replay_header = replay_block.header();
 
+    let custom_precompiles = HashMap::new();
+
     let mut builder = BlockBuilder::new(
         cfg,
         &parent,
@@ -216,25 +218,18 @@ pub async fn run_full_block(url: String, block_number: u64, chain_id: u64) -> an
             ..BlockOptions::default()
         },
         None,
+        custom_precompiles,
     )?;
 
     let mut state =
         blockchain.state_at_block_number(block_number - 1, irregular_state.state_overrides())?;
-
-    let custom_precompiles = HashMap::new();
 
     for transaction in replay_block.transactions() {
         let debug_context: Option<DebugContext<'_, L1ChainSpec, _, (), _>> = None;
         let ExecutionResultWithContext {
             result,
             evm_context: _,
-        } = builder.add_transaction(
-            &blockchain,
-            &mut state,
-            transaction.clone(),
-            &custom_precompiles,
-            debug_context,
-        );
+        } = builder.add_transaction(&blockchain, &mut state, transaction.clone(), debug_context);
 
         result?;
     }


### PR DESCRIPTION
This PR improves #976 by moving custom precompiles to the BlockBuilder, which removes the possibility of using different precompiles for different transactions.

The hh2 branch version of #995 