### PR TITLE
test: add test for matching Hardhat source names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2994,6 +2994,7 @@ dependencies = [
  "dunce",
  "edr_common",
  "edr_defaults",
+ "edr_solidity",
  "eyre",
  "foundry-cheatcodes-spec 0.3.8",
  "foundry-cheatcodes-spec 1.2.3",

--- a/crates/foundry/cheatcodes/Cargo.toml
+++ b/crates/foundry/cheatcodes/Cargo.toml
@@ -12,6 +12,7 @@ foundry-cheatcodes-spec.workspace = true
 # Nightly (2025-07-02)
 upstream-foundry-cheatcodes-spec = { git = "https://github.com/foundry-rs/foundry", rev = "6983a938580a", package = "foundry-cheatcodes-spec" }
 edr_common.workspace = true
+edr_solidity.workspace = true
 foundry-compilers.workspace = true
 foundry-evm-core.workspace = true
 


### PR DESCRIPTION
Adds a test for artifact id matching in `get*Code` cheatcodes to make sure that it matches Hardhat source names that are now prefixed with `project` or `npm` depending on whether the source file is a dependency. 

Also refactors `get_artifact_code` to allow testing the artifact id matching in isolation.