### PR TITLE
chore: update node to v22 in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "image": "mcr.microsoft.com/devcontainers/base:bullseye",
   "features": {
     "ghcr.io/devcontainers/features/node:1": {
-      "version": "18"
+      "version": "22"
     }
   },
   "postAttachCommand": "scripts/setup.sh",


### PR DESCRIPTION
Updates devcontainer node version to 22. Some parts of the code (HH3 project in `js/integration_tests/solidity_tests`) require node v22 to run.