### PR TITLE
chore/fix: release workflow early error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,6 @@ jobs:
         run: |
           pnpm changeset status --output status.json
           VERSION="$(jq -r '.releases[] | select(.name == "@nomicfoundation/edr").newVersion' status.json)"
-          [ -n "$VERSION" ] || exit 1
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Create Release Pull Request


### PR DESCRIPTION
The release workflow is [failing on main](https://github.com/NomicFoundation/edr/actions/runs/16509302271/job/46687723525) after https://github.com/NomicFoundation/edr/pull/1020.

When there is no new release, `[ -n "$VERSION" ] || exit 1` is exiting the workflow with an error, which is not what we want. This removes that early error and just continues. `changesets/action` won't open a PR.