### PR TITLE
feat: test execution time in nanoseconds

### DIFF
--- a/.changeset/tender-pillows-grab.md
+++ b/.changeset/tender-pillows-grab.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": minor
+---
+
+Changed test and test suite execution time from milliseconds to nanoseconds. Correspondingly, the `durationMs` property of `TestResult` and `SuiteResult` was renamed to `durationNs`.

--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -1301,7 +1301,7 @@ export declare class SuiteResult {
    */
   readonly id: ArtifactId
   /** See [edr_solidity_tests::result::SuiteResult::duration] */
-  readonly durationMs: bigint
+  readonly durationNs: bigint
   /** See [edr_solidity_tests::result::SuiteResult::test_results] */
   readonly testResults: Array<TestResult>
   /** See [edr_solidity_tests::result::SuiteResult::warnings] */
@@ -1322,7 +1322,7 @@ export declare class TestResult {
   /** See [edr_solidity_tests::result::TestResult::kind] */
   readonly kind: StandardTestKind | FuzzTestKind | InvariantTestKind
   /** See [edr_solidity_tests::result::TestResult::duration] */
-  readonly durationMs: bigint
+  readonly durationNs: bigint
   /**
    * Compute the error stack trace.
    * The result is either the stack trace or the reason why we couldn't

--- a/crates/edr_napi/src/solidity_tests/test_results.rs
+++ b/crates/edr_napi/src/solidity_tests/test_results.rs
@@ -32,7 +32,7 @@ pub struct SuiteResult {
     pub id: ArtifactId,
     /// See [edr_solidity_tests::result::SuiteResult::duration]
     #[napi(readonly)]
-    pub duration_ms: BigInt,
+    pub duration_ns: BigInt,
     /// See [edr_solidity_tests::result::SuiteResult::test_results]
     #[napi(readonly)]
     pub test_results: Vec<TestResult>,
@@ -49,7 +49,7 @@ impl SuiteResult {
     ) -> Self {
         Self {
             id: id.into(),
-            duration_ms: BigInt::from(suite_result.duration.as_millis()),
+            duration_ns: BigInt::from(suite_result.duration.as_nanos()),
             test_results: suite_result
                 .test_results
                 .into_iter()
@@ -84,7 +84,7 @@ pub struct TestResult {
     pub kind: Either3<StandardTestKind, FuzzTestKind, InvariantTestKind>,
     /// See [edr_solidity_tests::result::TestResult::duration]
     #[napi(readonly)]
-    pub duration_ms: BigInt,
+    pub duration_ns: BigInt,
 
     stack_trace_result: Option<Arc<StackTraceResult<String>>>,
     call_trace_arenas: Vec<(traces::TraceKind, SparsedTraceArena)>,
@@ -263,7 +263,7 @@ impl TestResult {
                     reverts: BigInt::from(reverts as u64),
                 }),
             },
-            duration_ms: BigInt::from(test_result.duration.as_millis()),
+            duration_ns: BigInt::from(test_result.duration.as_nanos()),
             stack_trace_result: test_result.stack_trace_result.map(Arc::new),
             call_trace_arenas: if include_trace {
                 test_result.traces

--- a/crates/tools/js/benchmark/src/solidity-tests.ts
+++ b/crates/tools/js/benchmark/src/solidity-tests.ts
@@ -94,12 +94,12 @@ export async function runSolidityTests(
     throw new Error(`Didn't run any tests for ${repoPath}`);
   }
 
-  results.sort((a, b) => Number(a.durationMs - b.durationMs));
+  results.sort((a, b) => Number(a.durationNs - b.durationNs));
   for (const result of results) {
-    console.log(result.id.name, result.durationMs, result.id.source);
+    console.log(result.id.name, result.durationNs / 1000000n, result.id.source);
     for (const test of result.testResults) {
       // @ts-ignore
-      console.log("  ", test.name, test.durationMs, test.kind.runs);
+      console.log("  ", test.name, test.durationNs / 1000000n, test.kind.runs);
     }
   }
 


### PR DESCRIPTION
Report Solidity test execution times in nanoseconds instead of milliseconds. This is needed for accurate comparisions with forge which reports nanoseconds when running `forge test --json`.