### PR TITLE
build: upgrade devcontainer to Debian 13

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "EDR",
-  "image": "mcr.microsoft.com/devcontainers/base:bookworm",
+  "image": "mcr.microsoft.com/devcontainers/base:trixie",
   "features": {
     "ghcr.io/devcontainers/features/node:1": {
       "version": "22"


### PR DESCRIPTION
When trying to install Foundry I ran into an error due to an outdated `glibc` version. The easiest path to upgrade `glibc` was to upgrade our devcontainer to a newer version of Debian. We decided to upgrade directly from v11 to v13 (trixie).