### PR TITLE
test: backport more test_cmd tests

### DIFF
--- a/crates/edr_solidity_tests/tests/it/repros.rs
+++ b/crates/edr_solidity_tests/tests/it/repros.rs
@@ -529,3 +529,16 @@ test_repro!(10586);
 
 // https://github.com/foundry-rs/foundry/issues/10957
 remote_test_repro!(10957);
+
+// https://github.com/foundry-rs/foundry/issues/9526
+test_repro!(9526);
+
+// https://github.com/foundry-rs/foundry/issues/10012
+test_repro!(10012, true);
+
+// https://github.com/foundry-rs/foundry/issues/5521
+test_repro!(5521, false, None, |res| {
+    let mut res = res.remove("default/repros/Issue5521.t.sol:Issue5521Test").unwrap();
+    let test = res.test_results.remove("test_stackPrank()").unwrap();
+    assert_eq!(test.status, TestStatus::Success);
+});

--- a/crates/edr_solidity_tests/tests/testdata/default/cheats/InterceptInitCode.t.sol
+++ b/crates/edr_solidity_tests/tests/testdata/default/cheats/InterceptInitCode.t.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.18;
+
+import "ds-test/test.sol";
+import "cheats/Vm.sol";
+
+contract SimpleContract {
+    uint256 public value;
+    constructor(uint256 _value) {
+        value = _value;
+    }
+}
+
+// `intercept_initcode` in `crates/forge/tests/cli/test_cmd.rs`
+contract InterceptInitcodeTest is DSTest {
+    Vm vm = Vm(HEVM_ADDRESS);
+
+    function testInterceptRegularCreate() public {
+        // Set up interception
+        vm.interceptInitcode();
+
+        // Try to create a contract - this should revert with the initcode
+        bytes memory initcode;
+        try new SimpleContract(42) {
+            assert(false);
+        } catch (bytes memory interceptedInitcode) {
+            initcode = interceptedInitcode;
+        }
+
+        // Verify the initcode contains the constructor argument
+        assertTrue(initcode.length > 0, "initcode should not be empty");
+
+        // The constructor argument is encoded as a 32-byte value at the end of the initcode
+        // We need to convert the last 32 bytes to uint256
+        uint256 value;
+        assembly {
+            value := mload(add(add(initcode, 0x20), sub(mload(initcode), 32)))
+        }
+        assertEq(value, 42, "initcode should contain constructor arg");
+    }
+
+    function testInterceptMultiple() public {
+        // First interception
+        vm.interceptInitcode();
+        bytes memory initcode1;
+        try new SimpleContract(1) {
+            assert(false);
+        } catch (bytes memory interceptedInitcode) {
+            initcode1 = interceptedInitcode;
+        }
+
+        // Second interception
+        vm.interceptInitcode();
+        bytes memory initcode2;
+        try new SimpleContract(2) {
+            assert(false);
+        } catch (bytes memory interceptedInitcode) {
+            initcode2 = interceptedInitcode;
+        }
+
+        // Verify different initcodes
+        assertTrue(initcode1.length > 0, "first initcode should not be empty");
+        assertTrue(initcode2.length > 0, "second initcode should not be empty");
+
+        // Extract constructor arguments from both initcodes
+        uint256 value1;
+        uint256 value2;
+        assembly {
+            value1 := mload(add(add(initcode1, 0x20), sub(mload(initcode1), 32)))
+            value2 := mload(add(add(initcode2, 0x20), sub(mload(initcode2), 32)))
+        }
+        assertEq(value1, 1, "first initcode should contain first arg");
+        assertEq(value2, 2, "second initcode should contain second arg");
+    }
+}

--- a/crates/edr_solidity_tests/tests/testdata/default/repros/Issue10012.t.sol
+++ b/crates/edr_solidity_tests/tests/testdata/default/repros/Issue10012.t.sol
@@ -1,0 +1,18 @@
+import "ds-test/test.sol";
+import "cheats/Vm.sol";
+
+contract Issue10012Test is DSTest {
+    function test_something() public {
+        CounterTestA counter = new CounterTestA();
+        counter.doSomething();
+    }
+}
+
+contract CounterTestA is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+
+    function doSomething() public {
+        vm.startStateDiffRecording();
+        require(1 > 2);
+    }
+}

--- a/crates/edr_solidity_tests/tests/testdata/default/repros/Issue5521.t.sol
+++ b/crates/edr_solidity_tests/tests/testdata/default/repros/Issue5521.t.sol
@@ -1,0 +1,46 @@
+import "ds-test/test.sol";
+import "cheats/Vm.sol";
+
+contract Issue5521Test is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+
+    function test_stackPrank() public {
+        string memory name = "player";
+        uint256 privateKey = uint256(keccak256(abi.encodePacked(name)));
+        address player = vm.addr(privateKey);
+        vm.label(player, name);
+
+        SenderLogger senderLogger = new SenderLogger();
+        Contract c = new Contract();
+
+        (address sender1, address origin1) = senderLogger.log();
+        assertEq(sender1, address(this));
+        assertEq(origin1, address(0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38));  // Default sender
+
+        vm.startPrank(player, player);
+        (address sender2, address origin2) = senderLogger.log();
+        assertEq(sender2, player);
+        assertEq(origin2, player);
+
+        c.f(); // vm.startPrank(player)
+        (address sender3, address origin3) = senderLogger.log();
+        assertEq(sender3, player);
+        assertEq(origin3, player);
+        vm.stopPrank();
+    }
+}
+
+contract Contract {
+    Vm public constant vm = Vm(address(bytes20(uint160(uint256(keccak256("hevm cheat code"))))));
+
+    function f() public {
+        vm.startPrank(msg.sender);
+    }
+}
+
+contract SenderLogger {
+    function log() public returns (address sender, address origin) {
+        sender = msg.sender;
+        origin = tx.origin;
+    }
+}

--- a/crates/edr_solidity_tests/tests/testdata/default/repros/Issue9526.t.sol
+++ b/crates/edr_solidity_tests/tests/testdata/default/repros/Issue9526.t.sol
@@ -1,0 +1,25 @@
+import "ds-test/test.sol";
+import "cheats/Vm.sol";
+
+contract Counter {
+    uint256 public number;
+
+    function setNumber(uint256 newNumber) public {
+        number = newNumber;
+    }
+
+    function increment() public {
+        number++;
+    }
+}
+
+contract Issue9526Test is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+
+    function test_start_stop_recording() public {
+        vm.startDebugTraceRecording();
+        Counter counter = new Counter();
+        counter.increment();
+        vm.stopAndReturnDebugTraceRecording();
+    }
+}

--- a/js/integration-tests/solidity-tests/package.json
+++ b/js/integration-tests/solidity-tests/package.json
@@ -21,7 +21,7 @@
     "build:dev": "tsc --build --incremental .",
     "prespecificTest": "cd ../../.. && pnpm build:dev",
     "pretest": "cd ../../.. && pnpm build:dev",
-    "specificTest": "node --test-concurrency=1 --import tsx/esm --test-name-pattern=\"Multifork\" test/unit.ts",
+    "specificTest": "node --test-concurrency=1 --import tsx/esm --test-name-pattern=\"ForkStateSetup\" test/unit.ts",
     "test": "node --import tsx/esm --test \"test/*.ts\""
   },
   "type": "module"

--- a/js/integration-tests/solidity-tests/test-contracts/ForkStateSetup.t.sol
+++ b/js/integration-tests/solidity-tests/test-contracts/ForkStateSetup.t.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.24;
+
+import "forge-std/src/Test.sol";
+import {StdChains} from "forge-std/src/StdChains.sol";
+
+// `should_preserve_fork_state_setup` in crates/forge/tests/cli/test_cmd.rs
+contract ForkStateSetupTest is Test {
+    struct Domain {
+        StdChains.Chain chain;
+        uint256 forkId;
+    }
+
+    struct Bridge {
+        Domain source;
+        Domain destination;
+        uint256 someVal;
+    }
+
+    struct SomeStruct {
+        Domain domain;
+        Bridge[] bridges;
+    }
+
+    mapping(uint256 => SomeStruct) internal data;
+
+    function setUp() public {
+        // Temporary workaround for `https://eth.llamarpc.com/` being down
+        setChain("mainnet", ChainData({
+            name: "mainnet",
+            rpcUrl: "https://reth-ethereum.ithaca.xyz/rpc",
+            chainId: 1
+        }));
+
+        StdChains.Chain memory chain1 = getChain("mainnet");
+        StdChains.Chain memory chain2 = getChain("base");
+        Domain memory domain1 = Domain(chain1, vm.createFork(chain1.rpcUrl, 22253716));
+        Domain memory domain2 = Domain(chain2, vm.createFork(chain2.rpcUrl, 28839981));
+        data[1].domain = domain1;
+        data[2].domain = domain2;
+
+        vm.selectFork(domain1.forkId);
+
+        data[2].bridges.push(Bridge(domain1, domain2, 123));
+        vm.selectFork(data[2].domain.forkId);
+        vm.selectFork(data[1].domain.forkId);
+        data[2].bridges.push(Bridge(domain1, domain2, 456));
+
+        assertEq(data[2].bridges.length, 2);
+    }
+
+    function test_assert_storage() public {
+        vm.selectFork(data[2].domain.forkId);
+        assertEq(data[2].bridges.length, 2);
+    }
+
+    function test_modify_and_storage() public {
+        data[3].domain = Domain(getChain("base"), vm.createFork(getChain("base").rpcUrl, 28839981));
+        data[3].bridges.push(Bridge(data[1].domain, data[2].domain, 123));
+        data[3].bridges.push(Bridge(data[1].domain, data[2].domain, 456));
+
+        vm.selectFork(data[2].domain.forkId);
+        assertEq(data[3].bridges.length, 2);
+    }
+}

--- a/js/integration-tests/solidity-tests/test/unit.ts
+++ b/js/integration-tests/solidity-tests/test/unit.ts
@@ -184,6 +184,23 @@ describe("Unit tests", () => {
     assert.equal(totalTests, 1);
   });
 
+  it("ForkStateSetup", async function (t) {
+    if (testContext.rpcUrl === undefined) {
+      return t.skip();
+    }
+
+    const { totalTests, failedTests, stackTraces } =
+      await testContext.runTestsWithStats("ForkStateSetupTest", {
+        rpcEndpoints: {
+          mainnet: testContext.rpcUrl!,
+          base: testContext.rpcUrl!.replace("eth-mainnet", "base-mainnet"),
+        },
+      });
+
+    assert.equal(totalTests, 2);
+    assert.equal(failedTests, 0);
+  });
+
   it("FailingSetup", async function () {
     const { totalTests, failedTests, stackTraces } =
       await testContext.runTestsWithStats("FailingSetupTest");


### PR DESCRIPTION
Backports the following tests

- should_not_panic_on_debug_trace_verbose
- state_diff_recording_with_revert
- should_apply_pranks_per_recorded_depth
- should_preserve_fork_state_setup 10296

from `crates/forge/tests/cli/test_cmd.rs`