### PR TITLE
fix: remove check for changeset from merge queue

### DIFF
--- a/.github/workflows/check-changeset-added.yml
+++ b/.github/workflows/check-changeset-added.yml
@@ -4,8 +4,6 @@
 name: Check that the PR has a changeset
 
 on:
-  merge_group:
-    types: [checks_requested]
   pull_request:
     branches:
       - main


### PR DESCRIPTION
The "Check that the PR has a changeset" workflow is [failing](https://github.com/NomicFoundation/edr/actions/runs/19541660367/job/55965995430) for the merge queue. This seems to be because the merge queue is not aware of the original PR.

It might be useful to have this in the future, but until we find a fix, we'll rely on the reviewer flagging this.