### PR TITLE
test: reduce memory consumption of issue 543 test by 40%

### DIFF
--- a/crates/edr_napi/test/mock.ts
+++ b/crates/edr_napi/test/mock.ts
@@ -10,15 +10,15 @@ describe("Provider", () => {
     const parsedJson = JSON.parse(fileContent);
     const structLog = parsedJson.structLogs[0];
 
-    // This creates a JSON of length ~950 000 000 characters.
+    // This creates a JSON of length ~570 000 000 characters.
     // JSON.stringify() crashes at ~500 000 000 characters.
-    for (let i = 1; i < 20000; i++) {
+    for (let i = 1; i < 12000; i++) {
       parsedJson.structLogs.push(structLog);
     }
 
     // Increased timeout is needed to allow the large JSON to be processed.
     // Local tests indicate <100.000ms timeout is enough, but CI may be slower.
-    this.timeout(500_000);
+    this.timeout(300_000);
 
     // Ignore this on testNoBuild
     // @ts-ignore


### PR DESCRIPTION
When my devcontainer was short on memory, I ran into a problem with the "issue 543" TS test "freezing" because the system would start writing RAM to disk and take forever.

By reducing the memory usage by 40%, we're still causing a crash in `JSON.stringify` but minimising the time & memory resources used.

I also lowered the timeout, as the test now runs quicker.