### PR TITLE
fix: ci workflow check-generated-files

### DIFF
--- a/.github/workflows/check-generated-files.yml
+++ b/.github/workflows/check-generated-files.yml
@@ -1,4 +1,4 @@
-name: EDR
+name: Check generated files
 
 on:
   push:


### PR DESCRIPTION
**Context**
When I created the workflow file I missed changing the name to it. Because the name is used for defining the concurrency group, the action did not run when pushing to main since it clashes with the workflow called `EDR`. See https://github.com/NomicFoundation/edr/actions/runs/18468742829

**Fix**
Rename workflow to avoid clashing names

for #871 
