### PR TITLE
fix: use hardfork-specific L1BlockInfo for dry_run

### DIFF
--- a/.changeset/social-moments-move.md
+++ b/.changeset/social-moments-move.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Fixed panic when executing eth_call transaction with Isthmus OP hardfork

--- a/crates/edr_evm/src/evm.rs
+++ b/crates/edr_evm/src/evm.rs
@@ -1,3 +1,3 @@
-pub use revm::{Context, MainBuilder, MainnetEvm};
-pub use revm_context::Evm;
+pub use revm::{MainBuilder, MainnetEvm};
+pub use revm_context::{Context, Evm, LocalContext};
 pub use revm_handler::{EthFrame, EvmTr as EvmTrait, FrameResult};

--- a/crates/edr_evm_spec/src/lib.rs
+++ b/crates/edr_evm_spec/src/lib.rs
@@ -35,7 +35,7 @@ pub trait ChainSpec {
     /// The chain's block type.
     type BlockEnv: Block;
     /// The chain's type for contextual information.
-    type Context: Debug + Default;
+    type Context: Debug;
     /// The chain's halt reason type.
     type HaltReason: HaltReasonTrait + 'static;
     /// The chain's signed transaction type.


### PR DESCRIPTION
While adding support for the Isthmus OP stack hardfork in Hardhat 3, the Hardhat team observed [an EDR panic in their tests](https://github.com/NomicFoundation/hardhat/actions/runs/18316863161/job/52159414667?pr=7522).

This PR resolves panics that occurred due to the prior usage of a default `L1BlockInfo` for "dry runs" (e.g. `eth_call`). Now, an EVM instance is always constructed using block-specific `L1BlockInfo`.