### PR TITLE
test: set fuzz seed by default

### DIFF
--- a/crates/edr_solidity_tests/tests/it/fuzz.rs
+++ b/crates/edr_solidity_tests/tests/it/fuzz.rs
@@ -145,6 +145,7 @@ async fn test_persist_fuzz_failure() {
     let filter = SolidityTestFilter::new(".*", ".*", ".*fuzz/FuzzFailurePersist.t.sol");
     let mut fuzz_config = TestFuzzConfig {
         runs: 1000,
+        seed: None,
         ..TestFuzzConfig::default()
     };
     let runner = TEST_DATA_DEFAULT

--- a/crates/edr_solidity_tests/tests/it/helpers.rs
+++ b/crates/edr_solidity_tests/tests/it/helpers.rs
@@ -229,7 +229,7 @@ impl Default for TestFuzzConfig {
             runs: 256,
             fail_on_revert: true,
             max_test_rejects: 65536,
-            seed: None,
+            seed: Some(U256::from(997u32)),
             dictionary: TestFuzzDictionaryConfig::default(),
             gas_report_samples: 256,
             failure_persist_dir: None,


### PR DESCRIPTION
Set fuzz seed by default for `edr_solidity_test` integration tests to avoid spurious failures. Local tests passed 25 times in a row with this.