### PR TITLE
ci: reduce benchmark time by 80%

### DIFF
--- a/crates/tools/js/benchmark/src/solidity-tests.ts
+++ b/crates/tools/js/benchmark/src/solidity-tests.ts
@@ -49,11 +49,11 @@ const DEFAULT_SAMPLES = 25;
 
 // Map of test suites to benchmark individually to number of samples (how many times to run the test suite)
 export const FORGE_STD_SAMPLES = {
-  [TOTAL_NAME]: DEFAULT_SAMPLES,
+  [TOTAL_NAME]: 5,
   StdCheatsTest: DEFAULT_SAMPLES,
   StdCheatsForkTest: 45,
   StdMathTest: 65,
-  StdStorageTest: DEFAULT_SAMPLES,
+  StdStorageTest: 5,
   StdUtilsForkTest: DEFAULT_SAMPLES,
 };
 

--- a/crates/tools/js/benchmark/src/solidity-tests.ts
+++ b/crates/tools/js/benchmark/src/solidity-tests.ts
@@ -45,16 +45,14 @@ const RPC_CACHE_PATH = "./edr-cache";
 const TOTAL_NAME = "Total";
 const TOTAL_EXPECTED_RESULTS = 15;
 
-const DEFAULT_SAMPLES = 25;
-
 // Map of test suites to benchmark individually to number of samples (how many times to run the test suite)
 export const FORGE_STD_SAMPLES = {
   [TOTAL_NAME]: 5,
-  StdCheatsTest: DEFAULT_SAMPLES,
+  StdCheatsTest: 25,
   StdCheatsForkTest: 45,
   StdMathTest: 65,
   StdStorageTest: 5,
-  StdUtilsForkTest: DEFAULT_SAMPLES,
+  StdUtilsForkTest: 25,
 };
 
 const REPO_DIR = "forge-std";


### PR DESCRIPTION
Following https://github.com/NomicFoundation/edr/pull/1012, Solidity test benchmark run times [increased](https://github.com/NomicFoundation/edr/actions/runs/16680238634/job/47217929068?pr=1042) to over an hour. The culprits are:

- `[TOTAL_NAME]` increased from 5 -> 25 (this task takes about 70 seconds)
- `StdStorageTest` increased from 5 -> 25 (this task takes about 69 seconds)

To the best of my knowledge, these two tests never caused false positives, so I propose returning them to their original sample count.