### PR TITLE
fix: test_assume_no_revert_with_data

### DIFF
--- a/crates/edr_solidity_tests/tests/it/cheats.rs
+++ b/crates/edr_solidity_tests/tests/it/cheats.rs
@@ -66,7 +66,7 @@ async fn test_cheats_local_isolated(test_data: &L1ForgeTestData) {
 
     let mut config = test_data.config_with_mock_rpc();
     config.evm_opts.isolate = true;
-    let runner = test_data.runner_with_config(config).await;
+    let runner = test_data.runner_with_fuzz_persistence(config).await;
 
     TestConfig::with_filter(runner, filter).run().await;
 }
@@ -81,7 +81,7 @@ async fn test_cheats_local_with_seed(test_data: &L1ForgeTestData) {
 
     let mut config = test_data.config_with_mock_rpc();
     config.cheats_config_options.seed = Some(U256::from(100));
-    let runner = test_data.runner_with_config(config).await;
+    let runner = test_data.runner_with_fuzz_persistence(config).await;
 
     TestConfig::with_filter(runner, filter).run().await;
 }
@@ -103,7 +103,7 @@ async fn test_cheats_sleep_test() {
 
     let mut runner_config = TEST_DATA_DEFAULT.config_with_mock_rpc();
     runner_config.fuzz.runs = 2;
-    let runner = TEST_DATA_DEFAULT.runner_with_config(runner_config).await;
+    let runner = TEST_DATA_DEFAULT.runner_with_fuzz_persistence(runner_config).await;
 
     TestConfig::with_filter(runner, filter).run().await;
 }
@@ -142,7 +142,7 @@ async fn test_cheats_local_paris_should_fail() {
 async fn test_gas_metering_reset() {
     let filter = SolidityTestFilter::new(".*", "GasMeteringResetTest", ".*cheats/");
     let config = TEST_DATA_DEFAULT.config_with_mock_rpc();
-    let runner = TEST_DATA_DEFAULT.runner_with_config(config).await;
+    let runner = TEST_DATA_DEFAULT.runner_with_fuzz_persistence(config).await;
     let suite_results = runner.test_collect(filter).await.suite_results;
 
     let suite_result = suite_results
@@ -178,7 +178,7 @@ async fn test_gas_metering_reset() {
 async fn test_expect_partial_revert() {
     let filter = SolidityTestFilter::new(".*", "ExpectPartialRevertTest", ".*cheats/");
     let config = TEST_DATA_DEFAULT.config_with_mock_rpc();
-    let runner = TEST_DATA_DEFAULT.runner_with_config(config).await;
+    let runner = TEST_DATA_DEFAULT.runner_with_fuzz_persistence(config).await;
     let suite_results = runner.test_collect(filter).await.suite_results;
 
     let suite_result = suite_results
@@ -202,6 +202,8 @@ async fn test_assume_no_revert() {
     let mut config = TEST_DATA_DEFAULT.config_with_mock_rpc();
     config.fuzz.runs = 100;
     config.fuzz.seed = Some(U256::from(100));
+    // It's important to disable failure persistence, otherwise saved seeds from tests can influence each other's execution.
+    config.fuzz.failure_persist_dir = None;
     let runner = TEST_DATA_DEFAULT.runner_with_config(config).await;
     let suite_results = runner.test_collect(filter).await.suite_results;
 
@@ -232,6 +234,8 @@ async fn test_assume_no_revert_with_data() {
     let filter = SolidityTestFilter::new(".*", "AssumeNoRevertWithDataTest", ".*cheats/");
     let mut config = TEST_DATA_DEFAULT.config_with_mock_rpc();
     config.fuzz.seed = Some(U256::from(100));
+    // It's important to disable failure persistence, otherwise saved seeds from tests can influence each other's execution.
+    config.fuzz.failure_persist_dir = None;
     let runner = TEST_DATA_DEFAULT.runner_with_config(config).await;
     let suite_results = runner.test_collect(filter).await.suite_results;
 

--- a/crates/edr_solidity_tests/tests/it/core.rs
+++ b/crates/edr_solidity_tests/tests/it/core.rs
@@ -884,7 +884,7 @@ async fn test_gas_report_revert() {
     );
     let mut config = TEST_DATA_DEFAULT.config_with_mock_rpc();
     config.generate_gas_report = true;
-    let runner = TEST_DATA_DEFAULT.runner_with_config(config).await;
+    let runner = TEST_DATA_DEFAULT.runner_with_fuzz_persistence(config).await;
     let SolidityTestsRunResult { test_result, .. } = runner.test_collect(filter).await;
 
     let gas_report = test_result.gas_report.unwrap();

--- a/crates/edr_solidity_tests/tests/it/fork.rs
+++ b/crates/edr_solidity_tests/tests/it/fork.rs
@@ -17,7 +17,7 @@ mod remote {
         );
         // let runner = TEST_DATA_DEFAULT.runner().await;
         let runner = TEST_DATA_DEFAULT
-            .runner_with_config(TEST_DATA_DEFAULT.config_with_remote_rpc())
+            .runner_with_fuzz_persistence(TEST_DATA_DEFAULT.config_with_remote_rpc())
             .await;
         let suite_result = runner.test_collect(filter).await.suite_results;
         assert_eq!(suite_result.len(), 1);
@@ -87,7 +87,7 @@ mod remote {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_transact_fork() {
         let runner = TEST_DATA_DEFAULT
-            .runner_with_config(TEST_DATA_DEFAULT.config_with_remote_rpc())
+            .runner_with_fuzz_persistence(TEST_DATA_DEFAULT.config_with_remote_rpc())
             .await;
         let filter =
             SolidityTestFilter::new(".*", ".*", &format!(".*fork{RE_PATH_SEPARATOR}Transact"));
@@ -99,7 +99,7 @@ mod remote {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_create_same_fork() {
         let runner = TEST_DATA_DEFAULT
-            .runner_with_config(TEST_DATA_DEFAULT.config_with_remote_rpc())
+            .runner_with_fuzz_persistence(TEST_DATA_DEFAULT.config_with_remote_rpc())
             .await;
         let filter =
             SolidityTestFilter::new(".*", ".*", &format!(".*fork{RE_PATH_SEPARATOR}ForkSame"));

--- a/crates/edr_solidity_tests/tests/it/fuzz.rs
+++ b/crates/edr_solidity_tests/tests/it/fuzz.rs
@@ -106,7 +106,7 @@ async fn test_fuzz_collection() {
     config.invariant.runs = 1000;
     config.fuzz.runs = 1000;
     config.fuzz.seed = Some(U256::from(6u32));
-    let runner = TEST_DATA_DEFAULT.runner_with_config(config).await;
+    let runner = TEST_DATA_DEFAULT.runner_with_fuzz_persistence(config).await;
     let results = runner.test_collect(filter).await.suite_results;
 
     assert_multiple(
@@ -204,7 +204,7 @@ async fn test_fuzz_gas_report() {
     config.fuzz.runs = 1000;
     config.fuzz.seed = Some(U256::from(6u32));
     config.generate_gas_report = true;
-    let runner = TEST_DATA_DEFAULT.runner_with_config(config).await;
+    let runner = TEST_DATA_DEFAULT.runner_with_fuzz_persistence(config).await;
     let test_result = runner.test_collect(filter).await.test_result;
 
     assert!(test_result.gas_report.is_some());
@@ -254,7 +254,7 @@ async fn test_should_not_shrink_fuzz_failure() {
     let mut config = TEST_DATA_DEFAULT.config_with_mock_rpc();
     config.fuzz.runs = 256;
     config.fuzz.seed = Some(U256::from(100));
-    let runner = TEST_DATA_DEFAULT.runner_with_config(config).await;
+    let runner = TEST_DATA_DEFAULT.runner_with_fuzz_persistence(config).await;
     let suite_results = runner.test_collect(filter).await.suite_results;
     let suite_result = suite_results.get("default/fuzz/FuzzFailureShrink.t.sol:FuzzFailureShrinkTest").unwrap();
     let test_result = suite_result.test_results.get("testAddOne(uint256)").unwrap();
@@ -268,7 +268,7 @@ async fn test_fuzz_can_scrape_bytecode() {
     let mut config = TEST_DATA_DEFAULT.config_with_mock_rpc();
     config.fuzz.runs = 2100;
     config.fuzz.seed = Some(U256::from(119u32));
-    let runner = TEST_DATA_DEFAULT.runner_with_config(config).await;
+    let runner = TEST_DATA_DEFAULT.runner_with_fuzz_persistence(config).await;
     let results = runner.test_collect(filter).await.suite_results;
 
     assert_multiple(
@@ -289,7 +289,7 @@ async fn test_fuzz_timeout() {
     let mut config = TEST_DATA_DEFAULT.config_with_mock_rpc();
     config.fuzz.max_test_rejects = 50000;
     config.fuzz.timeout = Some(1u32);
-    let runner = TEST_DATA_DEFAULT.runner_with_config(config).await;
+    let runner = TEST_DATA_DEFAULT.runner_with_fuzz_persistence(config).await;
     let results = runner.test_collect(filter).await.suite_results;
 
     assert_multiple(
@@ -306,7 +306,7 @@ async fn test_fuzz_fail_on_revert() {
     let filter = SolidityTestFilter::new(".*", ".*", ".*fuzz/FuzzFailOnRevert.t.sol");
     let mut config = TEST_DATA_DEFAULT.config_with_mock_rpc();
     config.fuzz.fail_on_revert = false;
-    let runner = TEST_DATA_DEFAULT.runner_with_config(config).await;
+    let runner = TEST_DATA_DEFAULT.runner_with_fuzz_persistence(config).await;
     let results = runner.test_collect(filter).await.suite_results;
 
     assert_multiple(

--- a/crates/edr_solidity_tests/tests/it/invariant.rs
+++ b/crates/edr_solidity_tests/tests/it/invariant.rs
@@ -990,7 +990,7 @@ async fn test_invariant_gas_report() {
         SolidityTestFilter::new(".*", ".*", ".*fuzz/invariant/common/InvariantTest1.t.sol");
     let mut config = TEST_DATA_DEFAULT.config_with_mock_rpc();
     config.generate_gas_report = true;
-    let runner = TEST_DATA_DEFAULT.runner_with_config(config).await;
+    let runner = TEST_DATA_DEFAULT.runner_with_fuzz_persistence(config).await;
     let test_result = runner.test_collect(filter).await.test_result;
 
     assert!(test_result.gas_report.is_some());

--- a/crates/edr_solidity_tests/tests/it/repros.rs
+++ b/crates/edr_solidity_tests/tests/it/repros.rs
@@ -78,7 +78,7 @@ macro_rules! test_repro {
                 let mut $runner_config = runner_config(None, &*TEST_DATA_DEFAULT, false).await;
                 $e
                 let filter = repro_filter($issue_number);
-                let runner = TEST_DATA_DEFAULT.runner_with_config($runner_config).await;
+                let runner = TEST_DATA_DEFAULT.runner_with_fuzz_persistence($runner_config).await;
                 let test_config = TestConfig::with_filter(runner, filter).set_should_fail(false);
                 test_config.run().await;
             }
@@ -146,7 +146,7 @@ async fn repro_config(
     TxEnv,
 > {
     let config = runner_config(sender, test_data, rpc_config).await;
-    let runner = TEST_DATA_DEFAULT.runner_with_config(config).await;
+    let runner = TEST_DATA_DEFAULT.runner_with_fuzz_persistence(config).await;
     let filter = repro_filter(issue);
     TestConfig::with_filter(runner, filter).set_should_fail(should_fail)
 }

--- a/crates/edr_solidity_tests/tests/it/spec.rs
+++ b/crates/edr_solidity_tests/tests/it/spec.rs
@@ -9,7 +9,7 @@ async fn test_shanghai_compat() {
     let filter = SolidityTestFilter::new("", "ShanghaiCompat", ".*spec");
     let mut config = TEST_DATA_PARIS.config_with_mock_rpc();
     config.evm_opts.spec = SpecId::SHANGHAI;
-    TestConfig::with_filter(TEST_DATA_PARIS.runner_with_config(config).await, filter)
+    TestConfig::with_filter(TEST_DATA_PARIS.runner_with_fuzz_persistence(config).await, filter)
         .run()
         .await;
 }


### PR DESCRIPTION
Also includes a small refactoring of testing config to avoid surprises around fuzzing persistence. `helper.rs` is due for a bigger refactoring, but it's out of scope now.