### PR TITLE
fix: bump upstream foundry cheatcode spec

### DIFF
--- a/.changeset/easy-taxis-chew.md
+++ b/.changeset/easy-taxis-chew.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Update list of unsupported cheatcodes with cheatcodes up to Foundry 1.3.6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3299,7 +3299,7 @@ dependencies = [
  "edr_solidity",
  "eyre",
  "foundry-cheatcodes-spec 0.3.8",
- "foundry-cheatcodes-spec 1.2.3",
+ "foundry-cheatcodes-spec 1.3.6",
  "foundry-compilers",
  "foundry-evm-core",
  "itertools 0.12.1",
@@ -3331,8 +3331,8 @@ dependencies = [
 
 [[package]]
 name = "foundry-cheatcodes-spec"
-version = "1.2.3"
-source = "git+https://github.com/foundry-rs/foundry?rev=6983a938580a#6983a938580a1eb25d9dbd61eb8cad8cd137a86d"
+version = "1.3.6"
+source = "git+https://github.com/foundry-rs/foundry?tag=v1.3.6#d2415887096b10226d13af9240b5bef5e6b0d815"
 dependencies = [
  "alloy-sol-types",
  "foundry-macros",
@@ -3619,8 +3619,8 @@ dependencies = [
 
 [[package]]
 name = "foundry-macros"
-version = "1.2.3"
-source = "git+https://github.com/foundry-rs/foundry?rev=6983a938580a#6983a938580a1eb25d9dbd61eb8cad8cd137a86d"
+version = "1.3.6"
+source = "git+https://github.com/foundry-rs/foundry?tag=v1.3.6#d2415887096b10226d13af9240b5bef5e6b0d815"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",

--- a/crates/foundry/cheatcodes/Cargo.toml
+++ b/crates/foundry/cheatcodes/Cargo.toml
@@ -9,8 +9,7 @@ edition.workspace = true
 edr_defaults.workspace = true
 
 foundry-cheatcodes-spec.workspace = true
-# Nightly (2025-07-02)
-upstream-foundry-cheatcodes-spec = { git = "https://github.com/foundry-rs/foundry", rev = "6983a938580a", package = "foundry-cheatcodes-spec" }
+upstream-foundry-cheatcodes-spec = { git = "https://github.com/foundry-rs/foundry", tag = "v1.3.6", package = "foundry-cheatcodes-spec" }
 edr_common.workspace = true
 edr_solidity.workspace = true
 foundry-compilers.workspace = true


### PR DESCRIPTION
Update list of unsupported cheatcodes with cheatcodes up to Foundry version 1.3.6.