### PR TITLE
chore: use different token for Changesets PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,4 +38,7 @@ jobs:
           title: "edr-${{ steps.get-version.outputs.version }}"
           commit: "edr-${{ steps.get-version.outputs.version }}"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # If the default GITHUB_TOKEN is used, checks will not run in release PRs.
+          # To have checks run, set up CHANGESETS_TOKEN in repo secrets with read/write
+          # permission for Contents and Pull requests scopes.
+          GITHUB_TOKEN: ${{ secrets.CHANGESETS_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The commit and PR created by the Changesets bot doesn't trigger any checks if we use the built-in `secrets.GITHUB_TOKEN`. This is to prevent a loop of workflow triggers. The only way around it is to use a different token. We will need to configure it in repo secrets later.