### PR TITLE
chore: enable coverage in integration tests

### DIFF
--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -116,6 +116,11 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - uses: ./.github/actions/setup-rust
+        with:
+          components: llvm-tools-preview
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Restore EDR RPC cache
         uses: actions/cache/restore@v4
@@ -123,9 +128,6 @@ jobs:
           path: |
             **/edr-cache
           key: edr-ts-rpc-cache-v1-${{ matrix.os }}
-
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Install package
         run: pnpm install --frozen-lockfile --prefer-offline
@@ -137,6 +139,7 @@ jobs:
         run: |
           source <(cargo llvm-cov show-env --export-prefix)
           pnpm -C crates/edr_napi test
+          # `--release` included to match `build:dev` compilation flags
           cargo llvm-cov report --release --codecov --output-path codecov.json
 
       - name: Upload coverage to Codecov
@@ -227,8 +230,28 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-node
 
+      - uses: ./.github/actions/setup-rust
+        with:
+          components: llvm-tools-preview
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
       - name: Install package
         run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Run integration tests
-        run: pnpm run --recursive --filter './js/integration-tests/*' test
+        shell: bash
+        run: |
+          source <(cargo llvm-cov show-env --export-prefix)
+          pnpm run --recursive --filter './js/integration-tests/*' test
+          # `--release` included to match `build:dev` compilation flags
+          cargo llvm-cov report --release --codecov --output-path codecov.json
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: codecov.json
+          name: ${{ matrix.os }}
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/hardhat-tests.yml
+++ b/.github/workflows/hardhat-tests.yml
@@ -23,7 +23,13 @@ jobs:
       - uses: ./.github/actions/setup-node
         with:
           node-version: ${{ matrix.node }}
+
       - uses: ./.github/actions/setup-rust
+        with:
+          components: llvm-tools-preview
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Install package
         run: pnpm install --frozen-lockfile --prefer-offline
@@ -50,7 +56,13 @@ jobs:
           FORCE_COLOR: 3
           NODE_OPTIONS: --max-old-space-size=4096
           DEBUG: "hardhat:core:hardhat-network:*"
-        run: cd hardhat-tests && pnpm test:ci
+        shell: bash
+        run: |
+          source <(cargo llvm-cov show-env --export-prefix)
+          pnpm -C hardhat-tests test:ci
+          # `--release` included to match `build:dev` compilation flags
+          cargo llvm-cov report --release --codecov --output-path codecov.json
+
   lint-hardhat-tests:
     name: Lint Hardhat tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
#1032 fell short of collecting coverage for all JS-based test suites. This PR extends the same method to integration tests and Hardhat tests.