### PR TITLE
Improve developer experience with devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,12 @@
       "version": "22"
     }
   },
-  "postCreateCommand": "scripts/setup.sh",
+  "postCreateCommand": {
+    // Fix target volumes permissions is needed
+    // since when the volume is created is owned by root
+    "fixTargetVolumePerms": "sudo chown -R $(whoami): /workspaces/${localWorkspaceFolderBasename}/target /workspaces/${localWorkspaceFolderBasename}/node_modules",
+    "setup": "scripts/setup.sh"
+  },
   "portsAttributes": {
     // The default port of mdbook
     "3000": {
@@ -34,5 +39,17 @@
         ]
       }
     }
-  }
+  },
+  "mounts": [
+    {
+      "source": "edr_cargo_target",
+      "target": "/workspaces/${localWorkspaceFolderBasename}/target",
+      "type": "volume"
+    },  
+    {
+      "source": "edr_node_modules",
+      "target": "/workspaces/${localWorkspaceFolderBasename}/node_modules",
+      "type": "volume"
+    }  
+  ]
 }


### PR DESCRIPTION
## Context
Developing with devcontainer when having a macos host really impacts the performance, thus the developer experience 😢 
With this PR I'm proposing some changes in the devcontainer configuration that improves the setup and makes the stack platform-consistent

Having bind mounts between linux<>macos is not recommended since the fs virtualization layer introduces a lot of overhead. This is really painful for directories are IO intensive - like the `target/` directory where cargo compiles all dependencies.
Also, `cargo build` output and the `node_modules` can be different depending on the platform - so having a bind mount of binaries or target directories between different platforms is not 'safe' since you can end up with files that are not meant for the platform you are running on

## Changes
With this PR, the devcontainer will have named volumes mounted in `target/` and `node_modules/` directories. This way, volumes are managed by docker, so no fs virtualization is needed and it's not "visible" from host filesystem, while keeping the benefit of volumes persisting over devcontainer rebuilds 

## Time report

These are the results of running `time cargo build` on each different setup: native macos, devcontainer with named volumes (this PR) and devcontainer with bind mount (current `main` config)

I ran `cargo fetch` and cleared `target/` directory before each of these runs so the download of dependencies is not included in here. I ran the command twice to make sure it was representative

**Native MacOS**

1:20.17 total
446.70s user 
46.19s system 614% cpu 

1:15.58 total
441.83s user 
44.37s system 643% cpu 

**Docker with named volume**

real    2m9.607s
user    10m25.644s
sys     1m45.600s

real    2m49.189s
user    12m42.114s
sys     3m16.812s

**Docker with bind mount**

real    4m36.097s
user    12m32.847s
sys     3m44.249s

real    4m15.525s
user    12m23.287s
sys     3m56.681s


### Conclusions
 - Current (`main`) configuration is around 3,5x times slower that native setup
 - The proposed change improves the devsetup significantly: times are reduced in half
 - Even if this PR improves the performance, there is still a significant difference between developing natively in MacOs vs developing within containers. 
  