### PR TITLE
fix: Node v22 build issue for hardhat-tests

### DIFF
--- a/hardhat-tests/.mocharc.json
+++ b/hardhat-tests/.mocharc.json
@@ -1,6 +1,9 @@
 {
   "require": "ts-node/register",
   "file": "./test/setup.ts",
+  "node-option": [
+    "no-experimental-strip-types"
+  ],
   "exclude": [
     "test/fixture-projects/**/*.ts",
     "test/fixture-projects/**/*.js",


### PR DESCRIPTION
After upgrading to the latest Node version (v22), I was experiencing issues to a newly enabled feature in Node v22 that handles integrated TypeScript support, causing the Mocha test runner to fail.

I added a configuration option to mocha to disable the feature.