### PR TITLE
fix: use test-remote feature flag for forking tests

### DIFF
--- a/crates/blockchain/fork/tests/integration/block.rs
+++ b/crates/blockchain/fork/tests/integration/block.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "test-remote")]
+
 use std::{str::FromStr as _, sync::Arc};
 
 use edr_block_api::BlockValidityError;

--- a/crates/blockchain/fork/tests/integration/logs.rs
+++ b/crates/blockchain/fork/tests/integration/logs.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "test-remote")]
+
 use std::str::FromStr as _;
 
 use edr_blockchain_api::GetBlockchainLogs as _;

--- a/crates/blockchain/fork/tests/integration/receipt.rs
+++ b/crates/blockchain/fork/tests/integration/receipt.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "test-remote")]
+
 use std::str::FromStr as _;
 
 use edr_blockchain_api::ReceiptByTransactionHash as _;

--- a/crates/blockchain/fork/tests/integration/state.rs
+++ b/crates/blockchain/fork/tests/integration/state.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "test-remote")]
+
 use edr_blockchain_api::{GetBlockchainBlock as _, StateAtBlock as _};
 use edr_state_api::irregular::IrregularState;
 use serial_test::serial;


### PR DESCRIPTION
The `test-remote` flag wasn't required for forking tests, after a recent refactor. This PR fixes the issue.