### PR TITLE
fix: forge comparison benchmark improvements

### DIFF
--- a/crates/tools/js/benchmark/patches/forge-std.patch
+++ b/crates/tools/js/benchmark/patches/forge-std.patch
@@ -10,24 +10,20 @@ index 756106d..b1bc08d 100644
 +artifacts
 +.DS_Store
 diff --git a/foundry.toml b/foundry.toml
-index 62ca21a..9daa823 100644
+index 62ca21a..51a474f 100644
 --- a/foundry.toml
 +++ b/foundry.toml
-@@ -1,8 +1,13 @@
+@@ -1,7 +1,9 @@
  [profile.default]
  fs_permissions = [{ access = "read-write", path = "./"}]
 +solc_version = "0.8.30"
  optimizer = true
  optimizer_runs = 200
++fuzz = { runs = 256, seed = "0x1234567890123456789012345678901234567890" }
  
-+[fuzz]
-+seed = "0x1234567890123456789012345678901234567890"
-+runs = 256
-+
  [rpc_endpoints]
  # The RPC URLs are modified versions of the default for testing initialization.
- mainnet = "https://eth.merkle.io" # Different API key.
-@@ -20,4 +25,4 @@ multiline_func_header = 'attributes_first'
+@@ -20,4 +22,4 @@ multiline_func_header = 'attributes_first'
  quote_style = 'double'
  number_underscore = 'preserve'
  single_line_statement_blocks = 'preserve'
@@ -73,19 +69,19 @@ index 0000000..7ffeba4
 +
 diff --git a/package-lock.json b/package-lock.json
 new file mode 100644
-index 0000000..8a86f11
+index 0000000..8715639
 --- /dev/null
 +++ b/package-lock.json
 @@ -0,0 +1,3161 @@
 +{
 +  "name": "forge-std",
-+  "version": "1.8.2",
++  "version": "1.10.0",
 +  "lockfileVersion": 3,
 +  "requires": true,
 +  "packages": {
 +    "": {
 +      "name": "forge-std",
-+      "version": "1.8.2",
++      "version": "1.10.0",
 +      "license": "(Apache-2.0 OR MIT)",
 +      "dependencies": {
 +        "hardhat": "^2.22.5"
@@ -3405,18 +3401,3 @@ diff --git a/test/fixtures/test.toml b/test/fixtures/testRead.toml
 similarity index 100%
 rename from test/fixtures/test.toml
 rename to test/fixtures/testRead.toml
-diff --git a/test/fixtures/testWrite.json b/test/fixtures/testWrite.json
-new file mode 100644
-index 0000000..caebf6d
---- /dev/null
-+++ b/test/fixtures/testWrite.json
-@@ -0,0 +1,8 @@
-+{
-+  "a": 123,
-+  "b": "test",
-+  "c": {
-+    "a": 123,
-+    "b": "test"
-+  }
-+}
-\ No newline at end of file

--- a/crates/tools/js/benchmark/patches/morpho-blue.patch
+++ b/crates/tools/js/benchmark/patches/morpho-blue.patch
@@ -10,29 +10,30 @@ index 00af394..0000000
 -forge install
 -yarn
 diff --git a/foundry.toml b/foundry.toml
-index 7242cf4..59b1f66 100644
+index 7242cf4..1bb3b6f 100644
 --- a/foundry.toml
 +++ b/foundry.toml
-@@ -7,11 +7,13 @@ optimizer = true
+@@ -7,11 +7,9 @@ optimizer = true
  optimizer_runs = 999999
  bytecode_hash = "none"
  evm_version = "paris"
+-
+-[profile.default.invariant]
+-runs = 16
+-depth = 256
+-fail_on_revert = true
 +allow_internal_expect_revert = true
- 
- [profile.default.invariant]
- runs = 16
- depth = 256
- fail_on_revert = true
-+seed = "1234"
++fuzz = { runs = 256, seed = "0x1234" }
++invariant = { runs = 16, depth = 256, fail_on_revert = true, seed = "0x1234" }
  
  [profile.default.fmt]
  wrap_comments = true
 diff --git a/hardhat.config.js b/hardhat.config.js
 new file mode 100644
-index 0000000..d750e86
+index 0000000..ffd179a
 --- /dev/null
 +++ b/hardhat.config.js
-@@ -0,0 +1,29 @@
+@@ -0,0 +1,36 @@
 +module.exports = {
 +"paths": {
 +  "sources": "src",
@@ -43,6 +44,9 @@ index 0000000..d750e86
 +"solidity": {
 +  "version": "0.8.19",
 +  "settings": {
++    "metadata": {
++      "bytecodeHash": "none"
++    },
 +    "optimizer": {
 +      "enabled": true,
 +      "runs": 999999,
@@ -53,11 +57,15 @@ index 0000000..d750e86
 +},
 +"solidityTest": {
 +  "allowInternalExpectRevert": true,
++  "fuzz": {
++    "runs": 256,
++    "seed": "0x1234",
++  },
 +  "invariant": {
 +    "runs": 16,
 +    "depth": 256,
 +    "failOnRevert": true,
-+    "seed": "1234",
++    "seed": "0x1234",
 +  },
 +}
 +};
@@ -12950,7 +12958,7 @@ index 5fbb815..5d3441b 100644
          vm.assume(x > type(uint128).max);
          vm.expectRevert(bytes(ErrorsLib.MAX_UINT128_EXCEEDED));
 diff --git a/yarn.lock b/yarn.lock
-index f97c8ad..9fc80db 100644
+index f97c8ad..fed487c 100644
 --- a/yarn.lock
 +++ b/yarn.lock
 @@ -4,44 +4,34 @@
@@ -13860,7 +13868,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-k9qbLoY7qn6C6Y1LI0gk2kyHXil2Tauj4kGzQ8pgxYXIGw8lWn8tuuL72E11CrlKaXRUvOgF0EXrv/msPI2SbA==
    dependencies:
      debug "^4.1.1"
-@@ -945,71 +918,26 @@
+@@ -945,71 +918,31 @@
  
  "@nomicfoundation/hardhat-foundry@^1.0.3":
    version "1.0.3"
@@ -13899,11 +13907,12 @@ index f97c8ad..9fc80db 100644
 +  resolved "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-arm64-gnu/-/solidity-analyzer-linux-arm64-gnu-0.1.1.tgz"
    integrity sha512-g4Cv2fO37ZsUENQ2vwPnZc2zRenHyAxHcyBjKcjaSmmkKrFr64yvzeNO8S3GBFCo90rfochLs99wFVGT/0owpg==
  
--"@nomicfoundation/solidity-analyzer-linux-arm64-musl@0.1.1":
--  version "0.1.1"
+ "@nomicfoundation/solidity-analyzer-linux-arm64-musl@0.1.1":
+   version "0.1.1"
 -  resolved "https://registry.yarnpkg.com/@nomicfoundation/solidity-analyzer-linux-arm64-musl/-/solidity-analyzer-linux-arm64-musl-0.1.1.tgz#c9e06b5d513dd3ab02a7ac069c160051675889a4"
--  integrity sha512-WJ3CE5Oek25OGE3WwzK7oaopY8xMw9Lhb0mlYuJl/maZVo+WtP36XoQTb7bW/i8aAdHW5Z+BqrHMux23pvxG3w==
--
++  resolved "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-arm64-musl/-/solidity-analyzer-linux-arm64-musl-0.1.1.tgz"
+   integrity sha512-WJ3CE5Oek25OGE3WwzK7oaopY8xMw9Lhb0mlYuJl/maZVo+WtP36XoQTb7bW/i8aAdHW5Z+BqrHMux23pvxG3w==
+ 
 -"@nomicfoundation/solidity-analyzer-linux-x64-gnu@0.1.1":
 -  version "0.1.1"
 -  resolved "https://registry.yarnpkg.com/@nomicfoundation/solidity-analyzer-linux-x64-gnu/-/solidity-analyzer-linux-x64-gnu-0.1.1.tgz#8d328d16839e52571f72f2998c81e46bf320f893"
@@ -13936,7 +13945,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-1LMtXj1puAxyFusBgUIy5pZk3073cNXYnXUpuNKFghHbIit/xZgbk0AokpUADbNm3gyD6bFWl3LRFh3dhVdREg==
    optionalDependencies:
      "@nomicfoundation/solidity-analyzer-darwin-arm64" "0.1.1"
-@@ -1025,12 +953,12 @@
+@@ -1025,12 +958,12 @@
  
  "@scure/base@~1.1.0":
    version "1.1.1"
@@ -13951,7 +13960,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-XyNh1rB0SkEqd3tXcXMi+Xe1fvg+kUIcoRIEujP1Jgv7DqW2r9lg3Ah0NkFaCs9sTkQAQA8kw7xiRXzENi9Rtw==
    dependencies:
      "@noble/hashes" "~1.2.0"
-@@ -1039,7 +967,7 @@
+@@ -1039,7 +972,7 @@
  
  "@scure/bip32@1.3.1":
    version "1.3.1"
@@ -13960,7 +13969,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-osvveYtyzdEVbt3OfwwXFr4P2iVBL5u1Q3q4ONBfDY/UpOuXmOlbgwc1xECEboY8wIays8Yt6onaWMUdUbfl0A==
    dependencies:
      "@noble/curves" "~1.1.0"
-@@ -1048,7 +976,7 @@
+@@ -1048,7 +981,7 @@
  
  "@scure/bip39@1.1.1":
    version "1.1.1"
@@ -13969,7 +13978,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-t+wDck2rVkh65Hmv280fYdVdY25J9YeEUIgn2LG1WM6gxFkGzcksoDiUkWVpVp3Oex9xGC68JU2dSbUfwZ2jPg==
    dependencies:
      "@noble/hashes" "~1.2.0"
-@@ -1056,7 +984,7 @@
+@@ -1056,7 +989,7 @@
  
  "@scure/bip39@1.2.1":
    version "1.2.1"
@@ -13978,7 +13987,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==
    dependencies:
      "@noble/hashes" "~1.3.0"
-@@ -1064,7 +992,7 @@
+@@ -1064,7 +997,7 @@
  
  "@sentry/core@5.30.0":
    version "5.30.0"
@@ -13987,7 +13996,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-TmfrII8w1PQZSZgPpUESqjB+jC6MvZJZdLtE/0hZ+SrnKhW3x5WlYLvTXZpcWePYBku7rl2wn1RZu6uT0qCTeg==
    dependencies:
      "@sentry/hub" "5.30.0"
-@@ -1075,7 +1003,7 @@
+@@ -1075,7 +1008,7 @@
  
  "@sentry/hub@5.30.0":
    version "5.30.0"
@@ -13996,7 +14005,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-2tYrGnzb1gKz2EkMDQcfLrDTvmGcQPuWxLnJKXJvYTQDGLlEvi2tWz1VIHjunmOvJrB5aIQLhm+dcMRwFZDCqQ==
    dependencies:
      "@sentry/types" "5.30.0"
-@@ -1084,7 +1012,7 @@
+@@ -1084,7 +1017,7 @@
  
  "@sentry/minimal@5.30.0":
    version "5.30.0"
@@ -14005,7 +14014,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-BwWb/owZKtkDX+Sc4zCSTNcvZUq7YcH3uAVlmh/gtR9rmUvbzAA3ewLuB3myi4wWRAMEtny6+J/FN/x+2wn9Xw==
    dependencies:
      "@sentry/hub" "5.30.0"
-@@ -1093,7 +1021,7 @@
+@@ -1093,7 +1026,7 @@
  
  "@sentry/node@^5.18.1":
    version "5.30.0"
@@ -14014,7 +14023,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-Br5oyVBF0fZo6ZS9bxbJZG4ApAjRqAnqFFurMVJJdunNb80brh7a5Qva2kjhm+U6r9NJAB5OmDyPkA1Qnt+QVg==
    dependencies:
      "@sentry/core" "5.30.0"
-@@ -1108,7 +1036,7 @@
+@@ -1108,7 +1041,7 @@
  
  "@sentry/tracing@5.30.0":
    version "5.30.0"
@@ -14023,7 +14032,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-dUFowCr0AIMwiLD7Fs314Mdzcug+gBVo/+NCMyDw8tFxJkwWAKl7Qa2OZxLQ0ZHjakcj1hNKfCQJ9rhyfOl4Aw==
    dependencies:
      "@sentry/hub" "5.30.0"
-@@ -1119,12 +1047,12 @@
+@@ -1119,12 +1052,12 @@
  
  "@sentry/types@5.30.0":
    version "5.30.0"
@@ -14038,7 +14047,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-zaYmoH0NWWtvnJjC9/CBseXMtKHm/tm40sz3YfJRxeQjyzRqNQPgivpd9R/oDJCYj999mzdW382p/qi2ypjLww==
    dependencies:
      "@sentry/types" "5.30.0"
-@@ -1132,21 +1060,21 @@
+@@ -1132,21 +1065,21 @@
  
  "@solidity-parser/parser@^0.14.0":
    version "0.14.5"
@@ -14063,7 +14072,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-YBepjbt+ZNBVmN3ev1amQH3lWCmHyt5qTbLCp/syXJRu/Kw2koXh44qayB1gMRxcL/gV8egmjN5xWSrYyfUtyw==
    dependencies:
      "@babel/generator" "7.17.7"
-@@ -1158,27 +1086,27 @@
+@@ -1158,27 +1091,27 @@
  
  "@tsconfig/node10@^1.0.7":
    version "1.0.9"
@@ -14096,7 +14105,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-wsz7AvbY5n2uVwpS2RHDYsW6wYOrhWxeTLFpxuzhO62w/ZDQEVIipArX731KA/hdqygP2zJ2RTkVXgzU1WrU1g==
    dependencies:
      lodash "^4.17.15"
-@@ -1186,54 +1114,54 @@
+@@ -1186,54 +1119,54 @@
  
  "@typechain/hardhat@^9.0.0":
    version "9.0.0"
@@ -14159,7 +14168,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==
    dependencies:
      "@types/minimatch" "*"
-@@ -1241,79 +1169,79 @@
+@@ -1241,79 +1174,79 @@
  
  "@types/lodash@^4.14.197":
    version "4.14.197"
@@ -14262,7 +14271,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-oM5JSKQCcICF1wvGgmecmHldZ48OZamtMxcGGVICOJA8o8cahXC1zEVAif8iwoc5j8etxFaRFnf095+CDsuoFQ==
    dependencies:
      "@types/node" "*"
-@@ -1321,32 +1249,19 @@
+@@ -1321,32 +1254,19 @@
  
  "@types/secp256k1@^4.0.1":
    version "4.0.3"
@@ -14299,7 +14308,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-t6jv+xHy+VYwc4xqZMn2Pa9DjcdzvzZmQGRjTFc8spIbRGHgBrEKbPq+rYXc7CCo0lxgYvSgKVg9qZAhpVQSjA==
    dependencies:
      buffer "^6.0.3"
-@@ -1359,44 +1274,44 @@ abstract-level@^1.0.0, abstract-level@^1.0.2, abstract-level@^1.0.3:
+@@ -1359,44 +1279,44 @@ abstract-level@^1.0.0, abstract-level@^1.0.2, abstract-level@^1.0.3:
  
  acorn-walk@^8.1.1:
    version "8.2.0"
@@ -14352,7 +14361,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==
    dependencies:
      clean-stack "^2.0.0"
-@@ -1404,7 +1319,7 @@ aggregate-error@^3.0.0:
+@@ -1404,7 +1324,7 @@ aggregate-error@^3.0.0:
  
  ajv@^6.12.3:
    version "6.12.6"
@@ -14361,7 +14370,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
    dependencies:
      fast-deep-equal "^3.1.1"
-@@ -1414,7 +1329,7 @@ ajv@^6.12.3:
+@@ -1414,7 +1334,7 @@ ajv@^6.12.3:
  
  ajv@^8.11.0:
    version "8.12.0"
@@ -14370,7 +14379,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==
    dependencies:
      fast-deep-equal "^3.1.1"
-@@ -1424,85 +1339,90 @@ ajv@^8.11.0:
+@@ -1424,85 +1344,90 @@ ajv@^8.11.0:
  
  amdefine@>=0.0.4:
    version "1.0.1"
@@ -14458,13 +14467,13 @@ index f97c8ad..9fc80db 100644
  
 -ansi-styles@^6.0.0, ansi-styles@^6.1.0:
 +ansi-styles@^6.0.0:
-+  version "6.2.1"
+   version "6.2.1"
+-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.1.tgz#0e62320cf99c21afff3b3012192546aacbfb05c5"
 +  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz"
 +  integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
 +
 +ansi-styles@^6.1.0:
-   version "6.2.1"
--  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.1.tgz#0e62320cf99c21afff3b3012192546aacbfb05c5"
++  version "6.2.1"
 +  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz"
    integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
  
@@ -14481,7 +14490,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==
    dependencies:
      normalize-path "^3.0.0"
-@@ -1510,34 +1430,39 @@ anymatch@~3.1.1, anymatch@~3.1.2:
+@@ -1510,34 +1435,39 @@ anymatch@~3.1.1, anymatch@~3.1.2:
  
  arg@^4.1.0:
    version "4.1.3"
@@ -14528,7 +14537,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==
    dependencies:
      call-bind "^1.0.2"
-@@ -1545,22 +1470,22 @@ array-buffer-byte-length@^1.0.0:
+@@ -1545,22 +1475,22 @@ array-buffer-byte-length@^1.0.0:
  
  array-ify@^1.0.0:
    version "1.0.0"
@@ -14555,7 +14564,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-kDdugMl7id9COE8R7MHF5jWk7Dqt/fs4Pv+JXoICnYwqpjjjbUurz6w5fT5IG6brLdJhv6/VoHB0H7oyIBXd+Q==
    dependencies:
      call-bind "^1.0.2"
-@@ -1571,7 +1496,7 @@ array.prototype.reduce@^1.0.5:
+@@ -1571,7 +1501,7 @@ array.prototype.reduce@^1.0.5:
  
  arraybuffer.prototype.slice@^1.0.1:
    version "1.0.1"
@@ -14564,7 +14573,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-09x0ZWFEjj4WD8PDbykUwo3t9arLn8NIzmmYEJFpYekOAQjpkGSyrQhNoRTcwwcFRu+ycWF78QZ63oWTqSjBcw==
    dependencies:
      array-buffer-byte-length "^1.0.0"
-@@ -1583,123 +1508,128 @@ arraybuffer.prototype.slice@^1.0.1:
+@@ -1583,123 +1513,128 @@ arraybuffer.prototype.slice@^1.0.1:
  
  arrify@^1.0.1:
    version "1.0.1"
@@ -14721,7 +14730,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
    dependencies:
      balanced-match "^1.0.0"
-@@ -1707,26 +1637,26 @@ brace-expansion@^1.1.7:
+@@ -1707,26 +1642,26 @@ brace-expansion@^1.1.7:
  
  brace-expansion@^2.0.1:
    version "2.0.1"
@@ -14752,7 +14761,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-XECYKJ+Dbzw0lbydyQuJzwNXtOpbMSq737qxJN11sIRTErOMShvDpbzTlgju7orJKvx4epULolZAuJGLzCmWRQ==
    dependencies:
      abstract-level "^1.0.2"
-@@ -1736,12 +1666,12 @@ browser-level@^1.0.1:
+@@ -1736,12 +1671,12 @@ browser-level@^1.0.1:
  
  browser-stdout@1.3.1:
    version "1.3.1"
@@ -14767,7 +14776,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==
    dependencies:
      buffer-xor "^1.0.3"
-@@ -1753,14 +1683,14 @@ browserify-aes@^1.2.0:
+@@ -1753,14 +1688,14 @@ browserify-aes@^1.2.0:
  
  bs58@^4.0.0:
    version "4.0.1"
@@ -14784,7 +14793,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==
    dependencies:
      bs58 "^4.0.0"
-@@ -1769,17 +1699,17 @@ bs58check@^2.1.2:
+@@ -1769,17 +1704,17 @@ bs58check@^2.1.2:
  
  buffer-from@^1.0.0:
    version "1.1.2"
@@ -14805,7 +14814,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
    dependencies:
      base64-js "^1.3.1"
-@@ -1787,19 +1717,19 @@ buffer@^6.0.3:
+@@ -1787,19 +1722,19 @@ buffer@^6.0.3:
  
  busboy@^1.6.0:
    version "1.6.0"
@@ -14828,7 +14837,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==
    dependencies:
      function-bind "^1.1.1"
-@@ -1807,12 +1737,12 @@ call-bind@^1.0.0, call-bind@^1.0.2:
+@@ -1807,12 +1742,12 @@ call-bind@^1.0.0, call-bind@^1.0.2:
  
  callsites@^3.0.0:
    version "3.1.0"
@@ -14843,7 +14852,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==
    dependencies:
      camelcase "^5.3.1"
-@@ -1821,39 +1751,39 @@ camelcase-keys@^6.2.2:
+@@ -1821,39 +1756,39 @@ camelcase-keys@^6.2.2:
  
  camelcase@^5.0.0, camelcase@^5.3.1:
    version "5.3.1"
@@ -14891,7 +14900,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-vX4YvVVtxlfSZ2VecZgFUTU5qPCYsobVI2O9FmwEXBhDigYGQA6jRXCycIs1yJnnWbZ6/+a2zNIF5DfVCcJBFQ==
    dependencies:
      assertion-error "^1.1.0"
-@@ -1864,14 +1794,9 @@ chai@^4.3.8:
+@@ -1864,14 +1799,9 @@ chai@^4.3.8:
      pathval "^1.1.1"
      type-detect "^4.0.5"
  
@@ -14907,7 +14916,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
    dependencies:
      ansi-styles "^3.2.1"
-@@ -1880,60 +1805,65 @@ chalk@^2.4.2:
+@@ -1880,60 +1810,65 @@ chalk@^2.4.2:
  
  chalk@^4.1.0, chalk@^4.1.2:
    version "4.1.2"
@@ -14994,7 +15003,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==
    dependencies:
      inherits "^2.0.1"
-@@ -1941,7 +1871,7 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
+@@ -1941,7 +1876,7 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
  
  classic-level@^1.2.0:
    version "1.3.0"
@@ -15003,7 +15012,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-iwFAJQYtqRTRM0F6L8h4JCt00ZSGdOyqh7yVrhhjrOpFhmBjNlRUey64MCiyo6UmQHMJ+No3c81nujPv+n9yrg==
    dependencies:
      abstract-level "^1.0.2"
-@@ -1952,19 +1882,19 @@ classic-level@^1.2.0:
+@@ -1952,19 +1887,19 @@ classic-level@^1.2.0:
  
  clean-stack@^2.0.0:
    version "2.2.0"
@@ -15026,7 +15035,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==
    dependencies:
      object-assign "^4.1.0"
-@@ -1974,7 +1904,7 @@ cli-table3@^0.5.0:
+@@ -1974,7 +1909,7 @@ cli-table3@^0.5.0:
  
  cli-truncate@^3.1.0:
    version "3.1.0"
@@ -15035,7 +15044,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==
    dependencies:
      slice-ansi "^5.0.0"
-@@ -1982,7 +1912,7 @@ cli-truncate@^3.1.0:
+@@ -1982,7 +1917,7 @@ cli-truncate@^3.1.0:
  
  cliui@^5.0.0:
    version "5.0.0"
@@ -15044,7 +15053,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==
    dependencies:
      string-width "^3.1.0"
-@@ -1991,7 +1921,7 @@ cliui@^5.0.0:
+@@ -1991,7 +1926,7 @@ cliui@^5.0.0:
  
  cliui@^7.0.2:
    version "7.0.4"
@@ -15053,7 +15062,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
    dependencies:
      string-width "^4.2.0"
-@@ -2000,7 +1930,7 @@ cliui@^7.0.2:
+@@ -2000,7 +1935,7 @@ cliui@^7.0.2:
  
  cliui@^8.0.1:
    version "8.0.1"
@@ -15062,7 +15071,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
    dependencies:
      string-width "^4.2.0"
-@@ -2009,53 +1939,53 @@ cliui@^8.0.1:
+@@ -2009,53 +1944,53 @@ cliui@^8.0.1:
  
  color-convert@^1.9.0:
    version "1.9.3"
@@ -15130,7 +15139,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==
    dependencies:
      array-back "^3.1.0"
-@@ -2065,7 +1995,7 @@ command-line-args@^5.1.1:
+@@ -2065,7 +2000,7 @@ command-line-args@^5.1.1:
  
  command-line-usage@^6.1.0:
    version "6.1.3"
@@ -15139,7 +15148,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-sH5ZSPr+7UStsloltmDh7Ce5fb8XPlHyoPzTpyyMuYCtervL65+ubVZ6Q61cFtFl62UyJlc8/JwERRbAFPUqgw==
    dependencies:
      array-back "^4.0.2"
-@@ -2075,17 +2005,17 @@ command-line-usage@^6.1.0:
+@@ -2075,17 +2010,17 @@ command-line-usage@^6.1.0:
  
  commander@11.0.0:
    version "11.0.0"
@@ -15160,7 +15169,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==
    dependencies:
      array-ify "^1.0.0"
-@@ -2093,12 +2023,12 @@ compare-func@^2.0.0:
+@@ -2093,12 +2028,12 @@ compare-func@^2.0.0:
  
  concat-map@0.0.1:
    version "0.0.1"
@@ -15175,7 +15184,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
    dependencies:
      buffer-from "^1.0.0"
-@@ -2108,51 +2038,46 @@ concat-stream@^1.6.0, concat-stream@^1.6.2:
+@@ -2108,51 +2043,46 @@ concat-stream@^1.6.0, concat-stream@^1.6.2:
  
  conventional-changelog-angular@^6.0.0:
    version "6.0.0"
@@ -15237,7 +15246,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==
    dependencies:
      import-fresh "^3.2.1"
-@@ -2162,12 +2087,12 @@ cosmiconfig@^8.0.0:
+@@ -2162,12 +2092,12 @@ cosmiconfig@^8.0.0:
  
  crc-32@^1.2.0:
    version "1.2.2"
@@ -15252,7 +15261,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==
    dependencies:
      cipher-base "^1.0.1"
-@@ -2178,7 +2103,7 @@ create-hash@^1.1.0, create-hash@^1.1.2, create-hash@^1.2.0:
+@@ -2178,7 +2108,7 @@ create-hash@^1.1.0, create-hash@^1.1.2, create-hash@^1.2.0:
  
  create-hmac@^1.1.4, create-hmac@^1.1.7:
    version "1.1.7"
@@ -15261,7 +15270,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==
    dependencies:
      cipher-base "^1.0.3"
-@@ -2190,12 +2115,12 @@ create-hmac@^1.1.4, create-hmac@^1.1.7:
+@@ -2190,12 +2120,12 @@ create-hmac@^1.1.4, create-hmac@^1.1.7:
  
  create-require@^1.1.0:
    version "1.1.1"
@@ -15276,7 +15285,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
    dependencies:
      path-key "^3.1.0"
-@@ -2204,43 +2129,43 @@ cross-spawn@^7.0.3:
+@@ -2204,43 +2134,43 @@ cross-spawn@^7.0.3:
  
  "crypt@>= 0.0.1":
    version "0.0.2"
@@ -15333,7 +15342,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==
    dependencies:
      decamelize "^1.1.0"
-@@ -2248,34 +2173,34 @@ decamelize-keys@^1.1.0:
+@@ -2248,34 +2178,34 @@ decamelize-keys@^1.1.0:
  
  decamelize@^1.1.0, decamelize@^1.2.0:
    version "1.2.0"
@@ -15374,7 +15383,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==
    dependencies:
      has-property-descriptors "^1.0.0"
-@@ -2283,79 +2208,79 @@ define-properties@^1.1.2, define-properties@^1.1.3, define-properties@^1.1.4, de
+@@ -2283,79 +2213,79 @@ define-properties@^1.1.2, define-properties@^1.1.3, define-properties@^1.1.4, de
  
  delayed-stream@~1.0.0:
    version "1.0.0"
@@ -15472,7 +15481,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
    dependencies:
      bn.js "^4.11.9"
-@@ -2368,7 +2293,7 @@ elliptic@6.5.4, elliptic@^6.5.2:
+@@ -2368,7 +2298,7 @@ elliptic@6.5.4, elliptic@^6.5.2:
  
  elliptic@^6.5.7:
    version "6.5.7"
@@ -15481,7 +15490,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==
    dependencies:
      bn.js "^4.11.9"
-@@ -2381,22 +2306,22 @@ elliptic@^6.5.7:
+@@ -2381,22 +2311,22 @@ elliptic@^6.5.7:
  
  emoji-regex@^7.0.1:
    version "7.0.3"
@@ -15509,7 +15518,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==
    dependencies:
      ansi-colors "^4.1.1"
-@@ -2404,19 +2329,19 @@ enquirer@^2.3.0:
+@@ -2404,19 +2334,19 @@ enquirer@^2.3.0:
  
  env-paths@^2.2.0:
    version "2.2.1"
@@ -15532,7 +15541,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-ioRRcXMO6OFyRpyzV3kE1IIBd4WG5/kltnzdxSCqoP8CMGs/Li+M1uF5o7lOkZVFjDs+NLesthnF66Pg/0q0Lw==
    dependencies:
      array-buffer-byte-length "^1.0.0"
-@@ -2461,12 +2386,12 @@ es-abstract@^1.19.0, es-abstract@^1.20.4, es-abstract@^1.21.2:
+@@ -2461,12 +2391,12 @@ es-abstract@^1.19.0, es-abstract@^1.20.4, es-abstract@^1.21.2:
  
  es-array-method-boxes-properly@^1.0.0:
    version "1.0.0"
@@ -15547,7 +15556,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==
    dependencies:
      get-intrinsic "^1.1.3"
-@@ -2475,7 +2400,7 @@ es-set-tostringtag@^2.0.1:
+@@ -2475,7 +2405,7 @@ es-set-tostringtag@^2.0.1:
  
  es-to-primitive@^1.2.1:
    version "1.2.1"
@@ -15556,7 +15565,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==
    dependencies:
      is-callable "^1.1.4"
-@@ -2484,22 +2409,22 @@ es-to-primitive@^1.2.1:
+@@ -2484,22 +2414,22 @@ es-to-primitive@^1.2.1:
  
  escalade@^3.1.1:
    version "3.1.1"
@@ -15584,7 +15593,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-yhi5S+mNTOuRvyW4gWlg5W1byMaQGWWSYHXsuFZ7GBo7tpyOwi2EdzMP/QWxh9hwkD2m+wDVHJsxhRIj+v/b/A==
    dependencies:
      esprima "^2.7.1"
-@@ -2509,29 +2434,29 @@ escodegen@1.8.x:
+@@ -2509,29 +2439,29 @@ escodegen@1.8.x:
    optionalDependencies:
      source-map "~0.2.0"
  
@@ -15620,7 +15629,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-1fRgyE4xUB8SoqLgN3eDfpDfwEfRxh2Sz1b7wzFbyQA+9TekMmvSjjoRu9SKcSVyK+vLkLIsVbJDsTWjw195OQ==
    dependencies:
      "@ethersproject/abi" "^5.0.0-beta.146"
-@@ -2552,14 +2477,14 @@ eth-gas-reporter@^0.2.25:
+@@ -2552,14 +2482,14 @@ eth-gas-reporter@^0.2.25:
  
  ethereum-bloom-filters@^1.0.6:
    version "1.0.10"
@@ -15638,7 +15647,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==
    dependencies:
      "@types/pbkdf2" "^3.0.0"
-@@ -2580,7 +2505,7 @@ ethereum-cryptography@0.1.3, ethereum-cryptography@^0.1.3:
+@@ -2580,7 +2510,7 @@ ethereum-cryptography@0.1.3, ethereum-cryptography@^0.1.3:
  
  ethereum-cryptography@^1.0.3:
    version "1.2.0"
@@ -15647,7 +15656,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-6yFQC9b5ug6/17CQpCyE3k9eKBMdhyVjzUy1WkiuY/E4vj/SXDBbCw8QEIaXqf0Mf2SnY6RmpDcwlUmBSS0EJw==
    dependencies:
      "@noble/hashes" "1.2.0"
-@@ -2588,9 +2513,19 @@ ethereum-cryptography@^1.0.3:
+@@ -2588,9 +2518,19 @@ ethereum-cryptography@^1.0.3:
      "@scure/bip32" "1.1.5"
      "@scure/bip39" "1.1.1"
  
@@ -15669,7 +15678,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-Z5Ba0T0ImZ8fqXrJbpHcbpAvIswRte2wGNR/KePnu8GbbvgJ47lMxT/ZZPG6i9Jaht4azPDop4HaM00J0J59ug==
    dependencies:
      "@noble/curves" "1.1.0"
-@@ -2600,15 +2535,28 @@ ethereum-cryptography@^2.0.0, ethereum-cryptography@^2.1.2:
+@@ -2600,15 +2540,28 @@ ethereum-cryptography@^2.0.0, ethereum-cryptography@^2.1.2:
  
  ethereumjs-abi@^0.6.8:
    version "0.6.8"
@@ -15701,7 +15710,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==
    dependencies:
      "@types/bn.js" "^4.11.3"
-@@ -2621,7 +2569,7 @@ ethereumjs-util@^6.0.0, ethereumjs-util@^6.2.1:
+@@ -2621,7 +2574,7 @@ ethereumjs-util@^6.0.0, ethereumjs-util@^6.2.1:
  
  ethereumjs-util@^7.1.4:
    version "7.1.5"
@@ -15710,7 +15719,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==
    dependencies:
      "@types/bn.js" "^5.1.0"
-@@ -2632,14 +2580,14 @@ ethereumjs-util@^7.1.4:
+@@ -2632,14 +2585,14 @@ ethereumjs-util@^7.1.4:
  
  ethers-maths@^4.0.2:
    version "4.0.2"
@@ -15727,7 +15736,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-kPltTvWiyu+OktYy1IStSO16i2e7cS9D9OxZ81q2UUaiNPVrm/RTcbxamCXF9VUSKzJIdJV68EAIhTEVBalRWg==
    dependencies:
      aes-js "3.0.0"
-@@ -2652,9 +2600,45 @@ ethers@^4.0.40:
+@@ -2652,9 +2605,45 @@ ethers@^4.0.40:
      uuid "2.0.1"
      xmlhttprequest "1.8.0"
  
@@ -15775,7 +15784,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==
    dependencies:
      "@ethersproject/abi" "5.7.0"
-@@ -2688,9 +2672,9 @@ ethers@^5.6.1, ethers@^5.7.1:
+@@ -2688,9 +2677,9 @@ ethers@^5.6.1, ethers@^5.7.1:
      "@ethersproject/web" "5.7.1"
      "@ethersproject/wordlists" "5.7.0"
  
@@ -15787,7 +15796,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-qX5kxIFMfg1i+epfgb0xF4WM7IqapIIu50pOJ17aebkxxa4BacW5jFrQRmCJpDEg2ZK2oNtR5QjrQ1WDBF29dA==
    dependencies:
      "@adraffy/ens-normalize" "1.9.2"
-@@ -2703,15 +2687,15 @@ ethers@^6.0.0, ethers@^6.7.1:
+@@ -2703,15 +2692,15 @@ ethers@^6.0.0, ethers@^6.7.1:
  
  ethjs-unit@0.1.6:
    version "0.1.6"
@@ -15806,7 +15815,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==
    dependencies:
      is-hex-prefixed "1.0.0"
-@@ -2719,35 +2703,20 @@ ethjs-util@0.1.6, ethjs-util@^0.1.6:
+@@ -2719,35 +2708,20 @@ ethjs-util@0.1.6, ethjs-util@^0.1.6:
  
  eventemitter3@^5.0.1:
    version "5.0.1"
@@ -15845,7 +15854,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==
    dependencies:
      cross-spawn "^7.0.3"
-@@ -2760,29 +2729,39 @@ execa@^5.0.0:
+@@ -2760,29 +2734,39 @@ execa@^5.0.0:
      signal-exit "^3.0.3"
      strip-final-newline "^2.0.0"
  
@@ -15895,7 +15904,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==
    dependencies:
      "@nodelib/fs.stat" "^2.0.2"
-@@ -2793,125 +2772,111 @@ fast-glob@^3.0.3:
+@@ -2793,125 +2777,111 @@ fast-glob@^3.0.3:
  
  fast-json-stable-stringify@^2.0.0:
    version "2.1.0"
@@ -15972,6 +15981,9 @@ index f97c8ad..9fc80db 100644
      locate-path "^5.0.0"
      path-exists "^4.0.0"
  
+-flat@^4.1.0:
+-  version "4.1.1"
+-  resolved "https://registry.yarnpkg.com/flat/-/flat-4.1.1.tgz#a392059cc382881ff98642f5da4dde0a959f309b"
 +find-up@^5.0.0, find-up@5.0.0:
 +  version "5.0.0"
 +  resolved "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz"
@@ -15980,9 +15992,8 @@ index f97c8ad..9fc80db 100644
 +    locate-path "^6.0.0"
 +    path-exists "^4.0.0"
 +
- flat@^4.1.0:
-   version "4.1.1"
--  resolved "https://registry.yarnpkg.com/flat/-/flat-4.1.1.tgz#a392059cc382881ff98642f5da4dde0a959f309b"
++flat@^4.1.0:
++  version "4.1.1"
 +  resolved "https://registry.npmjs.org/flat/-/flat-4.1.1.tgz"
    integrity sha512-FmTtBsHskrU6FJ2VxCnsDb84wu9zhmO3cUX2kGFb5tuwhfXxGciiT0oRY+cck35QmG+NmGh5eLz6lLCpWTqwpA==
    dependencies:
@@ -16053,7 +16064,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-UvSPKyhMn6LEd/WpUaV9C9t3zATuqoqfWc3QdPhPLb58prN9tqYPlPWi8Krxi44loBoUzlobqZ3+8tGpxxSzwA==
    dependencies:
      graceful-fs "^4.1.2"
-@@ -2922,16 +2887,25 @@ fs-extra@^0.30.0:
+@@ -2922,16 +2892,25 @@ fs-extra@^0.30.0:
  
  fs-extra@^11.0.0:
    version "11.1.1"
@@ -16082,7 +16093,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
    dependencies:
      graceful-fs "^4.1.2"
-@@ -2940,7 +2914,7 @@ fs-extra@^7.0.0, fs-extra@^7.0.1:
+@@ -2940,7 +2919,7 @@ fs-extra@^7.0.0, fs-extra@^7.0.1:
  
  fs-extra@^8.1.0:
    version "8.1.0"
@@ -16091,7 +16102,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
    dependencies:
      graceful-fs "^4.2.0"
-@@ -2949,7 +2923,7 @@ fs-extra@^8.1.0:
+@@ -2949,7 +2928,7 @@ fs-extra@^8.1.0:
  
  fs-extra@^9.1.0:
    version "9.1.0"
@@ -16100,7 +16111,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
    dependencies:
      at-least-node "^1.0.0"
-@@ -2959,32 +2933,22 @@ fs-extra@^9.1.0:
+@@ -2959,32 +2938,22 @@ fs-extra@^9.1.0:
  
  fs-readdir-recursive@^1.1.0:
    version "1.1.0"
@@ -16137,7 +16148,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==
    dependencies:
      call-bind "^1.0.2"
-@@ -2994,27 +2958,27 @@ function.prototype.name@^1.1.5:
+@@ -2994,27 +2963,27 @@ function.prototype.name@^1.1.5:
  
  functional-red-black-tree@^1.0.1:
    version "1.0.1"
@@ -16170,7 +16181,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==
    dependencies:
      function-bind "^1.1.1"
-@@ -3024,17 +2988,17 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3, get-intrinsic@
+@@ -3024,17 +2993,17 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3, get-intrinsic@
  
  get-port@^3.1.0:
    version "3.2.0"
@@ -16191,7 +16202,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==
    dependencies:
      call-bind "^1.0.2"
-@@ -3042,14 +3006,14 @@ get-symbol-description@^1.0.0:
+@@ -3042,14 +3011,14 @@ get-symbol-description@^1.0.0:
  
  getpass@^0.1.1:
    version "0.1.7"
@@ -16208,7 +16219,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-i08dAEgJ2g8z5buJIrCTduwPIhih3DP+hOCTyyryikfV8T0bNvHnGXO67i0DD1H4GBDETTclPy9njZbfluQYrQ==
    dependencies:
      chalk "^2.4.2"
-@@ -3057,7 +3021,7 @@ ghost-testrpc@^0.0.2:
+@@ -3057,7 +3026,7 @@ ghost-testrpc@^0.0.2:
  
  git-raw-commits@^2.0.11:
    version "2.0.11"
@@ -16217,7 +16228,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A==
    dependencies:
      dargs "^7.0.0"
-@@ -3068,38 +3032,25 @@ git-raw-commits@^2.0.11:
+@@ -3068,38 +3037,25 @@ git-raw-commits@^2.0.11:
  
  glob-parent@^5.1.2, glob-parent@~5.1.0, glob-parent@~5.1.2:
    version "5.1.2"
@@ -16264,7 +16275,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
    dependencies:
      fs.realpath "^1.0.0"
-@@ -3109,46 +3060,47 @@ glob@7.2.0:
+@@ -3109,46 +3065,47 @@ glob@7.2.0:
      once "^1.3.0"
      path-is-absolute "^1.0.0"
  
@@ -16325,7 +16336,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==
    dependencies:
      ini "^1.3.5"
-@@ -3157,19 +3109,19 @@ global-prefix@^3.0.0:
+@@ -3157,19 +3114,19 @@ global-prefix@^3.0.0:
  
  globals@^11.1.0:
    version "11.12.0"
@@ -16348,7 +16359,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==
    dependencies:
      "@types/glob" "^7.1.1"
-@@ -3183,24 +3135,24 @@ globby@^10.0.1:
+@@ -3183,24 +3140,24 @@ globby@^10.0.1:
  
  gopd@^1.0.1:
    version "1.0.1"
@@ -16377,7 +16388,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==
    dependencies:
      minimist "^1.2.5"
-@@ -3212,12 +3164,12 @@ handlebars@^4.0.1:
+@@ -3212,12 +3169,12 @@ handlebars@^4.0.1:
  
  har-schema@^2.0.0:
    version "2.0.0"
@@ -16392,7 +16403,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==
    dependencies:
      ajv "^6.12.3"
-@@ -3225,12 +3177,12 @@ har-validator@~5.1.3:
+@@ -3225,12 +3182,12 @@ har-validator@~5.1.3:
  
  hard-rejection@^2.1.0:
    version "2.1.0"
@@ -16407,7 +16418,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-INN26G3EW43adGKBNzYWOlI3+rlLnasXTwW79YNnUhXPDa+yHESgt639dJEs37gCjhkbNKcRRJnomXEuMFBXJg==
    dependencies:
      array-uniq "1.0.3"
-@@ -3239,16 +3191,16 @@ hardhat-gas-reporter@^1.0.9:
+@@ -3239,16 +3196,16 @@ hardhat-gas-reporter@^1.0.9:
  
  hardhat-tracer@^2.6.0:
    version "2.6.0"
@@ -16427,7 +16438,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-1PxRkfjhEzXs/wDxI5YgzYBxNmvzifBTjYzuopwel+vXpAhCudplusJthN5eig0FTs4qbi828DBIITEDh8x9LA==
    dependencies:
      "@ethersproject/abi" "^5.1.2"
-@@ -3302,93 +3254,93 @@ hardhat@^2.17.1:
+@@ -3302,93 +3259,93 @@ hardhat@^2.17.1:
  
  has-bigints@^1.0.1, has-bigints@^1.0.2:
    version "1.0.2"
@@ -16543,7 +16554,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==
    dependencies:
      hash.js "^1.0.3"
-@@ -3397,19 +3349,19 @@ hmac-drbg@^1.0.1:
+@@ -3397,19 +3354,19 @@ hmac-drbg@^1.0.1:
  
  hosted-git-info@^2.1.4:
    version "2.8.9"
@@ -16566,7 +16577,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-/EcDMwJZh3mABI2NhGfHOGOeOZITqfkEO4p/xK+l3NpyncIHUQBoMvCSF/b5GqvKtySC2srL/GGG3+EtlqlmCw==
    dependencies:
      caseless "^0.12.0"
-@@ -3419,7 +3371,7 @@ http-basic@^8.1.1:
+@@ -3419,7 +3376,7 @@ http-basic@^8.1.1:
  
  http-errors@2.0.0:
    version "2.0.0"
@@ -16575,7 +16586,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==
    dependencies:
      depd "2.0.0"
-@@ -3430,14 +3382,14 @@ http-errors@2.0.0:
+@@ -3430,14 +3387,14 @@ http-errors@2.0.0:
  
  http-response-object@^3.0.1:
    version "3.0.2"
@@ -16592,7 +16603,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==
    dependencies:
      assert-plus "^1.0.0"
-@@ -3446,7 +3398,7 @@ http-signature@~1.2.0:
+@@ -3446,7 +3403,7 @@ http-signature@~1.2.0:
  
  https-proxy-agent@^5.0.0:
    version "5.0.1"
@@ -16601,7 +16612,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
    dependencies:
      agent-base "6"
-@@ -3454,44 +3406,44 @@ https-proxy-agent@^5.0.0:
+@@ -3454,44 +3411,44 @@ https-proxy-agent@^5.0.0:
  
  human-signals@^2.1.0:
    version "2.1.0"
@@ -16654,7 +16665,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
    dependencies:
      parent-module "^1.0.0"
-@@ -3499,30 +3451,30 @@ import-fresh@^3.0.0, import-fresh@^3.2.1:
+@@ -3499,30 +3456,30 @@ import-fresh@^3.0.0, import-fresh@^3.2.1:
  
  indent-string@^4.0.0:
    version "4.0.0"
@@ -16691,7 +16702,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==
    dependencies:
      get-intrinsic "^1.2.0"
-@@ -3531,19 +3483,19 @@ internal-slot@^1.0.5:
+@@ -3531,19 +3488,19 @@ internal-slot@^1.0.5:
  
  interpret@^1.0.0:
    version "1.4.0"
@@ -16714,7 +16725,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==
    dependencies:
      call-bind "^1.0.2"
-@@ -3552,26 +3504,26 @@ is-array-buffer@^3.0.1, is-array-buffer@^3.0.2:
+@@ -3552,26 +3509,26 @@ is-array-buffer@^3.0.1, is-array-buffer@^3.0.2:
  
  is-arrayish@^0.2.1:
    version "0.2.1"
@@ -16745,7 +16756,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==
    dependencies:
      call-bind "^1.0.2"
-@@ -3579,95 +3531,95 @@ is-boolean-object@^1.1.0:
+@@ -3579,95 +3536,95 @@ is-boolean-object@^1.1.0:
  
  is-buffer@^2.0.5, is-buffer@~2.0.3:
    version "2.0.5"
@@ -16859,7 +16870,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==
    dependencies:
      call-bind "^1.0.2"
-@@ -3675,114 +3627,121 @@ is-regex@^1.1.4:
+@@ -3675,114 +3632,121 @@ is-regex@^1.1.4:
  
  is-shared-array-buffer@^1.0.2:
    version "1.0.2"
@@ -17005,7 +17016,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
    dependencies:
      argparse "^1.0.7"
-@@ -3790,71 +3749,64 @@ js-yaml@3.13.1:
+@@ -3790,71 +3754,64 @@ js-yaml@3.13.1:
  
  js-yaml@3.x:
    version "3.14.1"
@@ -17088,7 +17099,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
    dependencies:
      universalify "^2.0.0"
-@@ -3863,17 +3815,25 @@ jsonfile@^6.0.1:
+@@ -3863,17 +3820,25 @@ jsonfile@^6.0.1:
  
  jsonparse@^1.2.0:
    version "1.3.1"
@@ -17117,7 +17128,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==
    dependencies:
      assert-plus "1.0.0"
-@@ -3883,7 +3843,7 @@ jsprim@^1.2.2:
+@@ -3883,7 +3848,7 @@ jsprim@^1.2.2:
  
  keccak@^3.0.0, keccak@^3.0.2:
    version "3.0.3"
@@ -17126,7 +17137,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-JZrLIAJWuZxKbCilMpNz5Vj7Vtb4scDG3dMXLOsbzBmQGyjwE61BbW7bJkfKKCShXiQZt3T6sBgALRtmd+nZaQ==
    dependencies:
      node-addon-api "^2.0.0"
-@@ -3892,24 +3852,24 @@ keccak@^3.0.0, keccak@^3.0.2:
+@@ -3892,24 +3857,24 @@ keccak@^3.0.0, keccak@^3.0.2:
  
  kind-of@^6.0.2, kind-of@^6.0.3:
    version "6.0.3"
@@ -17155,7 +17166,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-t7bFwFtsQeD8cl8NIoQ2iwxA0CL/9IFw7/9gAjOonH0PWTTiRfY7Hq+Ejbsxh86tXobDQ6IOiddjNYIfOBs06w==
    dependencies:
      buffer "^6.0.3"
-@@ -3917,7 +3877,7 @@ level-transcoder@^1.0.1:
+@@ -3917,7 +3882,7 @@ level-transcoder@^1.0.1:
  
  level@^8.0.0:
    version "8.0.0"
@@ -17164,7 +17175,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-ypf0jjAk2BWI33yzEaaotpq7fkOPALKAgDBxggO6Q9HGX2MRXn0wbP1Jn/tJv1gtL867+YOjOB49WaUF3UoJNQ==
    dependencies:
      browser-level "^1.0.1"
-@@ -3925,7 +3885,7 @@ level@^8.0.0:
+@@ -3925,7 +3890,7 @@ level@^8.0.0:
  
  levn@~0.3.0:
    version "0.3.0"
@@ -17173,7 +17184,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==
    dependencies:
      prelude-ls "~1.1.2"
-@@ -3933,17 +3893,17 @@ levn@~0.3.0:
+@@ -3933,17 +3898,17 @@ levn@~0.3.0:
  
  lilconfig@2.1.0:
    version "2.1.0"
@@ -17194,7 +17205,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-Mw0cL6HXnHN1ag0mN/Dg4g6sr8uf8sn98w2Oc1ECtFto9tvRF7nkXGJRbx8gPlHyoR0pLyBr2lQHbWwmUHe1Sw==
    dependencies:
      chalk "5.3.0"
-@@ -3959,7 +3919,7 @@ lint-staged@^14.0.1:
+@@ -3959,7 +3924,7 @@ lint-staged@^14.0.1:
  
  listr2@6.6.1:
    version "6.6.1"
@@ -17203,7 +17214,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-+rAXGHh0fkEWdXBmX+L6mmfmXmXvDGEKzkjxO+8mP3+nI/r/CWznVBvsibXdxda9Zz0OW2e2ikphN3OwCT/jSg==
    dependencies:
      cli-truncate "^3.1.0"
-@@ -3971,7 +3931,7 @@ listr2@6.6.1:
+@@ -3971,7 +3936,7 @@ listr2@6.6.1:
  
  locate-path@^2.0.0:
    version "2.0.0"
@@ -17212,7 +17223,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==
    dependencies:
      p-locate "^2.0.0"
-@@ -3979,7 +3939,7 @@ locate-path@^2.0.0:
+@@ -3979,7 +3944,7 @@ locate-path@^2.0.0:
  
  locate-path@^3.0.0:
    version "3.0.0"
@@ -17221,7 +17232,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==
    dependencies:
      p-locate "^3.0.0"
-@@ -3987,88 +3947,88 @@ locate-path@^3.0.0:
+@@ -3987,88 +3952,88 @@ locate-path@^3.0.0:
  
  locate-path@^5.0.0:
    version "5.0.0"
@@ -17326,7 +17337,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==
    dependencies:
      chalk "^4.1.0"
-@@ -4076,7 +4036,7 @@ log-symbols@4.1.0:
+@@ -4076,7 +4041,7 @@ log-symbols@4.1.0:
  
  log-update@^5.0.1:
    version "5.0.1"
@@ -17335,7 +17346,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-5UtUDQ/6edw4ofyljDNcOVJQ4c7OjDro4h3y8e1GQL5iYElYclVHJ3zeWchylvMaKnDbDilC8irOVyexnA/Slw==
    dependencies:
      ansi-escapes "^5.0.0"
-@@ -4087,58 +4047,58 @@ log-update@^5.0.1:
+@@ -4087,58 +4052,58 @@ log-update@^5.0.1:
  
  loupe@^2.3.1:
    version "2.3.6"
@@ -17408,7 +17419,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==
    dependencies:
      hash-base "^3.0.0"
-@@ -4147,7 +4107,7 @@ md5.js@^1.3.4:
+@@ -4147,7 +4112,7 @@ md5.js@^1.3.4:
  
  memory-level@^1.0.0:
    version "1.0.0"
@@ -17417,7 +17428,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-UXzwewuWeHBz5krr7EvehKcmLFNoXxGcvuYhC41tRnkrTbJohtS7kVn9akmgirtRygg+f7Yjsfi8Uu5SGSQ4Og==
    dependencies:
      abstract-level "^1.0.0"
-@@ -4156,12 +4116,12 @@ memory-level@^1.0.0:
+@@ -4156,12 +4121,12 @@ memory-level@^1.0.0:
  
  memorystream@^0.3.1:
    version "0.3.1"
@@ -17432,7 +17443,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==
    dependencies:
      "@types/minimist" "^1.2.0"
-@@ -4178,22 +4138,22 @@ meow@^8.0.0, meow@^8.1.2:
+@@ -4178,22 +4143,22 @@ meow@^8.0.0, meow@^8.1.2:
  
  merge-stream@^2.0.0:
    version "2.0.0"
@@ -17460,7 +17471,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
    dependencies:
      braces "^3.0.2"
-@@ -4201,65 +4161,65 @@ micromatch@4.0.5, micromatch@^4.0.4:
+@@ -4201,65 +4166,65 @@ micromatch@4.0.5, micromatch@^4.0.4:
  
  mime-db@1.52.0:
    version "1.52.0"
@@ -17538,7 +17549,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==
    dependencies:
      arrify "^1.0.1"
-@@ -4268,68 +4228,38 @@ minimist-options@4.1.0:
+@@ -4268,68 +4233,38 @@ minimist-options@4.1.0:
  
  minimist@^1.2.5, minimist@^1.2.6:
    version "1.2.8"
@@ -17617,7 +17628,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==
    dependencies:
      ansi-colors "4.1.1"
-@@ -4356,7 +4286,7 @@ mocha@^10.0.0:
+@@ -4356,7 +4291,7 @@ mocha@^10.0.0:
  
  mocha@^7.1.1:
    version "7.2.0"
@@ -17626,7 +17637,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-O9CIypScywTVpNaRrCAgoUnJgozpIofjKUYmJhiCIJMiuYnLI6otcb1/kpW9/n/tJODHGZ7i8aLQoDVsMtOKQQ==
    dependencies:
      ansi-colors "3.2.3"
-@@ -4384,61 +4314,91 @@ mocha@^7.1.1:
+@@ -4384,61 +4319,91 @@ mocha@^7.1.1:
      yargs-parser "13.1.2"
      yargs-unparser "1.6.0"
  
@@ -17731,7 +17742,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==
    dependencies:
      object.getownpropertydescriptors "^2.0.3"
-@@ -4446,19 +4406,19 @@ node-environment-flags@1.0.6:
+@@ -4446,19 +4411,19 @@ node-environment-flags@1.0.6:
  
  node-gyp-build@^4.2.0, node-gyp-build@^4.3.0:
    version "4.6.0"
@@ -17754,7 +17765,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
    dependencies:
      hosted-git-info "^2.1.4"
-@@ -4468,7 +4428,7 @@ normalize-package-data@^2.5.0:
+@@ -4468,7 +4433,7 @@ normalize-package-data@^2.5.0:
  
  normalize-package-data@^3.0.0:
    version "3.0.3"
@@ -17763,7 +17774,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==
    dependencies:
      hosted-git-info "^4.0.1"
-@@ -4478,26 +4438,26 @@ normalize-package-data@^3.0.0:
+@@ -4478,26 +4443,26 @@ normalize-package-data@^3.0.0:
  
  normalize-path@^3.0.0, normalize-path@~3.0.0:
    version "3.0.0"
@@ -17794,7 +17805,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-wsJ9gfSz1/s4ZsJN01lyonwuxA1tml6X1yBDnfpMglypcBRFZZkus26EdPSlqS5GJfYddVZa22p3VNb3z5m5Ig==
    dependencies:
      bn.js "4.11.6"
-@@ -4505,37 +4465,27 @@ number-to-bn@1.7.0:
+@@ -4505,37 +4470,27 @@ number-to-bn@1.7.0:
  
  oauth-sign@~0.9.0:
    version "0.9.0"
@@ -17837,7 +17848,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==
    dependencies:
      call-bind "^1.0.2"
-@@ -4543,9 +4493,19 @@ object.assign@^4.1.4:
+@@ -4543,9 +4498,19 @@ object.assign@^4.1.4:
      has-symbols "^1.0.3"
      object-keys "^1.1.1"
  
@@ -17858,7 +17869,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-lq+61g26E/BgHv0ZTFgRvi7NMEPuAxLkFU7rukXjc/AlwH4Am5xXVnIXy3un1bg/JPbXHrixRkK1itUzzPiIjQ==
    dependencies:
      array.prototype.reduce "^1.0.5"
-@@ -4556,33 +4516,33 @@ object.getownpropertydescriptors@^2.0.3:
+@@ -4556,33 +4521,33 @@ object.getownpropertydescriptors@^2.0.3:
  
  obliterator@^2.0.0:
    version "2.0.4"
@@ -17898,7 +17909,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==
    dependencies:
      deep-is "~0.1.3"
-@@ -4594,95 +4554,102 @@ optionator@^0.8.1:
+@@ -4594,95 +4559,102 @@ optionator@^0.8.1:
  
  ordinal@^1.0.3:
    version "1.0.3"
@@ -17922,15 +17933,15 @@ index f97c8ad..9fc80db 100644
  
 -p-limit@^2.0.0, p-limit@^2.2.0:
 +p-limit@^2.0.0:
-   version "2.3.0"
--  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
++  version "2.3.0"
 +  resolved "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz"
 +  integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
 +  dependencies:
 +    p-try "^2.0.0"
 +
 +p-limit@^2.2.0:
-+  version "2.3.0"
+   version "2.3.0"
+-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
 +  resolved "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz"
    integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
    dependencies:
@@ -18017,7 +18028,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==
    dependencies:
      "@babel/code-frame" "^7.0.0"
-@@ -4692,47 +4659,47 @@ parse-json@^5.0.0:
+@@ -4692,47 +4664,47 @@ parse-json@^5.0.0:
  
  path-exists@^3.0.0:
    version "3.0.0"
@@ -18075,7 +18086,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==
    dependencies:
      create-hash "^1.1.2"
-@@ -4743,93 +4710,86 @@ pbkdf2@^3.0.17:
+@@ -4743,93 +4715,86 @@ pbkdf2@^3.0.17:
  
  performance-now@^2.1.0:
    version "2.1.0"
@@ -18187,7 +18198,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==
    dependencies:
      bytes "3.1.2"
-@@ -4839,7 +4799,7 @@ raw-body@^2.4.1:
+@@ -4839,7 +4804,7 @@ raw-body@^2.4.1:
  
  read-pkg-up@^7.0.1:
    version "7.0.1"
@@ -18196,7 +18207,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==
    dependencies:
      find-up "^4.1.0"
-@@ -4848,7 +4808,7 @@ read-pkg-up@^7.0.1:
+@@ -4848,7 +4813,7 @@ read-pkg-up@^7.0.1:
  
  read-pkg@^5.2.0:
    version "5.2.0"
@@ -18205,7 +18216,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==
    dependencies:
      "@types/normalize-package-data" "^2.4.0"
-@@ -4856,18 +4816,9 @@ read-pkg@^5.2.0:
+@@ -4856,18 +4821,9 @@ read-pkg@^5.2.0:
      parse-json "^5.0.0"
      type-fest "^0.6.0"
  
@@ -18225,7 +18236,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==
    dependencies:
      core-util-is "~1.0.0"
-@@ -4878,37 +4829,46 @@ readable-stream@^2.2.2:
+@@ -4878,37 +4834,46 @@ readable-stream@^2.2.2:
      string_decoder "~1.1.1"
      util-deprecate "~1.0.1"
  
@@ -18277,7 +18288,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==
    dependencies:
      indent-string "^4.0.0"
-@@ -4916,12 +4876,12 @@ redent@^3.0.0:
+@@ -4916,12 +4881,12 @@ redent@^3.0.0:
  
  reduce-flatten@^2.0.0:
    version "2.0.0"
@@ -18292,7 +18303,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==
    dependencies:
      call-bind "^1.0.2"
-@@ -4930,37 +4890,37 @@ regexp.prototype.flags@^1.5.0:
+@@ -4930,37 +4895,37 @@ regexp.prototype.flags@^1.5.0:
  
  req-cwd@^2.0.0:
    version "2.0.0"
@@ -18336,7 +18347,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
    dependencies:
      aws-sign2 "~0.7.0"
-@@ -4986,65 +4946,56 @@ request@^2.88.0:
+@@ -4986,65 +4951,56 @@ request@^2.88.0:
  
  require-directory@^2.1.1:
    version "2.1.1"
@@ -18421,7 +18432,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==
    dependencies:
      onetime "^5.1.0"
-@@ -5052,24 +5003,24 @@ restore-cursor@^4.0.0:
+@@ -5052,24 +5008,24 @@ restore-cursor@^4.0.0:
  
  reusify@^1.0.4:
    version "1.0.4"
@@ -18450,7 +18461,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==
    dependencies:
      hash-base "^3.0.0"
-@@ -5077,33 +5028,33 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
+@@ -5077,33 +5033,33 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
  
  rlp@^2.2.3, rlp@^2.2.4:
    version "2.2.7"
@@ -18489,7 +18500,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-9dVEFruWIsnie89yym+xWTAYASdpw3CJV7Li/6zBewGf9z2i1j31rP6jnY0pHEO4QZh6N0K11bFjWmdR8UGdPQ==
    dependencies:
      call-bind "^1.0.2"
-@@ -5113,31 +5064,31 @@ safe-array-concat@^1.0.0:
+@@ -5113,31 +5069,31 @@ safe-array-concat@^1.0.0:
  
  safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
    version "5.2.1"
@@ -18527,7 +18538,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-qJFF/8tW/zJsbyfh/iT/ZM5QNHE3CXxtLJbZsL+CzdJLBsPD7SedJZoUA4d8iAcN2IoMp/Dx80shOOd2x96X/g==
    dependencies:
      abbrev "1.0.x"
-@@ -5155,72 +5106,82 @@ sc-istanbul@^0.4.5:
+@@ -5155,72 +5111,82 @@ sc-istanbul@^0.4.5:
      which "^1.1.1"
      wordwrap "^1.0.0"
  
@@ -18559,17 +18570,17 @@ index f97c8ad..9fc80db 100644
  
 -"semver@2 || 3 || 4 || 5", semver@^5.5.0, semver@^5.7.0:
 +semver@^5.5.0:
++  version "5.7.2"
++  resolved "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz"
++  integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
++
++semver@^5.7.0:
    version "5.7.2"
 -  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
 +  resolved "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz"
    integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
  
 -semver@7.5.4, semver@^7.3.4:
-+semver@^5.7.0:
-+  version "5.7.2"
-+  resolved "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz"
-+  integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
-+
 +semver@^6.3.0:
 +  version "6.3.1"
 +  resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
@@ -18635,7 +18646,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==
    dependencies:
      inherits "^2.0.1"
-@@ -5228,7 +5189,7 @@ sha.js@^2.4.0, sha.js@^2.4.8:
+@@ -5228,7 +5194,7 @@ sha.js@^2.4.0, sha.js@^2.4.8:
  
  sha1@^1.1.1:
    version "1.1.1"
@@ -18644,7 +18655,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-dZBS6OrMjtgVkopB1Gmo4RQCDKiZsqcpAQpkV/aaj+FCrCg8r4I4qMkDPQjBgLIxlmu9k4nUbWq6ohXahOneYA==
    dependencies:
      charenc ">= 0.0.1"
-@@ -5236,19 +5197,19 @@ sha1@^1.1.1:
+@@ -5236,19 +5202,19 @@ sha1@^1.1.1:
  
  shebang-command@^2.0.0:
    version "2.0.0"
@@ -18667,7 +18678,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==
    dependencies:
      glob "^7.0.0"
-@@ -5257,7 +5218,7 @@ shelljs@^0.8.3:
+@@ -5257,7 +5223,7 @@ shelljs@^0.8.3:
  
  side-channel@^1.0.4:
    version "1.0.4"
@@ -18676,7 +18687,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==
    dependencies:
      call-bind "^1.0.0"
-@@ -5266,17 +5227,17 @@ side-channel@^1.0.4:
+@@ -5266,17 +5232,17 @@ side-channel@^1.0.4:
  
  signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
    version "3.0.7"
@@ -18697,7 +18708,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==
    dependencies:
      ansi-styles "^6.0.0"
-@@ -5284,7 +5245,7 @@ slice-ansi@^5.0.0:
+@@ -5284,7 +5250,7 @@ slice-ansi@^5.0.0:
  
  solc@0.7.3:
    version "0.7.3"
@@ -18706,7 +18717,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-GAsWNAjGzIDg7VxzP6mPjdurby3IkGCjQcM8GFYZT6RyaoUZKmMU6Y7YwG+tFGhv7dwZ8rmR4iwFDrrD99JwqA==
    dependencies:
      command-exists "^1.2.8"
-@@ -5299,7 +5260,7 @@ solc@0.7.3:
+@@ -5299,7 +5265,7 @@ solc@0.7.3:
  
  solidity-coverage@^0.8.4:
    version "0.8.4"
@@ -18715,7 +18726,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-xeHOfBOjdMF6hWTbt42iH4x+7j1Atmrf5OldDPMxI+i/COdExUxszOswD9qqvcBTaLGiOrrpnh9UZjSpt4rBsg==
    dependencies:
      "@ethersproject/abi" "^5.0.9"
-@@ -5325,7 +5286,7 @@ solidity-coverage@^0.8.4:
+@@ -5325,7 +5291,7 @@ solidity-coverage@^0.8.4:
  
  source-map-support@^0.5.13:
    version "0.5.21"
@@ -18724,7 +18735,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
    dependencies:
      buffer-from "^1.0.0"
-@@ -5333,24 +5294,29 @@ source-map-support@^0.5.13:
+@@ -5333,24 +5299,29 @@ source-map-support@^0.5.13:
  
  source-map@^0.5.0:
    version "0.5.7"
@@ -18759,7 +18770,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==
    dependencies:
      spdx-expression-parse "^3.0.0"
-@@ -5358,12 +5324,12 @@ spdx-correct@^3.0.0:
+@@ -5358,12 +5329,12 @@ spdx-correct@^3.0.0:
  
  spdx-exceptions@^2.1.0:
    version "2.3.0"
@@ -18774,7 +18785,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==
    dependencies:
      spdx-exceptions "^2.1.0"
-@@ -5371,24 +5337,24 @@ spdx-expression-parse@^3.0.0:
+@@ -5371,24 +5342,24 @@ spdx-expression-parse@^3.0.0:
  
  spdx-license-ids@^3.0.0:
    version "3.0.13"
@@ -18803,7 +18814,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==
    dependencies:
      asn1 "~0.2.3"
-@@ -5403,39 +5369,53 @@ sshpk@^1.7.0:
+@@ -5403,39 +5374,53 @@ sshpk@^1.7.0:
  
  stacktrace-parser@^0.1.10:
    version "0.1.10"
@@ -18864,7 +18875,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
    dependencies:
      is-fullwidth-code-point "^2.0.0"
-@@ -5443,25 +5423,43 @@ string-format@^2.0.0:
+@@ -5443,25 +5428,43 @@ string-format@^2.0.0:
  
  string-width@^3.0.0, string-width@^3.1.0:
    version "3.1.0"
@@ -18898,8 +18909,7 @@ index f97c8ad..9fc80db 100644
 +    strip-ansi "^6.0.1"
 +
 +string-width@^5.0.0:
-   version "5.1.2"
--  resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794"
++  version "5.1.2"
 +  resolved "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz"
 +  integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
 +  dependencies:
@@ -18908,12 +18918,13 @@ index f97c8ad..9fc80db 100644
 +    strip-ansi "^7.0.1"
 +
 +string-width@^5.0.1:
-+  version "5.1.2"
+   version "5.1.2"
+-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794"
 +  resolved "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz"
    integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
    dependencies:
      eastasianwidth "^0.2.0"
-@@ -5470,7 +5468,7 @@ string-width@^5.0.0, string-width@^5.0.1:
+@@ -5470,7 +5473,7 @@ string-width@^5.0.0, string-width@^5.0.1:
  
  string.prototype.trim@^1.2.7:
    version "1.2.7"
@@ -18922,7 +18933,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==
    dependencies:
      call-bind "^1.0.2"
-@@ -5479,7 +5477,7 @@ string.prototype.trim@^1.2.7:
+@@ -5479,7 +5482,7 @@ string.prototype.trim@^1.2.7:
  
  string.prototype.trimend@^1.0.6:
    version "1.0.6"
@@ -18931,7 +18942,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==
    dependencies:
      call-bind "^1.0.2"
-@@ -5488,132 +5486,113 @@ string.prototype.trimend@^1.0.6:
+@@ -5488,132 +5491,113 @@ string.prototype.trimend@^1.0.6:
  
  string.prototype.trimstart@^1.0.6:
    version "1.0.6"
@@ -19092,7 +19103,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-8fjNkrNlNCrVc/av+Jn+xxqfCjYaBoHqCsDz6mt030UMxJGr+GSfCV1dQt2gRtlL63+VPidwDVLr7V2OcTSdRw==
    dependencies:
      http-response-object "^3.0.1"
-@@ -5622,14 +5601,14 @@ sync-request@^6.0.0:
+@@ -5622,14 +5606,14 @@ sync-request@^6.0.0:
  
  sync-rpc@^1.2.1:
    version "1.3.6"
@@ -19109,7 +19120,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==
    dependencies:
      array-back "^4.0.1"
-@@ -5639,12 +5618,12 @@ table-layout@^1.0.2:
+@@ -5639,12 +5623,12 @@ table-layout@^1.0.2:
  
  text-extensions@^1.0.0:
    version "1.9.0"
@@ -19124,7 +19135,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-3ZBiG7JvP3wbDzA9iNY5zJQcHL4jn/0BWtXIkagfz7QgOL/LqjCEOBQuJNZfu0XYnv5JhKh+cDxCPM4ILrqruA==
    dependencies:
      "@types/concat-stream" "^1.6.0"
-@@ -5659,45 +5638,45 @@ then-request@^6.0.0:
+@@ -5659,45 +5643,45 @@ then-request@^6.0.0:
      promise "^8.0.0"
      qs "^6.4.0"
  
@@ -19181,7 +19192,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
    dependencies:
      psl "^1.1.28"
-@@ -5705,12 +5684,12 @@ tough-cookie@^2.3.3, tough-cookie@~2.5.0:
+@@ -5705,12 +5689,12 @@ tough-cookie@^2.3.3, tough-cookie@~2.5.0:
  
  trim-newlines@^3.0.0:
    version "3.0.1"
@@ -19196,7 +19207,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-H69ZwTw3rFHb5WYpQya40YAX2/w7Ut75uUECbgBIsLmM+BNuYnxsltfyyLMxy6sEeKxgijLTnQtLd0nKd6+IYw==
    dependencies:
      chalk "^4.1.0"
-@@ -5720,12 +5699,12 @@ ts-command-line-args@^2.2.0:
+@@ -5720,12 +5704,12 @@ ts-command-line-args@^2.2.0:
  
  ts-essentials@^7.0.1:
    version "7.0.3"
@@ -19212,7 +19223,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
    dependencies:
      "@cspotcode/source-map-support" "^0.8.0"
-@@ -5742,88 +5721,93 @@ ts-node@^10.8.1, ts-node@^10.9.1:
+@@ -5742,88 +5726,93 @@ ts-node@^10.8.1, ts-node@^10.9.1:
      v8-compile-cache-lib "^3.0.1"
      yn "3.1.1"
  
@@ -19327,7 +19338,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-fA7clol2IP/56yq6vkMTR+4URF1nGjV82Wx6Rf09EsqD4tkzMAvEaqYxVFCavJm/1xaRga/oD55K+4FtuXwQOQ==
    dependencies:
      "@types/prettier" "^2.1.1"
-@@ -5839,7 +5823,7 @@ typechain@^8.3.1:
+@@ -5839,7 +5828,7 @@ typechain@^8.3.1:
  
  typed-array-buffer@^1.0.0:
    version "1.0.0"
@@ -19336,7 +19347,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==
    dependencies:
      call-bind "^1.0.2"
-@@ -5848,7 +5832,7 @@ typed-array-buffer@^1.0.0:
+@@ -5848,7 +5837,7 @@ typed-array-buffer@^1.0.0:
  
  typed-array-byte-length@^1.0.0:
    version "1.0.0"
@@ -19345,7 +19356,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-Or/+kvLxNpeQ9DtSydonMxCx+9ZXOswtwJn17SNLvhptaXYDJvkFFP5zbfU/uLmvnBJlI4yrnXRxpdWH/M5tNA==
    dependencies:
      call-bind "^1.0.2"
-@@ -5858,7 +5842,7 @@ typed-array-byte-length@^1.0.0:
+@@ -5858,7 +5847,7 @@ typed-array-byte-length@^1.0.0:
  
  typed-array-byte-offset@^1.0.0:
    version "1.0.0"
@@ -19354,7 +19365,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-RD97prjEt9EL8YgAgpOkf3O4IF9lhJFr9g0htQkm0rchFp/Vx7LW5Q8fSXXub7BXAODyUQohRMyOc3faCPd0hg==
    dependencies:
      available-typed-arrays "^1.0.5"
-@@ -5869,7 +5853,7 @@ typed-array-byte-offset@^1.0.0:
+@@ -5869,7 +5858,7 @@ typed-array-byte-offset@^1.0.0:
  
  typed-array-length@^1.0.4:
    version "1.0.4"
@@ -19363,7 +19374,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==
    dependencies:
      call-bind "^1.0.2"
-@@ -5878,32 +5862,32 @@ typed-array-length@^1.0.4:
+@@ -5878,32 +5867,32 @@ typed-array-length@^1.0.4:
  
  typedarray@^0.0.6:
    version "0.0.6"
@@ -19403,7 +19414,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==
    dependencies:
      call-bind "^1.0.2"
-@@ -5913,66 +5897,66 @@ unbox-primitive@^1.0.2:
+@@ -5913,66 +5902,66 @@ unbox-primitive@^1.0.2:
  
  undici@^5.14.0:
    version "5.23.0"
@@ -19486,7 +19497,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==
    dependencies:
      spdx-correct "^3.0.0"
-@@ -5980,7 +5964,7 @@ validate-npm-package-license@^3.0.1:
+@@ -5980,7 +5969,7 @@ validate-npm-package-license@^3.0.1:
  
  verror@1.10.0:
    version "1.10.0"
@@ -19495,7 +19506,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==
    dependencies:
      assert-plus "^1.0.0"
-@@ -5989,7 +5973,7 @@ verror@1.10.0:
+@@ -5989,7 +5978,7 @@ verror@1.10.0:
  
  web3-utils@^1.3.6:
    version "1.10.1"
@@ -19504,7 +19515,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-r6iUUw/uMnNcWXjhRv33Nyrhxq3VGOPBXeSzxhOXIci4SvC/LPTpROY0uTrMX7ztKyODYrHp8WhTkEf+ZnHssw==
    dependencies:
      "@ethereumjs/util" "^8.1.0"
-@@ -6003,7 +5987,7 @@ web3-utils@^1.3.6:
+@@ -6003,7 +5992,7 @@ web3-utils@^1.3.6:
  
  which-boxed-primitive@^1.0.2:
    version "1.0.2"
@@ -19513,7 +19524,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==
    dependencies:
      is-bigint "^1.0.1"
-@@ -6014,12 +5998,12 @@ which-boxed-primitive@^1.0.2:
+@@ -6014,12 +6003,12 @@ which-boxed-primitive@^1.0.2:
  
  which-module@^2.0.0:
    version "2.0.1"
@@ -19528,7 +19539,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==
    dependencies:
      available-typed-arrays "^1.0.5"
-@@ -6028,40 +6012,54 @@ which-typed-array@^1.1.10, which-typed-array@^1.1.11:
+@@ -6028,40 +6017,54 @@ which-typed-array@^1.1.10, which-typed-array@^1.1.11:
      gopd "^1.0.1"
      has-tostringtag "^1.0.0"
  
@@ -19590,7 +19601,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==
    dependencies:
      reduce-flatten "^2.0.0"
-@@ -6069,12 +6067,12 @@ wordwrapjs@^4.0.0:
+@@ -6069,12 +6072,12 @@ wordwrapjs@^4.0.0:
  
  workerpool@6.2.1:
    version "6.2.1"
@@ -19605,7 +19616,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==
    dependencies:
      ansi-styles "^3.2.0"
-@@ -6083,7 +6081,7 @@ wrap-ansi@^5.1.0:
+@@ -6083,7 +6086,7 @@ wrap-ansi@^5.1.0:
  
  wrap-ansi@^7.0.0:
    version "7.0.0"
@@ -19614,7 +19625,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
    dependencies:
      ansi-styles "^4.0.0"
-@@ -6092,7 +6090,7 @@ wrap-ansi@^7.0.0:
+@@ -6092,7 +6095,7 @@ wrap-ansi@^7.0.0:
  
  wrap-ansi@^8.0.1, wrap-ansi@^8.1.0:
    version "8.1.0"
@@ -19623,7 +19634,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==
    dependencies:
      ansi-styles "^6.1.0"
-@@ -6101,80 +6099,80 @@ wrap-ansi@^8.0.1, wrap-ansi@^8.1.0:
+@@ -6101,80 +6104,80 @@ wrap-ansi@^8.0.1, wrap-ansi@^8.1.0:
  
  wrappy@1:
    version "1.0.2"
@@ -19726,7 +19737,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==
    dependencies:
      flat "^4.1.0"
-@@ -6183,7 +6181,7 @@ yargs-unparser@1.6.0:
+@@ -6183,7 +6186,7 @@ yargs-unparser@1.6.0:
  
  yargs-unparser@2.0.0:
    version "2.0.0"
@@ -19735,7 +19746,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==
    dependencies:
      camelcase "^6.0.0"
-@@ -6191,9 +6189,9 @@ yargs-unparser@2.0.0:
+@@ -6191,9 +6194,9 @@ yargs-unparser@2.0.0:
      flat "^5.0.2"
      is-plain-obj "^2.1.0"
  
@@ -19747,7 +19758,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==
    dependencies:
      cliui "^5.0.0"
-@@ -6207,22 +6205,9 @@ yargs@13.3.2, yargs@^13.3.0:
+@@ -6207,22 +6210,9 @@ yargs@13.3.2, yargs@^13.3.0:
      y18n "^4.0.0"
      yargs-parser "^13.1.2"
  
@@ -19771,7 +19782,7 @@ index f97c8ad..9fc80db 100644
    integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
    dependencies:
      cliui "^8.0.1"
-@@ -6233,12 +6218,25 @@ yargs@^17.0.0:
+@@ -6233,12 +6223,25 @@ yargs@^17.0.0:
      y18n "^5.0.5"
      yargs-parser "^21.1.1"
  

--- a/crates/tools/js/benchmark/patches/prb-math.patch
+++ b/crates/tools/js/benchmark/patches/prb-math.patch
@@ -1,22 +1,22 @@
 diff --git a/foundry.toml b/foundry.toml
-index 4bedfa5..925c6cf 100644
+index 4bedfa5..cb8f725 100644
 --- a/foundry.toml
 +++ b/foundry.toml
-@@ -12,6 +12,8 @@
-   solc = "0.8.26"
-   src = "src"
-   test = "test"
-+  [fuzz]
-+  seed = "1234"
- 
- [profile.ci]
-   fuzz = { runs = 10_000, max_test_rejects = 100_000 }
+@@ -5,7 +5,7 @@
+   auto_detect_solc = false
+   bytecode_hash = "none"
+   evm_version = "shanghai"
+-  fuzz = { runs = 256 }
++  fuzz = { runs = 256, seed = "0x1234" }
+   optimizer = true
+   optimizer_runs = 10_000
+   out = "out"
 diff --git a/hardhat.config.js b/hardhat.config.js
 new file mode 100644
-index 0000000..66f3aa0
+index 0000000..9aef871
 --- /dev/null
 +++ b/hardhat.config.js
-@@ -0,0 +1,26 @@
+@@ -0,0 +1,29 @@
 +module.exports = {
 +"paths": {
 +  "sources": "src",
@@ -27,6 +27,9 @@ index 0000000..66f3aa0
 +"solidity": {
 +  "version": "0.8.26",
 +  "settings": {
++    "metadata": {
++      "bytecodeHash": "none"
++    },
 +    "optimizer": {
 +      "enabled": true,
 +      "runs": 10000
@@ -37,9 +40,9 @@ index 0000000..66f3aa0
 +"solidityTest": {
 +  "allowInternalExpectRevert": true,
 +  "fuzz": {
-+    "runs": 256
-+  },
-+	"seed": "1234"
++    "runs": 256,
++	  "seed": "0x1234"
++  }
 +}
 +};
 +

--- a/crates/tools/js/benchmark/patches/solady.patch
+++ b/crates/tools/js/benchmark/patches/solady.patch
@@ -318,10 +318,10 @@ index 03fea9c..0000000
 -The most intended usage pattern is to place it at the end of an `execute` function.
 \ No newline at end of file
 diff --git a/foundry.toml b/foundry.toml
-index 6afdd63..3b103e2 100644
+index 6afdd63..41130c5 100644
 --- a/foundry.toml
 +++ b/foundry.toml
-@@ -5,16 +5,13 @@
+@@ -5,16 +5,15 @@
  # The Default Profile
  [profile.default]
  solc_version = "0.8.30"
@@ -336,9 +336,22 @@ index 6afdd63..3b103e2 100644
 -remappings = [
 -  "forge-std=test/utils/forge-std/"
 -]
++fuzz = { runs = 256, seed = "0x4444" }
++invariant = { runs = 10, depth = 15, seed = "0x4444"}
  
  [profile.pre_global_structs]
  skip = ["*/g/*", "*/*7702*", "*/*Transient*", "*/ext/ithaca/*", "*/ext/zksync/*"]
+@@ -46,10 +45,3 @@ remappings = [
+ 
+ [fmt]
+ line_length = 100 # While we allow up to 120, we lint at 100 for readability.
+-
+-[profile.default.fuzz]
+-runs = 256
+-
+-[invariant]
+-depth = 15
+-runs = 10
 diff --git a/hardhat.config.js b/hardhat.config.js
 new file mode 100644
 index 0000000..a46a72f

--- a/crates/tools/js/benchmark/patches/uniswap-v4-core.patch
+++ b/crates/tools/js/benchmark/patches/uniswap-v4-core.patch
@@ -1,20 +1,23 @@
 diff --git a/foundry.toml b/foundry.toml
-index ef26ef2..8fce0c5 100644
+index ef26ef2..843f6e8 100644
 --- a/foundry.toml
 +++ b/foundry.toml
-@@ -10,7 +10,8 @@ bytecode_hash = "none"
+@@ -8,10 +8,8 @@ evm_version = "cancun"
+ gas_limit = "300000000"
+ bytecode_hash = "none"
  allow_internal_expect_revert = true
- 
- [profile.default.fuzz]
+-
+-[profile.default.fuzz]
 -runs = 1000
-+# Due to lack of inline config support in Hardhat
-+runs = 10
- seed = "0x4444"
+-seed = "0x4444"
++# Runs is 10 due to lack of inline config support in Hardhat
++fuzz = { runs = 10, seed = "0x4444" }
  
  [profile.pr.fuzz]
+ runs = 10000
 diff --git a/hardhat.config.js b/hardhat.config.js
 new file mode 100644
-index 0000000..981b154
+index 0000000..12dcdc4
 --- /dev/null
 +++ b/hardhat.config.js
 @@ -0,0 +1,38 @@
@@ -51,7 +54,7 @@ index 0000000..981b154
 +  "gasLimit": 300000000n,
 +  "fuzz": {
 +    "runs": 10,
-+    "seed":"0x4444"
++    "seed": "0x4444"
 +  }
 +}
 +};

--- a/crates/tools/js/benchmark/src/solidity-tests.ts
+++ b/crates/tools/js/benchmark/src/solidity-tests.ts
@@ -472,7 +472,7 @@ export function parseForgeTestDuration(
 
   for (const part of parts) {
     // Use regex to split number and unit exactly
-    const match = part.match(/^(\d+(?:\.\d+)?)([a-zA-Zµ]+)$/);
+    const match = part.match(/^(\d+)([a-zA-Zµ]+)$/);
     if (match === null) {
       throw new Error(`Invalid duration format: ${part}`);
     }

--- a/crates/tools/js/benchmark/src/solidity-tests.ts
+++ b/crates/tools/js/benchmark/src/solidity-tests.ts
@@ -446,10 +446,26 @@ function getForgeTestRuns(kind: ForgeTestKind): string {
   return "";
 }
 
-export function parseForgeTestDuration(duration: string): bigint {
+interface LegacyForgeTestDuration {
+  secs: number;
+  nanos: number;
+}
+
+function isLegacyForgeTestDuration(obj: any): obj is LegacyForgeTestDuration {
+  return typeof obj.secs === "number" && typeof obj.nanos === "number";
+}
+
+export function parseForgeTestDuration(
+  duration: string | LegacyForgeTestDuration
+): bigint {
+  if (isLegacyForgeTestDuration(duration)) {
+    return BigInt(duration.secs) * 1000000000n + BigInt(duration.nanos);
+  }
+
   if (duration.length === 0) {
     throw new Error("Expected duration, got empty string");
   }
+
   // Parse duration like "5ms 287µs 747ns" into nanoseconds
   const parts = duration.split(" ");
   let totalNs = 0n;
@@ -462,21 +478,33 @@ export function parseForgeTestDuration(duration: string): bigint {
     }
 
     const [, numberStr, unit] = match;
-    const value = parseFloat(numberStr);
+    const value = parseInt(numberStr, 10);
+    if (value >= 1000) {
+      throw new Error(`Expected value to be less than 1000, got '${value}'`);
+    }
 
     // Exact unit matching
     switch (unit) {
-      case "ms":
-        totalNs += BigInt(Math.round(value * 1000000));
+      case "ns":
+        totalNs += BigInt(value);
         break;
       case "µs":
-        totalNs += BigInt(Math.round(value * 1000));
+        totalNs += BigInt(value) * 1_000n;
         break;
-      case "ns":
-        totalNs += BigInt(Math.round(value));
+      case "us":
+        totalNs += BigInt(value) * 1_000n;
+        break;
+      case "ms":
+        totalNs += BigInt(value) * 1_000_000n;
         break;
       case "s":
-        totalNs += BigInt(Math.round(value * 1000000000));
+        totalNs += BigInt(value) * 1_000_000_000n;
+        break;
+      case "m":
+        totalNs += BigInt(value) * 60n * 1_000_000_000n;
+        break;
+      case "h":
+        totalNs += BigInt(value) * 60n * 60n * 1_000_000_000n;
         break;
       default:
         throw new Error(`Unknown duration unit: ${unit}`);

--- a/crates/tools/js/benchmark/test/test-solidity-tests.ts
+++ b/crates/tools/js/benchmark/test/test-solidity-tests.ts
@@ -45,6 +45,7 @@ describe("parseForgeTestDuration", () => {
   });
 
   it("invalid formats should throw", () => {
+    assert.throws(() => parseForgeTestDuration("123.4ms"));
     assert.throws(() => parseForgeTestDuration("123"));
     assert.throws(() => parseForgeTestDuration("123 456ms"));
     assert.throws(() => parseForgeTestDuration("123456ms"));

--- a/crates/tools/js/benchmark/test/test-solidity-tests.ts
+++ b/crates/tools/js/benchmark/test/test-solidity-tests.ts
@@ -14,6 +14,26 @@ describe("parseForgeTestDuration", () => {
     assert.equal(parseForgeTestDuration("5ms 287µs 747ns"), 5287747n);
     assert.equal(parseForgeTestDuration("1s 500ms"), 1500000000n);
     assert.equal(parseForgeTestDuration("2s 100ms 50µs 25ns"), 2100050025n);
+    assert.equal(
+      parseForgeTestDuration("3m 2s 100ms 50µs 25ns"),
+      3n * 60n * 1_000_000_000n + 2100050025n
+    );
+    assert.equal(
+      parseForgeTestDuration("4h 3m 2s 100ms 50µs 25ns"),
+      4n * 60n * 60n * 1_000_000_000n + 3n * 60n * 1_000_000_000n + 2100050025n
+    );
+  });
+
+  it("legacy format", () => {
+    assert.equal(parseForgeTestDuration({ secs: 0, nanos: 1001 }), 1001n);
+    assert.equal(
+      parseForgeTestDuration({ secs: 3, nanos: 1001 }),
+      3n * 1_000_000_000n + 1001n
+    );
+    assert.equal(
+      parseForgeTestDuration({ secs: 3, nanos: 0 }),
+      3n * 1_000_000_000n
+    );
   });
 
   it("zero values", () => {
@@ -27,23 +47,24 @@ describe("parseForgeTestDuration", () => {
   it("invalid formats should throw", () => {
     assert.throws(() => parseForgeTestDuration("123"));
     assert.throws(() => parseForgeTestDuration("123 456ms"));
+    assert.throws(() => parseForgeTestDuration("123456ms"));
     assert.throws(() => parseForgeTestDuration("abc"));
     assert.throws(() => parseForgeTestDuration("123xyz"));
     assert.throws(() => parseForgeTestDuration(""));
   });
 
   it("unknown units should throw", () => {
-    assert.throws(() => parseForgeTestDuration("123us"), {
-      message: "Unknown duration unit: us",
+    assert.throws(() => parseForgeTestDuration("123ls"), {
+      message: "Unknown duration unit: ls",
     });
-    assert.throws(() => parseForgeTestDuration("123ms 456us"), {
-      message: "Unknown duration unit: us",
+    assert.throws(() => parseForgeTestDuration("123ms 456ls"), {
+      message: "Unknown duration unit: ls",
     });
     assert.throws(() => parseForgeTestDuration("123min"), {
       message: "Unknown duration unit: min",
     });
-    assert.throws(() => parseForgeTestDuration("123h"), {
-      message: "Unknown duration unit: h",
+    assert.throws(() => parseForgeTestDuration("123j"), {
+      message: "Unknown duration unit: j",
     });
   });
 });


### PR DESCRIPTION
Includes two commits with improvements for the Forge comparison benchmark:

- [Improve forge duration parsing](https://github.com/NomicFoundation/edr/commit/3d166a7ad2037e0ba1d52ca97030545d36975d04)
  - handle more types of `forge` duration strings/structs
- [Improve patches](https://github.com/NomicFoundation/edr/commit/27505186b021aa7927824350e7932c74f924a300)
  - Use inline tables for fuzz/invariant configs for consistencyt
  - Always prefix fuzz/invariant seed with 0x to make sure it's interpreted as hex by both tools
  - Add missing `bytecodeHash: "none"` configs to HH3 config
  - Fix missing fuzz seed in `morph-blue`
  - Fix silently failing fuzz seed config in `prb-math`