### PR TITLE
build: update deprecated toolchain file to toml format

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
     schedule:
       interval: "daily"
     commit-message:
-      prefix: "bump"
+      prefix: "build"

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,2 @@
-1.89.0
+[toolchain]
+channel = "1.89.0"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-rust_version=$(<rust-toolchain)
+rust_version=$(grep '^channel = ' rust-toolchain | sed 's/.*"\(.*\)".*/\1/')
 
 # rustup
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain $rust_version


### PR DESCRIPTION
Dependabot silently stopped working in our repo a long time ago (likely while we were still part of the Hardhat repo), when our `rust-toolchain` file format was deprecated:
<img width="902" height="165" alt="image" src="https://github.com/user-attachments/assets/ef43bf10-ba92-4c9d-840b-22296edb233b" />

This PR updates the file to the supported TOML format.

I also update the dependabot PR prefix to `build` to align with EDR's usage of the [conventional commit standard](https://www.conventionalcommits.org/en/v1.0.0/).