### PR TITLE
chore: fix inconsistent function-level config override test failures

### DIFF
--- a/js/integration-tests/solidity-tests/test-contracts/InvariantTest1.t.sol
+++ b/js/integration-tests/solidity-tests/test-contracts/InvariantTest1.t.sol
@@ -4,18 +4,10 @@ pragma solidity ^0.8.18;
 import {Test} from "forge-std/src/Test.sol";
 
 contract InvariantBreaker {
-    bool public flag0 = true;
     bool public flag1 = true;
 
-    function set0(int256 val) public returns (bool) {
-        if (val % 100 == 0) {
-            flag0 = false;
-        }
-        return flag0;
-    }
-
     function set1(int256 val) public returns (bool) {
-        if (val % 10 == 0 && !flag0) {
+        if (val % 10 == 0 && val % 10 == 1) {
             flag1 = false;
         }
         return flag1;

--- a/js/integration-tests/solidity-tests/test-contracts/InvariantTestFunctionOverride.sol
+++ b/js/integration-tests/solidity-tests/test-contracts/InvariantTestFunctionOverride.sol
@@ -3,10 +3,11 @@ pragma solidity ^0.8.18;
 
 import {Test} from "forge-std/src/Test.sol";
 
-contract InvariantBreaker {
+contract TargetContractTest1 {
     bool public flag1 = true;
 
     function set1(int256 val) public returns (bool) {
+        // Condition that can never be true
         if (val % 10 == 0 && val % 10 == 1) {
             flag1 = false;
         }
@@ -14,11 +15,11 @@ contract InvariantBreaker {
     }
 }
 
-contract InvariantTest1 is Test {
-    InvariantBreaker inv;
+contract InvariantTestFunctionOverride is Test {
+    TargetContractTest1 inv;
 
     function setUp() public {
-        inv = new InvariantBreaker();
+        inv = new TargetContractTest1();
     }
 
     function invariant_neverFalse() public view {

--- a/js/integration-tests/solidity-tests/test/fuzz.ts
+++ b/js/integration-tests/solidity-tests/test/fuzz.ts
@@ -582,39 +582,47 @@ describe("Fuzz and invariant testing", function () {
     const OVERRIDEN_RUNS = 1;
     const OVERRIDEN_DEPTH = 5;
 
-    const artifact = testContext.matchingTest("InvariantTest1")[0];
+    const artifact = testContext.matchingTest(
+      "InvariantTestFunctionOverride"
+    )[0];
 
     const invariantConfig = {
       runs: GLOBAL_RUNS,
       depth: GLOBAL_DEPTH,
     };
 
-    const result1 = await testContext.runTestsWithStats("InvariantTest1", {
-      invariant: invariantConfig,
-    });
+    const result1 = await testContext.runTestsWithStats(
+      "InvariantTestFunctionOverride",
+      {
+        invariant: invariantConfig,
+      }
+    );
 
     const test_result1 = result1.suiteResults[0].testResults[0];
     const invariantKind = test_result1.kind as InvariantTestKind;
     assert.equal(invariantKind.runs, BigInt(GLOBAL_RUNS));
     assert.equal(invariantKind.calls, BigInt(GLOBAL_RUNS * GLOBAL_DEPTH));
 
-    const result2 = await testContext.runTestsWithStats("InvariantTest1", {
-      invariant: invariantConfig,
-      testFunctionOverrides: [
-        {
-          identifier: {
-            contractArtifact: artifact,
-            functionSelector: "0xd6e738f5", // invariant_neverFalse()
-          },
-          config: {
-            invariant: {
-              runs: OVERRIDEN_RUNS,
-              depth: OVERRIDEN_DEPTH,
+    const result2 = await testContext.runTestsWithStats(
+      "InvariantTestFunctionOverride",
+      {
+        invariant: invariantConfig,
+        testFunctionOverrides: [
+          {
+            identifier: {
+              contractArtifact: artifact,
+              functionSelector: "0xd6e738f5", // invariant_neverFalse()
+            },
+            config: {
+              invariant: {
+                runs: OVERRIDEN_RUNS,
+                depth: OVERRIDEN_DEPTH,
+              },
             },
           },
-        },
-      ],
-    });
+        ],
+      }
+    );
     const test_result2 = result2.suiteResults[0].testResults[0];
     const invariantKind2 = test_result2.kind as InvariantTestKind;
     assert.equal(invariantKind2.runs, BigInt(OVERRIDEN_RUNS)); // Overridden


### PR DESCRIPTION
Test was inconsistent due to a contract misassumption - the invariant testing was finding counterexamples which caused the test to fail and no more runs to be executed. Fixed the test contract to make sure it can never fail.