### PR TITLE
build: only run setup after devcontainer creation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
       "version": "22"
     }
   },
-  "postAttachCommand": "scripts/setup.sh",
+  "postCreateCommand": "scripts/setup.sh",
   "portsAttributes": {
     // The default port of mdbook
     "3000": {


### PR DESCRIPTION
Prevents the setup script from running every time you start a devcontainer. It should suffice to only run it after devcontainer creation.