### PR TITLE
fix(ci): release workflow 

### DIFF
--- a/.github/workflows/edr-npm-release.yml
+++ b/.github/workflows/edr-npm-release.yml
@@ -534,7 +534,7 @@ jobs:
         with:
           node-version: 24
       - name: Update npm to make sure it supports Trusted Publishing
-        run:  npm install -g npm@v11.6.2
+        run: npm install -g npm@v11.6.2
       - name: Download packed tarball
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Changes
- Change the release workflow file so that the `check_commit` job is only required for `publish` job. As a consequence of this, the `prepare` and `release` jobs will run for all branches and commits, not only for release commits
- Change the `check_commit` job so that it directly determines the publish tag
  - Moved the if-else statement from publish job here
- Simplify the `publish` job so that it publishes using the tag defined by `check_commit` job
- Fix inexistent output variable

### Evidence
 - [If tag output is empty then publish job doesn't run](https://github.com/NomicFoundation/edr/actions/runs/19069502599)
 - [If tag in known, then it would execute the publish command](https://github.com/NomicFoundation/edr/actions/runs/19069360609)
 - [unknown tag fails](https://github.com/NomicFoundation/edr/actions/runs/19069192311) 