### PR TITLE
chore: fix race condition in integration tests

### DIFF
--- a/js/helpers/src/index.ts
+++ b/js/helpers/src/index.ts
@@ -75,10 +75,13 @@ export async function buildSolidityTestsInput(
   testSuiteIds: ArtifactId[];
   tracingConfig: TracingConfigWithBuffers;
 }> {
-  // NOTE: We run the compile task first to ensure all the artifacts for them are generated
-  // Then, we compile just the test sources. We don't do it in one go because the user
-  // is likely to use different compilation options for the tests and the sources.
-  await hre.tasks.getTask("compile").run();
+  // Cache assumes one build process at a time.
+  await buildMutex().use(async () => {
+    // NOTE: We run the compile task first to ensure all the artifacts for them are generated
+    // Then, we compile just the test sources. We don't do it in one go because the user
+    // is likely to use different compilation options for the tests and the sources.
+    await hre.tasks.getTask("compile").run();
+  });
 
   // NOTE: A test file is either a file with a `.sol` extension in the `tests.solidity`
   // directory or a file with a `.t.sol` extension in the `sources.solidity` directory


### PR DESCRIPTION
We are seeing integration tests fail after a change in #1055.

I was no longer able to reproduce it locally with this fix.