### PR TITLE
fix: remove isolation mode hack

### DIFF
--- a/crates/edr_solidity_tests/src/multi_runner.rs
+++ b/crates/edr_solidity_tests/src/multi_runner.rs
@@ -184,7 +184,7 @@ impl<
             coverage,
             mut evm_opts,
             project_root,
-            mut cheats_config_options,
+            cheats_config_options,
             fuzz,
             invariant,
             enable_fuzz_fixtures,
@@ -208,12 +208,6 @@ impl<
             include_traces = IncludeTraces::All;
             // Enable EVM isolation for more accurate gas measurements
             evm_opts.isolate = true;
-        }
-
-        // HACK: When EVM isolation is enabled, we need to allow internal expectRevert
-        // calls because we have a bug in isolation mode.
-        if evm_opts.isolate {
-            cheats_config_options.allow_internal_expect_revert = true;
         }
 
         Ok(Self {


### PR DESCRIPTION
Removes the hack [introduced](https://github.com/NomicFoundation/edr/pull/1147/files#diff-bd0001d25e0dc485810c1b1e3f06130594c921cbe9a2fdfdd8200d4e7c041bd5R212) introduced to make isolation mode work. This allows us to validate that the Foundry refork addressed the core issue.