### PR TITLE
chore: add svm-solc feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ foundry-evm-traces = { path = "crates/foundry/evm/traces" }
 
 # solc & compilation utilities
 foundry-block-explorers = { version = "0.18.0", default-features = false }
-foundry-compilers = { version = "0.17.3", default-features = false }
+foundry-compilers = { version = "0.17.3", default-features = false, features = ["svm-solc"] }
 
 ## revm
 op-revm = { version = "8.1.0", default-features = false, features = ["c-kzg", "dev", "serde", "std"] }


### PR DESCRIPTION
The tests of the `edr_solidity` crate don't build without this feature. We didn't notice this before, because there are transient dependencies in other crates that enable this feature.

I'm adding the feature in the workspace root since it'll apply to all packages due to feature unification anyway.