### PR TITLE
chore: improve docs script and remove warnings

### DIFF
--- a/.github/scripts/cargo-doc.sh
+++ b/.github/scripts/cargo-doc.sh
@@ -1,22 +1,20 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
+
+edr_pkgs=($(
+  cargo metadata --format-version 1 --no-deps \
+  | jq -r '.packages[].name | select(startswith("edr_"))'
+))
+
+foundry_pkgs=($(
+  cargo metadata --format-version 1 --no-deps \
+  | jq -r --arg path "$PWD/crates/foundry/" \
+    '.packages[] | select(.manifest_path | startswith($path)) | .id'
+))
 
 # For EDR crates, test that docs build and they don't have warnings
-for dir in crates/edr_*/ ; do
-    if [ -d "$dir" ]; then
-      pushd "$dir" > /dev/null
-      RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features
-      popd > /dev/null
-    fi
-done
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features "${edr_pkgs[@]/#/--package=}"
 
 # For Foundry crates, only test that docs build and allow linking to private items
-for dir in crates/foundry/* ; do
-    if [ -d "$dir" ]; then
-      pushd "$dir" > /dev/null
-      cargo doc --all-features --no-deps --document-private-items
-      popd > /dev/null
-    fi
-done
-
+RUSTDOCFLAGS="-A warnings" cargo doc --no-deps --all-features --document-private-items "${foundry_pkgs[@]/#/--package=}"


### PR DESCRIPTION
We have an issue currently where Foundry source files have doc warnings.

<img width="1166" height="627" alt="image" src="https://github.com/user-attachments/assets/cf297f0a-0769-4ad1-bdea-116bc366c6ad" />

This PR removes those warnings by adding `RUSTDOCFLAGS="-A warnings"`. I also changed the script a little to run a single `cargo doc` command per group rather than one per crate (this may improve parallelism?), but let me know if you prefer the previous version.