### PR TITLE
fix replay block tool for L1 blocks

### DIFF
--- a/crates/edr_provider/src/data.rs
+++ b/crates/edr_provider/src/data.rs
@@ -3985,12 +3985,14 @@ mod tests {
     #[cfg(feature = "test-remote")]
     mod alchemy {
         use edr_chain_l1::L1ChainSpec;
-        use edr_eth::block;
         use edr_evm::impl_full_block_tests;
         use edr_test_utils::env::get_alchemy_url;
 
         use super::*;
-        use crate::ForkConfig;
+        use crate::{
+            test_utils::{l1_header_overrides, l1_header_overrides_before_merge},
+            ForkConfig,
+        };
 
         #[test]
         fn run_call_in_hardfork_context() -> anyhow::Result<()> {
@@ -4152,42 +4154,26 @@ mod tests {
             Ok(())
         }
 
-        fn l1_header_overrides(
-            replay_header: &block::Header,
-        ) -> HeaderOverrides<edr_evm_spec::EvmSpecId> {
-            HeaderOverrides {
-                beneficiary: Some(replay_header.beneficiary),
-                gas_limit: Some(replay_header.gas_limit),
-                extra_data: Some(replay_header.extra_data.clone()),
-                mix_hash: Some(replay_header.mix_hash),
-                nonce: Some(replay_header.nonce),
-                parent_beacon_block_root: replay_header.parent_beacon_block_root,
-                state_root: Some(replay_header.state_root),
-                timestamp: Some(replay_header.timestamp),
-                ..HeaderOverrides::<edr_evm_spec::EvmSpecId>::default()
-            }
-        }
-
         impl_full_block_tests! {
             mainnet_byzantium => L1ChainSpec {
                 block_number: 4_370_001,
                 url: get_alchemy_url(),
-                header_overrides_constructor: l1_header_overrides,
+                header_overrides_constructor: l1_header_overrides_before_merge,
             },
             mainnet_constantinople => L1ChainSpec {
                 block_number: 7_280_001,
                 url: get_alchemy_url(),
-                header_overrides_constructor: l1_header_overrides,
+                header_overrides_constructor: l1_header_overrides_before_merge,
             },
             mainnet_istanbul => L1ChainSpec {
                 block_number: 9_069_001,
                 url: get_alchemy_url(),
-                header_overrides_constructor: l1_header_overrides,
+                header_overrides_constructor: l1_header_overrides_before_merge,
             },
             mainnet_muir_glacier => L1ChainSpec {
                 block_number: 9_300_077,
                 url: get_alchemy_url(),
-                header_overrides_constructor: l1_header_overrides,
+                header_overrides_constructor: l1_header_overrides_before_merge,
             },
             mainnet_shanghai => L1ChainSpec {
                 block_number: 17_050_001,

--- a/crates/edr_provider/src/test_utils.rs
+++ b/crates/edr_provider/src/test_utils.rs
@@ -40,7 +40,28 @@ pub fn create_test_config<HardforkT: Default>() -> ProviderConfig<HardforkT> {
     create_test_config_with_fork(None)
 }
 
+/// Default header overrides for replaying L1 blocks before The Merge
+pub fn l1_header_overrides_before_merge(
+    replay_header: &block::Header,
+) -> block::HeaderOverrides<edr_evm_spec::EvmSpecId> {
+    block::HeaderOverrides {
+        nonce: Some(replay_header.nonce),
+        ..l1_header_overrides(replay_header)
+    }
+}
+
 /// Default header overrides for replaying L1 blocks.
+pub fn l1_header_overrides(
+    replay_header: &block::Header,
+) -> block::HeaderOverrides<edr_evm_spec::EvmSpecId> {
+    block::HeaderOverrides {
+        // Extra_data field in L1 has arbitrary additional data
+        extra_data: Some(replay_header.extra_data.clone()),
+        ..header_overrides(replay_header)
+    }
+}
+
+/// Default header overrides for replaying blocks.
 pub fn header_overrides<HardforkT: Default>(
     replay_header: &block::Header,
 ) -> block::HeaderOverrides<HardforkT> {

--- a/crates/tools/src/remote_block.rs
+++ b/crates/tools/src/remote_block.rs
@@ -7,7 +7,7 @@ use edr_eth::block;
 use edr_evm::{blockchain::BlockchainErrorForChainSpec, test_utils::run_full_block, BlockReceipts};
 use edr_evm_spec::{EvmTransactionValidationError, TransactionValidation};
 use edr_op::{test_utils::isthmus_header_overrides, OpChainSpec};
-use edr_provider::{spec::SyncRuntimeSpec, test_utils::header_overrides};
+use edr_provider::{spec::SyncRuntimeSpec, test_utils::l1_header_overrides};
 use edr_receipt::{log::FilterLog, AsExecutionReceipt};
 use edr_rpc_eth::client::EthRpcClient;
 
@@ -24,8 +24,13 @@ pub async fn replay(
 ) -> anyhow::Result<()> {
     match chain_type {
         SupportedChainTypes::L1 => {
-            replay_chain_specific_block::<L1ChainSpec>("L1", url, header_overrides, block_number)
-                .await
+            replay_chain_specific_block::<L1ChainSpec>(
+                edr_chain_l1::CHAIN_TYPE,
+                url,
+                l1_header_overrides,
+                block_number,
+            )
+            .await
         }
         SupportedChainTypes::Op => {
             replay_chain_specific_block::<OpChainSpec>(


### PR DESCRIPTION
The Ethereum block's `extra data` field  contains arbitrary additional data as raw bytes. 
As it's arbitrary data, EDR has no way generating the same block unless it copies the content from the block being replayed. 

This fix overrides `extra_data` field when using the replay-block tool in the same way that it replays blocks in integration tests.
