### PR TITLE
chore: use os pinned versions in CI workflows 

### DIFF
--- a/.github/workflows/check-changeset-added.yml
+++ b/.github/workflows/check-changeset-added.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   check-if-changeset:
     name: Check that PR has a changeset
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # don't run this check in the changesets PR
     if: github.head_ref != 'changeset-release/main'
     steps:

--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-24.04", "macos-15", "windows-latest"]
+        os: ["ubuntu-24.04", "macos-15", "windows-2025"]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
@@ -106,7 +106,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [18.15]
-        os: [ubuntu-24.04, macos-15, windows-latest]
+        os: [ubuntu-24.04, macos-15, windows-2025]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-24.04", "macos-latest", "windows-latest"]
+        os: ["ubuntu-24.04", "macos-15", "windows-latest"]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
@@ -106,7 +106,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [18.15]
-        os: [ubuntu-24.04, macos-latest, windows-latest]
+        os: [ubuntu-24.04, macos-15, windows-latest]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   check-edr:
     name: Check EDR
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       RUSTFLAGS: -Dwarnings
     steps:
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ["ubuntu-24.04", "macos-latest", "windows-latest"]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
@@ -106,7 +106,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [18.15]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-24.04, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v3
 
@@ -160,7 +160,7 @@ jobs:
 
   edr-style:
     name: Check EDR Style
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: check-edr
     steps:
       - uses: actions/checkout@v4
@@ -183,7 +183,7 @@ jobs:
 
   edr-docs:
     name: Build EDR Docs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: check-edr
     steps:
       - uses: actions/checkout@v4
@@ -197,7 +197,7 @@ jobs:
 
   build-and-lint:
     name: Build and lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node
@@ -211,7 +211,7 @@ jobs:
 
   edr-napi-typings-file:
     name: Check that edr_napi typings file is up to date
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node
@@ -226,7 +226,7 @@ jobs:
         run: git diff --exit-code
   edr-integration-tests:
     name: Run integration tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-node
@@ -252,6 +252,6 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           files: codecov.json
-          name: ubuntu-latest
+          name: ubuntu-24.04
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/edr-npm-release.yml
+++ b/.github/workflows/edr-npm-release.yml
@@ -42,14 +42,14 @@ jobs:
           - host: windows-2022
             build: pnpm run build
             target: x86_64-pc-windows-msvc
-          - host: ubuntu-22.04
+          - host: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust@sha256:4b2638c0987845c4ab3488574a215a2a866b99fb28588788786f2b8cbcb40e71
             build: |-
               set -e &&
               pnpm run build --target x86_64-unknown-linux-gnu &&
               strip *.node
-          - host: ubuntu-22.04
+          - host: ubuntu-24.04
             target: x86_64-unknown-linux-musl
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust@sha256:2003f7f7027adaab2c97bf576ce6bb87640a77c62a6898ed2359c050c49872a5
             build: |-
@@ -62,7 +62,7 @@ jobs:
             build: |
               pnpm run build --target aarch64-apple-darwin
               strip -x *.node
-          - host: ubuntu-22.04
+          - host: ubuntu-24.04
             target: aarch64-unknown-linux-gnu
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust@sha256:08cb2c8326ae78cf8ffd58f81523dd9592a4778c2c5f314251f5773ea204f289
             build: |-
@@ -76,7 +76,7 @@ jobs:
               export CXXFLAGS="-B/usr/aarch64-unknown-linux-gnu/lib/gcc/aarch64-unknown-linux-gnu/4.8.5 --sysroot=/usr/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot" &&
               pnpm run build --target aarch64-unknown-linux-gnu &&
               aarch64-unknown-linux-gnu-strip *.node
-          - host: ubuntu-22.04
+          - host: ubuntu-24.04
             target: aarch64-unknown-linux-musl
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust@sha256:2003f7f7027adaab2c97bf576ce6bb87640a77c62a6898ed2359c050c49872a5
             build: |-
@@ -201,7 +201,7 @@ jobs:
         node:
           - "18"
           - "20"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node
@@ -229,7 +229,7 @@ jobs:
         node:
           - "18"
           - "20"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node
@@ -258,7 +258,7 @@ jobs:
         node:
           - "18"
           - "20"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -300,7 +300,7 @@ jobs:
         node:
           - "18"
           - "20"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -333,7 +333,7 @@ jobs:
             pnpm testNoBuild
   check_commit:
     name: Check commit
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: github.event_name != 'pull_request' || github.event.pull_request.author_association == 'OWNER' || github.event.pull_request.author_association == 'MEMBER' || github.event.pull_request.author_association == 'COLLABORATOR'
     steps:
       - uses: actions/checkout@v4
@@ -357,7 +357,7 @@ jobs:
   publish:
     name: Publish
     environment: edr-release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
       - check_commit
       - test-macOS-windows-binding

--- a/.github/workflows/hardhat-tests.yml
+++ b/.github/workflows/hardhat-tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [20]
-        os: ["macos-latest", "ubuntu-latest", "windows-latest"]
+        os: ["macos-latest", "ubuntu-24.04", "windows-latest"]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node
@@ -65,7 +65,7 @@ jobs:
 
   lint-hardhat-tests:
     name: Lint Hardhat tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node

--- a/.github/workflows/hardhat-tests.yml
+++ b/.github/workflows/hardhat-tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [20]
-        os: ["macos-15", "ubuntu-24.04", "windows-latest"]
+        os: ["macos-15", "ubuntu-24.04", "windows-2025"]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node

--- a/.github/workflows/hardhat-tests.yml
+++ b/.github/workflows/hardhat-tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [20]
-        os: ["macos-latest", "ubuntu-24.04", "windows-latest"]
+        os: ["macos-15", "ubuntu-24.04", "windows-latest"]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   action:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: dessant/lock-threads@e460dfeb36e731f3aeb214be6b0c9a9d9a67eda6
         with:

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -23,7 +23,7 @@ defaults:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       MDBOOK_VERSION: 0.4.36
     steps:
@@ -47,7 +47,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: build
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/test-recent-mainnet-block.yml
+++ b/.github/workflows/test-recent-mainnet-block.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   test-recent-mainnet-block:
     name: Test recent mainnet block
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust

--- a/.github/workflows/test-recent-optimism-block.yml
+++ b/.github/workflows/test-recent-optimism-block.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   test-recent-op-block:
     name: Test recent OP block (${{ matrix.network }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Using `latest` tags is a bad practice that can lead to unexpected changes and opens the door to security risks.

This PR updates CI jobs to use pinned versions of ubuntu, macos and windows. The version mapping was done considering [this](https://github.com/actions/runner-images/blob/41a7cee3c1afb1b3aad170ffae8d85bf262db862/README.md) is the current github runner-images documentation

I also updated jobs that were running in `ubuntu-22.04` to `ubuntu-24.04`