### PR TITLE
chore/fix: remove temp file from changesets PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,9 @@ jobs:
       - name: Get version from package.json
         id: get-version
         run: |
-          pnpm changeset status --output status.json
-          VERSION="$(jq -r '.releases[] | select(.name == "@nomicfoundation/edr").newVersion' status.json)"
+          STATUS="$RUNNER_TEMP/status.json"
+          pnpm changeset status --output "$STATUS"
+          VERSION="$(jq -r '.releases[] | select(.name == "@nomicfoundation/edr").newVersion' "$STATUS")"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Create Release Pull Request


### PR DESCRIPTION
It appears that Changesets is adding any files in the repository in its versioning commit, as seen in https://github.com/NomicFoundation/edr/pull/1024/commits/6f1288d7e40472e5edf5c02d780f5c5780f89216. This moves the temporary file to a temporary directory.