### PR TITLE
chore: increase benchmark samples

### DIFF
--- a/crates/tools/js/benchmark/src/solidity-tests.ts
+++ b/crates/tools/js/benchmark/src/solidity-tests.ts
@@ -52,7 +52,7 @@ export const FORGE_STD_SAMPLES = {
   [TOTAL_NAME]: DEFAULT_SAMPLES,
   StdCheatsTest: DEFAULT_SAMPLES,
   StdCheatsForkTest: 45,
-  StdMathTest: 45,
+  StdMathTest: 65,
   StdStorageTest: DEFAULT_SAMPLES,
   StdUtilsForkTest: DEFAULT_SAMPLES,
 };


### PR DESCRIPTION
Since we're seeing benchmark CI jobs fail often, and this is attributed to high variability, this PR increases the number of samples for some test suites.