### PR TITLE
chore: audit npm install scripts

### DIFF
--- a/.github/workflows/edr-npm-release.yml
+++ b/.github/workflows/edr-npm-release.yml
@@ -128,7 +128,7 @@ jobs:
             curl -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable
             export PATH="/root/.cargo/bin:$PATH"
 
-            npm i -g pnpm@10.17.1
+            npm i -g pnpm@10.17.1 --ignore-scripts
             pnpm -v
             pnpm install --frozen-lockfile --prefer-offline
             pnpm run build --strip
@@ -151,7 +151,7 @@ jobs:
             curl -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable
             export PATH="/root/.cargo/bin:$PATH"
 
-            npm i -g pnpm@10.17.1
+            npm i -g pnpm@10.17.1 --ignore-scripts
             pnpm -v
             pnpm install --frozen-lockfile --prefer-offline
             pnpm run build --strip

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
-enable-pre-post-scripts=true
+ignore-scripts=true
 engine-strict=true

--- a/book/src/01_getting_started/04_benchmark.md
+++ b/book/src/01_getting_started/04_benchmark.md
@@ -14,7 +14,7 @@ To measure real-world performance, we use a build of [Hardhat](https://github.co
 ```bash
 cd packages/hardhat-core &&
 pnpm build &&
-npm link
+pnpm link
 ```
 
 For this example we will use [openzeppelin-contracts](https://github.com/OpenZeppelin/openzeppelin-contracts):
@@ -22,13 +22,13 @@ For this example we will use [openzeppelin-contracts](https://github.com/OpenZep
 ```bash
 git clone https://github.com/OpenZeppelin/openzeppelin-contracts.git &&
 cd openzeppelin-contracts &&
-npm install
+pnpm install
 ```
 
 To use your local hardhat build in a third-party project, run:
 
 ```bash
-npm link hardhat
+pnpm link hardhat
 ```
 
 To validate that this worked, you can run:

--- a/book/src/02_development/02_verdaccio.md
+++ b/book/src/02_development/02_verdaccio.md
@@ -4,20 +4,20 @@
 
 ## Installation
 
-`npm i -g verdaccio`
+`pnpm i -g verdaccio`
 
 ## Usage
 
 1. In one terminal, run `verdaccio`
 2. In another terminal login with `pnpm login --registry=http://localhost:4873/`. Any user and password will do.
 3. Publish your package by passing the verdaccio registry as a parameter: `pnpm publish --registry=http://localhost:4873/`.
-4. Go to the project where you want to test and install the package with `npm i your-package --registry=http://localhost:4873/`.
+4. Go to the project where you want to test and install the package with `pnpm i your-package --registry=http://localhost:4873/`.
 
 > Note: Read [Local Release](./03_local_release.md) on special instructions for publishing EDR NPM packages using Verdaccio.
 
 ## Updating a package
 
-If after publishing to `verdaccio` you want to make some changes and try them, you’ll have to publish the package with a new version and then run `npm i your-package@latest --registry=http://localhost:4873/` in the test project.
+If after publishing to `verdaccio` you want to make some changes and try them, you’ll have to publish the package with a new version and then run `pnpm i your-package@latest --registry=http://localhost:4873/` in the test project.
 
 # Resetting Verdaccio
 

--- a/book/src/02_development/04_update_napi_targets.md
+++ b/book/src/02_development/04_update_napi_targets.md
@@ -1,7 +1,7 @@
 First, install `@napi-rs/cli`:
 
 ```bash
-npm -g i @napi-rs/cli
+pnpm -g i @napi-rs/cli
 ```
 
 Then follow the steps in [this document](https://napi.rs/docs/introduction/simple-package) to generate a package with the desired supported target triples.

--- a/crates/edr_solidity/benches/contracts_identifier.rs
+++ b/crates/edr_solidity/benches/contracts_identifier.rs
@@ -6,7 +6,7 @@
 //!
 //! 2. In the `forge-std` repo root:
 //!
-//!    2.1. `npm i`
+//!    2.1. `pnpm i`
 //!    2.2. `npx hardhat compile`
 //!
 //! 3. In the `crates/edr_solidity` directory:


### PR DESCRIPTION
I did a review to make sure npm install scripts are disabled. 

Since we're using `pnpm` that has install scripts disabled by default, this was mainly a matter of making sure that we're not setting the `onlyBuiltDependencies` PNPM [setting.](https://pnpm.io/9.x/package_json#pnpmonlybuiltdependencies) I verified this by running `rg --no-ignore onlyBuiltDependencies` in the repo root which yielded no results.

I replaced incorrect usages of `npm` with `pnpm` in docs and scripts.

There is one place where we need to use `npm` instead of `pnpm`: when we're installing the latter in CI. I explicitly added the `--ignore-scripts` command to these `npm` invocations.

For additional defense in depth, I also set `ignore-scripts=true` in the `.nvmrc` in the repo root just in case someone's using `npm` instead of `pnpm` accidentally.