### PR TITLE
edr-0.12.0-next.13 (next)

### DIFF
--- a/.github/workflows/edr-npm-release.yml
+++ b/.github/workflows/edr-npm-release.yml
@@ -587,6 +587,13 @@ jobs:
                 }
               ]
             }
+      - name: Download packed tarball
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.prepare.outputs.filename }}
+          path: .
+      - name: Decompress tarball
+        run: tar -xvzf ${{ needs.prepare.outputs.filename }}
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
       - name: Setup node
@@ -597,13 +604,6 @@ jobs:
           cache: pnpm
       - name: Update npm to make sure it supports Trusted Publishing
         run: npm install -g npm@v11.6.2
-      - name: Download packed tarball
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ needs.prepare.outputs.filename }}
-          path: .
-      - name: Decompress tarball
-        run: tar -xvzf ${{ needs.prepare.outputs.filename }}
       - name: Publish
         run: |
           if [ "${{ needs.check_commit.outputs.tag}}" = "next" ]


### PR DESCRIPTION
Create PR with pre-release name so we can workaround all the release-PR process and just trigger the release workflow by hand and be able to publish (since the commit name has a release-format)

**Failure**: 
`Error: Error: No pnpm version is specified.`

**Rationale** 
it failed because It was trying to setup `pnpm` without having the `package.json` file  in scope because it still hadn't downloaded the tarball.

**Fix**: 
First dowload and decompress the tarball, then setup pnpm and node - as we are doing in the `review` job

