### PR TITLE
build: upgrade to REVM v31

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.0.23"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6093bc69509849435a2d68237a2e9fea79d27390c8e62f1e4012c460aabad8"
+checksum = "90d103d3e440ad6f703dd71a5b58a6abd24834563bde8a5fabe706e00242f810"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -80,15 +80,16 @@ dependencies = [
  "rand 0.8.5",
  "secp256k1 0.30.0",
  "serde",
+ "serde_json",
  "serde_with",
  "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.0.23"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d1cfed4fefd13b5620cb81cdb6ba397866ff0de514c1b24806e6e79cdff5570"
+checksum = "48ead76c8c84ab3a50c31c56bc2c748c2d64357ad2131c32f9b10ab790a25e1a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -157,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.0.23"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5937e2d544e9b71000942d875cbc57965b32859a666ea543cc57aae5a06d602d"
+checksum = "7bdbec74583d0067798d77afa43d58f00d93035335d7ceaa5d3f93857d461bb9"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -172,7 +173,9 @@ dependencies = [
  "derive_more 2.0.1",
  "either",
  "serde",
- "sha2 0.10.9",
+ "serde_with",
+ "sha2",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -199,9 +202,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-hardforks"
-version = "0.2.12"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819a3620fe125e0fff365363315ee5e24c23169173b19747dfd6deba33db8990"
+checksum = "1e29d7eacf42f89c21d7f089916d0bdb4f36139a31698790e8837d2dbbd4b2c3"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
@@ -212,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15516116086325c157c18261d768a20677f0f699348000ed391d4ad0dcb82530"
+checksum = "5513d5e6bd1cba6bdcf5373470f559f320c05c8c59493b6e98912fbe6733943f"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -224,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.0.23"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b590caa6b6d8bc10e6e7a7696c59b1e550e89f27f50d1ee13071150d3a3e3f66"
+checksum = "31b67c5a702121e618217f7a86f314918acb2622276d0273490e2d4534490bc0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -239,9 +242,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.0.23"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36fe5af1fca03277daa56ad4ce5f6d623d3f4c2273ea30b9ee8674d18cefc1fa"
+checksum = "612296e6b723470bb1101420a73c63dfd535aa9bf738ce09951aedbd4ab7292e"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -265,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.0.23"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793df1e3457573877fbde8872e4906638fde565ee2d3bd16d04aad17d43dbf0e"
+checksum = "a0e7918396eecd69d9c907046ec8a93fb09b89e2f325d5e7ea9c4e3929aa0dd2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -278,20 +281,19 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6177ed26655d4e84e00b65cb494d4e0b8830e7cae7ef5d63087d445a2600fb55"
+checksum = "355bf68a433e0fd7f7d33d5a9fc2583fde70bf5c530f63b80845f8da5505cf28"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
  "bytes",
  "cfg-if",
  "const-hex",
- "derive_arbitrary",
  "derive_more 2.0.1",
- "foldhash",
+ "foldhash 0.2.0",
  "getrandom 0.3.2",
- "hashbrown 0.15.2",
+ "hashbrown 0.16.0",
  "indexmap 2.9.0",
  "itoa",
  "k256",
@@ -300,6 +302,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rand 0.9.1",
+ "rayon",
  "ruint",
  "rustc-hash",
  "serde",
@@ -309,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.0.23"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59879a772ebdcde9dc4eb38b2535d32e8503d3175687cc09e763a625c5fcf32"
+checksum = "55c1313a527a2e464d067c031f3c2ec073754ef615cc0eabca702fd0fe35729c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -332,7 +335,6 @@ dependencies = [
  "either",
  "futures",
  "futures-utils-wasm",
- "http 1.3.1",
  "lru 0.13.0",
  "parking_lot 0.12.3",
  "pin-project",
@@ -389,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.0.23"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f060e3bb9f319eb01867a2d6d1ff9e0114e8877f5ca8f5db447724136106cae"
+checksum = "45f802228273056528dfd6cc8845cc91a7c7e0c6fc1a66d19e8673743dacdc7e"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -409,9 +411,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.0.23"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d47b637369245d2dafef84b223b1ff5ea59e6cd3a98d2d3516e32788a0b216df"
+checksum = "33ff3df608dcabd6bdd197827ff2b8faaa6cefe0c462f7dc5e74108666a01f56"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -422,9 +424,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.0.23"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e26b4dd90b33bd158975307fb9cf5fafa737a0e33cbb772a8648bf8be13c104"
+checksum = "cdbf6d1766ca41e90ac21c4bc5cbc5e9e965978a25873c3f90b3992d905db4cb"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -433,9 +435,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.0.23"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f9cbf5f781b9ee39cfdddea078fdef6015424f4c8282ef0e5416d15ca352c4"
+checksum = "07da696cc7fbfead4b1dda8afe408685cae80975cbb024f843ba74d9639cd0d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -451,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.0.23"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46586ec3c278639fc0e129f0eb73dbfa3d57f683c44b2ff5e066fab7ba63fa1f"
+checksum = "a15e4831b71eea9d20126a411c1c09facf1d01d5cac84fd51d532d3c429cfc26"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -472,9 +474,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.0.23"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc9a2184493c374ca1dbba9569d37215c23e489970f8c3994f731cb3ed6b0b7d"
+checksum = "fb0c800e2ce80829fca1491b3f9063c29092850dc6cf19249d5f678f0ce71bb0"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -486,9 +488,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.0.23"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e1722bc30feef87cc0fa824e43c9013f9639cc6c037be7be28a31361c788be2"
+checksum = "751d1887f7d202514a82c5b3caf28ee8bd4a2ad9549e4f498b6f0bff99b52add"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -497,9 +499,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.0.23"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3674beb29e68fbbc7be302b611cf35fe07b736e308012a280861df5a2361395"
+checksum = "9cf0b42ffbf558badfecf1dde0c3c5ed91f29bb7e97876d0bed008c3d5d67171"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -531,9 +533,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a14f21d053aea4c6630687c2f4ad614bed4c81e14737a9b904798b24f30ea849"
+checksum = "f3ce480400051b5217f19d6e9a82d9010cdde20f1ae9c00d53591e4a1afbb312"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -545,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34d99282e7c9ef14eb62727981a985a01869e586d1dec729d3bb33679094c100"
+checksum = "6d792e205ed3b72f795a8044c52877d2e6b6e9b1d13f431478121d8d4eaa9028"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
@@ -564,9 +566,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda029f955b78e493360ee1d7bd11e1ab9f2a220a5715449babc79d6d0a01105"
+checksum = "0bd1247a8f90b465ef3f1207627547ec16940c35597875cdc09c49d58b19693c"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -582,9 +584,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10db1bd7baa35bc8d4a1b07efbf734e73e5ba09f2580fb8cee3483a36087ceb2"
+checksum = "954d1b2533b9b2c7959652df3076954ecb1122a28cc740aa84e7b0a49f6ac0a9"
 dependencies = [
  "serde",
  "winnow",
@@ -592,9 +594,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58377025a47d8b8426b3e4846a251f2c1991033b27f517aade368146f6ab1dfe"
+checksum = "70319350969a3af119da6fb3e9bddb1bce66c9ea933600cb297c8b1850ad2a3c"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -604,12 +606,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.0.23"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89bec2f59a41c0e259b6fe92f78dfc49862c17d10f938db9c33150d5a7f42b6"
+checksum = "71b3deee699d6f271eab587624a9fa84d02d0755db7a95a043d52a6488d16ebe"
 dependencies = [
  "alloy-json-rpc",
- "alloy-primitives",
+ "auto_impl",
  "base64 0.22.1",
  "derive_more 2.0.1",
  "futures",
@@ -696,12 +698,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.0.23"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f916ff6d52f219c44a9684aea764ce2c7e1d53bd4a724c9b127863aeacc30bb"
+checksum = "cd7ce8ed34106acd6e21942022b6a15be6454c2c3ead4d76811d3bdcd63cf771"
 dependencies = [
- "alloy-primitives",
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -1379,11 +1380,11 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1397,15 +1398,6 @@ dependencies = [
  "serde",
  "tap",
  "wyz",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -1441,7 +1433,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
- "sha2 0.10.9",
+ "sha2",
  "tinyvec",
 ]
 
@@ -1491,9 +1483,9 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "2.1.1"
+version = "2.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7318cfa722931cb5fe0838b98d3ce5621e75f6a6408abc21721d80de9223f2e4"
+checksum = "e00bf4b112b07b505472dbefd19e37e53307e2bfed5a79e0cc161d58ccd0e687"
 dependencies = [
  "blst",
  "cc",
@@ -1680,7 +1672,7 @@ dependencies = [
  "hmac",
  "k256",
  "serde",
- "sha2 0.10.9",
+ "sha2",
  "thiserror 1.0.69",
 ]
 
@@ -1696,7 +1688,7 @@ dependencies = [
  "once_cell",
  "pbkdf2 0.12.2",
  "rand 0.8.5",
- "sha2 0.10.9",
+ "sha2",
  "thiserror 1.0.69",
 ]
 
@@ -1714,7 +1706,7 @@ dependencies = [
  "generic-array",
  "ripemd",
  "serde",
- "sha2 0.10.9",
+ "sha2",
  "sha3",
  "thiserror 1.0.69",
 ]
@@ -1957,7 +1949,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "crossterm_winapi",
  "parking_lot 0.12.3",
  "rustix 0.38.44",
@@ -2026,8 +2018,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
 ]
 
 [[package]]
@@ -2045,12 +2047,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "strsim 0.11.1",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
  "quote",
  "syn 2.0.100",
 ]
@@ -2219,7 +2247,7 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "const-oid",
  "crypto-common",
  "subtle",
@@ -2726,7 +2754,6 @@ dependencies = [
  "edr_runtime",
  "edr_signer",
  "edr_test_utils",
- "hashbrown 0.14.5",
  "hex",
  "itertools 0.10.5",
  "lazy_static",
@@ -3646,7 +3673,7 @@ dependencies = [
  "revm-context-interface",
  "revm-primitives",
  "serde",
- "sha2 0.10.9",
+ "sha2",
  "thiserror 1.0.69",
 ]
 
@@ -3777,7 +3804,7 @@ dependencies = [
  "scrypt",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "sha3",
  "thiserror 1.0.69",
  "uuid 0.8.2",
@@ -3891,6 +3918,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -4010,7 +4043,7 @@ dependencies = [
  "semver 1.0.26",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "solar-parse",
  "solar-sema",
  "svm-rs",
@@ -4182,7 +4215,6 @@ dependencies = [
  "eyre",
  "foundry-compilers",
  "foundry-evm-core",
- "hashbrown 0.15.2",
  "rayon",
  "revm",
  "semver 1.0.26",
@@ -4240,9 +4272,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-fork-db"
-version = "0.16.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bdf390c3633b0eb14c6bb26a0aeb63ea0200f1350ccbe07493f23148f58c4a5"
+checksum = "17e22c563793782d2b3ca99bac6de70cd2a98be8c9f575590ef3605da47b4deb"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -4434,7 +4466,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2deb07a133b1520dc1a5690e9bd08950108873d7ed5de38dcc74d3b5ebffa110"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "libc",
  "libgit2-sys",
  "log",
@@ -4544,10 +4576,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
 
 [[package]]
 name = "hashbrown"
@@ -4557,7 +4585,16 @@ checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+dependencies = [
+ "foldhash 0.2.0",
  "rayon",
  "serde",
 ]
@@ -5042,6 +5079,7 @@ dependencies = [
  "arbitrary",
  "equivalent",
  "hashbrown 0.15.2",
+ "rayon",
  "serde",
 ]
 
@@ -5239,7 +5277,7 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "serdect",
- "sha2 0.10.9",
+ "sha2",
  "signature",
 ]
 
@@ -5320,54 +5358,8 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "libc",
-]
-
-[[package]]
-name = "libsecp256k1"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79019718125edc905a079a70cfa5f3820bc76139fc91d6f9abc27ea2a887139"
-dependencies = [
- "arrayref",
- "base64 0.22.1",
- "digest 0.9.0",
- "libsecp256k1-core",
- "libsecp256k1-gen-ecmult",
- "libsecp256k1-gen-genmult",
- "rand 0.8.5",
- "serde",
- "sha2 0.9.9",
-]
-
-[[package]]
-name = "libsecp256k1-core"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be9b9bb642d8522a44d533eab56c16c738301965504753b03ad1de3425d5451"
-dependencies = [
- "crunchy",
- "digest 0.9.0",
- "subtle",
-]
-
-[[package]]
-name = "libsecp256k1-gen-ecmult"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3038c808c55c87e8a172643a7d87187fc6c4174468159cb3090659d55bcb4809"
-dependencies = [
- "libsecp256k1-core",
-]
-
-[[package]]
-name = "libsecp256k1-gen-genmult"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db8d6ba2cec9eacc40e6e8ccc98931840301f1006e95647ceb2dd5c3aa06f7c"
-dependencies = [
- "libsecp256k1-core",
 ]
 
 [[package]]
@@ -5583,7 +5575,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55740c4ae1d8696773c78fdafd5d0e5fe9bc9f1b071c7ba493ba5c413a9184f3"
 dependencies = [
  "anyhow",
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "ctor",
  "napi-derive",
  "napi-sys",
@@ -5871,21 +5863,14 @@ dependencies = [
 
 [[package]]
 name = "op-revm"
-version = "8.1.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce1dc7533f4e5716c55cd3d62488c6200cb4dfda96e0c75a7e484652464343b"
+checksum = "9e599c71e91670fb922e3cdcb04783caed1226352da19d674bd001b3bf2bc433"
 dependencies = [
  "auto_impl",
- "once_cell",
  "revm",
  "serde",
 ]
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
@@ -5893,7 +5878,7 @@ version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -5968,7 +5953,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -6126,9 +6111,9 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
  "phf_macros",
  "phf_shared",
@@ -6137,19 +6122,19 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
+ "fastrand",
  "phf_shared",
- "rand 0.8.5",
 ]
 
 [[package]]
 name = "phf_macros"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -6160,9 +6145,9 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -6356,7 +6341,7 @@ checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "lazy_static",
  "num-traits",
  "rand 0.9.1",
@@ -6370,9 +6355,9 @@ dependencies = [
 
 [[package]]
 name = "proptest-derive"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee1c9ac207483d5e7db4940700de86a9aae46ef90c48b57f99fe7edb8345e49"
+checksum = "095a99f75c69734802359b682be8daaf8980296731f6470434ea2c652af1dd30"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6572,7 +6557,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -6784,9 +6769,9 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "27.1.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6bf82101a1ad8a2b637363a37aef27f88b4efc8a6e24c72bf5f64923dc5532"
+checksum = "f7bba993ce958f0b6eb23d2644ea8360982cb60baffedf961441e36faba6a2ca"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -6803,12 +6788,11 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "6.1.0"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6922f7f4fbc15ca61ea459711ff75281cc875648c797088c34e4e064de8b8a7c"
+checksum = "3f2b51c414b7e79edd4a0569d06e2c4c029f8b60e5f3ee3e2fa21dc6c3717ee3"
 dependencies = [
  "bitvec",
- "once_cell",
  "phf",
  "revm-primitives",
  "serde",
@@ -6816,10 +6800,11 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "8.0.4"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd508416a35a4d8a9feaf5ccd06ac6d6661cd31ee2dc0252f9f7316455d71f9"
+checksum = "f69efee45130bd9e5b0a7af27552fddc70bc161dafed533c2f818a2d1eb654e6"
 dependencies = [
+ "bitvec",
  "cfg-if",
  "derive-where",
  "revm-bytecode",
@@ -6832,9 +6817,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "9.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc90302642d21c8f93e0876e201f3c5f7913c4fcb66fb465b0fd7b707dfe1c79"
+checksum = "5ce2525e93db0ae2a3ec7dcde5443dfdb6fbf321c5090380d775730c67bc6cee"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -6848,9 +6833,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "7.0.2"
+version = "9.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61495e01f01c343dd90e5cb41f406c7081a360e3506acf1be0fc7880bfb04eb"
+checksum = "c2602625aa11ab1eda8e208e96b652c0bfa989b86c104a36537a62b081228af9"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -6862,9 +6847,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "7.0.2"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20628d6cd62961a05f981230746c16854f903762d01937f13244716530bf98f"
+checksum = "58a4621143d6515e32f969306d9c85797ae0d3fe0c74784f1fda02ba441e5a08"
 dependencies = [
  "auto_impl",
  "either",
@@ -6875,9 +6860,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "8.1.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1529c8050e663be64010e80ec92bf480315d21b1f2dbf65540028653a621b27d"
+checksum = "e756198d43b6c4c5886548ffbc4594412d1a82b81723525c6e85ed6da0e91c5f"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -6894,9 +6879,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "8.1.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f78db140e332489094ef314eaeb0bd1849d6d01172c113ab0eb6ea8ab9372926"
+checksum = "c3fdd1e74cc99c6173c8692b6e480291e2ad0c21c716d9dc16e937ab2e0da219"
 dependencies = [
  "auto_impl",
  "either",
@@ -6912,9 +6897,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.26.5"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7b99a2332cf8eed9e9a22fffbf76dfadc99d2c45de6ae6431a1eb9f657dd97a"
+checksum = "21caa99f22184a6818946362778cccd3ff02f743c1e085bee87700671570ecb7"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -6930,21 +6915,22 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "24.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff9d7d9d71e8a33740b277b602165b6e3d25fff091ba3d7b5a8d373bf55f28a7"
+checksum = "44efb7c2f4034a5bfd3d71ebfed076e48ac75e4972f1c117f2a20befac7716cd"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
  "revm-primitives",
+ "revm-state",
  "serde",
 ]
 
 [[package]]
 name = "revm-precompile"
-version = "25.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cee3f336b83621294b4cfe84d817e3eef6f3d0fce00951973364cc7f860424d"
+checksum = "585098ede6d84d6fc6096ba804b8e221c44dc77679571d32664a55e665aa236b"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -6957,34 +6943,33 @@ dependencies = [
  "c-kzg",
  "cfg-if",
  "k256",
- "libsecp256k1",
- "once_cell",
  "p256",
  "revm-primitives",
  "ripemd",
  "rug",
  "secp256k1 0.31.1",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
 name = "revm-primitives"
-version = "20.1.0"
+version = "21.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66145d3dc61c0d6403f27fc0d18e0363bb3b7787e67970a05c71070092896599"
+checksum = "536f30e24c3c2bf0d3d7d20fa9cf99b93040ed0f021fd9301c78cddb0dacda13"
 dependencies = [
  "alloy-primitives",
  "num_enum",
+ "once_cell",
  "serde",
 ]
 
 [[package]]
 name = "revm-state"
-version = "7.0.2"
+version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc830a0fd2600b91e371598e3d123480cd7bb473dd6def425a51213aa6c6d57"
+checksum = "5a0b4873815e31cbc3e5b183b9128b86c09a487c027aaf8cc5cf4b9688878f9b"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "revm-bytecode",
  "revm-primitives",
  "serde",
@@ -7044,9 +7029,9 @@ dependencies = [
 
 [[package]]
 name = "rug"
-version = "1.27.0"
+version = "1.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4207e8d668e5b8eb574bda8322088ccd0d7782d3d03c7e8d562e82ed82bdcbc3"
+checksum = "58ad2e973fe3c3214251a840a621812a4f40468da814b1a3d6947d433c2af11f"
 dependencies = [
  "az",
  "gmp-mpfr-sys",
@@ -7056,14 +7041,15 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.15.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11256b5fe8c68f56ac6f39ef0720e592f33d2367a4782740d9c9142e889c7fb4"
+checksum = "a68df0380e5c9d20ce49534f292a36a7514ae21350726efe1865bdb1fa91d278"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
  "ark-ff 0.3.0",
  "ark-ff 0.4.2",
+ "ark-ff 0.5.0",
  "bytes",
  "fastrlp 0.3.1",
  "fastrlp 0.4.0",
@@ -7077,7 +7063,7 @@ dependencies = [
  "rand 0.9.1",
  "rlp",
  "ruint-macro",
- "serde",
+ "serde_core",
  "valuable",
  "zeroize",
 ]
@@ -7127,7 +7113,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -7140,7 +7126,7 @@ version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -7307,7 +7293,7 @@ dependencies = [
  "hmac",
  "pbkdf2 0.11.0",
  "salsa20",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -7372,7 +7358,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -7385,7 +7371,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
@@ -7437,18 +7423,28 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7543,7 +7539,7 @@ version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -7593,19 +7589,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
 ]
 
 [[package]]
@@ -7853,7 +7836,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "081b4d9e2ddd3c7bb90079b3eb253b957ef9eb5c860ed6d6a4068884ec3a8b85"
 dependencies = [
  "alloy-primitives",
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "bumpalo",
  "itertools 0.14.0",
  "memchr",
@@ -7875,7 +7858,7 @@ checksum = "93b017d4017ee8324e669c6e5e6fe9a282ed07eb6171e5384ddd17b8a854766f"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "bumpalo",
  "derive_more 2.0.1",
  "either",
@@ -7992,7 +7975,7 @@ dependencies = [
  "semver 1.0.26",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "tempfile",
  "thiserror 2.0.12",
  "url",
@@ -8036,9 +8019,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ac494e7266fcdd2ad80bf4375d55d27a117ea5c866c26d0e97fe5b3caeeb75"
+checksum = "ff790eb176cc81bb8936aed0f7b9f14fc4670069a2d371b3e3b0ecce908b2cb3"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -9303,7 +9286,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,6 @@ alloy-json-abi.opt-level = 3
 alloy-primitives.opt-level = 3
 alloy-sol-type-parser.opt-level = 3
 alloy-sol-types.opt-level = 3
-hashbrown.opt-level = 3
 keccak.opt-level = 3
 revm-interpreter.opt-level = 3
 revm-precompile.opt-level = 3
@@ -197,13 +196,13 @@ foundry-compilers = { version = "0.18.0", default-features = false, features = [
 ] }
 
 ## revm
-op-revm = { version = "8.1.0", default-features = false, features = [
+op-revm = { version = "12.0.0", default-features = false, features = [
     "c-kzg",
     "dev",
     "serde",
     "std",
 ] }
-revm = { version = "27.1.0", default-features = false, features = [
+revm = { version = "31.0.0", default-features = false, features = [
     "arbitrary",
     "blst",
     "c-kzg",
@@ -215,34 +214,34 @@ revm = { version = "27.1.0", default-features = false, features = [
     "serde",
     "std",
 ] }
-revm-bytecode = { version = "6.1.0", default-features = false, features = [
+revm-bytecode = { version = "7.1.0", default-features = false, features = [
     "serde",
     "std",
 ] }
-revm-context = { version = "8.0.4", default-features = false }
-revm-context-interface = { version = "9.0.0", default-features = false }
-revm-database-interface = { version = "7.0.2", default-features = false }
-revm-handler = { version = "8.1.0", default-features = false }
-revm-inspector = { version = "8.1.0", default-features = false }
-revm-interpreter = { version = "24.0.0", default-features = false }
-revm-precompile = { version = "25.0.0", default-features = false, features = [
+revm-context = { version = "11.0.0", default-features = false }
+revm-context-interface = { version = "12.0.0", default-features = false }
+revm-database-interface = { version = "8.0.4", default-features = false }
+revm-handler = { version = "12.0.0", default-features = false }
+revm-inspector = { version = "12.0.0", default-features = false }
+revm-interpreter = { version = "29.0.0", default-features = false }
+revm-precompile = { version = "29.0.0", default-features = false, features = [
     "blst",
     "c-kzg",
     "std",
 ] }
-revm-primitives = { version = "20.1.0", default-features = false, features = [
+revm-primitives = { version = "21.0.1", default-features = false, features = [
     "hashbrown",
     "rand",
     "serde",
     "std",
 ] }
-revm-state = { version = "7.0.2", default-features = false }
-c-kzg = { version = "2.1.0", default-features = false, features = [
+revm-state = { version = "8.1.0", default-features = false }
+c-kzg = { version = "2.1.4", default-features = false, features = [
     "ethereum_kzg_settings",
 ] }
 
-revm-inspectors = { version = "0.26.5", features = ["serde"] }
-foundry-fork-db = "0.16"
+revm-inspectors = { version = "0.32.0", features = ["serde"] }
+foundry-fork-db = "0.20"
 
 ## ethers
 ethers-contract-abigen = { version = "2.0.14", default-features = false }
@@ -275,17 +274,16 @@ alloy-transport-ws = { version = "1.0.22", default-features = false }
 
 alloy-dyn-abi = { version = "1.2.1", features = ["eip712"] }
 alloy-json-abi = "1.2.1"
-alloy-primitives = { version = "1.2.1", features = [
+alloy-primitives = { version = "1.4.1", features = [
     "getrandom",
     "rand",
     "map-fxhash",
     "map-foldhash",
-    "map-hashbrown",
     "map-indexmap",
 ] }
 alloy-sol-macro-expander = "1.2.1"
 alloy-sol-macro-input = "1.2.1"
-alloy-sol-types = "1.2.1"
+alloy-sol-types = "1.3.1"
 syn-solidity = "=0.8.25"
 
 alloy-chains = "0.2.6"

--- a/crates/block/storage/src/contiguous.rs
+++ b/crates/block/storage/src/contiguous.rs
@@ -141,7 +141,7 @@ impl<
             .map(|transaction| (*transaction.transaction_hash(), block.clone()))
             .collect();
 
-        let mut hash_to_block = HashMap::new();
+        let mut hash_to_block = HashMap::default();
         hash_to_block.insert(block_hash, block.clone());
 
         Self {

--- a/crates/block/storage/src/reservable.rs
+++ b/crates/block/storage/src/reservable.rs
@@ -58,7 +58,7 @@ impl<BlockReceiptT: ReceiptTrait, BlockT, HardforkT, SignedTransactionT>
             reservations: RwLock::new(Vec::new()),
             storage: RwLock::new(SparseBlockStorage::default()),
             state_diffs: Vec::new(),
-            number_to_diff_index: HashMap::new(),
+            number_to_diff_index: HashMap::default(),
             last_block_number,
         }
     }

--- a/crates/block/storage/src/sparse.rs
+++ b/crates/block/storage/src/sparse.rs
@@ -40,13 +40,13 @@ impl<
             .map(|transaction| (*transaction.transaction_hash(), block.clone()))
             .collect();
 
-        let mut hash_to_block = HashMap::new();
+        let mut hash_to_block = HashMap::default();
         hash_to_block.insert(*block_hash, block.clone());
 
-        let mut hash_to_total_difficulty = HashMap::new();
+        let mut hash_to_total_difficulty = HashMap::default();
         hash_to_total_difficulty.insert(*block_hash, total_difficulty);
 
-        let mut number_to_block = HashMap::new();
+        let mut number_to_block = HashMap::default();
         number_to_block.insert(block.block_header().number, block);
 
         Self {
@@ -54,7 +54,7 @@ impl<
             hash_to_total_difficulty,
             number_to_block,
             transaction_hash_to_block,
-            transaction_hash_to_receipt: HashMap::new(),
+            transaction_hash_to_receipt: HashMap::default(),
             phantom: PhantomData,
         }
     }

--- a/crates/blockchain/fork/src/lib.rs
+++ b/crates/blockchain/fork/src/lib.rs
@@ -346,7 +346,7 @@ impl<
                                 Account {
                                     info: beacon_roots_contract(),
                                     status: AccountStatus::Created | AccountStatus::Touched,
-                                    storage: HashMap::new(),
+                                    storage: HashMap::default(),
                                     transaction_id: 0,
                                 },
                             ),
@@ -355,7 +355,7 @@ impl<
                                 Account {
                                     info: history_storage_contract(),
                                     status: AccountStatus::Created | AccountStatus::Touched,
-                                    storage: HashMap::new(),
+                                    storage: HashMap::default(),
                                     transaction_id: 0,
                                 },
                             ),
@@ -384,7 +384,7 @@ impl<
                             Account {
                                 info: beacon_roots_contract(),
                                 status: AccountStatus::Created | AccountStatus::Touched,
-                                storage: HashMap::new(),
+                                storage: HashMap::default(),
                                 transaction_id: 0,
                             },
                         )]

--- a/crates/blockchain/local/src/lib.rs
+++ b/crates/blockchain/local/src/lib.rs
@@ -463,7 +463,7 @@ mod tests {
                     *address,
                     Account {
                         info: info.clone(),
-                        storage: HashMap::new(),
+                        storage: HashMap::default(),
                         status: AccountStatus::Created | AccountStatus::Touched,
                         transaction_id: 0,
                     },

--- a/crates/edr_chain_l1/src/chains.rs
+++ b/crates/edr_chain_l1/src/chains.rs
@@ -212,7 +212,7 @@ pub(crate) fn l1_chain_configs() -> &'static HashMap<u64, ChainConfig<Hardfork>>
     static CONFIGS: OnceLock<HashMap<u64, ChainConfig<Hardfork>>> = OnceLock::new();
 
     CONFIGS.get_or_init(|| {
-        let mut hardforks = HashMap::new();
+        let mut hardforks = HashMap::default();
         hardforks.insert(L1_MAINNET_CHAIN_ID, mainnet_config().clone());
         hardforks.insert(HOLESKY_CHAIN_ID, holesky_config().clone());
         hardforks.insert(HOODI_CHAIN_ID, hoodi_config().clone());

--- a/crates/edr_coverage/tests/integration/e2e.rs
+++ b/crates/edr_coverage/tests/integration/e2e.rs
@@ -67,7 +67,7 @@ fn deploy_contract(
         evm_config.to_cfg_env(blockchain.hardfork()),
         signed.into(),
         block_env,
-        &HashMap::new(),
+        &HashMap::default(),
     )?;
     let address = if let ExecutionResult::Success {
         output: Output::Create(_, Some(address)),
@@ -126,7 +126,7 @@ fn call_inc_by(
         evm_config.to_cfg_env(blockchain.hardfork()),
         signed.into(),
         block_env,
-        &HashMap::new(),
+        &HashMap::default(),
         &mut coverage_collector,
     )?;
 

--- a/crates/edr_eth/Cargo.toml
+++ b/crates/edr_eth/Cargo.toml
@@ -17,7 +17,6 @@ edr_eip7702.workspace = true
 edr_primitives.workspace = true
 edr_receipt.workspace = true
 edr_signer.workspace = true
-hashbrown = { version = "0.14.3", default-features = false, features = ["ahash", "allocator-api2", "inline-more"] }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 itertools = { version = "0.10.5", default-features = false, features = ["use_alloc"] }
 log = { version = "0.4.17", default-features = false }

--- a/crates/edr_napi/src/account.rs
+++ b/crates/edr_napi/src/account.rs
@@ -82,7 +82,7 @@ impl TryFrom<AccountOverride> for Predeploy {
     fn try_from(value: AccountOverride) -> Result<Self, Self::Error> {
         let (address, account_override) = value.try_into()?;
 
-        let storage = account_override.storage.unwrap_or_else(HashMap::new);
+        let storage = account_override.storage.unwrap_or_else(HashMap::default);
         let balance = account_override.balance.unwrap_or(U256::ZERO);
         let nonce = account_override.nonce.unwrap_or(0);
         let code = account_override.code.ok_or_else(|| {

--- a/crates/edr_napi/src/context.rs
+++ b/crates/edr_napi/src/context.rs
@@ -390,8 +390,8 @@ impl Context {
         }
 
         Ok(Self {
-            provider_factories: HashMap::new(),
-            solidity_test_runner_factories: HashMap::new(),
+            provider_factories: HashMap::default(),
+            solidity_test_runner_factories: HashMap::default(),
             #[cfg(feature = "tracing")]
             _tracing_write_guard: guard,
         })

--- a/crates/edr_napi/src/precompile.rs
+++ b/crates/edr_napi/src/precompile.rs
@@ -1,4 +1,4 @@
-use edr_precompile::{PrecompileFn, PrecompileWithAddress};
+use edr_precompile::PrecompileFn;
 use edr_primitives::Address;
 use napi::bindgen_prelude::Uint8Array;
 use napi_derive::napi;
@@ -24,11 +24,11 @@ impl Precompile {
     }
 }
 
-impl From<PrecompileWithAddress> for Precompile {
-    fn from(value: PrecompileWithAddress) -> Self {
+impl From<edr_precompile::Precompile> for Precompile {
+    fn from(value: edr_precompile::Precompile) -> Self {
         Self {
-            address: value.0,
-            precompile_fn: value.1,
+            address: *value.address(),
+            precompile_fn: value.into_precompile(),
         }
     }
 }

--- a/crates/edr_napi/src/result.rs
+++ b/crates/edr_napi/src/result.rs
@@ -112,7 +112,9 @@ impl From<EvmHaltReason> for ExceptionalHalt {
             EvmHaltReason::StackOverflow => ExceptionalHalt::StackOverflow,
             EvmHaltReason::OutOfOffset => ExceptionalHalt::OutOfOffset,
             EvmHaltReason::CreateCollision => ExceptionalHalt::CreateCollision,
-            EvmHaltReason::PrecompileError => ExceptionalHalt::PrecompileError,
+            EvmHaltReason::PrecompileError | EvmHaltReason::PrecompileErrorWithContext(_) => {
+                ExceptionalHalt::PrecompileError
+            }
             EvmHaltReason::NonceOverflow => ExceptionalHalt::NonceOverflow,
             EvmHaltReason::CreateContractSizeLimit => ExceptionalHalt::CreateContractSizeLimit,
             EvmHaltReason::CreateContractStartingWithEF => {
@@ -198,7 +200,7 @@ impl From<&AfterMessage<EvmHaltReason>> for ExecutionResult {
             }
             edr_evm_spec::result::ExecutionResult::Halt { reason, gas_used } => {
                 Either3::C(HaltResult {
-                    reason: ExceptionalHalt::from(*reason),
+                    reason: ExceptionalHalt::from(reason.clone()),
                     gas_used: BigInt::from(*gas_used),
                 })
             }

--- a/crates/edr_op/src/hardfork/generated.rs
+++ b/crates/edr_op/src/hardfork/generated.rs
@@ -96,7 +96,7 @@ pub mod xterio_eth;
 pub mod zora;
 
 pub(super) fn chain_configs() -> HashMap<u64, ChainConfig<Hardfork>> {
-    HashMap::from([
+    [
         (arena_z::MAINNET_CHAIN_ID, arena_z::mainnet_config()),
         (arena_z::SEPOLIA_CHAIN_ID, arena_z::sepolia_config()),
         (automata::MAINNET_CHAIN_ID, automata::mainnet_config()),
@@ -177,5 +177,7 @@ pub(super) fn chain_configs() -> HashMap<u64, ChainConfig<Hardfork>> {
         (xterio_eth::MAINNET_CHAIN_ID, xterio_eth::mainnet_config()),
         (zora::MAINNET_CHAIN_ID, zora::mainnet_config()),
         (zora::SEPOLIA_CHAIN_ID, zora::sepolia_config()),
-    ])
+    ]
+    .into_iter()
+    .collect()
 }

--- a/crates/edr_op/src/hardfork/generated/arena_z.rs
+++ b/crates/edr_op/src/hardfork/generated/arena_z.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};
@@ -59,6 +59,10 @@ pub(super) fn mainnet_config() -> ChainConfig<OpSpecId> {
                 condition: ForkCondition::Timestamp(1746806401),
                 hardfork: OpSpecId::ISTHMUS,
             },
+            HardforkActivation {
+                condition: ForkCondition::Timestamp(1764691201),
+                hardfork: OpSpecId::JOVIAN,
+            },
         ]),
     }
 }
@@ -112,6 +116,10 @@ pub(super) fn sepolia_config() -> ChainConfig<OpSpecId> {
             HardforkActivation {
                 condition: ForkCondition::Timestamp(1747839600),
                 hardfork: OpSpecId::ISTHMUS,
+            },
+            HardforkActivation {
+                condition: ForkCondition::Timestamp(1763568001),
+                hardfork: OpSpecId::JOVIAN,
             },
         ]),
     }

--- a/crates/edr_op/src/hardfork/generated/automata.rs
+++ b/crates/edr_op/src/hardfork/generated/automata.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};

--- a/crates/edr_op/src/hardfork/generated/base.rs
+++ b/crates/edr_op/src/hardfork/generated/base.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};
@@ -59,6 +59,10 @@ pub(super) fn mainnet_config() -> ChainConfig<OpSpecId> {
                 condition: ForkCondition::Timestamp(1746806401),
                 hardfork: OpSpecId::ISTHMUS,
             },
+            HardforkActivation {
+                condition: ForkCondition::Timestamp(1764691201),
+                hardfork: OpSpecId::JOVIAN,
+            },
         ]),
     }
 }
@@ -112,6 +116,10 @@ pub(super) fn sepolia_config() -> ChainConfig<OpSpecId> {
             HardforkActivation {
                 condition: ForkCondition::Timestamp(1744905600),
                 hardfork: OpSpecId::ISTHMUS,
+            },
+            HardforkActivation {
+                condition: ForkCondition::Timestamp(1763568001),
+                hardfork: OpSpecId::JOVIAN,
             },
         ]),
     }

--- a/crates/edr_op/src/hardfork/generated/bob.rs
+++ b/crates/edr_op/src/hardfork/generated/bob.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};
@@ -58,6 +58,10 @@ pub(super) fn mainnet_config() -> ChainConfig<OpSpecId> {
             HardforkActivation {
                 condition: ForkCondition::Timestamp(1746806401),
                 hardfork: OpSpecId::ISTHMUS,
+            },
+            HardforkActivation {
+                condition: ForkCondition::Timestamp(1764691201),
+                hardfork: OpSpecId::JOVIAN,
             },
         ]),
     }

--- a/crates/edr_op/src/hardfork/generated/boba.rs
+++ b/crates/edr_op/src/hardfork/generated/boba.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};

--- a/crates/edr_op/src/hardfork/generated/camp.rs
+++ b/crates/edr_op/src/hardfork/generated/camp.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};

--- a/crates/edr_op/src/hardfork/generated/celo.rs
+++ b/crates/edr_op/src/hardfork/generated/celo.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};

--- a/crates/edr_op/src/hardfork/generated/creator_chain_testnet.rs
+++ b/crates/edr_op/src/hardfork/generated/creator_chain_testnet.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};
@@ -58,6 +58,10 @@ pub(super) fn sepolia_config() -> ChainConfig<OpSpecId> {
             HardforkActivation {
                 condition: ForkCondition::Timestamp(1744905600),
                 hardfork: OpSpecId::ISTHMUS,
+            },
+            HardforkActivation {
+                condition: ForkCondition::Timestamp(1763568001),
+                hardfork: OpSpecId::JOVIAN,
             },
         ]),
     }

--- a/crates/edr_op/src/hardfork/generated/cyber.rs
+++ b/crates/edr_op/src/hardfork/generated/cyber.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};

--- a/crates/edr_op/src/hardfork/generated/ethernity.rs
+++ b/crates/edr_op/src/hardfork/generated/ethernity.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};
@@ -59,6 +59,10 @@ pub(super) fn mainnet_config() -> ChainConfig<OpSpecId> {
                 condition: ForkCondition::Timestamp(1746806401),
                 hardfork: OpSpecId::ISTHMUS,
             },
+            HardforkActivation {
+                condition: ForkCondition::Timestamp(1764691201),
+                hardfork: OpSpecId::JOVIAN,
+            },
         ]),
     }
 }
@@ -112,6 +116,10 @@ pub(super) fn sepolia_config() -> ChainConfig<OpSpecId> {
             HardforkActivation {
                 condition: ForkCondition::Timestamp(1744905600),
                 hardfork: OpSpecId::ISTHMUS,
+            },
+            HardforkActivation {
+                condition: ForkCondition::Timestamp(1763568001),
+                hardfork: OpSpecId::JOVIAN,
             },
         ]),
     }

--- a/crates/edr_op/src/hardfork/generated/fraxtal.rs
+++ b/crates/edr_op/src/hardfork/generated/fraxtal.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};

--- a/crates/edr_op/src/hardfork/generated/funki.rs
+++ b/crates/edr_op/src/hardfork/generated/funki.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};

--- a/crates/edr_op/src/hardfork/generated/hashkeychain.rs
+++ b/crates/edr_op/src/hardfork/generated/hashkeychain.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};

--- a/crates/edr_op/src/hardfork/generated/ink.rs
+++ b/crates/edr_op/src/hardfork/generated/ink.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};
@@ -59,6 +59,10 @@ pub(super) fn mainnet_config() -> ChainConfig<OpSpecId> {
                 condition: ForkCondition::Timestamp(1746806401),
                 hardfork: OpSpecId::ISTHMUS,
             },
+            HardforkActivation {
+                condition: ForkCondition::Timestamp(1764691201),
+                hardfork: OpSpecId::JOVIAN,
+            },
         ]),
     }
 }
@@ -112,6 +116,10 @@ pub(super) fn sepolia_config() -> ChainConfig<OpSpecId> {
             HardforkActivation {
                 condition: ForkCondition::Timestamp(1744905600),
                 hardfork: OpSpecId::ISTHMUS,
+            },
+            HardforkActivation {
+                condition: ForkCondition::Timestamp(1763568001),
+                hardfork: OpSpecId::JOVIAN,
             },
         ]),
     }

--- a/crates/edr_op/src/hardfork/generated/lisk.rs
+++ b/crates/edr_op/src/hardfork/generated/lisk.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};
@@ -59,6 +59,10 @@ pub(super) fn mainnet_config() -> ChainConfig<OpSpecId> {
                 condition: ForkCondition::Timestamp(1746806401),
                 hardfork: OpSpecId::ISTHMUS,
             },
+            HardforkActivation {
+                condition: ForkCondition::Timestamp(1764691201),
+                hardfork: OpSpecId::JOVIAN,
+            },
         ]),
     }
 }
@@ -112,6 +116,10 @@ pub(super) fn sepolia_config() -> ChainConfig<OpSpecId> {
             HardforkActivation {
                 condition: ForkCondition::Timestamp(1744905600),
                 hardfork: OpSpecId::ISTHMUS,
+            },
+            HardforkActivation {
+                condition: ForkCondition::Timestamp(1763568001),
+                hardfork: OpSpecId::JOVIAN,
             },
         ]),
     }

--- a/crates/edr_op/src/hardfork/generated/lyra.rs
+++ b/crates/edr_op/src/hardfork/generated/lyra.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};
@@ -58,6 +58,10 @@ pub(super) fn mainnet_config() -> ChainConfig<OpSpecId> {
             HardforkActivation {
                 condition: ForkCondition::Timestamp(1746806401),
                 hardfork: OpSpecId::ISTHMUS,
+            },
+            HardforkActivation {
+                condition: ForkCondition::Timestamp(1764691201),
+                hardfork: OpSpecId::JOVIAN,
             },
         ]),
     }

--- a/crates/edr_op/src/hardfork/generated/metal.rs
+++ b/crates/edr_op/src/hardfork/generated/metal.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};
@@ -59,6 +59,10 @@ pub(super) fn mainnet_config() -> ChainConfig<OpSpecId> {
                 condition: ForkCondition::Timestamp(1746806401),
                 hardfork: OpSpecId::ISTHMUS,
             },
+            HardforkActivation {
+                condition: ForkCondition::Timestamp(1764691201),
+                hardfork: OpSpecId::JOVIAN,
+            },
         ]),
     }
 }
@@ -112,6 +116,10 @@ pub(super) fn sepolia_config() -> ChainConfig<OpSpecId> {
             HardforkActivation {
                 condition: ForkCondition::Timestamp(1744905600),
                 hardfork: OpSpecId::ISTHMUS,
+            },
+            HardforkActivation {
+                condition: ForkCondition::Timestamp(1763568001),
+                hardfork: OpSpecId::JOVIAN,
             },
         ]),
     }

--- a/crates/edr_op/src/hardfork/generated/mint.rs
+++ b/crates/edr_op/src/hardfork/generated/mint.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};
@@ -58,6 +58,10 @@ pub(super) fn mainnet_config() -> ChainConfig<OpSpecId> {
             HardforkActivation {
                 condition: ForkCondition::Timestamp(1746806401),
                 hardfork: OpSpecId::ISTHMUS,
+            },
+            HardforkActivation {
+                condition: ForkCondition::Timestamp(1764691201),
+                hardfork: OpSpecId::JOVIAN,
             },
         ]),
     }

--- a/crates/edr_op/src/hardfork/generated/mode.rs
+++ b/crates/edr_op/src/hardfork/generated/mode.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};
@@ -59,6 +59,10 @@ pub(super) fn mainnet_config() -> ChainConfig<OpSpecId> {
                 condition: ForkCondition::Timestamp(1746806401),
                 hardfork: OpSpecId::ISTHMUS,
             },
+            HardforkActivation {
+                condition: ForkCondition::Timestamp(1764691201),
+                hardfork: OpSpecId::JOVIAN,
+            },
         ]),
     }
 }
@@ -112,6 +116,10 @@ pub(super) fn sepolia_config() -> ChainConfig<OpSpecId> {
             HardforkActivation {
                 condition: ForkCondition::Timestamp(1744905600),
                 hardfork: OpSpecId::ISTHMUS,
+            },
+            HardforkActivation {
+                condition: ForkCondition::Timestamp(1763568001),
+                hardfork: OpSpecId::JOVIAN,
             },
         ]),
     }

--- a/crates/edr_op/src/hardfork/generated/op.rs
+++ b/crates/edr_op/src/hardfork/generated/op.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};
@@ -59,6 +59,10 @@ pub(super) fn mainnet_config() -> ChainConfig<OpSpecId> {
                 condition: ForkCondition::Timestamp(1746806401),
                 hardfork: OpSpecId::ISTHMUS,
             },
+            HardforkActivation {
+                condition: ForkCondition::Timestamp(1764691201),
+                hardfork: OpSpecId::JOVIAN,
+            },
         ]),
     }
 }
@@ -112,6 +116,10 @@ pub(super) fn sepolia_config() -> ChainConfig<OpSpecId> {
             HardforkActivation {
                 condition: ForkCondition::Timestamp(1744905600),
                 hardfork: OpSpecId::ISTHMUS,
+            },
+            HardforkActivation {
+                condition: ForkCondition::Timestamp(1763568001),
+                hardfork: OpSpecId::JOVIAN,
             },
         ]),
     }

--- a/crates/edr_op/src/hardfork/generated/orderly.rs
+++ b/crates/edr_op/src/hardfork/generated/orderly.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};
@@ -58,6 +58,10 @@ pub(super) fn mainnet_config() -> ChainConfig<OpSpecId> {
             HardforkActivation {
                 condition: ForkCondition::Timestamp(1746806401),
                 hardfork: OpSpecId::ISTHMUS,
+            },
+            HardforkActivation {
+                condition: ForkCondition::Timestamp(1764691201),
+                hardfork: OpSpecId::JOVIAN,
             },
         ]),
     }

--- a/crates/edr_op/src/hardfork/generated/ozean.rs
+++ b/crates/edr_op/src/hardfork/generated/ozean.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};

--- a/crates/edr_op/src/hardfork/generated/pivotal.rs
+++ b/crates/edr_op/src/hardfork/generated/pivotal.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};

--- a/crates/edr_op/src/hardfork/generated/polynomial.rs
+++ b/crates/edr_op/src/hardfork/generated/polynomial.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};
@@ -58,6 +58,10 @@ pub(super) fn mainnet_config() -> ChainConfig<OpSpecId> {
             HardforkActivation {
                 condition: ForkCondition::Timestamp(1746806401),
                 hardfork: OpSpecId::ISTHMUS,
+            },
+            HardforkActivation {
+                condition: ForkCondition::Timestamp(1764691201),
+                hardfork: OpSpecId::JOVIAN,
             },
         ]),
     }

--- a/crates/edr_op/src/hardfork/generated/race.rs
+++ b/crates/edr_op/src/hardfork/generated/race.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};

--- a/crates/edr_op/src/hardfork/generated/radius_testnet.rs
+++ b/crates/edr_op/src/hardfork/generated/radius_testnet.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};

--- a/crates/edr_op/src/hardfork/generated/redstone.rs
+++ b/crates/edr_op/src/hardfork/generated/redstone.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};

--- a/crates/edr_op/src/hardfork/generated/settlus_mainnet.rs
+++ b/crates/edr_op/src/hardfork/generated/settlus_mainnet.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};

--- a/crates/edr_op/src/hardfork/generated/settlus_sepolia.rs
+++ b/crates/edr_op/src/hardfork/generated/settlus_sepolia.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};

--- a/crates/edr_op/src/hardfork/generated/shape.rs
+++ b/crates/edr_op/src/hardfork/generated/shape.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};

--- a/crates/edr_op/src/hardfork/generated/silent_data_mainnet.rs
+++ b/crates/edr_op/src/hardfork/generated/silent_data_mainnet.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};

--- a/crates/edr_op/src/hardfork/generated/snax.rs
+++ b/crates/edr_op/src/hardfork/generated/snax.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};
@@ -58,6 +58,10 @@ pub(super) fn mainnet_config() -> ChainConfig<OpSpecId> {
             HardforkActivation {
                 condition: ForkCondition::Timestamp(1746806401),
                 hardfork: OpSpecId::ISTHMUS,
+            },
+            HardforkActivation {
+                condition: ForkCondition::Timestamp(1764691201),
+                hardfork: OpSpecId::JOVIAN,
             },
         ]),
     }

--- a/crates/edr_op/src/hardfork/generated/soneium.rs
+++ b/crates/edr_op/src/hardfork/generated/soneium.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};
@@ -58,6 +58,10 @@ pub(super) fn mainnet_config() -> ChainConfig<OpSpecId> {
             HardforkActivation {
                 condition: ForkCondition::Timestamp(1746806401),
                 hardfork: OpSpecId::ISTHMUS,
+            },
+            HardforkActivation {
+                condition: ForkCondition::Timestamp(1764691201),
+                hardfork: OpSpecId::JOVIAN,
             },
         ]),
     }

--- a/crates/edr_op/src/hardfork/generated/soneium_minato.rs
+++ b/crates/edr_op/src/hardfork/generated/soneium_minato.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};
@@ -58,6 +58,10 @@ pub(super) fn sepolia_config() -> ChainConfig<OpSpecId> {
             HardforkActivation {
                 condition: ForkCondition::Timestamp(1744905600),
                 hardfork: OpSpecId::ISTHMUS,
+            },
+            HardforkActivation {
+                condition: ForkCondition::Timestamp(1763568001),
+                hardfork: OpSpecId::JOVIAN,
             },
         ]),
     }

--- a/crates/edr_op/src/hardfork/generated/sseed.rs
+++ b/crates/edr_op/src/hardfork/generated/sseed.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};

--- a/crates/edr_op/src/hardfork/generated/swan.rs
+++ b/crates/edr_op/src/hardfork/generated/swan.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};

--- a/crates/edr_op/src/hardfork/generated/swell.rs
+++ b/crates/edr_op/src/hardfork/generated/swell.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};
@@ -56,8 +56,12 @@ pub(super) fn mainnet_config() -> ChainConfig<OpSpecId> {
                 hardfork: OpSpecId::HOLOCENE,
             },
             HardforkActivation {
-                condition: ForkCondition::Timestamp(1763438401),
+                condition: ForkCondition::Timestamp(1764648001),
                 hardfork: OpSpecId::ISTHMUS,
+            },
+            HardforkActivation {
+                condition: ForkCondition::Timestamp(1764691201),
+                hardfork: OpSpecId::JOVIAN,
             },
         ]),
     }

--- a/crates/edr_op/src/hardfork/generated/tbn.rs
+++ b/crates/edr_op/src/hardfork/generated/tbn.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};
@@ -58,6 +58,10 @@ pub(super) fn mainnet_config() -> ChainConfig<OpSpecId> {
             HardforkActivation {
                 condition: ForkCondition::Timestamp(1746806401),
                 hardfork: OpSpecId::ISTHMUS,
+            },
+            HardforkActivation {
+                condition: ForkCondition::Timestamp(1764691201),
+                hardfork: OpSpecId::JOVIAN,
             },
         ]),
     }

--- a/crates/edr_op/src/hardfork/generated/unichain.rs
+++ b/crates/edr_op/src/hardfork/generated/unichain.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};
@@ -59,6 +59,10 @@ pub(super) fn mainnet_config() -> ChainConfig<OpSpecId> {
                 condition: ForkCondition::Timestamp(1746806401),
                 hardfork: OpSpecId::ISTHMUS,
             },
+            HardforkActivation {
+                condition: ForkCondition::Timestamp(1764691201),
+                hardfork: OpSpecId::JOVIAN,
+            },
         ]),
     }
 }
@@ -112,6 +116,10 @@ pub(super) fn sepolia_config() -> ChainConfig<OpSpecId> {
             HardforkActivation {
                 condition: ForkCondition::Timestamp(1744905600),
                 hardfork: OpSpecId::ISTHMUS,
+            },
+            HardforkActivation {
+                condition: ForkCondition::Timestamp(1763568001),
+                hardfork: OpSpecId::JOVIAN,
             },
         ]),
     }

--- a/crates/edr_op/src/hardfork/generated/worldchain.rs
+++ b/crates/edr_op/src/hardfork/generated/worldchain.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};

--- a/crates/edr_op/src/hardfork/generated/xterio_eth.rs
+++ b/crates/edr_op/src/hardfork/generated/xterio_eth.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};

--- a/crates/edr_op/src/hardfork/generated/zora.rs
+++ b/crates/edr_op/src/hardfork/generated/zora.rs
@@ -3,7 +3,7 @@
 // generated. To make changes, update the generator script instead in
 // `crates/tool/op_chain_config_generator/src/op_chain_config.rs`.
 //
-// source: https://github.com/ethereum-optimism/superchain-registry/tree/0cc526c0acdfffac5b1966bf7465406e41f33b00/superchain/configs
+// source: https://github.com/ethereum-optimism/superchain-registry/tree/f33efe105393d892365fda9fda42eb69951d011a/superchain/configs
 
 use edr_chain_config::{ChainConfig, ForkCondition, HardforkActivation, HardforkActivations};
 use edr_eip1559::{BaseFeeActivation, BaseFeeParams, ConstantBaseFeeParams, DynamicBaseFeeParams};
@@ -59,6 +59,10 @@ pub(super) fn mainnet_config() -> ChainConfig<OpSpecId> {
                 condition: ForkCondition::Timestamp(1746806401),
                 hardfork: OpSpecId::ISTHMUS,
             },
+            HardforkActivation {
+                condition: ForkCondition::Timestamp(1764691201),
+                hardfork: OpSpecId::JOVIAN,
+            },
         ]),
     }
 }
@@ -112,6 +116,10 @@ pub(super) fn sepolia_config() -> ChainConfig<OpSpecId> {
             HardforkActivation {
                 condition: ForkCondition::Timestamp(1744905600),
                 hardfork: OpSpecId::ISTHMUS,
+            },
+            HardforkActivation {
+                condition: ForkCondition::Timestamp(1763568001),
+                hardfork: OpSpecId::JOVIAN,
             },
         ]),
     }

--- a/crates/edr_op/src/lib.rs
+++ b/crates/edr_op/src/lib.rs
@@ -28,7 +28,7 @@ pub mod test_utils;
 /// OP transaction types
 pub mod transaction;
 
-use edr_primitives::U256;
+pub use op_revm::L1BlockInfo;
 
 pub use self::spec::OpChainSpec;
 
@@ -46,37 +46,3 @@ pub type InvalidHeader = revm_context_interface::result::InvalidHeader;
 
 /// OP Stack invalid transaction error.
 pub type InvalidTransaction = op_revm::OpTransactionError;
-
-/// Helper type for constructing an [`op_revm::L1BlockInfo`].
-///
-/// This type duplicates [`op_revm::L1BlockInfo`] but excludes the private
-/// field to allow manual construction.
-#[derive(Clone, Debug, Default)]
-pub struct L1BlockInfo {
-    /// The base fee of the L1 origin block.
-    pub l1_base_fee: U256,
-    /// The current L1 fee overhead. None if Ecotone is activated.
-    pub l1_fee_overhead: Option<U256>,
-    /// The current L1 fee scalar.
-    pub l1_base_fee_scalar: U256,
-    /// The current L1 blob base fee. None if Ecotone is not activated, except
-    /// if `empty_scalars` is `true`.
-    pub l1_blob_base_fee: Option<U256>,
-    /// The current L1 blob base fee scalar. None if Ecotone is not activated.
-    pub l1_blob_base_fee_scalar: Option<U256>,
-}
-
-impl From<L1BlockInfo> for op_revm::L1BlockInfo {
-    fn from(value: L1BlockInfo) -> Self {
-        // [`op_revm::L1BlockInfo`] contains a private field, so we need to construct it
-        // like this
-        let mut l1_block_info = Self::default();
-        l1_block_info.l1_base_fee = value.l1_base_fee;
-        l1_block_info.l1_fee_overhead = value.l1_fee_overhead;
-        l1_block_info.l1_base_fee_scalar = value.l1_base_fee_scalar;
-        l1_block_info.l1_blob_base_fee = value.l1_blob_base_fee;
-        l1_block_info.l1_blob_base_fee_scalar = value.l1_blob_base_fee_scalar;
-
-        l1_block_info
-    }
-}

--- a/crates/edr_op/tests/integration/provider.rs
+++ b/crates/edr_op/tests/integration/provider.rs
@@ -29,7 +29,7 @@ async fn sepolia_call_with_remote_chain_id() -> anyhow::Result<()> {
     let mut config = create_test_config_with_fork(Some(ForkConfig {
         block_number: None,
         cache_dir: edr_defaults::CACHE_DIR.into(),
-        chain_overrides: HashMap::new(),
+        chain_overrides: HashMap::default(),
         http_headers: None,
         url: op::sepolia_url(),
     }));

--- a/crates/edr_provider/src/data.rs
+++ b/crates/edr_provider/src/data.rs
@@ -693,7 +693,7 @@ where
             filters: HashMap::default(),
             last_filter_id: U256::ZERO,
             logger,
-            impersonated_accounts: HashSet::new(),
+            impersonated_accounts: HashSet::default(),
             subscriber_callback,
             timer,
             block_state_cache,
@@ -2830,7 +2830,7 @@ fn create_blockchain_and_state<
                         info,
                         // TODO: Add support for overriding the storage
                         // TODO: https://github.com/NomicFoundation/edr/issues/911
-                        storage: HashMap::new(),
+                        storage: HashMap::default(),
                         status: AccountStatus::Created | AccountStatus::Touched,
                         transaction_id: 0,
                     };
@@ -2943,7 +2943,10 @@ fn create_blockchain_and_state<
 
                 let account = Account {
                     info,
-                    storage: account_override.storage.clone().unwrap_or(HashMap::new()),
+                    storage: account_override
+                        .storage
+                        .clone()
+                        .unwrap_or(HashMap::default()),
                     status: AccountStatus::Created | AccountStatus::Touched,
                     transaction_id: 0,
                 };
@@ -4078,7 +4081,7 @@ mod tests {
             let default_config = create_test_config_with_fork(Some(ForkConfig {
                 block_number: Some(EIP_1559_ACTIVATION_BLOCK),
                 cache_dir: edr_defaults::CACHE_DIR.into(),
-                chain_overrides: HashMap::new(),
+                chain_overrides: HashMap::default(),
                 http_headers: None,
                 url: get_alchemy_url(),
             }));

--- a/crates/edr_provider/src/debug_trace.rs
+++ b/crates/edr_provider/src/debug_trace.rs
@@ -70,7 +70,7 @@ pub fn debug_trace_transaction<'header, ChainSpecT: BlockChainSpec>(
                     evm_config,
                     transaction,
                     &block,
-                    &edr_primitives::HashMap::new(),
+                    &edr_primitives::HashMap::default(),
                     &mut DualInspector::new(&mut eip3155_tracer, &mut evm_observer),
                 )?;
 
@@ -99,7 +99,7 @@ pub fn debug_trace_transaction<'header, ChainSpecT: BlockChainSpec>(
                 evm_config.clone(),
                 transaction,
                 &block,
-                &edr_primitives::HashMap::new(),
+                &edr_primitives::HashMap::default(),
             )?;
         }
     }

--- a/crates/edr_provider/src/requests/eth/filter.rs
+++ b/crates/edr_provider/src/requests/eth/filter.rs
@@ -202,7 +202,7 @@ fn validate_filter_criteria<
 
     let addresses = filter
         .address
-        .map_or(HashSet::new(), |addresses| match addresses {
+        .map_or(HashSet::default(), |addresses| match addresses {
             OneOrMore::One(address) => iter::once(address).collect(),
             OneOrMore::Many(addresses) => addresses.into_iter().collect(),
         });

--- a/crates/edr_provider/src/test_utils.rs
+++ b/crates/edr_provider/src/test_utils.rs
@@ -134,7 +134,7 @@ pub fn create_test_config_with_fork<HardforkT: Default>(
         network_id: 123,
         observability: observability::ObservabilityConfig::default(),
         owned_accounts,
-        precompile_overrides: HashMap::new(),
+        precompile_overrides: HashMap::default(),
     }
 }
 
@@ -216,7 +216,7 @@ where
         let fork = fork.map(|json_rpc_url| ForkConfig {
             block_number: None,
             cache_dir: edr_defaults::CACHE_DIR.into(),
-            chain_overrides: HashMap::new(),
+            chain_overrides: HashMap::default(),
             http_headers: None,
             url: json_rpc_url,
         });

--- a/crates/edr_provider/tests/integration/issues/issue_324.rs
+++ b/crates/edr_provider/tests/integration/issues/issue_324.rs
@@ -27,7 +27,7 @@ async fn issue_324() -> anyhow::Result<()> {
     let mut config = create_test_config_with_fork(Some(ForkConfig {
         block_number: Some(DEPLOYMENT_BLOCK_NUMBER),
         cache_dir: edr_defaults::CACHE_DIR.into(),
-        chain_overrides: HashMap::new(),
+        chain_overrides: HashMap::default(),
         http_headers: None,
         url: get_alchemy_url().replace("mainnet", "sepolia"),
     }));

--- a/crates/edr_provider/tests/integration/issues/issue_356.rs
+++ b/crates/edr_provider/tests/integration/issues/issue_356.rs
@@ -29,7 +29,7 @@ async fn issue_356() -> anyhow::Result<()> {
         // Pre-cancun Sepolia block
         block_number: Some(4243456),
         cache_dir: edr_defaults::CACHE_DIR.into(),
-        chain_overrides: HashMap::new(),
+        chain_overrides: HashMap::default(),
         http_headers: None,
         url: get_alchemy_url().replace("mainnet", "sepolia"),
     }));

--- a/crates/edr_provider/tests/integration/issues/issue_384.rs
+++ b/crates/edr_provider/tests/integration/issues/issue_384.rs
@@ -20,7 +20,7 @@ async fn avalanche_chain_mine_local_block() -> anyhow::Result<()> {
     let config = create_test_config_with_fork(Some(ForkConfig {
         block_number: Some(BLOCK_NUMBER),
         cache_dir: edr_defaults::CACHE_DIR.into(),
-        chain_overrides: HashMap::new(),
+        chain_overrides: HashMap::default(),
         http_headers: None,
         url: get_infura_url().replace("mainnet", "avalanche-mainnet"),
     }));

--- a/crates/edr_provider/tests/integration/issues/issue_503.rs
+++ b/crates/edr_provider/tests/integration/issues/issue_503.rs
@@ -19,7 +19,7 @@ async fn issue_503() -> anyhow::Result<()> {
     let mut config = create_test_config_with_fork(Some(ForkConfig {
         block_number: Some(19_909_475),
         cache_dir: edr_defaults::CACHE_DIR.into(),
-        chain_overrides: HashMap::new(),
+        chain_overrides: HashMap::default(),
         http_headers: None,
         url: get_alchemy_url(),
     }));

--- a/crates/edr_provider/tests/integration/issues/issue_533.rs
+++ b/crates/edr_provider/tests/integration/issues/issue_533.rs
@@ -19,7 +19,7 @@ async fn issue_533() -> anyhow::Result<()> {
     let mut config = create_test_config_with_fork(Some(ForkConfig {
         block_number: Some(20_384_300),
         cache_dir: edr_defaults::CACHE_DIR.into(),
-        chain_overrides: HashMap::new(),
+        chain_overrides: HashMap::default(),
         http_headers: None,
         url: get_alchemy_url(),
     }));

--- a/crates/edr_provider/tests/integration/issues/issue_588.rs
+++ b/crates/edr_provider/tests/integration/issues/issue_588.rs
@@ -21,7 +21,7 @@ async fn issue_588() -> anyhow::Result<()> {
     let early_mainnet_fork = create_test_config_with_fork(Some(ForkConfig {
         block_number: Some(2_675_000),
         cache_dir: edr_defaults::CACHE_DIR.into(),
-        chain_overrides: HashMap::new(),
+        chain_overrides: HashMap::default(),
         http_headers: None,
         url: get_alchemy_url(),
     }));

--- a/crates/edr_provider/tests/integration/rip7212.rs
+++ b/crates/edr_provider/tests/integration/rip7212.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use edr_chain_l1::{rpc::call::L1CallRequest, L1ChainSpec};
 use edr_precompile::secp256r1;
-use edr_primitives::{bytes, Bytes, HashMap};
+use edr_primitives::{bytes, Bytes};
 use edr_provider::{
     test_utils::create_test_config, time::CurrentTime, MethodInvocation, NoopLogger, Provider,
     ProviderRequest,
@@ -52,10 +52,12 @@ async fn rip7212_disabled() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn rip7212_enabled() -> anyhow::Result<()> {
     let mut config = create_test_config();
-    config.precompile_overrides = HashMap::from([(
+    config.precompile_overrides = [(
         *secp256r1::P256VERIFY.address(),
         *secp256r1::P256VERIFY.precompile(),
-    )]);
+    )]
+    .into_iter()
+    .collect();
 
     let logger = Box::new(NoopLogger::<L1ChainSpec>::default());
     let subscriber = Box::new(|_event| {});

--- a/crates/edr_runtime/src/mempool.rs
+++ b/crates/edr_runtime/src/mempool.rs
@@ -209,7 +209,7 @@ impl<SignedTransactionT: ExecutableTransaction> MemPool<SignedTransactionT> {
         Self {
             block_gas_limit,
             pending_transactions: IndexMap::new(),
-            hash_to_transaction: HashMap::new(),
+            hash_to_transaction: HashMap::default(),
             future_transactions: IndexMap::new(),
             next_order_id: 0,
         }

--- a/crates/edr_runtime/src/transaction.rs
+++ b/crates/edr_runtime/src/transaction.rs
@@ -34,11 +34,13 @@ pub fn validate<TransactionT: Transaction>(
     transaction: TransactionT,
     spec_id: EvmSpecId,
 ) -> Result<TransactionT, CreationError> {
+    const EIP7623_DISABLED: bool = false;
+
     if transaction.kind() == TxKind::Create && transaction.input().is_empty() {
         return Err(CreationError::ContractMissingData);
     }
 
-    match validate_initial_tx_gas(&transaction, spec_id) {
+    match validate_initial_tx_gas(&transaction, spec_id, EIP7623_DISABLED) {
         Ok(_) => Ok(transaction),
         Err(EvmTransactionValidationError::CallGasCostMoreThanGasLimit {
             initial_gas,

--- a/crates/edr_scenarios/src/lib.rs
+++ b/crates/edr_scenarios/src/lib.rs
@@ -11,7 +11,7 @@ use chrono::{DateTime, Utc};
 use edr_block_header::BlobGas;
 use edr_chain_config::ChainOverride;
 use edr_napi_core::provider::Config as ProviderConfig;
-use edr_primitives::{hash_map::HashMap, Address, ChainId, B256};
+use edr_primitives::{Address, ChainId, HashMap, B256};
 use edr_provider::{AccountOverride, ForkConfig, MiningConfig};
 use edr_test_utils::secret_key::{secret_key_from_str, secret_key_to_str};
 use serde::{Deserialize, Serialize};
@@ -92,7 +92,7 @@ impl From<ScenarioProviderConfig> for ProviderConfig {
                 .map(SerializableSecretKey::into_inner)
                 .collect::<Vec<_>>(),
             // Overriding precompiles is not supported in scenarios
-            precompile_overrides: HashMap::new(),
+            precompile_overrides: HashMap::default(),
         }
     }
 }
@@ -116,7 +116,7 @@ impl TryFrom<ProviderConfig> for ScenarioProviderConfig {
             chain_id: value.chain_id,
             // Chain overrides are not supported for newly recorded scenarios. We merely maintain it
             // for backwards compatibility for Hardhat 2.
-            chain_overrides: HashMap::new(),
+            chain_overrides: HashMap::default(),
             coinbase: value.coinbase,
             fork: value.fork,
             genesis_state: value.genesis_state,

--- a/crates/edr_solidity_tests/src/gas_report.rs
+++ b/crates/edr_solidity_tests/src/gas_report.rs
@@ -260,7 +260,7 @@ impl From<GasReport> for edr_gas_report::GasReport {
                     status: contract.status,
                 }];
 
-                let mut functions: HashMap<String, Vec<FunctionGasReport>> = HashMap::new();
+                let mut functions = HashMap::default();
                 contract.functions.iter().for_each(|(_, sigs)| {
                     for (sig, gas_info) in sigs.iter() {
                         let reports = gas_info

--- a/crates/foundry/cheatcodes/src/evm.rs
+++ b/crates/foundry/cheatcodes/src/evm.rs
@@ -38,7 +38,7 @@ use foundry_evm_core::evm_context::{
     split_context, BlockEnvTr, ChainContextTr, EvmBuilderTrait, HardforkTr, TransactionEnvTr,
     TransactionErrorTrait,
 };
-use record_debug_step::{convert_call_trace_to_debug_step, flatten_call_trace};
+use record_debug_step::{convert_call_trace_ctx_to_debug_step, flatten_call_trace};
 use serde::Serialize;
 
 mod fork;
@@ -3036,7 +3036,7 @@ impl Cheatcode for stopAndReturnDebugTraceRecordingCall {
 
         let debug_steps: Vec<DebugStep> = steps
             .iter()
-            .map(|&step| convert_call_trace_to_debug_step(step))
+            .map(|step| convert_call_trace_ctx_to_debug_step(step))
             .collect();
         // Free up memory by clearing the steps if they are not recorded outside of
         // cheatcode usage.

--- a/crates/foundry/cheatcodes/src/evm/record_debug_step.rs
+++ b/crates/foundry/cheatcodes/src/evm/record_debug_step.rs
@@ -2,16 +2,24 @@ use alloy_primitives::{Bytes, U256};
 use foundry_evm_core::buffer::{get_buffer_accesses, BufferKind};
 use foundry_evm_traces::CallTraceArena;
 use revm::{bytecode::opcode::OpCode, interpreter::InstructionResult};
-use revm_inspectors::tracing::types::{CallTraceStep, RecordedMemory, TraceMemberOrder};
+use revm_inspectors::tracing::types::{
+    CallTraceNode, CallTraceStep, RecordedMemory, TraceMemberOrder,
+};
 use spec::Vm::DebugStep;
+
+// Context for a CallTraceStep, includes depth and contract address.
+pub(crate) struct CallTraceCtx<'a> {
+    pub node: &'a CallTraceNode,
+    pub step: &'a CallTraceStep,
+}
 
 // Do a depth first traverse of the nodes and steps and return steps
 // that are after `node_start_idx`
-pub(crate) fn flatten_call_trace(
+pub(crate) fn flatten_call_trace<'a>(
     root: usize,
-    arena: &CallTraceArena,
+    arena: &'a CallTraceArena,
     node_start_idx: usize,
-) -> Vec<&CallTraceStep> {
+) -> Vec<CallTraceCtx<'a>> {
     let mut steps = Vec::new();
     let mut record_started = false;
 
@@ -30,7 +38,7 @@ fn recursive_flatten_call_trace<'a>(
     arena: &'a CallTraceArena,
     node_start_idx: usize,
     record_started: &mut bool,
-    flatten_steps: &mut Vec<&'a CallTraceStep>,
+    flatten_steps: &mut Vec<CallTraceCtx<'a>>,
 ) {
     // Once node_idx exceeds node_start_idx, start recording steps
     // for all the recursive processing.
@@ -52,7 +60,7 @@ fn recursive_flatten_call_trace<'a>(
                         .steps
                         .get(*step_idx)
                         .expect("Step index should be valid");
-                    flatten_steps.push(step);
+                    flatten_steps.push(CallTraceCtx { node, step });
                 }
             }
             TraceMemberOrder::Call(call_idx) => {
@@ -74,25 +82,34 @@ fn recursive_flatten_call_trace<'a>(
 }
 
 // Function to convert CallTraceStep to DebugStep
-pub(crate) fn convert_call_trace_to_debug_step(step: &CallTraceStep) -> DebugStep {
-    let opcode = step.op.get();
-    let stack = get_stack_inputs_for_opcode(opcode, step.stack.as_ref());
+pub(crate) fn convert_call_trace_ctx_to_debug_step(ctx: &CallTraceCtx) -> DebugStep {
+    let opcode = ctx.step.op.get();
+    let stack = get_stack_inputs_for_opcode(opcode, ctx.step.stack.as_deref());
 
-    let memory = get_memory_input_for_opcode(opcode, step.stack.as_ref(), step.memory.as_ref());
+    let memory =
+        get_memory_input_for_opcode(opcode, ctx.step.stack.as_deref(), ctx.step.memory.as_ref());
 
-    let is_out_of_gas = step.status == Some(InstructionResult::OutOfGas)
-        || step.status == Some(InstructionResult::MemoryOOG)
-        || step.status == Some(InstructionResult::MemoryLimitOOG)
-        || step.status == Some(InstructionResult::PrecompileOOG)
-        || step.status == Some(InstructionResult::InvalidOperandOOG);
+    let is_out_of_gas = matches!(
+        ctx.step.status,
+        Some(
+            InstructionResult::OutOfGas
+                | InstructionResult::MemoryOOG
+                | InstructionResult::MemoryLimitOOG
+                | InstructionResult::PrecompileOOG
+                | InstructionResult::InvalidOperandOOG
+        )
+    );
+
+    let depth = ctx.node.trace.depth as u64 + 1;
+    let contract_addr = ctx.node.execution_address();
 
     DebugStep {
         stack,
         memoryInput: memory,
-        opcode: step.op.get(),
-        depth: step.depth,
+        opcode: ctx.step.op.get(),
+        depth,
         isOutOfGas: is_out_of_gas,
-        contractAddr: step.contract,
+        contractAddr: contract_addr,
     }
 }
 
@@ -100,7 +117,7 @@ pub(crate) fn convert_call_trace_to_debug_step(step: &CallTraceStep) -> DebugSte
 // is the last value of the vector
 fn get_memory_input_for_opcode(
     opcode: u8,
-    stack: Option<&Vec<U256>>,
+    stack: Option<&[U256]>,
     memory: Option<&RecordedMemory>,
 ) -> Bytes {
     let mut memory_input = Bytes::new();
@@ -122,7 +139,7 @@ fn get_memory_input_for_opcode(
 
 // The expected `stack` here is from the trace stack, where the top of the stack
 // is the last value of the vector
-fn get_stack_inputs_for_opcode(opcode: u8, stack: Option<&Vec<U256>>) -> Vec<U256> {
+fn get_stack_inputs_for_opcode(opcode: u8, stack: Option<&[U256]>) -> Vec<U256> {
     let mut inputs = Vec::new();
 
     let Some(op) = OpCode::new(opcode) else {

--- a/crates/foundry/cheatcodes/src/lib.rs
+++ b/crates/foundry/cheatcodes/src/lib.rs
@@ -392,7 +392,11 @@ impl<
 {
     #[inline]
     pub(crate) fn is_precompile(&self, address: &Address) -> bool {
-        self.ecx.journaled_state.inner.precompiles.contains(address)
+        self.ecx
+            .journaled_state
+            .warm_addresses
+            .precompiles()
+            .contains(address)
     }
 }
 

--- a/crates/foundry/evm/core/src/backend/mod.rs
+++ b/crates/foundry/evm/core/src/backend/mod.rs
@@ -1822,39 +1822,40 @@ impl<
     ) -> Result<(), BackendError> {
         // Fetch the account from the journaled state. Will create a new account if it
         // does not already exist.
-        let mut state_acc = journaled_state.load_account(self, *target)?;
+        let mut state_acc = journaled_state.load_account_mut(self, *target)?;
 
         // Set the account's bytecode and code hash, if the `bytecode` field is present.
         if let Some(bytecode) = source.code.as_ref() {
-            state_acc.info.code_hash = keccak256(bytecode);
+            let bytecode_hash = keccak256(bytecode);
             let bytecode = Bytecode::new_raw(bytecode.0.clone().into());
-            state_acc.info.code = Some(bytecode);
+            state_acc.set_code(bytecode_hash, bytecode);
         }
 
+        // Set the account's balance.
+        state_acc.set_balance(source.balance);
+
         // Set the account's storage, if the `storage` field is present.
-        if let Some(storage) = source.storage.as_ref() {
-            state_acc.storage = storage
-                .iter()
-                .map(|(slot, value)| {
+        if let Some(acc) = journaled_state.state.get_mut(target) {
+            if let Some(storage) = source.storage.as_ref() {
+                for (slot, value) in storage {
                     let slot = U256::from_be_bytes(slot.0);
-                    (
+                    acc.storage.insert(
                         slot,
                         EvmStorageSlot::new_changed(
-                            state_acc
-                                .storage
+                            acc.storage
                                 .get(&slot)
                                 .map(|s| s.present_value)
                                 .unwrap_or_default(),
                             U256::from_be_bytes(value.0),
                             0,
                         ),
-                    )
-                })
-                .collect();
-        }
-        // Set the account's nonce and balance.
-        state_acc.info.nonce = source.nonce.unwrap_or_default();
-        state_acc.info.balance = source.balance;
+                    );
+                }
+            }
+
+            // Set the account's nonce.
+            acc.info.nonce = source.nonce.unwrap_or_default();
+        };
 
         // Touch the account to ensure the loaded information persists if called in
         // `setUp`.
@@ -2353,8 +2354,8 @@ impl<BlockT: BlockEnvTr, TxT: TransactionEnvTr, HardforkT: HardforkTr>
             journal_inner
         };
         journal
-            .precompiles
-            .extend(self.precompiles().addresses().copied());
+            .warm_addresses
+            .set_precompile_addresses(self.precompiles().addresses().copied().collect());
         journal
     }
 }

--- a/crates/foundry/evm/core/src/backend/predeploy.rs
+++ b/crates/foundry/evm/core/src/backend/predeploy.rs
@@ -1,6 +1,5 @@
 use alloy_primitives::Address;
 use revm::{
-    primitives::hash_map::HashMap,
     state::{Account, AccountInfo, AccountStatus, EvmStorage},
     DatabaseCommit,
 };
@@ -33,7 +32,7 @@ pub(super) fn insert_predeploys(
             };
             (predeploy.address, account)
         })
-        .collect::<HashMap<_, _>>();
+        .collect();
 
     db.commit(changes);
 }

--- a/crates/foundry/evm/core/src/fork/multi.rs
+++ b/crates/foundry/evm/core/src/fork/multi.rs
@@ -28,7 +28,7 @@ use futures::{
 use super::CreateFork;
 use crate::{
     evm_context::{BlockEnvTr, EvmEnv, HardforkTr, TransactionEnvTr},
-    fork::provider::{ProviderBuilder, RetryProvider},
+    fork::provider::ProviderBuilder,
 };
 
 /// The _unique_ identifier for a specific fork, this could be the name of the
@@ -233,7 +233,7 @@ impl<BlockT: BlockEnvTr, TxT: TransactionEnvTr, HardforkT: HardforkTr>
     }
 }
 
-type Handler = BackendHandler<Arc<RetryProvider>>;
+type Handler = BackendHandler;
 
 type CreateFuture<BlockT, TxT, HardforkT> = Pin<
     Box<

--- a/crates/foundry/evm/coverage/Cargo.toml
+++ b/crates/foundry/evm/coverage/Cargo.toml
@@ -9,14 +9,19 @@ edition.workspace = true
 foundry-compilers.workspace = true
 foundry-evm-core.workspace = true
 
-alloy-primitives.workspace = true
+alloy-primitives = { workspace = true, features = [
+    "getrandom",
+    "map-foldhash",
+    "map-fxhash",
+    "map-indexmap",
+    "rand",
+    "rayon"
+] }
 eyre = "0.6"
 rayon = "1"
 revm.workspace = true
 semver = "1"
 tracing.workspace = true
-# Needed by alloy-primitives with hashbrown feature
-hashbrown = { version = "0.15.2", features = ["rayon"] }
 
 [lints]
 workspace = true

--- a/crates/foundry/evm/coverage/src/inspector.rs
+++ b/crates/foundry/evm/coverage/src/inspector.rs
@@ -41,8 +41,9 @@ where
     CTX: ContextTr<Journal: JournalExt>,
 {
     fn initialize_interp(&mut self, interpreter: &mut Interpreter, _context: &mut CTX) {
-        get_or_insert_contract_hash(interpreter);
-        self.insert_map(interpreter);
+        let map = self.get_or_insert_map(interpreter);
+        // Reserve some space early to avoid reallocating too often.
+        map.reserve(8192.min(interpreter.bytecode.len()));
     }
 
     fn step(&mut self, interpreter: &mut Interpreter, _context: &mut CTX) {
@@ -64,7 +65,7 @@ impl LineCoverageCollector {
     /// See comments on `current_map` for more details.
     #[inline]
     fn get_or_insert_map(&mut self, interpreter: &mut Interpreter) -> &mut HitMap {
-        let hash = get_or_insert_contract_hash(interpreter);
+        let hash = interpreter.bytecode.get_or_calculate_hash();
         if self.current_hash != *hash {
             self.insert_map(interpreter);
         }
@@ -75,7 +76,7 @@ impl LineCoverageCollector {
     #[cold]
     #[inline(never)]
     fn insert_map(&mut self, interpreter: &mut Interpreter) {
-        let hash = interpreter.bytecode.hash().unwrap_or_else(|| eof_panic());
+        let hash = interpreter.bytecode.hash().unwrap();
         self.current_hash = hash;
         // Converts the mutable reference to a `NonNull` pointer.
         self.current_map = self
@@ -84,23 +85,4 @@ impl LineCoverageCollector {
             .or_insert_with(|| HitMap::new(interpreter.bytecode.original_bytes()))
             .into();
     }
-}
-
-/// Helper function for extracting contract hash used to record coverage hit
-/// map.
-///
-/// If the contract hash is zero (contract not yet created but it's going to be
-/// created in current tx) then the hash is calculated from the bytecode.
-#[inline]
-fn get_or_insert_contract_hash(interpreter: &mut Interpreter) -> B256 {
-    if interpreter.bytecode.hash().is_none_or(|h| h.is_zero()) {
-        interpreter.bytecode.regenerate_hash();
-    }
-    interpreter.bytecode.hash().unwrap_or_else(|| eof_panic())
-}
-
-#[cold]
-#[inline(never)]
-fn eof_panic() -> ! {
-    panic!("coverage does not support EOF");
 }

--- a/crates/foundry/evm/coverage/src/lib.rs
+++ b/crates/foundry/evm/coverage/src/lib.rs
@@ -18,13 +18,12 @@ use std::{
 };
 
 use alloy_primitives::{
-    map::{B256HashMap, HashMap},
+    map::{B256HashMap, DefaultHashBuilder, HashMap},
     Bytes,
 };
 use analysis::SourceAnalysis;
 use eyre::Result;
 use foundry_compilers::artifacts::sourcemap::SourceMap;
-use hashbrown as _;
 use semver::Version;
 
 pub mod analysis;
@@ -232,10 +231,7 @@ impl HitMap {
     pub fn new(bytecode: Bytes) -> Self {
         Self {
             bytecode,
-            hits: HashMap::with_capacity_and_hasher(
-                1024,
-                alloy_primitives::map::foldhash::fast::RandomState::default(),
-            ),
+            hits: HashMap::with_capacity_and_hasher(1024, DefaultHashBuilder::default()),
         }
     }
 
@@ -261,6 +257,12 @@ impl HitMap {
     #[inline]
     pub fn hits(&mut self, pc: u32, hits: u32) {
         *self.hits.entry(pc).or_default() += hits;
+    }
+
+    /// Reserve space for additional hits.
+    #[inline]
+    pub fn reserve(&mut self, additional: usize) {
+        self.hits.reserve(additional);
     }
 
     /// Merge another hitmap into this, assuming the bytecode is consistent

--- a/crates/foundry/evm/evm/src/inspectors/stack.rs
+++ b/crates/foundry/evm/evm/src/inspectors/stack.rs
@@ -862,11 +862,7 @@ impl<
 
                 for (addr, acc_mut) in &mut state {
                     // mark all accounts cold, besides preloaded addresses
-                    if !context
-                        .journaled_state
-                        .warm_preloaded_addresses
-                        .contains(addr)
-                    {
+                    if context.journaled_state.warm_addresses.is_cold(addr) {
                         acc_mut.mark_cold();
                     }
 
@@ -1340,6 +1336,7 @@ impl<
                         .and_then(|selector| mocks.get(selector))
                 }) {
                     call.bytecode_address = *target;
+                    call.known_bytecode = None;
                 }
             }
 
@@ -1370,7 +1367,7 @@ impl<
                 CallScheme::StaticCall => {
                     let JournaledState {
                         state,
-                        warm_preloaded_addresses,
+                        warm_addresses,
                         ..
                     } = &mut ecx.journaled_state.inner;
                     for (addr, acc_mut) in state {
@@ -1381,7 +1378,7 @@ impl<
                             continue;
                         }
 
-                        if !warm_preloaded_addresses.contains(addr) {
+                        if warm_addresses.is_cold(addr) {
                             acc_mut.mark_cold();
                         }
 

--- a/crates/foundry/evm/traces/src/decoder/mod.rs
+++ b/crates/foundry/evm/traces/src/decoder/mod.rs
@@ -346,9 +346,9 @@ impl CallTraceDecoder {
     /// [`CallTraceDecoder::decode_event`] for more details.
     pub async fn populate_traces(&self, traces: &mut Vec<CallTraceNode>) {
         for node in traces {
-            node.trace.decoded = self.decode_function(&node.trace).await;
+            node.trace.decoded = Some(Box::new(self.decode_function(&node.trace).await));
             for log in &mut node.logs {
-                log.decoded = self.decode_event(&log.raw_log).await;
+                log.decoded = Some(Box::new(self.decode_event(&log.raw_log).await));
             }
         }
     }

--- a/crates/foundry/evm/traces/src/lib.rs
+++ b/crates/foundry/evm/traces/src/lib.rs
@@ -107,8 +107,8 @@ impl SparsedTraceArena {
                                 .steps
                                 .get(step_idx)
                                 .expect("step_idx should be within steps bounds");
-                            if let Some(DecodedTraceStep::InternalCall(_, end_step_idx)) =
-                                &step.decoded
+                            if let Some(decoded) = &step.decoded
+                                && let DecodedTraceStep::InternalCall(_, end_step_idx) = &**decoded
                             {
                                 internal_calls.push((item_idx, remove, *end_step_idx));
                                 // we decide if we should remove it later

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -2,13 +2,13 @@ pub use revm_bytecode::{self as bytecode, Bytecode};
 pub use revm_primitives::{
     address,
     alloy_primitives::{
+        map::{hash_map, hash_set, HashMap, HashSet},
         Bloom, BloomInput, ChainId, StorageKey, StorageValue, B512, B64, U128, U160, U64, U8,
     },
     b256, bytes,
     eip3860::MAX_INITCODE_SIZE,
     hardfork::UnknownHardfork,
-    hash_map, hash_set, hex, hex_literal, keccak256, Address, Bytes, HashMap, HashSet, B256,
-    KECCAK_EMPTY, U256,
+    hex, hex_literal, keccak256, Address, Bytes, B256, KECCAK_EMPTY, U256,
 };
 
 /// The KECCAK of the RLP encoding of empty data.

--- a/crates/state/api/src/diff.rs
+++ b/crates/state/api/src/diff.rs
@@ -23,7 +23,7 @@ impl StateDiff {
             })
             .or_insert(Account {
                 info: account_info,
-                storage: HashMap::new(),
+                storage: HashMap::default(),
                 status: AccountStatus::Touched,
                 transaction_id: 0,
             });

--- a/crates/state/fork/src/lib.rs
+++ b/crates/state/fork/src/lib.rs
@@ -63,10 +63,10 @@ impl<
         Self {
             local_state,
             remote_state: Arc::new(Mutex::new(CachedRemoteState::new(remote_state))),
-            removed_storage_slots: HashSet::new(),
+            removed_storage_slots: HashSet::default(),
             current_state: RwLock::new((state_root, local_root)),
             hash_generator,
-            removed_remote_accounts: HashSet::new(),
+            removed_remote_accounts: HashSet::default(),
         }
     }
 

--- a/crates/state/persistent_trie/src/state.rs
+++ b/crates/state/persistent_trie/src/state.rs
@@ -311,7 +311,7 @@ mod tests {
     use super::*;
 
     fn precompiled_contracts() -> HashMap<Address, AccountInfo> {
-        let mut accounts = HashMap::new();
+        let mut accounts = HashMap::default();
 
         // Mimic precompiles activation
         for idx in 1..=8 {
@@ -352,7 +352,7 @@ mod tests {
 
     #[test]
     fn with_accounts_empty() {
-        let accounts = HashMap::new();
+        let accounts = HashMap::default();
         let state = PersistentAccountAndStorageTrie::with_accounts(&accounts);
 
         assert_eq!(state.state_root(), KECCAK_NULL_RLP);

--- a/crates/state/remote/src/cached.rs
+++ b/crates/state/remote/src/cached.rs
@@ -45,8 +45,8 @@ impl<
     pub fn new(remote: RemoteState<RpcBlockT, RpcReceiptT, RpcTransactionT>) -> Self {
         Self {
             remote,
-            account_cache: HashMap::new(),
-            code_cache: HashMap::new(),
+            account_cache: HashMap::default(),
+            code_cache: HashMap::default(),
         }
     }
 }

--- a/crates/test/block_replay/src/lib.rs
+++ b/crates/test/block_replay/src/lib.rs
@@ -183,7 +183,7 @@ pub async fn run_full_block<
     let state = prior_blockchain
         .state_at_block_number(block_number - 1, prior_irregular_state.state_overrides())?;
 
-    let custom_precompiles = HashMap::new();
+    let custom_precompiles = HashMap::default();
 
     let mut builder = ChainSpecT::BlockBuilder::new_block_builder(
         &prior_blockchain,
@@ -393,7 +393,7 @@ pub async fn assert_replay_header<
     let state = prior_blockchain
         .state_at_block_number(block_number - 1, prior_irregular_state.state_overrides())?;
 
-    let custom_precompiles = HashMap::new();
+    let custom_precompiles = HashMap::default();
 
     let builder = ChainSpecT::BlockBuilder::new_block_builder(
         &prior_blockchain,

--- a/crates/tool/op_chain_config_generator/src/main.rs
+++ b/crates/tool/op_chain_config_generator/src/main.rs
@@ -295,11 +295,11 @@ fn write_generated_module_file(generated_chains: Vec<ChainConfigSpec>) -> anyhow
 
         pub(super) fn chain_configs() -> HashMap<u64, ChainConfig<Hardfork>> {{
 
-            HashMap::from([
+            [
 
                 {config_tuples}
             
-            ])
+            ].into_iter().collect()
         }}
         "
     )?;


### PR DESCRIPTION
This PR upgrades REVM (and its associated child crates) to v31. Changes to the Foundry code were inspired by https://github.com/foundry-rs/foundry/pull/12094.

A follow-up PR will add the Osaka hardfork to the EDR N-API bindings and include the associated changeset.

### Merging

There are several commits on this PR that don't need to be maintained in the history, as they were only meant to fix accidental formatting. As such, this PR should be squashed before merging into the `refork-foundry-1.3.0` branch.