### PR TITLE
chore: upgrade to Rust edition 2024

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,7 +124,7 @@ dependencies = [
  "proptest",
  "serde",
  "serde_json",
- "winnow 0.7.7",
+ "winnow",
 ]
 
 [[package]]
@@ -587,7 +587,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10db1bd7baa35bc8d4a1b07efbf734e73e5ba09f2580fb8cee3483a36087ceb2"
 dependencies = [
  "serde",
- "winnow 0.7.7",
+ "winnow",
 ]
 
 [[package]]
@@ -1461,12 +1461,12 @@ dependencies = [
 
 [[package]]
 name = "cargo_toml"
-version = "0.15.3"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "599aa35200ffff8f04c1925aa1acc92fa2e08874379ef42e210a80e527e60838"
+checksum = "374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77"
 dependencies = [
  "serde",
- "toml 0.7.8",
+ "toml 0.9.5",
 ]
 
 [[package]]
@@ -2746,7 +2746,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
- "toml 0.5.11",
+ "toml 0.9.5",
  "tracing",
 ]
 
@@ -3370,7 +3370,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.12",
  "tracing",
- "winnow 0.7.7",
+ "winnow",
  "yansi",
 ]
 
@@ -5586,7 +5586,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
- "toml_edit 0.22.24",
+ "toml_edit",
 ]
 
 [[package]]
@@ -6797,6 +6797,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7661,27 +7670,30 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit 0.19.15",
-]
-
-[[package]]
-name = "toml"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
 dependencies = [
  "indexmap 2.9.0",
  "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit 0.22.24",
+ "serde_spanned 0.6.8",
+ "toml_datetime 0.6.8",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
+dependencies = [
+ "indexmap 2.9.0",
+ "serde",
+ "serde_spanned 1.0.0",
+ "toml_datetime 0.7.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
@@ -7694,16 +7706,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.19.15"
+name = "toml_datetime"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
 dependencies = [
- "indexmap 2.9.0",
  "serde",
- "serde_spanned",
- "toml_datetime",
- "winnow 0.5.40",
 ]
 
 [[package]]
@@ -7714,10 +7722,25 @@ checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
  "indexmap 2.9.0",
  "serde",
- "serde_spanned",
- "toml_datetime",
- "winnow 0.7.7",
+ "serde_spanned 0.6.8",
+ "toml_datetime 0.6.8",
+ "winnow",
 ]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tools"
@@ -8565,18 +8588,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.5.40"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb8234a863ea0e8cd7284fcdd4f145233eb00fee02bbdd9861aec44e6477bc5"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ resolver = "2"
 
 [workspace.package]
 version = "0.3.8"
-edition = "2021"
+edition = "2024"
 
 [profile.dev]
 rpath = true

--- a/crates/edr_napi_core/src/logger.rs
+++ b/crates/edr_napi_core/src/logger.rs
@@ -1142,10 +1142,10 @@ impl<ChainSpecT: ProviderSpec<TimerT>, TimerT: Clone + TimeSinceEpoch>
 
     /// Retrieves the collapsed method with the provided name, if it exists.
     fn collapsed_method(&mut self, method: &str) -> Option<&mut CollapsedMethod> {
-        if let LoggingState::CollapsingMethod(collapsed_method) = &mut self.state {
-            if collapsed_method.method == method {
-                return Some(collapsed_method);
-            }
+        if let LoggingState::CollapsingMethod(collapsed_method) = &mut self.state
+            && collapsed_method.method == method
+        {
+            return Some(collapsed_method);
         }
 
         None

--- a/crates/edr_provider/Cargo.toml
+++ b/crates/edr_provider/Cargo.toml
@@ -72,8 +72,8 @@ serial_test = "2.0.0"
 tempfile = "3.7.1"
 
 [build-dependencies]
-cargo_toml = { version = "0.15.3", default-features = false }
-toml = { version = "0.5.9", default-features = false }
+cargo_toml = { version = "0.22.3", default-features = false }
+toml = { version = "0.9.5", default-features = false }
 
 [features]
 test-utils = ["dep:anyhow", "dep:edr_test_utils"]

--- a/crates/edr_provider/build.rs
+++ b/crates/edr_provider/build.rs
@@ -10,12 +10,16 @@ fn main() {
         .get("revm")
     {
         Some(Dependency::Simple(s)) => s.clone(),
-        Some(Dependency::Detailed(DependencyDetail {
-            version: Some(version),
-            git,
-            rev,
-            ..
-        })) => {
+        Some(Dependency::Detailed(detailed)) => {
+            let DependencyDetail {
+                version: Some(version),
+                git,
+                rev,
+                ..
+            } = &**detailed
+            else {
+                panic!("Unrecognized revm dependency format")
+            };
             let rev = rev.clone().map_or(String::new(), |rev| format!("@{rev}"));
             let git = git
                 .clone()

--- a/crates/edr_provider/src/data.rs
+++ b/crates/edr_provider/src/data.rs
@@ -893,10 +893,10 @@ where
         let slot = EvmStorageSlot::new_changed(old_value, value, 0);
         let account_info = modified_state.basic(address).and_then(|mut account_info| {
             // Retrieve the code if it's not empty. This is needed for the irregular state.
-            if let Some(account_info) = &mut account_info {
-                if account_info.code_hash != KECCAK_EMPTY {
-                    account_info.code = Some(modified_state.code_by_hash(account_info.code_hash)?);
-                }
+            if let Some(account_info) = &mut account_info
+                && account_info.code_hash != KECCAK_EMPTY
+            {
+                account_info.code = Some(modified_state.code_by_hash(account_info.code_hash)?);
             }
 
             Ok(account_info)
@@ -1903,10 +1903,10 @@ where
 
             result.base_fee_per_gas = base_fee_per_gas;
             result.gas_used_ratio = gas_used_ratio;
-            if let Some(reward) = opt_reward.as_mut() {
-                if let Some(remote_reward) = remote_reward {
-                    *reward = remote_reward;
-                }
+            if let Some(reward) = opt_reward.as_mut()
+                && let Some(remote_reward) = remote_reward
+            {
+                *reward = remote_reward;
             }
         }
 

--- a/crates/edr_provider/src/requests/eth/call.rs
+++ b/crates/edr_provider/src/requests/eth/call.rs
@@ -43,19 +43,19 @@ pub fn handle_call_request<
         .log_call(hardfork, &transaction, &result)
         .map_err(ProviderError::Logger)?;
 
-    if data.bail_on_call_failure() {
-        if let Some(failure) = TransactionFailure::from_execution_result::<ChainSpecT, TimerT>(
+    if data.bail_on_call_failure()
+        && let Some(failure) = TransactionFailure::from_execution_result::<ChainSpecT, TimerT>(
             &result.execution_result,
             None,
             &result.trace,
-        ) {
-            return Err(ProviderError::TransactionFailed(Box::new(
-                TransactionFailureWithTraces {
-                    failure,
-                    traces: vec![result.trace],
-                },
-            )));
-        }
+        )
+    {
+        return Err(ProviderError::TransactionFailed(Box::new(
+            TransactionFailureWithTraces {
+                failure,
+                traces: vec![result.trace],
+            },
+        )));
     }
 
     let output = result.execution_result.into_output().unwrap_or_default();

--- a/crates/edr_provider/src/requests/validation.rs
+++ b/crates/edr_provider/src/requests/validation.rs
@@ -164,10 +164,10 @@ pub fn validate_send_transaction_request<
         return Err(ProviderError::Eip4844TransactionUnsupported);
     }
 
-    if let Some(transaction_type) = request.transaction_type {
-        if transaction_type == u8::from(edr_chain_l1::L1TransactionType::Eip4844) {
-            return Err(ProviderError::Eip4844TransactionUnsupported);
-        }
+    if let Some(transaction_type) = request.transaction_type
+        && transaction_type == u8::from(edr_chain_l1::L1TransactionType::Eip4844)
+    {
+        return Err(ProviderError::Eip4844TransactionUnsupported);
     }
 
     validate_transaction_and_call_request::<ChainSpecT, TimerT>(data.hardfork(), request).map_err(|err| match err {
@@ -247,14 +247,13 @@ fn validate_transaction_spec<ChainSpecT: ProviderSpec<TimerT>, TimerT: Clone + T
         }
     }
 
-    if let Some(max_fee_per_gas) = value.max_fee_per_gas() {
-        if let Some(max_priority_fee_per_gas) = value.max_priority_fee_per_gas() {
-            if max_priority_fee_per_gas > max_fee_per_gas {
-                return Err(ProviderError::InvalidTransactionInput(format!(
-                    "maxPriorityFeePerGas ({max_priority_fee_per_gas}) is bigger than maxFeePerGas ({max_fee_per_gas})"
-                )));
-            }
-        }
+    if let Some(max_fee_per_gas) = value.max_fee_per_gas()
+        && let Some(max_priority_fee_per_gas) = value.max_priority_fee_per_gas()
+        && max_priority_fee_per_gas > max_fee_per_gas
+    {
+        return Err(ProviderError::InvalidTransactionInput(format!(
+            "maxPriorityFeePerGas ({max_priority_fee_per_gas}) is bigger than maxFeePerGas ({max_fee_per_gas})"
+        )));
     }
 
     if (value.blobs().is_some() || value.blob_hashes().is_some()) && value.to().is_none() {

--- a/crates/edr_rpc_client/src/cache/filter.rs
+++ b/crates/edr_rpc_client/src/cache/filter.rs
@@ -79,21 +79,20 @@ impl<'a> TryFrom<&'a LogFilterOptions> for CacheableLogFilterRange<'a> {
     fn try_from(value: &'a LogFilterOptions) -> Result<Self, Self::Error> {
         let map_err = |_| LogFilterOptionsNotCacheableError(value.clone());
 
-        if let Some(from_block) = &value.from_block {
-            if let Some(to_block) = &value.to_block {
-                if value.block_hash.is_none() {
-                    let range = Self::Range {
-                        from_block: from_block.try_into().map_err(map_err)?,
-                        to_block: to_block.try_into().map_err(map_err)?,
-                    };
+        if let Some(from_block) = &value.from_block
+            && let Some(to_block) = &value.to_block
+            && value.block_hash.is_none()
+        {
+            let range = Self::Range {
+                from_block: from_block.try_into().map_err(map_err)?,
+                to_block: to_block.try_into().map_err(map_err)?,
+            };
 
-                    return Ok(range);
-                }
-            }
-        } else if let Some(block_hash) = &value.block_hash {
-            if value.from_block.is_none() {
-                return Ok(Self::Hash(block_hash));
-            }
+            return Ok(range);
+        } else if let Some(block_hash) = &value.block_hash
+            && value.from_block.is_none()
+        {
+            return Ok(Self::Hash(block_hash));
         }
 
         Err(LogFilterOptionsNotCacheableError(value.clone()))

--- a/crates/edr_rpc_client/src/client.rs
+++ b/crates/edr_rpc_client/src/client.rs
@@ -350,15 +350,15 @@ impl<MethodT: RpcMethod + Serialize> RpcClient<MethodT> {
         result: ResultT,
         resolve_block_number: impl Fn(ResultT) -> Option<u64>,
     ) -> Result<Option<String>, RpcClientError> {
-        if let Some(block_number) = resolve_block_number(result) {
-            if let Some(resolved_cache_key) = block_tag_resolver.resolve_block_tag(block_number) {
-                return match resolved_cache_key {
-                    ResolvedSymbolicTag::NeedsSafetyCheck(safety_checker) => {
-                        self.validate_block_number(safety_checker).await
-                    }
-                    ResolvedSymbolicTag::Resolved(cache_key) => Ok(Some(cache_key)),
-                };
-            }
+        if let Some(block_number) = resolve_block_number(result)
+            && let Some(resolved_cache_key) = block_tag_resolver.resolve_block_tag(block_number)
+        {
+            return match resolved_cache_key {
+                ResolvedSymbolicTag::NeedsSafetyCheck(safety_checker) => {
+                    self.validate_block_number(safety_checker).await
+                }
+                ResolvedSymbolicTag::Resolved(cache_key) => Ok(Some(cache_key)),
+            };
         }
         Ok(None)
     }

--- a/crates/edr_solidity/src/compiler.rs
+++ b/crates/edr_solidity/src/compiler.rs
@@ -864,10 +864,10 @@ fn decode_bytecodes(
                 .abi;
 
             for item in contract_abi_output {
-                if item.r#type.as_deref() == Some("error") {
-                    if let Ok(custom_error) = CustomError::from_abi(item.clone()) {
-                        contract.add_custom_error(custom_error);
-                    }
+                if item.r#type.as_deref() == Some("error")
+                    && let Ok(custom_error) = CustomError::from_abi(item.clone())
+                {
+                    contract.add_custom_error(custom_error);
                 }
             }
 

--- a/crates/edr_solidity/src/contracts_identifier.rs
+++ b/crates/edr_solidity/src/contracts_identifier.rs
@@ -214,12 +214,11 @@ impl ContractsIdentifier {
 
         let result = self.search_bytecode_from_root(is_create, &normalized_code);
 
-        if self.enable_cache {
-            if let Some(result) = &result {
-                if !self.cache.contains_key(&*normalized_code) {
-                    self.cache.insert(normalized_code.to_vec(), result.clone());
-                }
-            }
+        if self.enable_cache
+            && let Some(result) = &result
+            && !self.cache.contains_key(&*normalized_code)
+        {
+            self.cache.insert(normalized_code.to_vec(), result.clone());
         }
 
         result

--- a/crates/edr_solidity/src/linker.rs
+++ b/crates/edr_solidity/src/linker.rs
@@ -193,10 +193,10 @@ impl<'a> Linker<'a> {
         if let Some(bytecode) = &contract.bytecode {
             references.extend(bytecode.link_references.clone());
         }
-        if let Some(deployed_bytecode) = &contract.deployed_bytecode {
-            if let Some(bytecode) = &deployed_bytecode.bytecode {
-                references.extend(bytecode.link_references.clone());
-            }
+        if let Some(deployed_bytecode) = &contract.deployed_bytecode
+            && let Some(bytecode) = &deployed_bytecode.bytecode
+        {
+            references.extend(bytecode.link_references.clone());
         }
 
         for (file_path, libs) in &references {
@@ -451,13 +451,12 @@ impl<'a> Linker<'a> {
                     .deployed_bytecode
                     .as_mut()
                     .and_then(|b| b.to_mut().bytecode.as_mut())
+                    && !deployed_bytecode.link(&file.to_string_lossy(), name, address)
                 {
-                    if !deployed_bytecode.link(&file.to_string_lossy(), name, address) {
-                        // If we didn't link, there is nothing to link. By calling `resolve()` we
-                        // make sure that the `BytecodeObject::Unlinked` is turned into
-                        // `BytecodeObject:Bytecode`.
-                        deployed_bytecode.object.resolve();
-                    }
+                    // If we didn't link, there is nothing to link. By calling `resolve()` we
+                    // make sure that the `BytecodeObject::Unlinked` is turned into
+                    // `BytecodeObject:Bytecode`.
+                    deployed_bytecode.object.resolve();
                 }
             }
         }

--- a/crates/edr_solidity_tests/tests/it/core.rs
+++ b/crates/edr_solidity_tests/tests/it/core.rs
@@ -704,7 +704,9 @@ async fn test_logs() {
 async fn test_env_vars() {
     let env_var_key = "_foundryCheatcodeSetEnvTestKey";
     let env_var_val = "_foundryCheatcodeSetEnvTestVal";
-    env::remove_var(env_var_key);
+    unsafe {
+        env::remove_var(env_var_key);
+    }
 
     let filter = SolidityTestFilter::new("testSetEnv", ".*", ".*");
     let runner = TEST_DATA_DEFAULT.runner().await;

--- a/crates/edr_solidity_tests/tests/it/helpers/integration_test_config.rs
+++ b/crates/edr_solidity_tests/tests/it/helpers/integration_test_config.rs
@@ -357,10 +357,10 @@ impl IntegrationTestConfig {
         // checks. If users wish to enable all options they need to do so
         // explicitly.
         let mut model_checker = self.model_checker.clone();
-        if let Some(model_checker_settings) = &mut model_checker {
-            if model_checker_settings.targets.is_none() {
-                model_checker_settings.targets = Some(vec![ModelCheckerTarget::Assert]);
-            }
+        if let Some(model_checker_settings) = &mut model_checker
+            && model_checker_settings.targets.is_none()
+        {
+            model_checker_settings.targets = Some(vec![ModelCheckerTarget::Assert]);
         }
 
         let mut settings = Settings {

--- a/crates/edr_solidity_tests/tests/it/helpers/solidity_test_filter.rs
+++ b/crates/edr_solidity_tests/tests/it/helpers/solidity_test_filter.rs
@@ -75,19 +75,19 @@ impl SolidityTestFilter {
 
 impl TestFilter for SolidityTestFilter {
     fn matches_test(&self, test_name: &str) -> bool {
-        if let Some(exclude) = &self.exclude_tests {
-            if exclude.is_match(test_name) {
-                return false;
-            }
+        if let Some(exclude) = &self.exclude_tests
+            && exclude.is_match(test_name)
+        {
+            return false;
         }
         self.test_regex.is_match(test_name)
     }
 
     fn matches_contract(&self, contract_name: &str) -> bool {
-        if let Some(exclude) = &self.exclude_contracts {
-            if exclude.is_match(contract_name) {
-                return false;
-            }
+        if let Some(exclude) = &self.exclude_contracts
+            && exclude.is_match(contract_name)
+        {
+            return false;
         }
 
         self.contract_regex.is_match(contract_name)
@@ -98,10 +98,10 @@ impl TestFilter for SolidityTestFilter {
             return false;
         };
 
-        if let Some(exclude) = &self.exclude_paths {
-            if exclude.is_match(path) {
-                return false;
-            }
+        if let Some(exclude) = &self.exclude_paths
+            && exclude.is_match(path)
+        {
+            return false;
         }
         self.path_regex.is_match(path)
     }

--- a/crates/foundry/cheatcodes/spec/src/lib.rs
+++ b/crates/foundry/cheatcodes/spec/src/lib.rs
@@ -171,11 +171,11 @@ interface Vm {{
     /// Checks that the `file` has the specified `contents`. If that is not the
     /// case, updates the file and then fails the test.
     fn ensure_file_contents(file: &Path, contents: &str) {
-        if let Ok(old_contents) = fs::read_to_string(file) {
-            if normalize_newlines(&old_contents) == normalize_newlines(contents) {
-                // File is already up to date.
-                return;
-            }
+        if let Ok(old_contents) = fs::read_to_string(file)
+            && normalize_newlines(&old_contents) == normalize_newlines(contents)
+        {
+            // File is already up to date.
+            return;
         }
 
         eprintln!(

--- a/crates/foundry/cheatcodes/src/evm.rs
+++ b/crates/foundry/cheatcodes/src/evm.rs
@@ -2831,10 +2831,11 @@ fn inner_stop_gas_snapshot<
             .retain(|record| !(record.group == group && record.name == name));
 
         // Clear last snapshot cache if we have an exact match.
-        if let Some((snapshot_group, snapshot_name)) = &ccx.state.gas_metering.active_gas_snapshot {
-            if snapshot_group == &group && snapshot_name == &name {
-                ccx.state.gas_metering.active_gas_snapshot = None;
-            }
+        if let Some((snapshot_group, snapshot_name)) = &ccx.state.gas_metering.active_gas_snapshot
+            && snapshot_group == &group
+            && snapshot_name == &name
+        {
+            ccx.state.gas_metering.active_gas_snapshot = None;
         }
 
         Ok(value.abi_encode())

--- a/crates/foundry/cheatcodes/src/evm/mapping.rs
+++ b/crates/foundry/cheatcodes/src/evm/mapping.rs
@@ -300,10 +300,10 @@ pub(crate) fn step(mapping_slots: &mut HashMap<Address, MappingSlots>, interpret
             }
         }
         opcode::SSTORE => {
-            if let Some(mapping_slots) = mapping_slots.get_mut(&interpreter.input.target_address) {
-                if let Ok(slot) = interpreter.stack.peek(0) {
-                    mapping_slots.insert(slot.into());
-                }
+            if let Some(mapping_slots) = mapping_slots.get_mut(&interpreter.input.target_address)
+                && let Ok(slot) = interpreter.stack.peek(0)
+            {
+                mapping_slots.insert(slot.into());
             }
         }
         _ => {}

--- a/crates/foundry/cheatcodes/src/fs.rs
+++ b/crates/foundry/cheatcodes/src/fs.rs
@@ -814,23 +814,22 @@ impl<'a> ArtifactIdQuery<'a> {
             .next()
             .expect("split always returns at least one element");
 
-        if let Some(path) = &self.file {
-            if !id.source.ends_with(path) {
-                return false;
-            }
+        if let Some(path) = &self.file
+            && !id.source.ends_with(path)
+        {
+            return false;
         }
-        if let Some(name) = self.contract_name {
-            if id_name != name {
-                return false;
-            }
+        if let Some(name) = self.contract_name
+            && id_name != name
+        {
+            return false;
         }
-        if let Some(version) = &self.version {
-            if id.version.minor != version.minor
+        if let Some(version) = &self.version
+            && (id.version.minor != version.minor
                 || id.version.major != version.major
-                || id.version.patch != version.patch
-            {
-                return false;
-            }
+                || id.version.patch != version.patch)
+        {
+            return false;
         }
         true
     }

--- a/crates/foundry/cheatcodes/src/test/expect.rs
+++ b/crates/foundry/cheatcodes/src/test/expect.rs
@@ -2174,18 +2174,18 @@ fn expect_call<
 ) -> Result {
     let expecteds = state.expected_calls.entry(*target).or_default();
 
-    if let Some(val) = value {
-        if *val > U256::ZERO {
-            // If the value of the transaction is non-zero, the EVM adds a call stipend of
-            // 2300 gas to ensure that the basic fallback function can be
-            // called.
-            let positive_value_cost_stipend = 2300;
-            if let Some(gas) = &mut gas {
-                *gas += positive_value_cost_stipend;
-            }
-            if let Some(min_gas) = &mut min_gas {
-                *min_gas += positive_value_cost_stipend;
-            }
+    if let Some(val) = value
+        && *val > U256::ZERO
+    {
+        // If the value of the transaction is non-zero, the EVM adds a call stipend of
+        // 2300 gas to ensure that the basic fallback function can be
+        // called.
+        let positive_value_cost_stipend = 2300;
+        if let Some(gas) = &mut gas {
+            *gas += positive_value_cost_stipend;
+        }
+        if let Some(min_gas) = &mut min_gas {
+            *min_gas += positive_value_cost_stipend;
         }
     }
 

--- a/crates/foundry/cheatcodes/src/test/revert_handlers.rs
+++ b/crates/foundry/cheatcodes/src/test/revert_handlers.rs
@@ -49,14 +49,13 @@ fn handle_revert(
     // If expected reverter address is set then check it matches the actual
     // reverter.
     if let (Some(expected_reverter), Some(&actual_reverter)) = (revert_params.reverter(), reverter)
+        && expected_reverter != actual_reverter
     {
-        if expected_reverter != actual_reverter {
-            return Err(fmt_err!(
-                "Reverter != expected reverter: {} != {}",
-                actual_reverter,
-                expected_reverter
-            ));
-        }
+        return Err(fmt_err!(
+            "Reverter != expected reverter: {} != {}",
+            actual_reverter,
+            expected_reverter
+        ));
     }
 
     let expected_reason = revert_params.reason();
@@ -148,10 +147,9 @@ pub(crate) fn handle_expect_revert(
         // Reverter check
         if let (Some(expected_reverter), Some(actual_reverter)) =
             (expected_revert.reverter, expected_revert.reverted_by)
+            && expected_reverter == actual_reverter
         {
-            if expected_reverter == actual_reverter {
-                reverter_match = Some(true);
-            }
+            reverter_match = Some(true);
         }
 
         // Reason check
@@ -203,10 +201,9 @@ fn decode_revert(revert: Vec<u8>) -> Vec<u8> {
     if matches!(
         revert.get(..4).map(|s| s.try_into().unwrap()),
         Some(Vm::CheatcodeError::SELECTOR | alloy_sol_types::Revert::SELECTOR)
-    ) {
-        if let Ok(decoded) = Vec::<u8>::abi_decode(&revert[4..]) {
-            return decoded;
-        }
+    ) && let Ok(decoded) = Vec::<u8>::abi_decode(&revert[4..])
+    {
+        return decoded;
     }
     revert
 }

--- a/crates/foundry/evm/core/src/abi/fmt/ui.rs
+++ b/crates/foundry/evm/core/src/abi/fmt/ui.rs
@@ -40,7 +40,7 @@ impl<T: UIfmt> UIfmt for &T {
 
 impl<T: UIfmt> UIfmt for Option<T> {
     fn pretty(&self) -> String {
-        if let Some(ref inner) = self {
+        if let Some(inner) = self {
             inner.pretty()
         } else {
             String::new()

--- a/crates/foundry/evm/core/src/backend/mod.rs
+++ b/crates/foundry/evm/core/src/backend/mod.rs
@@ -1938,10 +1938,10 @@ pub struct Fork {
 impl Fork {
     /// Returns true if the account is a contract
     pub fn is_contract(&self, acc: Address) -> bool {
-        if let Ok(Some(acc)) = self.db.basic_ref(acc) {
-            if acc.code_hash != KECCAK_EMPTY {
-                return true;
-            }
+        if let Ok(Some(acc)) = self.db.basic_ref(acc)
+            && acc.code_hash != KECCAK_EMPTY
+        {
+            return true;
         }
         is_contract_in_state(&self.journaled_state, acc)
     }

--- a/crates/foundry/evm/core/src/decode.rs
+++ b/crates/foundry/evm/core/src/decode.rs
@@ -157,10 +157,10 @@ impl RevertDecoder {
     /// See [`decode_revert`] for more information.
     pub fn maybe_decode(&self, err: &[u8], status: Option<InstructionResult>) -> Option<String> {
         if err.len() < edr_defaults::SELECTOR_LEN {
-            if let Some(status) = status {
-                if !status.is_ok() {
-                    return Some(format!("EvmError: {status:?}"));
-                }
+            if let Some(status) = status
+                && !status.is_ok()
+            {
+                return Some(format!("EvmError: {status:?}"));
             }
             return if err.is_empty() {
                 None

--- a/crates/foundry/evm/core/src/fork/multi.rs
+++ b/crates/foundry/evm/core/src/fork/multi.rs
@@ -304,10 +304,10 @@ impl<BlockT: BlockEnvTr, TxT: TransactionEnvTr, HardforkT: HardforkTr>
     ) -> Option<&mut Vec<CreateSender<BlockT, TxT, HardforkT>>> {
         for task in self.pending_tasks.iter_mut() {
             #[allow(irrefutable_let_patterns)]
-            if let ForkTask::Create(_, in_progress, _, additional) = task {
-                if in_progress == id {
-                    return Some(additional);
-                }
+            if let ForkTask::Create(_, in_progress, _, additional) = task
+                && in_progress == id
+            {
+                return Some(additional);
             }
         }
         None
@@ -560,11 +560,11 @@ impl<BlockT, TxT, HardforkT> Drop for ShutDownMultiFork<BlockT, TxT, HardforkT> 
         trace!(target: "fork::multi", "initiating shutdown");
         let (sender, rx) = oneshot_channel();
         let req = Request::ShutDown(sender);
-        if let Some(mut handler) = self.handler.take() {
-            if handler.try_send(req).is_ok() {
-                let _ = rx.recv();
-                trace!(target: "fork::cache", "multifork backend shutdown");
-            }
+        if let Some(mut handler) = self.handler.take()
+            && handler.try_send(req).is_ok()
+        {
+            let _ = rx.recv();
+            trace!(target: "fork::cache", "multifork backend shutdown");
         }
     }
 }

--- a/crates/foundry/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/foundry/evm/evm/src/executors/fuzz/mod.rs
@@ -330,11 +330,11 @@ impl<
             }
         }
 
-        if let Some(reason) = &result.reason {
-            if let Some(reason) = SkipReason::decode_self(reason) {
-                result.skipped = true;
-                result.reason = reason.0;
-            }
+        if let Some(reason) = &result.reason
+            && let Some(reason) = SkipReason::decode_self(reason)
+        {
+            result.skipped = true;
+            result.reason = reason.0;
         }
 
         state.log_stats();

--- a/crates/foundry/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/foundry/evm/evm/src/executors/invariant/mod.rs
@@ -1047,7 +1047,8 @@ impl<
             HardforkT,
             TransactionErrorT,
         >,
-        impl Strategy<Value = BasicTxDetails>,
+        impl Strategy<Value = BasicTxDetails>
+            + use<BlockT, TxT, EvmBuilderT, HaltReasonT, HardforkT, TransactionErrorT, ChainContextT>,
     )> {
         // Finds out the chosen deployed contracts and/or senders.
         self.select_contract_artifacts(invariant_contract.address)?;

--- a/crates/foundry/evm/evm/src/executors/invariant/replay.rs
+++ b/crates/foundry/evm/evm/src/executors/invariant/replay.rs
@@ -390,10 +390,10 @@ fn set_up_inner_replay<
     >,
     inner_sequence: &[Option<BasicTxDetails>],
 ) {
-    if let Some(fuzzer) = &mut executor.inspector.fuzzer {
-        if let Some(call_generator) = &mut fuzzer.call_generator {
-            call_generator.last_sequence = Arc::new(RwLock::new(inner_sequence.to_owned()));
-            call_generator.set_replay(true);
-        }
+    if let Some(fuzzer) = &mut executor.inspector.fuzzer
+        && let Some(call_generator) = &mut fuzzer.call_generator
+    {
+        call_generator.last_sequence = Arc::new(RwLock::new(inner_sequence.to_owned()));
+        call_generator.set_replay(true);
     }
 }

--- a/crates/foundry/evm/evm/src/executors/invariant/result.rs
+++ b/crates/foundry/evm/evm/src/executors/invariant/result.rs
@@ -153,10 +153,10 @@ pub(crate) fn assert_invariants<
 > {
     let mut inner_sequence = vec![];
 
-    if let Some(fuzzer) = &executor.inspector.fuzzer {
-        if let Some(call_generator) = &fuzzer.call_generator {
-            inner_sequence.extend(call_generator.last_sequence.read().iter().cloned());
-        }
+    if let Some(fuzzer) = &executor.inspector.fuzzer
+        && let Some(call_generator) = &fuzzer.call_generator
+    {
+        inner_sequence.extend(call_generator.last_sequence.read().iter().cloned());
     }
 
     let CallInvariantResult {

--- a/crates/foundry/evm/fuzz/src/lib.rs
+++ b/crates/foundry/evm/fuzz/src/lib.rs
@@ -90,32 +90,32 @@ impl BaseCounterExample {
         show_solidity: bool,
         indeterminism_reasons: Option<IndeterminismReasons>,
     ) -> Self {
-        if let Some((name, abi)) = &contracts.get(&addr) {
-            if let Some(func) = abi.functions().find(|f| f.selector() == bytes[..4]) {
-                // skip the function selector when decoding
-                if let Ok(args) = func.abi_decode_input(&bytes[4..]) {
-                    return Self {
-                        sender: Some(sender),
-                        addr: Some(addr),
-                        calldata: bytes.clone(),
-                        contract_name: Some(name.clone()),
-                        func_name: Some(func.name.clone()),
-                        signature: Some(func.signature()),
-                        args: Some(
-                            foundry_evm_core::abi::fmt::format_tokens(&args)
-                                .format(", ")
-                                .to_string(),
-                        ),
-                        raw_args: Some(
-                            foundry_evm_core::abi::fmt::format_tokens_raw(&args)
-                                .format(", ")
-                                .to_string(),
-                        ),
-                        traces,
-                        show_solidity,
-                        indeterminism_reasons,
-                    };
-                }
+        if let Some((name, abi)) = &contracts.get(&addr)
+            && let Some(func) = abi.functions().find(|f| f.selector() == bytes[..4])
+        {
+            // skip the function selector when decoding
+            if let Ok(args) = func.abi_decode_input(&bytes[4..]) {
+                return Self {
+                    sender: Some(sender),
+                    addr: Some(addr),
+                    calldata: bytes.clone(),
+                    contract_name: Some(name.clone()),
+                    func_name: Some(func.name.clone()),
+                    signature: Some(func.signature()),
+                    args: Some(
+                        foundry_evm_core::abi::fmt::format_tokens(&args)
+                            .format(", ")
+                            .to_string(),
+                    ),
+                    raw_args: Some(
+                        foundry_evm_core::abi::fmt::format_tokens_raw(&args)
+                            .format(", ")
+                            .to_string(),
+                    ),
+                    traces,
+                    show_solidity,
+                    indeterminism_reasons,
+                };
             }
         }
 
@@ -168,28 +168,28 @@ impl BaseCounterExample {
 impl fmt::Display for BaseCounterExample {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Display counterexample as solidity.
-        if self.show_solidity {
-            if let (Some(sender), Some(contract), Some(address), Some(func_name), Some(args)) = (
+        if self.show_solidity
+            && let (Some(sender), Some(contract), Some(address), Some(func_name), Some(args)) = (
                 &self.sender,
                 &self.contract_name,
                 &self.addr,
                 &self.func_name,
                 &self.raw_args,
-            ) {
-                writeln!(f, "\t\tvm.prank({sender});")?;
-                write!(
-                    f,
-                    "\t\t{}({}).{}({});",
-                    contract
-                        .split_once(':')
-                        .map_or(contract.as_str(), |(_, contract)| contract),
-                    address,
-                    func_name,
-                    args
-                )?;
+            )
+        {
+            writeln!(f, "\t\tvm.prank({sender});")?;
+            write!(
+                f,
+                "\t\t{}({}).{}({});",
+                contract
+                    .split_once(':')
+                    .map_or(contract.as_str(), |(_, contract)| contract),
+                address,
+                func_name,
+                args
+            )?;
 
-                return Ok(());
-            }
+            return Ok(());
         }
 
         // Regular counterexample display.

--- a/crates/foundry/evm/fuzz/src/strategies/calldata.rs
+++ b/crates/foundry/evm/fuzz/src/strategies/calldata.rs
@@ -10,7 +10,10 @@ use crate::{
 
 /// Given a function, it returns a strategy which generates valid calldata
 /// for that function's input types, following declared test fixtures.
-pub fn fuzz_calldata(func: Function, fuzz_fixtures: &FuzzFixtures) -> impl Strategy<Value = Bytes> {
+pub fn fuzz_calldata(
+    func: Function,
+    fuzz_fixtures: &FuzzFixtures,
+) -> impl Strategy<Value = Bytes> + use<> {
     // We need to compose all the strategies generated for each parameter in all
     // possible combinations, accounting any parameter declared fixture
     let strats = func
@@ -42,7 +45,7 @@ pub fn fuzz_calldata(func: Function, fuzz_fixtures: &FuzzFixtures) -> impl Strat
 pub fn fuzz_calldata_from_state(
     func: Function,
     state: &EvmFuzzState,
-) -> impl Strategy<Value = Bytes> {
+) -> impl Strategy<Value = Bytes> + use<> {
     let strats = func
         .inputs
         .iter()

--- a/crates/foundry/evm/fuzz/src/strategies/int.rs
+++ b/crates/foundry/evm/fuzz/src/strategies/int.rs
@@ -162,10 +162,10 @@ impl IntStrategy {
 
         // Generate value tree from fixture.
         let fixture = &self.fixtures[runner.rng().random_range(0..self.fixtures.len())];
-        if let Some(int_fixture) = fixture.as_int() {
-            if int_fixture.1 == self.bits {
-                return Ok(IntValueTree::new(int_fixture.0, false));
-            }
+        if let Some(int_fixture) = fixture.as_int()
+            && int_fixture.1 == self.bits
+        {
+            return Ok(IntValueTree::new(int_fixture.0, false));
         }
 
         // If fixture is not a valid type, raise error and generate random value.

--- a/crates/foundry/evm/fuzz/src/strategies/invariants.rs
+++ b/crates/foundry/evm/fuzz/src/strategies/invariants.rs
@@ -97,7 +97,7 @@ fn select_random_sender(
     fuzz_state: &EvmFuzzState,
     senders: Rc<SenderFilters>,
     dictionary_weight: u32,
-) -> impl Strategy<Value = Address> {
+) -> impl Strategy<Value = Address> + use<> {
     if !senders.targeted.is_empty() {
         any::<prop::sample::Index>()
             .prop_map(move |index| *index.get(&senders.targeted))
@@ -122,7 +122,7 @@ pub fn fuzz_contract_with_calldata(
     fuzz_fixtures: &FuzzFixtures,
     target: Address,
     func: Function,
-) -> impl Strategy<Value = CallDetails> {
+) -> impl Strategy<Value = CallDetails> + use<> {
     // We need to compose all the strategies generated for each parameter in all
     // possible combinations.
     // `prop_oneof!` / `TupleUnion` `Arc`s for cheap cloning.

--- a/crates/foundry/evm/fuzz/src/strategies/param.rs
+++ b/crates/foundry/evm/fuzz/src/strategies/param.rs
@@ -45,11 +45,11 @@ fn fuzz_param_inner(
     param: &DynSolType,
     mut fuzz_fixtures: Option<(&[DynSolValue], &str)>,
 ) -> BoxedStrategy<DynSolValue> {
-    if let Some((fixtures, name)) = fuzz_fixtures {
-        if !fixtures.iter().all(|f| f.matches(param)) {
-            error!("fixtures for {name:?} do not match type {param}");
-            fuzz_fixtures = None;
-        }
+    if let Some((fixtures, name)) = fuzz_fixtures
+        && !fixtures.iter().all(|f| f.matches(param))
+    {
+        error!("fixtures for {name:?} do not match type {param}");
+        fuzz_fixtures = None;
     }
     let fuzz_fixtures = fuzz_fixtures.map(|(f, _)| f);
 

--- a/crates/foundry/evm/fuzz/src/strategies/state.rs
+++ b/crates/foundry/evm/fuzz/src/strategies/state.rs
@@ -190,12 +190,12 @@ impl FuzzDictionary {
         result: &Bytes,
         run_depth: u32,
     ) {
-        if let Some(function) = function {
-            if !function.outputs.is_empty() {
-                // Decode result and collect samples to be used in subsequent fuzz runs.
-                if let Ok(decoded_result) = function.abi_decode_output(result) {
-                    self.insert_sample_values(decoded_result, run_depth);
-                }
+        if let Some(function) = function
+            && !function.outputs.is_empty()
+        {
+            // Decode result and collect samples to be used in subsequent fuzz runs.
+            if let Ok(decoded_result) = function.abi_decode_output(result) {
+                self.insert_sample_values(decoded_result, run_depth);
             }
         }
     }

--- a/crates/foundry/evm/fuzz/src/strategies/uint.rs
+++ b/crates/foundry/evm/fuzz/src/strategies/uint.rs
@@ -139,10 +139,10 @@ impl UintStrategy {
 
         // Generate value tree from fixture.
         let fixture = &self.fixtures[runner.rng().random_range(0..self.fixtures.len())];
-        if let Some(uint_fixture) = fixture.as_uint() {
-            if uint_fixture.1 == self.bits {
-                return Ok(UintValueTree::new(uint_fixture.0, false));
-            }
+        if let Some(uint_fixture) = fixture.as_uint()
+            && uint_fixture.1 == self.bits
+        {
+            return Ok(UintValueTree::new(uint_fixture.0, false));
         }
 
         // If fixture is not a valid type, raise error and generate random value.

--- a/crates/foundry/evm/traces/src/decoder/mod.rs
+++ b/crates/foundry/evm/traces/src/decoder/mod.rs
@@ -302,10 +302,10 @@ impl CallTraceDecoder {
         for error in abi.errors() {
             self.push_error(error.clone());
         }
-        if let Some(address) = address {
-            if abi.receive.is_some() {
-                self.receive_contracts.push(*address);
-            }
+        if let Some(address) = address
+            && abi.receive.is_some()
+        {
+            self.receive_contracts.push(*address);
         }
     }
 
@@ -352,12 +352,11 @@ impl CallTraceDecoder {
             let functions = match self.functions.get(selector) {
                 Some(fs) => fs,
                 None => {
-                    if let Some(identifier) = &self.signature_identifier {
-                        if let Some(function) =
+                    if let Some(identifier) = &self.signature_identifier
+                        && let Some(function) =
                             identifier.write().await.identify_function(selector).await
-                        {
-                            functions.push(function);
-                        }
+                    {
+                        functions.push(function);
                     }
                     &functions
                 }
@@ -411,10 +410,10 @@ impl CallTraceDecoder {
                 }
             }
 
-            if args.is_none() {
-                if let Ok(v) = func.abi_decode_input(&trace.data[edr_defaults::SELECTOR_LEN..]) {
-                    args = Some(v.iter().map(|value| self.apply_label(value)).collect());
-                }
+            if args.is_none()
+                && let Ok(v) = func.abi_decode_input(&trace.data[edr_defaults::SELECTOR_LEN..])
+            {
+                args = Some(v.iter().map(|value| self.apply_label(value)).collect());
             }
         }
 
@@ -531,13 +530,12 @@ impl CallTraceDecoder {
     fn decode_function_output(&self, trace: &CallTrace, funcs: &[Function]) -> Option<String> {
         let data = &trace.output;
         if trace.success {
-            if trace.address == CHEATCODE_ADDRESS {
-                if let Some(decoded) = funcs
+            if trace.address == CHEATCODE_ADDRESS
+                && let Some(decoded) = funcs
                     .iter()
                     .find_map(|func| self.decode_cheatcode_outputs(func))
-                {
-                    return Some(decoded);
-                }
+            {
+                return Some(decoded);
             }
 
             if let Some(values) = funcs
@@ -593,10 +591,10 @@ impl CallTraceDecoder {
         let events = match self.events.get(&(t0, log.topics().len() - 1)) {
             Some(es) => es,
             None => {
-                if let Some(identifier) = &self.signature_identifier {
-                    if let Some(event) = identifier.write().await.identify_event(&t0[..]).await {
-                        events.push(get_indexed_event(event, log));
-                    }
+                if let Some(identifier) = &self.signature_identifier
+                    && let Some(event) = identifier.write().await.identify_event(&t0[..]).await
+                {
+                    events.push(get_indexed_event(event, log));
                 }
                 &events
             }
@@ -658,10 +656,10 @@ impl CallTraceDecoder {
     }
 
     fn apply_label(&self, value: &DynSolValue) -> String {
-        if let DynSolValue::Address(addr) = value {
-            if let Some(label) = self.labels.get(addr) {
-                return format!("{label}: [{addr}]");
-            }
+        if let DynSolValue::Address(addr) = value
+            && let Some(label) = self.labels.get(addr)
+        {
+            return format!("{label}: [{addr}]");
         }
         format_token(value)
     }

--- a/crates/foundry/evm/traces/src/identifier/signatures.rs
+++ b/crates/foundry/evm/traces/src/identifier/signatures.rs
@@ -82,10 +82,10 @@ impl SignaturesIdentifier {
     #[instrument(target = "evm::traces", skip(self))]
     pub fn save(&self) {
         if let Some(cached_path) = &self.cached_path {
-            if let Some(parent) = cached_path.parent() {
-                if let Err(err) = std::fs::create_dir_all(parent) {
-                    warn!(target: "evm::traces", ?parent, ?err, "failed to create cache");
-                }
+            if let Some(parent) = cached_path.parent()
+                && let Err(err) = std::fs::create_dir_all(parent)
+            {
+                warn!(target: "evm::traces", ?parent, ?err, "failed to create cache");
             }
             if let Err(err) = fs::write_json_file(cached_path, &self.cached) {
                 warn!(target: "evm::traces", ?cached_path, ?err, "failed to flush signature cache");
@@ -125,11 +125,11 @@ impl SignaturesIdentifier {
             {
                 for (hex_id, selector_result) in query.into_iter().zip(res.into_iter()) {
                     let mut found = false;
-                    if let Some(decoded_results) = selector_result {
-                        if let Some(decoded_result) = decoded_results.into_iter().next() {
-                            cache.insert(hex_id.clone(), decoded_result);
-                            found = true;
-                        }
+                    if let Some(decoded_results) = selector_result
+                        && let Some(decoded_result) = decoded_results.into_iter().next()
+                    {
+                        cache.insert(hex_id.clone(), decoded_result);
+                        found = true;
                     }
                     if !found {
                         self.unavailable.insert(hex_id.clone());

--- a/crates/foundry/evm/traces/src/lib.rs
+++ b/crates/foundry/evm/traces/src/lib.rs
@@ -167,10 +167,11 @@ fn clear_node(
             items_to_remove.insert(item_idx);
         }
 
-        if let Some((end_node, end_step_idx)) = cur_ignore_end {
-            if node_idx == *end_node && item_idx == *end_step_idx {
-                *cur_ignore_end = None;
-            }
+        if let Some((end_node, end_step_idx)) = cur_ignore_end
+            && node_idx == *end_node
+            && item_idx == *end_step_idx
+        {
+            *cur_ignore_end = None;
         }
     }
 

--- a/crates/tools/src/scenario.rs
+++ b/crates/tools/src/scenario.rs
@@ -99,10 +99,10 @@ pub async fn execute(scenario_path: &Path, max_count: Option<usize>) -> anyhow::
         anyhow::bail!("This scenario expects logging, but logging is not yet implemented")
     }
 
-    if let Some(chain_type) = config.chain_type {
-        if chain_type != edr_generic::CHAIN_TYPE {
-            anyhow::bail!("Unsupported chain type: {chain_type}")
-        }
+    if let Some(chain_type) = config.chain_type
+        && chain_type != edr_generic::CHAIN_TYPE
+    {
+        anyhow::bail!("Unsupported chain type: {chain_type}")
     }
 
     let provider_config = edr_provider::ProviderConfig::<edr_chain_l1::Hardfork>::try_from(
@@ -147,10 +147,10 @@ pub async fn execute(scenario_path: &Path, max_count: Option<usize>) -> anyhow::
     let mut success: usize = 0;
     let mut failure: usize = 0;
     for (i, request) in requests.into_iter().enumerate() {
-        if let Some(max_count) = max_count {
-            if i >= max_count {
-                break;
-            }
+        if let Some(max_count) = max_count
+            && i >= max_count
+        {
+            break;
         }
         let p = provider.clone();
         let response = task::spawn_blocking(move || p.handle_request(request))


### PR DESCRIPTION
This PR upgrades the EDR repo to Rust edition 2024.

Motivation: Foundry has upgraded to Rust edition 2024 and Foundry code makes extensive use of the new [let chains in if and while](https://doc.rust-lang.org/nightly/edition-guide/rust-2024/let-chains.html#let-chains-in-if-and-while) feature. 

I've successfully rebased the Foundry upgrade branch on top of this PR.