### PR TITLE
Add Slack integration and update macos-13 to macos-15-intel

### DIFF
--- a/.github/workflows/edr-npm-release.yml
+++ b/.github/workflows/edr-npm-release.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          - host: macos-13
+          - host: macos-15-intel
             target: x86_64-apple-darwin
             build: pnpm run build --strip
 
@@ -184,7 +184,7 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          - host: macos-13
+          - host: macos-15-intel
             target: x86_64-apple-darwin
           - host: macos-14
             target: aarch64-apple-darwin


### PR DESCRIPTION
- Add Slack notifications before deploying, and at deployment time (after review). 
- Move macos-13 to macos-15-intel. See https://github.com/actions/runner-images/issues/13046