### PR TITLE
feat: add `allowInternalExpectRevert` config option

### DIFF
--- a/.changeset/stupid-dryers-know.md
+++ b/.changeset/stupid-dryers-know.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Add `allowInternalExpectRevert` config option

--- a/.changeset/stupid-dryers-know.md
+++ b/.changeset/stupid-dryers-know.md
@@ -2,4 +2,4 @@
 "@nomicfoundation/edr": patch
 ---
 
-Add `allowInternalExpectRevert` config option
+Add `allowInternalExpectRevert` config option to customize the behavior of the `expectRevert` cheatcode

--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -125,43 +125,6 @@ export const MERGE: string
 export const SHANGHAI: string
 export const CANCUN: string
 export const PRAGUE: string
-/** Enumeration of supported OP hardforks. */
-export enum OpHardfork {
-  Bedrock = 100,
-  Regolith = 101,
-  Canyon = 102,
-  Ecotone = 103,
-  Fjord = 104,
-  Granite = 105,
-  Holocene = 106,
-  Isthmus = 107
-}
-/**
- * Tries to parse the provided string to create an [`OpHardfork`]
- * instance.
- *
- * Returns an error if the string does not match any known hardfork.
- */
-export declare function opHardforkFromString(hardfork: string): OpHardfork
-/** Returns the string representation of the provided OP hardfork. */
-export declare function opHardforkToString(hardfork: OpHardfork): string
-/**
- * Returns the latest supported OP hardfork.
- *
- * The returned value will be updated after each network upgrade.
- */
-export declare function opLatestHardfork(): OpHardfork
-export const OP_CHAIN_TYPE: string
-export declare function opGenesisState(hardfork: OpHardfork): Array<AccountOverride>
-export declare function opProviderFactory(): ProviderFactory
-export const BEDROCK: string
-export const REGOLITH: string
-export const CANYON: string
-export const ECOTONE: string
-export const FJORD: string
-export const GRANITE: string
-export const HOLOCENE: string
-export const ISTHMUS: string
 /** Specification of a chain with possible overrides. */
 export interface ChainOverride {
   /** The chain ID */
@@ -840,7 +803,6 @@ export enum IncludeTraces {
   All = 2
 }
 export declare function l1SolidityTestRunnerFactory(): SolidityTestRunnerFactory
-export declare function opSolidityTestRunnerFactory(): SolidityTestRunnerFactory
 /** The stack trace result */
 export interface StackTrace {
   /** Enum tag for JS. */
@@ -1307,11 +1269,6 @@ export declare class EdrContext {
    *is called to know when all tests are done.
    */
   runSolidityTests(chainType: string, artifacts: Array<Artifact>, testSuites: Array<ArtifactId>, configArgs: SolidityTestRunnerConfigArgs, tracingConfig: TracingConfigWithBuffers, onTestSuiteCompletedCallback: (result: SuiteResult) => void): Promise<void>
-  /**
-   *Creates a mock provider, which always returns the given response.
-   *For testing purposes.
-   */
-  createMockProvider(mockedResponse: any): Provider
 }
 export declare class Precompile {
   /** Returns the address of the precompile. */

--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -125,6 +125,43 @@ export const MERGE: string
 export const SHANGHAI: string
 export const CANCUN: string
 export const PRAGUE: string
+/** Enumeration of supported OP hardforks. */
+export enum OpHardfork {
+  Bedrock = 100,
+  Regolith = 101,
+  Canyon = 102,
+  Ecotone = 103,
+  Fjord = 104,
+  Granite = 105,
+  Holocene = 106,
+  Isthmus = 107
+}
+/**
+ * Tries to parse the provided string to create an [`OpHardfork`]
+ * instance.
+ *
+ * Returns an error if the string does not match any known hardfork.
+ */
+export declare function opHardforkFromString(hardfork: string): OpHardfork
+/** Returns the string representation of the provided OP hardfork. */
+export declare function opHardforkToString(hardfork: OpHardfork): string
+/**
+ * Returns the latest supported OP hardfork.
+ *
+ * The returned value will be updated after each network upgrade.
+ */
+export declare function opLatestHardfork(): OpHardfork
+export const OP_CHAIN_TYPE: string
+export declare function opGenesisState(hardfork: OpHardfork): Array<AccountOverride>
+export declare function opProviderFactory(): ProviderFactory
+export const BEDROCK: string
+export const REGOLITH: string
+export const CANYON: string
+export const ECOTONE: string
+export const FJORD: string
+export const GRANITE: string
+export const HOLOCENE: string
+export const ISTHMUS: string
 /** Specification of a chain with possible overrides. */
 export interface ChainOverride {
   /** The chain ID */
@@ -520,6 +557,11 @@ export interface SolidityTestRunnerConfigArgs {
    */
   ffi?: boolean
   /**
+   * Allow expecting reverts with `expectRevert` at the same callstack depth
+   * as the test. Defaults to false.
+   */
+  allowInternalExpectRevert?: boolean
+  /**
    * The value of `msg.sender` in tests as hex string.
    * Defaults to `0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38`.
    */
@@ -798,6 +840,7 @@ export enum IncludeTraces {
   All = 2
 }
 export declare function l1SolidityTestRunnerFactory(): SolidityTestRunnerFactory
+export declare function opSolidityTestRunnerFactory(): SolidityTestRunnerFactory
 /** The stack trace result */
 export interface StackTrace {
   /** Enum tag for JS. */
@@ -1264,6 +1307,11 @@ export declare class EdrContext {
    *is called to know when all tests are done.
    */
   runSolidityTests(chainType: string, artifacts: Array<Artifact>, testSuites: Array<ArtifactId>, configArgs: SolidityTestRunnerConfigArgs, tracingConfig: TracingConfigWithBuffers, onTestSuiteCompletedCallback: (result: SuiteResult) => void): Promise<void>
+  /**
+   *Creates a mock provider, which always returns the given response.
+   *For testing purposes.
+   */
+  createMockProvider(mockedResponse: any): Provider
 }
 export declare class Precompile {
   /** Returns the address of the precompile. */

--- a/crates/edr_napi/index.js
+++ b/crates/edr_napi/index.js
@@ -310,7 +310,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { GENERIC_CHAIN_TYPE, genericChainProviderFactory, L1_CHAIN_TYPE, l1GenesisState, l1ProviderFactory, SpecId, l1HardforkFromString, l1HardforkToString, l1HardforkLatest, FRONTIER, FRONTIER_THAWING, HOMESTEAD, DAO_FORK, TANGERINE, SPURIOUS_DRAGON, BYZANTIUM, CONSTANTINOPLE, PETERSBURG, ISTANBUL, MUIR_GLACIER, BERLIN, LONDON, ARROW_GLACIER, GRAY_GLACIER, MERGE, SHANGHAI, CANCUN, PRAGUE, MineOrdering, EdrContext, addStatementCoverageInstrumentation, Precompile, precompileP256Verify, ProviderFactory, Response, Provider, SuccessReason, ExceptionalHalt, CachedChains, CachedEndpoints, FsAccessPermission, IncludeTraces, SolidityTestRunnerFactory, l1SolidityTestRunnerFactory, SuiteResult, TestResult, TestStatus, CallKind, LogKind, linkHexStringBytecode, printStackTrace, Exit, ExitCode, BytecodeWrapper, ContractFunctionType, ReturnData, StackTraceEntryType, stackTraceEntryTypeToString, FALLBACK_FUNCTION_NAME, RECEIVE_FUNCTION_NAME, CONSTRUCTOR_FUNCTION_NAME, UNRECOGNIZED_FUNCTION_NAME, UNKNOWN_FUNCTION_NAME, PRECOMPILE_FUNCTION_NAME, UNRECOGNIZED_CONTRACT_NAME, RawTrace, getLatestSupportedSolcVersion } = nativeBinding
+const { GENERIC_CHAIN_TYPE, genericChainProviderFactory, L1_CHAIN_TYPE, l1GenesisState, l1ProviderFactory, SpecId, l1HardforkFromString, l1HardforkToString, l1HardforkLatest, FRONTIER, FRONTIER_THAWING, HOMESTEAD, DAO_FORK, TANGERINE, SPURIOUS_DRAGON, BYZANTIUM, CONSTANTINOPLE, PETERSBURG, ISTANBUL, MUIR_GLACIER, BERLIN, LONDON, ARROW_GLACIER, GRAY_GLACIER, MERGE, SHANGHAI, CANCUN, PRAGUE, OpHardfork, opHardforkFromString, opHardforkToString, opLatestHardfork, OP_CHAIN_TYPE, opGenesisState, opProviderFactory, BEDROCK, REGOLITH, CANYON, ECOTONE, FJORD, GRANITE, HOLOCENE, ISTHMUS, MineOrdering, EdrContext, addStatementCoverageInstrumentation, Precompile, precompileP256Verify, ProviderFactory, Response, Provider, SuccessReason, ExceptionalHalt, CachedChains, CachedEndpoints, FsAccessPermission, IncludeTraces, SolidityTestRunnerFactory, l1SolidityTestRunnerFactory, opSolidityTestRunnerFactory, SuiteResult, TestResult, TestStatus, CallKind, LogKind, linkHexStringBytecode, printStackTrace, Exit, ExitCode, BytecodeWrapper, ContractFunctionType, ReturnData, StackTraceEntryType, stackTraceEntryTypeToString, FALLBACK_FUNCTION_NAME, RECEIVE_FUNCTION_NAME, CONSTRUCTOR_FUNCTION_NAME, UNRECOGNIZED_FUNCTION_NAME, UNKNOWN_FUNCTION_NAME, PRECOMPILE_FUNCTION_NAME, UNRECOGNIZED_CONTRACT_NAME, RawTrace, getLatestSupportedSolcVersion } = nativeBinding
 
 module.exports.GENERIC_CHAIN_TYPE = GENERIC_CHAIN_TYPE
 module.exports.genericChainProviderFactory = genericChainProviderFactory
@@ -340,6 +340,21 @@ module.exports.MERGE = MERGE
 module.exports.SHANGHAI = SHANGHAI
 module.exports.CANCUN = CANCUN
 module.exports.PRAGUE = PRAGUE
+module.exports.OpHardfork = OpHardfork
+module.exports.opHardforkFromString = opHardforkFromString
+module.exports.opHardforkToString = opHardforkToString
+module.exports.opLatestHardfork = opLatestHardfork
+module.exports.OP_CHAIN_TYPE = OP_CHAIN_TYPE
+module.exports.opGenesisState = opGenesisState
+module.exports.opProviderFactory = opProviderFactory
+module.exports.BEDROCK = BEDROCK
+module.exports.REGOLITH = REGOLITH
+module.exports.CANYON = CANYON
+module.exports.ECOTONE = ECOTONE
+module.exports.FJORD = FJORD
+module.exports.GRANITE = GRANITE
+module.exports.HOLOCENE = HOLOCENE
+module.exports.ISTHMUS = ISTHMUS
 module.exports.MineOrdering = MineOrdering
 module.exports.EdrContext = EdrContext
 module.exports.addStatementCoverageInstrumentation = addStatementCoverageInstrumentation
@@ -356,6 +371,7 @@ module.exports.FsAccessPermission = FsAccessPermission
 module.exports.IncludeTraces = IncludeTraces
 module.exports.SolidityTestRunnerFactory = SolidityTestRunnerFactory
 module.exports.l1SolidityTestRunnerFactory = l1SolidityTestRunnerFactory
+module.exports.opSolidityTestRunnerFactory = opSolidityTestRunnerFactory
 module.exports.SuiteResult = SuiteResult
 module.exports.TestResult = TestResult
 module.exports.TestStatus = TestStatus

--- a/crates/edr_napi/index.js
+++ b/crates/edr_napi/index.js
@@ -310,7 +310,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { GENERIC_CHAIN_TYPE, genericChainProviderFactory, L1_CHAIN_TYPE, l1GenesisState, l1ProviderFactory, SpecId, l1HardforkFromString, l1HardforkToString, l1HardforkLatest, FRONTIER, FRONTIER_THAWING, HOMESTEAD, DAO_FORK, TANGERINE, SPURIOUS_DRAGON, BYZANTIUM, CONSTANTINOPLE, PETERSBURG, ISTANBUL, MUIR_GLACIER, BERLIN, LONDON, ARROW_GLACIER, GRAY_GLACIER, MERGE, SHANGHAI, CANCUN, PRAGUE, OpHardfork, opHardforkFromString, opHardforkToString, opLatestHardfork, OP_CHAIN_TYPE, opGenesisState, opProviderFactory, BEDROCK, REGOLITH, CANYON, ECOTONE, FJORD, GRANITE, HOLOCENE, ISTHMUS, MineOrdering, EdrContext, addStatementCoverageInstrumentation, Precompile, precompileP256Verify, ProviderFactory, Response, Provider, SuccessReason, ExceptionalHalt, CachedChains, CachedEndpoints, FsAccessPermission, IncludeTraces, SolidityTestRunnerFactory, l1SolidityTestRunnerFactory, opSolidityTestRunnerFactory, SuiteResult, TestResult, TestStatus, CallKind, LogKind, linkHexStringBytecode, printStackTrace, Exit, ExitCode, BytecodeWrapper, ContractFunctionType, ReturnData, StackTraceEntryType, stackTraceEntryTypeToString, FALLBACK_FUNCTION_NAME, RECEIVE_FUNCTION_NAME, CONSTRUCTOR_FUNCTION_NAME, UNRECOGNIZED_FUNCTION_NAME, UNKNOWN_FUNCTION_NAME, PRECOMPILE_FUNCTION_NAME, UNRECOGNIZED_CONTRACT_NAME, RawTrace, getLatestSupportedSolcVersion } = nativeBinding
+const { GENERIC_CHAIN_TYPE, genericChainProviderFactory, L1_CHAIN_TYPE, l1GenesisState, l1ProviderFactory, SpecId, l1HardforkFromString, l1HardforkToString, l1HardforkLatest, FRONTIER, FRONTIER_THAWING, HOMESTEAD, DAO_FORK, TANGERINE, SPURIOUS_DRAGON, BYZANTIUM, CONSTANTINOPLE, PETERSBURG, ISTANBUL, MUIR_GLACIER, BERLIN, LONDON, ARROW_GLACIER, GRAY_GLACIER, MERGE, SHANGHAI, CANCUN, PRAGUE, MineOrdering, EdrContext, addStatementCoverageInstrumentation, Precompile, precompileP256Verify, ProviderFactory, Response, Provider, SuccessReason, ExceptionalHalt, CachedChains, CachedEndpoints, FsAccessPermission, IncludeTraces, SolidityTestRunnerFactory, l1SolidityTestRunnerFactory, SuiteResult, TestResult, TestStatus, CallKind, LogKind, linkHexStringBytecode, printStackTrace, Exit, ExitCode, BytecodeWrapper, ContractFunctionType, ReturnData, StackTraceEntryType, stackTraceEntryTypeToString, FALLBACK_FUNCTION_NAME, RECEIVE_FUNCTION_NAME, CONSTRUCTOR_FUNCTION_NAME, UNRECOGNIZED_FUNCTION_NAME, UNKNOWN_FUNCTION_NAME, PRECOMPILE_FUNCTION_NAME, UNRECOGNIZED_CONTRACT_NAME, RawTrace, getLatestSupportedSolcVersion } = nativeBinding
 
 module.exports.GENERIC_CHAIN_TYPE = GENERIC_CHAIN_TYPE
 module.exports.genericChainProviderFactory = genericChainProviderFactory
@@ -340,21 +340,6 @@ module.exports.MERGE = MERGE
 module.exports.SHANGHAI = SHANGHAI
 module.exports.CANCUN = CANCUN
 module.exports.PRAGUE = PRAGUE
-module.exports.OpHardfork = OpHardfork
-module.exports.opHardforkFromString = opHardforkFromString
-module.exports.opHardforkToString = opHardforkToString
-module.exports.opLatestHardfork = opLatestHardfork
-module.exports.OP_CHAIN_TYPE = OP_CHAIN_TYPE
-module.exports.opGenesisState = opGenesisState
-module.exports.opProviderFactory = opProviderFactory
-module.exports.BEDROCK = BEDROCK
-module.exports.REGOLITH = REGOLITH
-module.exports.CANYON = CANYON
-module.exports.ECOTONE = ECOTONE
-module.exports.FJORD = FJORD
-module.exports.GRANITE = GRANITE
-module.exports.HOLOCENE = HOLOCENE
-module.exports.ISTHMUS = ISTHMUS
 module.exports.MineOrdering = MineOrdering
 module.exports.EdrContext = EdrContext
 module.exports.addStatementCoverageInstrumentation = addStatementCoverageInstrumentation
@@ -371,7 +356,6 @@ module.exports.FsAccessPermission = FsAccessPermission
 module.exports.IncludeTraces = IncludeTraces
 module.exports.SolidityTestRunnerFactory = SolidityTestRunnerFactory
 module.exports.l1SolidityTestRunnerFactory = l1SolidityTestRunnerFactory
-module.exports.opSolidityTestRunnerFactory = opSolidityTestRunnerFactory
 module.exports.SuiteResult = SuiteResult
 module.exports.TestResult = TestResult
 module.exports.TestStatus = TestStatus

--- a/crates/edr_napi/src/solidity_tests/config.rs
+++ b/crates/edr_napi/src/solidity_tests/config.rs
@@ -51,6 +51,9 @@ pub struct SolidityTestRunnerConfigArgs {
     /// tests to execute arbitrary programs on your computer.
     /// Defaults to false.
     pub ffi: Option<bool>,
+    /// Allow expecting reverts with `expectRevert` at the same callstack depth
+    /// as the test. Defaults to false.
+    pub allow_internal_expect_revert: Option<bool>,
     /// The value of `msg.sender` in tests as hex string.
     /// Defaults to `0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38`.
     #[debug("{:?}", sender.as_ref().map(hex::encode))]
@@ -167,6 +170,7 @@ impl SolidityTestRunnerConfigArgs {
             labels,
             isolate,
             ffi,
+            allow_internal_expect_revert,
             sender,
             tx_origin,
             initial_balance,
@@ -254,6 +258,7 @@ impl SolidityTestRunnerConfigArgs {
                 .into_iter()
                 .map(|AddressLabel { address, label }| Ok((address.try_cast()?, label)))
                 .collect::<Result<_, napi::Error>>()?,
+            allow_internal_expect_revert: allow_internal_expect_revert.unwrap_or(false),
         };
 
         let on_collected_coverage_fn = observability.map_or_else(

--- a/crates/foundry/cheatcodes/src/config.rs
+++ b/crates/foundry/cheatcodes/src/config.rs
@@ -49,6 +49,8 @@ pub struct CheatsConfig<HardforkT> {
     pub available_artifacts: Arc<ContractsByArtifact>,
     /// Version of the script/test contract which is currently running.
     pub running_version: Option<Version>,
+    /// Whether to allow `expectRevert` to work for internal calls.
+    pub internal_expect_revert: bool,
 }
 
 /// Solidity test execution contexts.
@@ -88,6 +90,9 @@ pub struct CheatsConfigOptions {
     pub prompt_timeout: u64,
     /// Address labels
     pub labels: HashMap<Address, String>,
+    /// Allow expecting reverts with `expectRevert` at the same callstack depth
+    /// as the test.
+    pub allow_internal_expect_revert: bool,
 }
 
 impl<HardforkT: HardforkTr> CheatsConfig<HardforkT> {
@@ -107,6 +112,7 @@ impl<HardforkT: HardforkTr> CheatsConfig<HardforkT> {
             rpc_storage_caching,
             fs_permissions,
             labels,
+            allow_internal_expect_revert,
         } = config;
 
         let fs_permissions = fs_permissions.joined(&project_root);
@@ -124,6 +130,7 @@ impl<HardforkT: HardforkTr> CheatsConfig<HardforkT> {
             labels,
             available_artifacts,
             running_version,
+            internal_expect_revert: allow_internal_expect_revert,
         }
     }
 
@@ -268,6 +275,7 @@ impl<HardforkT: HardforkTr> Default for CheatsConfig<HardforkT> {
             labels: HashMap::default(),
             available_artifacts: Arc::<ContractsByArtifact>::default(),
             running_version: Option::default(),
+            internal_expect_revert: false,
         }
     }
 }
@@ -288,6 +296,7 @@ mod tests {
             fs_permissions,
             prompt_timeout: 0,
             labels: HashMap::default(),
+            allow_internal_expect_revert: false,
         };
 
         CheatsConfig::new(

--- a/crates/foundry/cheatcodes/src/inspector.rs
+++ b/crates/foundry/cheatcodes/src/inspector.rs
@@ -1217,7 +1217,7 @@ impl<
                     return match revert_handlers::handle_expect_revert(
                         cheatcode_call,
                         false,
-                        expected_revert.allow_internal,
+                        self.config.internal_expect_revert || expected_revert.allow_internal,
                         &expected_revert,
                         outcome.result.result,
                         outcome.result.output.clone(),
@@ -1625,7 +1625,7 @@ impl<
                 return match revert_handlers::handle_expect_revert(
                     false,
                     true,
-                    false,
+                    self.config.internal_expect_revert,
                     &expected_revert,
                     outcome.result.result,
                     outcome.result.output.clone(),

--- a/js/integration-tests/solidity-tests/test-contracts/InternalExpectRevert.t.sol
+++ b/js/integration-tests/solidity-tests/test-contracts/InternalExpectRevert.t.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/src/Test.sol";
+
+contract InternalExpectRevertTest is Test {
+    function testInternalExpectRevert() public {
+        vm.expectRevert();
+        revert("reverted in top level scope");
+    }
+}

--- a/js/integration-tests/solidity-tests/test/unit.ts
+++ b/js/integration-tests/solidity-tests/test/unit.ts
@@ -279,4 +279,37 @@ describe("Unit tests", () => {
     assert.equal(totalTests, 1);
     assert.equal(failedTests, 0);
   });
+
+  describe("InternalExpectRevert", async function () {
+    it("allowInternalExpectRevert is true", async function () {
+      const { totalTests, failedTests } = await testContext.runTestsWithStats(
+        "InternalExpectRevertTest",
+        {
+          allowInternalExpectRevert: true,
+        },
+        L1_CHAIN_TYPE
+      );
+
+      assert.equal(totalTests, 1);
+      assert.equal(failedTests, 0);
+    });
+
+    it("allowInternalExpectRevert default", async function () {
+      const { totalTests, failedTests, stackTraces } =
+        await testContext.runTestsWithStats(
+          "InternalExpectRevertTest",
+          undefined,
+          L1_CHAIN_TYPE
+        );
+
+      assert.equal(totalTests, 1);
+      assert.equal(failedTests, 1);
+
+      const stackTrace = stackTraces.get("testInternalExpectRevert()");
+      assert.equal(
+        stackTrace?.reason,
+        "call didn't revert at a lower depth than cheatcode call depth"
+      );
+    });
+  });
 });


### PR DESCRIPTION
Add `allowInternalExpectRevert` global config option which is needed by the [Uniswap v4 ](https://github.com/Uniswap/v4-core/blob/59d3ecf53afa9264a16bba0e38f4c5d2231f80bc/foundry.toml#L10) and [prb-math](https://github.com/PaulRBerg/prb-math/blob/aad73cfc6cdc2c9b660199b5b1e9db391ea48640/foundry.toml#L4) repos.

Only JS tests, no Rust tests as this will be tested once on the Rust side once we have inline config option support, and the JS tests give enough confidence until then.