### PR TITLE
ci: migrate soltest benchmarks to microseconds

### DIFF
--- a/.github/workflows/edr-benchmark.yml
+++ b/.github/workflows/edr-benchmark.yml
@@ -133,8 +133,7 @@ jobs:
           tool: customSmallerIsBetter
           output-file-path: js/benchmark/soltest-report.json
           gh-repository: github.com/nomic-foundation-automation/edr-benchmark-results
-          # TODO revert this to main
-          gh-pages-branch: migrate-soltests-to-microseconds
+          gh-pages-branch: main
           benchmark-data-dir-path: soltests
           github-token: ${{ secrets.BENCHMARK_GITHUB_TOKEN }}
           # Only save the data for main branch pushes. For PRs we only compare


### PR DESCRIPTION
Switch to microseconds resolution from milliseconds for soltest benchmarks, as ms resolution is too low and it causes spurious failures.

TODOs before merging:
- https://github.com/nomic-foundation-automation/edr-benchmark-results/pull/3
- Revert 16ff8a6ae0907bf44285bba74266c34addd412b3