### PR TITLE
fix: broken JSON-RPC tests after Alchemy API change

### DIFF
--- a/crates/edr_rpc_eth/src/client.rs
+++ b/crates/edr_rpc_eth/src/client.rs
@@ -793,7 +793,10 @@ mod tests {
                 panic!("Expected HttpStatus error, got: {error:?}");
             };
 
-            assert_eq!(reqwest::Error::from(error).status(), Some(reqwest::StatusCode::BAD_REQUEST));
+            assert_eq!(
+                reqwest::Error::from(error).status(),
+                Some(reqwest::StatusCode::BAD_REQUEST)
+            );
         }
 
         #[tokio::test]
@@ -917,7 +920,10 @@ mod tests {
                 panic!("Expected HttpStatus error, got: {error:?}");
             };
 
-            assert_eq!(reqwest::Error::from(error).status(), Some(reqwest::StatusCode::BAD_REQUEST));
+            assert_eq!(
+                reqwest::Error::from(error).status(),
+                Some(reqwest::StatusCode::BAD_REQUEST)
+            );
         }
 
         #[tokio::test]


### PR DESCRIPTION
This fixes two [test failures](https://github.com/NomicFoundation/edr/actions/runs/18598654079/job/53031762074?pr=1111) due to a change in the JSON-RPC API of Alchemy.

Previously they were treating these tests as JSON-RPC errors. Now they're treating them as bad HTTP requests.