### PR TITLE
fix json-rpc `eth_feeHistory` method

### DIFF
--- a/.changeset/hungry-beans-agree.md
+++ b/.changeset/hungry-beans-agree.md
@@ -1,0 +1,6 @@
+---
+"hardhat-edr-tests": minor
+"@nomicfoundation/edr": minor
+---
+
+make all parameters of `eth_feeHistory` rpc call & provider method call required

--- a/crates/edr_provider/src/requests/eth/gas.rs
+++ b/crates/edr_provider/src/requests/eth/gas.rs
@@ -69,7 +69,7 @@ pub fn handle_fee_history<
     data: &mut ProviderData<ChainSpecT, TimerT>,
     block_count: U256,
     newest_block: BlockSpec,
-    reward_percentiles: Option<Vec<f64>>,
+    reward_percentiles: Vec<f64>,
 ) -> Result<FeeHistoryResult, ProviderErrorForChainSpec<ChainSpecT>> {
     if data.evm_spec_id() < EvmSpecId::LONDON {
         return Err(ProviderError::InvalidInput(
@@ -94,9 +94,9 @@ pub fn handle_fee_history<
 
     validate_post_merge_block_tags::<ChainSpecT, TimerT>(data.hardfork(), &newest_block)?;
 
-    let reward_percentiles = reward_percentiles.map(|percentiles| {
-        let mut validated_percentiles = Vec::with_capacity(percentiles.len());
-        for (i, percentile) in percentiles.iter().copied().enumerate() {
+    let reward_percentiles = {
+        let mut validated_percentiles = Vec::with_capacity(reward_percentiles.len());
+        for (i, percentile) in reward_percentiles.iter().copied().enumerate() {
             validated_percentiles.push(RewardPercentile::try_from(percentile).map_err(|_err| {
                 ProviderError::InvalidInput(format!(
                     "The reward percentile number {} is invalid. It must be a float between 0 and 100, but is {} instead.",
@@ -105,7 +105,7 @@ pub fn handle_fee_history<
                 ))
             })?);
             if i > 0 {
-                let prev = *percentiles
+                let prev = *reward_percentiles
                     .get(i - 1)
                     .expect("previous percentile should exist");
                 if prev > percentile {
@@ -114,8 +114,8 @@ The reward percentiles should be in non-decreasing order, but the percentile num
                 }
             }
         }
-        Ok(validated_percentiles)
-    }).transpose()?;
+        validated_percentiles
+    };
 
     data.fee_history(block_count, &newest_block, reward_percentiles)
 }

--- a/crates/edr_provider/src/requests/methods.rs
+++ b/crates/edr_provider/src/requests/methods.rs
@@ -78,8 +78,7 @@ pub enum MethodInvocation<ChainSpecT: RpcSpec> {
         /// newest block
         BlockSpec,
         /// reward percentiles
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        Option<Vec<f64>>,
+        Vec<f64>,
     ),
     /// `eth_gasPrice`
     #[serde(rename = "eth_gasPrice", with = "edr_eth::serde::empty_params")]

--- a/crates/edr_provider/tests/integration/eth_request_serialization.rs
+++ b/crates/edr_provider/tests/integration/eth_request_serialization.rs
@@ -109,7 +109,7 @@ fn test_serde_eth_fee_history() {
     help_test_method_invocation_serde(MethodInvocation::<L1ChainSpec>::FeeHistory(
         U256::from(3),
         BlockSpec::Number(100),
-        Some(vec![0.5_f64, 10_f64, 80_f64, 90_f64, 99.5_f64]),
+        vec![0.5_f64, 10_f64, 80_f64, 90_f64, 99.5_f64],
     ));
 }
 

--- a/crates/edr_rpc_client/src/cache/key.rs
+++ b/crates/edr_rpc_client/src/cache/key.rs
@@ -23,12 +23,6 @@ impl<T> CacheKeyVariant for Option<T> {
     }
 }
 
-impl<T> CacheKeyVariant for Vec<T> {
-    fn cache_key_variant(&self) -> u8 {
-        u8::from(!self.is_empty())
-    }
-}
-
 /// A cache key that can be used to read from the cache.
 /// It's based on not-fully resolved data, so it's not safe to write to this
 /// cache key. Specifically, it's not checked whether the block number is safe

--- a/crates/edr_rpc_client/src/cache/key.rs
+++ b/crates/edr_rpc_client/src/cache/key.rs
@@ -23,6 +23,12 @@ impl<T> CacheKeyVariant for Option<T> {
     }
 }
 
+impl<T> CacheKeyVariant for Vec<T> {
+    fn cache_key_variant(&self) -> u8 {
+        u8::from(!self.is_empty())
+    }
+}
+
 /// A cache key that can be used to read from the cache.
 /// It's based on not-fully resolved data, so it's not safe to write to this
 /// cache key. Specifically, it's not checked whether the block number is safe

--- a/crates/edr_rpc_eth/src/cacheable_method_invocation.rs
+++ b/crates/edr_rpc_eth/src/cacheable_method_invocation.rs
@@ -83,13 +83,10 @@ impl CachedRequestMethod<'_> {
                 block_count,
                 newest_block,
                 reward_percentiles,
-            } => {
-                let hasher = hasher
-                    .hash_u256(block_count)
-                    .hash_block_spec(newest_block)?
-                    .hash_u8(reward_percentiles.cache_key_variant());
-                hasher.hash_reward_percentiles(reward_percentiles)
-            }
+            } => hasher
+                .hash_u256(block_count)
+                .hash_block_spec(newest_block)?
+                .hash_reward_percentiles(reward_percentiles),
             CachedRequestMethod::GetBalance {
                 address,
                 block_spec,

--- a/crates/edr_rpc_eth/src/cacheable_method_invocation.rs
+++ b/crates/edr_rpc_eth/src/cacheable_method_invocation.rs
@@ -22,7 +22,7 @@ pub enum CachedRequestMethod<'a> {
     FeeHistory {
         block_count: &'a U256,
         newest_block: CacheableBlockSpec<'a>,
-        reward_percentiles: &'a Option<Vec<RewardPercentile>>,
+        reward_percentiles: &'a Vec<RewardPercentile>,
     },
     /// `eth_getBalance`
     GetBalance {
@@ -88,10 +88,7 @@ impl CachedRequestMethod<'_> {
                     .hash_u256(block_count)
                     .hash_block_spec(newest_block)?
                     .hash_u8(reward_percentiles.cache_key_variant());
-                match reward_percentiles {
-                    Some(reward_percentiles) => hasher.hash_reward_percentiles(reward_percentiles),
-                    None => hasher,
-                }
+                hasher.hash_reward_percentiles(reward_percentiles)
             }
             CachedRequestMethod::GetBalance {
                 address,

--- a/crates/edr_rpc_eth/src/client.rs
+++ b/crates/edr_rpc_eth/src/client.rs
@@ -64,7 +64,7 @@ impl<RpcSpecT: RpcSpec> EthRpcClient<RpcSpecT> {
         &self,
         block_count: u64,
         newest_block: BlockSpec,
-        reward_percentiles: Option<Vec<RewardPercentile>>,
+        reward_percentiles: Vec<RewardPercentile>,
     ) -> Result<FeeHistoryResult, RpcClientError> {
         self.inner
             .call(RequestMethod::FeeHistory(
@@ -990,7 +990,7 @@ mod tests {
                 .fee_history(
                     /* block count */ 1,
                     BlockSpec::latest(),
-                    /* reward percentiles */ None,
+                    /* reward percentiles */ vec![],
                 )
                 .await
                 .expect("should have succeeded");

--- a/crates/edr_rpc_eth/src/request_methods.rs
+++ b/crates/edr_rpc_eth/src/request_methods.rs
@@ -19,8 +19,7 @@ pub enum RequestMethod {
         /// newest block
         BlockSpec,
         /// reward percentiles
-        #[serde(skip_serializing_if = "Option::is_none")]
-        Option<Vec<RewardPercentile>>,
+        Vec<RewardPercentile>,
     ),
     /// `eth_chainId`
     #[serde(rename = "eth_chainId", with = "edr_eth::serde::empty_params")]

--- a/hardhat-tests/test/internal/hardhat-network/provider/modules/eth/hardforks.ts
+++ b/hardhat-tests/test/internal/hardhat-network/provider/modules/eth/hardforks.ts
@@ -52,10 +52,10 @@ describe("Eth module - hardfork dependant tests", function () {
     });
   }
 
-  const privateKey = Buffer.from(
+  const privateKey = new Uint8Array(Buffer.from(
     DEFAULT_ACCOUNTS[1].privateKey.slice(2),
     "hex"
-  );
+  ));
 
   function getSampleSignedTx(common: Common) {
     const tx = TransactionFactory.fromTxData(

--- a/hardhat-tests/test/internal/hardhat-network/provider/modules/eth/hardforks.ts
+++ b/hardhat-tests/test/internal/hardhat-network/provider/modules/eth/hardforks.ts
@@ -1127,7 +1127,7 @@ describe("Eth module - hardfork dependant tests", function () {
         useProviderAndCommon(hardfork);
 
         it(`Should be enabled when ${hardfork} is activated`, async function () {
-          await this.provider.send("eth_feeHistory", ["0x1", "latest"]);
+          await this.provider.send("eth_feeHistory", ["0x1", "latest", []]);
         });
       }
     });

--- a/hardhat-tests/test/internal/hardhat-network/provider/modules/eth/hardforks.ts
+++ b/hardhat-tests/test/internal/hardhat-network/provider/modules/eth/hardforks.ts
@@ -1115,7 +1115,7 @@ describe("Eth module - hardfork dependant tests", function () {
         await assertInvalidInputError(
           this.provider,
           "eth_feeHistory",
-          ["0x1", "latest"],
+          ["0x1", "latest", []],
           "eth_feeHistory is disabled. It only works with the London hardfork or a later one."
         );
       });

--- a/hardhat-tests/test/internal/hardhat-network/provider/modules/eth/hardforks.ts
+++ b/hardhat-tests/test/internal/hardhat-network/provider/modules/eth/hardforks.ts
@@ -52,10 +52,9 @@ describe("Eth module - hardfork dependant tests", function () {
     });
   }
 
-  const privateKey = new Uint8Array(Buffer.from(
-    DEFAULT_ACCOUNTS[1].privateKey.slice(2),
-    "hex"
-  ));
+  const privateKey = new Uint8Array(
+    Buffer.from(DEFAULT_ACCOUNTS[1].privateKey.slice(2), "hex")
+  );
 
   function getSampleSignedTx(common: Common) {
     const tx = TransactionFactory.fromTxData(

--- a/hardhat-tests/test/internal/hardhat-network/provider/modules/eth/methods/feeHistory.ts
+++ b/hardhat-tests/test/internal/hardhat-network/provider/modules/eth/methods/feeHistory.ts
@@ -81,6 +81,7 @@ describe("Eth module", function () {
             const { reward } = await this.provider.send("eth_feeHistory", [
               numberToRpcQuantity(1),
               "latest",
+              [],
             ]);
 
             assert.isUndefined(reward);

--- a/hardhat-tests/test/internal/hardhat-network/provider/modules/eth/methods/feeHistory.ts
+++ b/hardhat-tests/test/internal/hardhat-network/provider/modules/eth/methods/feeHistory.ts
@@ -305,7 +305,7 @@ describe("Eth module", function () {
             const { oldestBlock } = await this.provider.send("eth_feeHistory", [
               numberToRpcQuantity(2),
               "latest",
-              []
+              [],
             ]);
 
             assert.equal(oldestBlock, numberToRpcQuantity(firstBlock + 2));
@@ -334,7 +334,7 @@ describe("Eth module", function () {
             const { oldestBlock } = await this.provider.send("eth_feeHistory", [
               numberToRpcQuantity(1024),
               "latest",
-              []
+              [],
             ]);
 
             assert.equal(oldestBlock, firstBlock);

--- a/hardhat-tests/test/internal/hardhat-network/provider/modules/eth/methods/feeHistory.ts
+++ b/hardhat-tests/test/internal/hardhat-network/provider/modules/eth/methods/feeHistory.ts
@@ -27,14 +27,14 @@ describe("Eth module", function () {
             await assertInvalidInputError(
               this.provider,
               "eth_feeHistory",
-              [numberToRpcQuantity(0), "latest"],
+              [numberToRpcQuantity(0), "latest", []],
               "blockCount should be at least 1"
             );
 
             await assertInvalidInputError(
               this.provider,
               "eth_feeHistory",
-              [numberToRpcQuantity(1025), "latest"],
+              [numberToRpcQuantity(1025), "latest", []],
               "blockCount should be at most 1024"
             );
           });
@@ -45,7 +45,7 @@ describe("Eth module", function () {
             await assertInvalidInputError(
               this.provider,
               "eth_feeHistory",
-              [numberToRpcQuantity(1), numberToRpcQuantity(block)],
+              [numberToRpcQuantity(1), numberToRpcQuantity(block), []],
               `Received invalid block tag ${block}`
             );
           });
@@ -305,6 +305,7 @@ describe("Eth module", function () {
             const { oldestBlock } = await this.provider.send("eth_feeHistory", [
               numberToRpcQuantity(2),
               "latest",
+              []
             ]);
 
             assert.equal(oldestBlock, numberToRpcQuantity(firstBlock + 2));
@@ -314,7 +315,7 @@ describe("Eth module", function () {
 
             const { oldestBlock: oldestBlock2 } = await this.provider.send(
               "eth_feeHistory",
-              [numberToRpcQuantity(3), numberToRpcQuantity(firstBlock + 4)]
+              [numberToRpcQuantity(3), numberToRpcQuantity(firstBlock + 4), []]
             );
 
             assert.equal(oldestBlock2, numberToRpcQuantity(firstBlock + 2));
@@ -333,6 +334,7 @@ describe("Eth module", function () {
             const { oldestBlock } = await this.provider.send("eth_feeHistory", [
               numberToRpcQuantity(1024),
               "latest",
+              []
             ]);
 
             assert.equal(oldestBlock, firstBlock);
@@ -353,7 +355,7 @@ describe("Eth module", function () {
 
             const { gasUsedRatio } = await this.provider.send(
               "eth_feeHistory",
-              [numberToRpcQuantity(2), "latest"]
+              [numberToRpcQuantity(2), "latest", []]
             );
 
             const block: RpcBlockOutput = await this.provider.send(
@@ -396,7 +398,7 @@ describe("Eth module", function () {
 
             const { gasUsedRatio } = await this.provider.send(
               "eth_feeHistory",
-              [numberToRpcQuantity(2), "pending"]
+              [numberToRpcQuantity(2), "pending", []]
             );
 
             assert.deepEqual(gasUsedRatio, [
@@ -430,7 +432,7 @@ describe("Eth module", function () {
 
             const { baseFeePerGas, oldestBlock } = await this.provider.send(
               "eth_feeHistory",
-              [numberToRpcQuantity(3), numberToRpcQuantity(firstBlock + 2)]
+              [numberToRpcQuantity(3), numberToRpcQuantity(firstBlock + 2), []]
             );
 
             assert.equal(oldestBlock, firstBlock);
@@ -447,7 +449,7 @@ describe("Eth module", function () {
           it("Should compute it for the pending block", async function () {
             const { baseFeePerGas, oldestBlock } = await this.provider.send(
               "eth_feeHistory",
-              [numberToRpcQuantity(1), "latest"]
+              [numberToRpcQuantity(1), "latest", []]
             );
 
             assert.equal(oldestBlock, firstBlock);
@@ -460,7 +462,7 @@ describe("Eth module", function () {
           it("Should compute it for the block after the pending one", async function () {
             const { baseFeePerGas, oldestBlock } = await this.provider.send(
               "eth_feeHistory",
-              [numberToRpcQuantity(1), "pending"]
+              [numberToRpcQuantity(1), "pending", []]
             );
 
             assert.equal(oldestBlock, numberToRpcQuantity(firstBlock + 1));


### PR DESCRIPTION
## Context
[Ethereum JSON-RPC specifies](https://ethereum.github.io/execution-apis/api-documentation/) that all `eth_feeHistory` method parameters are required

Before these changes, the third parameter `rewardPercentiles` was optional in EDR. This was probably because [Alchemy documentation](https://www.alchemy.com/docs/node/ethereum/ethereum-api-endpoints/eth-fee-history) states that the parameter is optional - even if now it's rejecting the requests that do specify it

## Changes
- Change rpc `eth_feeHistory` method definition to receive a `Vec<f64>` instead of an `Option<Vec<f64>>`
- Bonus track: [fixed ts type check failure](https://github.com/NomicFoundation/edr/commit/e3255dbe47df1f2464dac9c1b5584a6258ec5f8e)