### PR TITLE
chore: add unsupported cheatcodes to the Vm interface

### DIFF
--- a/crates/foundry/cheatcodes/assets/cheatcodes.json
+++ b/crates/foundry/cheatcodes/assets/cheatcodes.json
@@ -3229,7 +3229,7 @@
     {
       "func": {
         "id": "attachBlob",
-        "description": "Attach an EIP-4844 blob to the next call",
+        "description": "Scripting cheatcodes are not supported.",
         "declaration": "function attachBlob(bytes calldata blob) external;",
         "visibility": "external",
         "mutability": "",
@@ -3249,7 +3249,7 @@
     {
       "func": {
         "id": "attachDelegation_0",
-        "description": "Designate the next call as an EIP-7702 transaction",
+        "description": "EIP-7702 cheatcodes are not supported.",
         "declaration": "function attachDelegation(SignedDelegation calldata signedDelegation) external;",
         "visibility": "external",
         "mutability": "",
@@ -3269,7 +3269,7 @@
     {
       "func": {
         "id": "attachDelegation_1",
-        "description": "Designate the next call as an EIP-7702 transaction, with optional cross-chain validity.",
+        "description": "EIP-7702 cheatcodes are not supported.",
         "declaration": "function attachDelegation(SignedDelegation calldata signedDelegation, bool crossChain) external;",
         "visibility": "external",
         "mutability": "",
@@ -3329,7 +3329,7 @@
     {
       "func": {
         "id": "breakpoint_0",
-        "description": "Writes a breakpoint to jump to in the debugger.",
+        "description": "Debugging cheatcodes are not supported.",
         "declaration": "function breakpoint(string calldata char) external pure;",
         "visibility": "external",
         "mutability": "pure",
@@ -3349,7 +3349,7 @@
     {
       "func": {
         "id": "breakpoint_1",
-        "description": "Writes a conditional breakpoint to jump to in the debugger.",
+        "description": "Debugging cheatcodes are not supported.",
         "declaration": "function breakpoint(string calldata char, bool value) external pure;",
         "visibility": "external",
         "mutability": "pure",
@@ -3369,7 +3369,7 @@
     {
       "func": {
         "id": "broadcastRawTransaction",
-        "description": "Takes a signed transaction and broadcasts it to the network.",
+        "description": "Scripting cheatcodes are not supported.",
         "declaration": "function broadcastRawTransaction(bytes calldata data) external;",
         "visibility": "external",
         "mutability": "",
@@ -3389,7 +3389,7 @@
     {
       "func": {
         "id": "broadcast_0",
-        "description": "Has the next call (at this call depth only) create transactions that can later be signed and sent onchain.\nBroadcasting address is determined by checking the following in order:\n1. If `--sender` argument was provided, that address is used.\n2. If exactly one signer (e.g. private key, hw wallet, keystore) is set when `forge broadcast` is invoked, that signer is used.\n3. Otherwise, default foundry sender (1804c8AB1F12E6bbf3894d4083f33e07309d1f38) is used.",
+        "description": "Scripting cheatcodes are not supported.",
         "declaration": "function broadcast() external;",
         "visibility": "external",
         "mutability": "",
@@ -3409,7 +3409,7 @@
     {
       "func": {
         "id": "broadcast_1",
-        "description": "Has the next call (at this call depth only) create a transaction with the address provided\nas the sender that can later be signed and sent onchain.",
+        "description": "Scripting cheatcodes are not supported.",
         "declaration": "function broadcast(address signer) external;",
         "visibility": "external",
         "mutability": "",
@@ -3429,7 +3429,7 @@
     {
       "func": {
         "id": "broadcast_2",
-        "description": "Has the next call (at this call depth only) create a transaction with the private key\nprovided as the sender that can later be signed and sent onchain.",
+        "description": "Scripting cheatcodes are not supported.",
         "declaration": "function broadcast(uint256 privateKey) external;",
         "visibility": "external",
         "mutability": "",
@@ -3849,7 +3849,7 @@
     {
       "func": {
         "id": "createWallet_0",
-        "description": "Derives a private key from the name, labels the account with that name, and returns the wallet.",
+        "description": "Key management cheatcodes are not supported.",
         "declaration": "function createWallet(string calldata walletLabel) external returns (Wallet memory wallet);",
         "visibility": "external",
         "mutability": "",
@@ -3869,7 +3869,7 @@
     {
       "func": {
         "id": "createWallet_1",
-        "description": "Generates a wallet from the private key and returns the wallet.",
+        "description": "Key management cheatcodes are not supported.",
         "declaration": "function createWallet(uint256 privateKey) external returns (Wallet memory wallet);",
         "visibility": "external",
         "mutability": "",
@@ -3889,7 +3889,7 @@
     {
       "func": {
         "id": "createWallet_2",
-        "description": "Generates a wallet from the private key, labels the account with that name, and returns the wallet.",
+        "description": "Key management cheatcodes are not supported.",
         "declaration": "function createWallet(uint256 privateKey, string calldata walletLabel) external returns (Wallet memory wallet);",
         "visibility": "external",
         "mutability": "",
@@ -4013,7 +4013,7 @@
     {
       "func": {
         "id": "deployCode_0",
-        "description": "Deploys a contract from an artifact file. Takes in the relative path to the json file or the path to the\nartifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.",
+        "description": "Contract deployment cheatcodes are not supported.",
         "declaration": "function deployCode(string calldata artifactPath) external returns (address deployedAddress);",
         "visibility": "external",
         "mutability": "",
@@ -4033,7 +4033,7 @@
     {
       "func": {
         "id": "deployCode_1",
-        "description": "Deploys a contract from an artifact file. Takes in the relative path to the json file or the path to the\nartifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.\nAdditionally accepts abi-encoded constructor arguments.",
+        "description": "Contract deployment cheatcodes are not supported.",
         "declaration": "function deployCode(string calldata artifactPath, bytes calldata constructorArgs) external returns (address deployedAddress);",
         "visibility": "external",
         "mutability": "",
@@ -4053,7 +4053,7 @@
     {
       "func": {
         "id": "deployCode_2",
-        "description": "Deploys a contract from an artifact file. Takes in the relative path to the json file or the path to the\nartifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.\nAdditionally accepts `msg.value`.",
+        "description": "Contract deployment cheatcodes are not supported.",
         "declaration": "function deployCode(string calldata artifactPath, uint256 value) external returns (address deployedAddress);",
         "visibility": "external",
         "mutability": "",
@@ -4073,7 +4073,7 @@
     {
       "func": {
         "id": "deployCode_3",
-        "description": "Deploys a contract from an artifact file. Takes in the relative path to the json file or the path to the\nartifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.\nAdditionally accepts abi-encoded constructor arguments and `msg.value`.",
+        "description": "Contract deployment cheatcodes are not supported.",
         "declaration": "function deployCode(string calldata artifactPath, bytes calldata constructorArgs, uint256 value) external returns (address deployedAddress);",
         "visibility": "external",
         "mutability": "",
@@ -4093,7 +4093,7 @@
     {
       "func": {
         "id": "deployCode_4",
-        "description": "Deploys a contract from an artifact file, using the CREATE2 salt. Takes in the relative path to the json file or the path to the\nartifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.",
+        "description": "Contract deployment cheatcodes are not supported.",
         "declaration": "function deployCode(string calldata artifactPath, bytes32 salt) external returns (address deployedAddress);",
         "visibility": "external",
         "mutability": "",
@@ -4113,7 +4113,7 @@
     {
       "func": {
         "id": "deployCode_5",
-        "description": "Deploys a contract from an artifact file, using the CREATE2 salt. Takes in the relative path to the json file or the path to the\nartifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.\nAdditionally accepts abi-encoded constructor arguments.",
+        "description": "Contract deployment cheatcodes are not supported.",
         "declaration": "function deployCode(string calldata artifactPath, bytes calldata constructorArgs, bytes32 salt) external returns (address deployedAddress);",
         "visibility": "external",
         "mutability": "",
@@ -4133,7 +4133,7 @@
     {
       "func": {
         "id": "deployCode_6",
-        "description": "Deploys a contract from an artifact file, using the CREATE2 salt. Takes in the relative path to the json file or the path to the\nartifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.\nAdditionally accepts `msg.value`.",
+        "description": "Contract deployment cheatcodes are not supported.",
         "declaration": "function deployCode(string calldata artifactPath, uint256 value, bytes32 salt) external returns (address deployedAddress);",
         "visibility": "external",
         "mutability": "",
@@ -4153,7 +4153,7 @@
     {
       "func": {
         "id": "deployCode_7",
-        "description": "Deploys a contract from an artifact file, using the CREATE2 salt. Takes in the relative path to the json file or the path to the\nartifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.\nAdditionally accepts abi-encoded constructor arguments and `msg.value`.",
+        "description": "Contract deployment cheatcodes are not supported.",
         "declaration": "function deployCode(string calldata artifactPath, bytes calldata constructorArgs, uint256 value, bytes32 salt) external returns (address deployedAddress);",
         "visibility": "external",
         "mutability": "",
@@ -4173,7 +4173,7 @@
     {
       "func": {
         "id": "deriveKey_0",
-        "description": "Derive a private key from a provided mnemonic string (or mnemonic file path)\nat the derivation path `m/44'/60'/0'/0/{index}`.",
+        "description": "Key management cheatcodes are not supported.",
         "declaration": "function deriveKey(string calldata mnemonic, uint32 index) external pure returns (uint256 privateKey);",
         "visibility": "external",
         "mutability": "pure",
@@ -4193,7 +4193,7 @@
     {
       "func": {
         "id": "deriveKey_1",
-        "description": "Derive a private key from a provided mnemonic string (or mnemonic file path)\nat `{derivationPath}{index}`.",
+        "description": "Key management cheatcodes are not supported.",
         "declaration": "function deriveKey(string calldata mnemonic, string calldata derivationPath, uint32 index) external pure returns (uint256 privateKey);",
         "visibility": "external",
         "mutability": "pure",
@@ -4293,7 +4293,7 @@
     {
       "func": {
         "id": "eip712HashStruct_0",
-        "description": "Generates the struct hash of the canonical EIP-712 type representation and its abi-encoded data.\nSupports 2 different inputs:\n 1. Name of the type (i.e. \"PermitSingle\"):\n    * requires previous binding generation with `forge bind-json`.\n    * bindings will be retrieved from the path configured in `foundry.toml`.\n 2. String representation of the type (i.e. \"Foo(Bar bar) Bar(uint256 baz)\").\n    * Note: the cheatcode will use the canonical type even if the input is malformated\n            with the wrong order of elements or with extra whitespaces.",
+        "description": "EIP-712 cheatcodes are not supported.",
         "declaration": "function eip712HashStruct(string calldata typeNameOrDefinition, bytes calldata abiEncodedData) external pure returns (bytes32 typeHash);",
         "visibility": "external",
         "mutability": "pure",
@@ -4313,7 +4313,7 @@
     {
       "func": {
         "id": "eip712HashStruct_1",
-        "description": "Generates the struct hash of the canonical EIP-712 type representation and its abi-encoded data.\nRequires previous binding generation with `forge bind-json`.\nParams:\n * `bindingsPath`: path where the output of `forge bind-json` is stored.\n * `typeName`: Name of the type (i.e. \"PermitSingle\").\n * `abiEncodedData`: ABI-encoded data for the struct that is being hashed.",
+        "description": "EIP-712 cheatcodes are not supported.",
         "declaration": "function eip712HashStruct(string calldata bindingsPath, string calldata typeName, bytes calldata abiEncodedData) external pure returns (bytes32 typeHash);",
         "visibility": "external",
         "mutability": "pure",
@@ -4333,7 +4333,7 @@
     {
       "func": {
         "id": "eip712HashType_0",
-        "description": "Generates the hash of the canonical EIP-712 type representation.\nSupports 2 different inputs:\n 1. Name of the type (i.e. \"Transaction\"):\n    * requires previous binding generation with `forge bind-json`.\n    * bindings will be retrieved from the path configured in `foundry.toml`.\n 2. String representation of the type (i.e. \"Foo(Bar bar) Bar(uint256 baz)\").\n    * Note: the cheatcode will output the canonical type even if the input is malformated\n            with the wrong order of elements or with extra whitespaces.",
+        "description": "EIP-712 cheatcodes are not supported.",
         "declaration": "function eip712HashType(string calldata typeNameOrDefinition) external pure returns (bytes32 typeHash);",
         "visibility": "external",
         "mutability": "pure",
@@ -4353,7 +4353,7 @@
     {
       "func": {
         "id": "eip712HashType_1",
-        "description": "Generates the hash of the canonical EIP-712 type representation.\nRequires previous binding generation with `forge bind-json`.\nParams:\n * `bindingsPath`: path where the output of `forge bind-json` is stored.\n * `typeName`: Name of the type (i.e. \"Transaction\").",
+        "description": "EIP-712 cheatcodes are not supported.",
         "declaration": "function eip712HashType(string calldata bindingsPath, string calldata typeName) external pure returns (bytes32 typeHash);",
         "visibility": "external",
         "mutability": "pure",
@@ -4373,7 +4373,7 @@
     {
       "func": {
         "id": "eip712HashTypedData",
-        "description": "Generates a ready-to-sign digest of human-readable typed data following the EIP-712 standard.",
+        "description": "EIP-712 cheatcodes are not supported.",
         "declaration": "function eip712HashTypedData(string calldata jsonData) external pure returns (bytes32 digest);",
         "visibility": "external",
         "mutability": "pure",
@@ -5853,7 +5853,7 @@
     {
       "func": {
         "id": "foundryVersionAtLeast",
-        "description": "Returns true if the current Foundry version is greater than or equal to the given version.\nThe given version string must be in the format `major.minor.patch`.\nThis is equivalent to `foundryVersionCmp(version) >= 0`.",
+        "description": "Foundry-specific version cheatcodes are not supported.",
         "declaration": "function foundryVersionAtLeast(string calldata version) external view returns (bool);",
         "visibility": "external",
         "mutability": "view",
@@ -5873,7 +5873,7 @@
     {
       "func": {
         "id": "foundryVersionCmp",
-        "description": "Compares the current Foundry version with the given version string.\nThe given version string must be in the format `major.minor.patch`.\nReturns:\n-1 if current Foundry version is less than the given version\n0 if current Foundry version equals the given version\n1 if current Foundry version is greater than the given version\nThis result can then be used with a comparison operator against `0`.\nFor example, to check if the current Foundry version is greater than or equal to `1.0.0`:\n`if (foundryVersionCmp(\"1.0.0\") >= 0) { ... }`",
+        "description": "Foundry-specific version cheatcodes are not supported.",
         "declaration": "function foundryVersionCmp(string calldata version) external view returns (int256);",
         "visibility": "external",
         "mutability": "view",
@@ -5913,7 +5913,7 @@
     {
       "func": {
         "id": "getArtifactPathByCode",
-        "description": "Gets the artifact path from code (aka. creation code).",
+        "description": "Contract deployment cheatcodes are not supported.",
         "declaration": "function getArtifactPathByCode(bytes calldata code) external view returns (string memory path);",
         "visibility": "external",
         "mutability": "view",
@@ -5933,7 +5933,7 @@
     {
       "func": {
         "id": "getArtifactPathByDeployedCode",
-        "description": "Gets the artifact path from deployed code (aka. runtime code).",
+        "description": "Contract deployment cheatcodes are not supported.",
         "declaration": "function getArtifactPathByDeployedCode(bytes calldata deployedCode) external view returns (string memory path);",
         "visibility": "external",
         "mutability": "view",
@@ -6033,7 +6033,7 @@
     {
       "func": {
         "id": "getBroadcast",
-        "description": "Returns the most recent broadcast for the given contract on `chainId` matching `txType`.\nFor example:\nThe most recent deployment can be fetched by passing `txType` as `CREATE` or `CREATE2`.\nThe most recent call can be fetched by passing `txType` as `CALL`.",
+        "description": "Contract deployment cheatcodes are not supported.",
         "declaration": "function getBroadcast(string calldata contractName, uint64 chainId, BroadcastTxType txType) external view returns (BroadcastTxSummary memory);",
         "visibility": "external",
         "mutability": "view",
@@ -6053,7 +6053,7 @@
     {
       "func": {
         "id": "getBroadcasts_0",
-        "description": "Returns all broadcasts for the given contract on `chainId` with the specified `txType`.\nSorted such that the most recent broadcast is the first element, and the oldest is the last. i.e descending order of BroadcastTxSummary.blockNumber.",
+        "description": "Contract deployment cheatcodes are not supported.",
         "declaration": "function getBroadcasts(string calldata contractName, uint64 chainId, BroadcastTxType txType) external view returns (BroadcastTxSummary[] memory);",
         "visibility": "external",
         "mutability": "view",
@@ -6073,7 +6073,7 @@
     {
       "func": {
         "id": "getBroadcasts_1",
-        "description": "Returns all broadcasts for the given contract on `chainId`.\nSorted such that the most recent broadcast is the first element, and the oldest is the last. i.e descending order of BroadcastTxSummary.blockNumber.",
+        "description": "Contract deployment cheatcodes are not supported.",
         "declaration": "function getBroadcasts(string calldata contractName, uint64 chainId) external view returns (BroadcastTxSummary[] memory);",
         "visibility": "external",
         "mutability": "view",
@@ -6173,7 +6173,7 @@
     {
       "func": {
         "id": "getDeployment_0",
-        "description": "Returns the most recent deployment for the current `chainId`.",
+        "description": "Contract deployment cheatcodes are not supported.",
         "declaration": "function getDeployment(string calldata contractName) external view returns (address deployedAddress);",
         "visibility": "external",
         "mutability": "view",
@@ -6193,7 +6193,7 @@
     {
       "func": {
         "id": "getDeployment_1",
-        "description": "Returns the most recent deployment for the given contract on `chainId`",
+        "description": "Contract deployment cheatcodes are not supported.",
         "declaration": "function getDeployment(string calldata contractName, uint64 chainId) external view returns (address deployedAddress);",
         "visibility": "external",
         "mutability": "view",
@@ -6213,7 +6213,7 @@
     {
       "func": {
         "id": "getDeployments",
-        "description": "Returns all deployments for the given contract on `chainId`\nSorted in descending order of deployment time i.e descending order of BroadcastTxSummary.blockNumber.\nThe most recent deployment is the first element, and the oldest is the last.",
+        "description": "Contract deployment cheatcodes are not supported.",
         "declaration": "function getDeployments(string calldata contractName, uint64 chainId) external view returns (address[] memory deployedAddresses);",
         "visibility": "external",
         "mutability": "view",
@@ -6233,7 +6233,7 @@
     {
       "func": {
         "id": "getFoundryVersion",
-        "description": "Returns the Foundry version.\nFormat: <cargo_version>-<tag>+<git_sha_short>.<unix_build_timestamp>.<profile>\nSample output: 0.3.0-nightly+3cb96bde9b.1737036656.debug\nNote: Build timestamps may vary slightly across platforms due to separate CI jobs.\nFor reliable version comparisons, use UNIX format (e.g., >= 1700000000)\nto compare timestamps while ignoring minor time differences.",
+        "description": "Foundry-specific version cheatcodes are not supported.",
         "declaration": "function getFoundryVersion() external view returns (string memory version);",
         "visibility": "external",
         "mutability": "view",
@@ -6433,7 +6433,7 @@
     {
       "func": {
         "id": "getWallets",
-        "description": "Returns addresses of available unlocked wallets in the script environment.",
+        "description": "Scripting cheatcodes are not supported.",
         "declaration": "function getWallets() external returns (address[] memory wallets);",
         "visibility": "external",
         "mutability": "",
@@ -8675,7 +8675,7 @@
     {
       "func": {
         "id": "rememberKeys_0",
-        "description": "Derive a set number of wallets from a mnemonic at the derivation path `m/44'/60'/0'/0/{0..count}`.\nThe respective private keys are saved to the local forge wallet for later use and their addresses are returned.",
+        "description": "Key management cheatcodes are not supported.",
         "declaration": "function rememberKeys(string calldata mnemonic, string calldata derivationPath, uint32 count) external returns (address[] memory keyAddrs);",
         "visibility": "external",
         "mutability": "",
@@ -8695,7 +8695,7 @@
     {
       "func": {
         "id": "rememberKeys_1",
-        "description": "Derive a set number of wallets from a mnemonic in the specified language at the derivation path `m/44'/60'/0'/0/{0..count}`.\nThe respective private keys are saved to the local forge wallet for later use and their addresses are returned.",
+        "description": "Key management cheatcodes are not supported.",
         "declaration": "function rememberKeys(string calldata mnemonic, string calldata derivationPath, string calldata language, uint32 count) external returns (address[] memory keyAddrs);",
         "visibility": "external",
         "mutability": "",
@@ -9739,7 +9739,7 @@
     {
       "func": {
         "id": "signAndAttachDelegation_0",
-        "description": "Sign an EIP-7702 authorization and designate the next call as an EIP-7702 transaction",
+        "description": "EIP-7702 cheatcodes are not supported.",
         "declaration": "function signAndAttachDelegation(address implementation, uint256 privateKey) external returns (SignedDelegation memory signedDelegation);",
         "visibility": "external",
         "mutability": "",
@@ -9759,7 +9759,7 @@
     {
       "func": {
         "id": "signAndAttachDelegation_1",
-        "description": "Sign an EIP-7702 authorization and designate the next call as an EIP-7702 transaction for specific nonce",
+        "description": "EIP-7702 cheatcodes are not supported.",
         "declaration": "function signAndAttachDelegation(address implementation, uint256 privateKey, uint64 nonce) external returns (SignedDelegation memory signedDelegation);",
         "visibility": "external",
         "mutability": "",
@@ -9779,7 +9779,7 @@
     {
       "func": {
         "id": "signAndAttachDelegation_2",
-        "description": "Sign an EIP-7702 authorization and designate the next call as an EIP-7702 transaction, with optional cross-chain validity.",
+        "description": "EIP-7702 cheatcodes are not supported.",
         "declaration": "function signAndAttachDelegation(address implementation, uint256 privateKey, bool crossChain) external returns (SignedDelegation memory signedDelegation);",
         "visibility": "external",
         "mutability": "",
@@ -9819,7 +9819,7 @@
     {
       "func": {
         "id": "signDelegation_0",
-        "description": "Sign an EIP-7702 authorization for delegation",
+        "description": "EIP-7702 cheatcodes are not supported.",
         "declaration": "function signDelegation(address implementation, uint256 privateKey) external returns (SignedDelegation memory signedDelegation);",
         "visibility": "external",
         "mutability": "",
@@ -9839,7 +9839,7 @@
     {
       "func": {
         "id": "signDelegation_1",
-        "description": "Sign an EIP-7702 authorization for delegation for specific nonce",
+        "description": "EIP-7702 cheatcodes are not supported.",
         "declaration": "function signDelegation(address implementation, uint256 privateKey, uint64 nonce) external returns (SignedDelegation memory signedDelegation);",
         "visibility": "external",
         "mutability": "",
@@ -9859,7 +9859,7 @@
     {
       "func": {
         "id": "signDelegation_2",
-        "description": "Sign an EIP-7702 authorization for delegation, with optional cross-chain validity.",
+        "description": "EIP-7702 cheatcodes are not supported.",
         "declaration": "function signDelegation(address implementation, uint256 privateKey, bool crossChain) external returns (SignedDelegation memory signedDelegation);",
         "visibility": "external",
         "mutability": "",
@@ -10121,7 +10121,7 @@
     {
       "func": {
         "id": "startBroadcast_0",
-        "description": "Has all subsequent calls (at this call depth only) create transactions that can later be signed and sent onchain.\nBroadcasting address is determined by checking the following in order:\n1. If `--sender` argument was provided, that address is used.\n2. If exactly one signer (e.g. private key, hw wallet, keystore) is set when `forge broadcast` is invoked, that signer is used.\n3. Otherwise, default foundry sender (1804c8AB1F12E6bbf3894d4083f33e07309d1f38) is used.",
+        "description": "Scripting cheatcodes are not supported.",
         "declaration": "function startBroadcast() external;",
         "visibility": "external",
         "mutability": "",
@@ -10141,7 +10141,7 @@
     {
       "func": {
         "id": "startBroadcast_1",
-        "description": "Has all subsequent calls (at this call depth only) create transactions with the address\nprovided that can later be signed and sent onchain.",
+        "description": "Scripting cheatcodes are not supported.",
         "declaration": "function startBroadcast(address signer) external;",
         "visibility": "external",
         "mutability": "",
@@ -10161,7 +10161,7 @@
     {
       "func": {
         "id": "startBroadcast_2",
-        "description": "Has all subsequent calls (at this call depth only) create transactions with the private key\nprovided that can later be signed and sent onchain.",
+        "description": "Scripting cheatcodes are not supported.",
         "declaration": "function startBroadcast(uint256 privateKey) external;",
         "visibility": "external",
         "mutability": "",
@@ -10401,7 +10401,7 @@
     {
       "func": {
         "id": "stopBroadcast",
-        "description": "Stops collecting onchain transactions.",
+        "description": "Scripting cheatcodes are not supported.",
         "declaration": "function stopBroadcast() external;",
         "visibility": "external",
         "mutability": "",

--- a/crates/foundry/cheatcodes/assets/cheatcodes.json
+++ b/crates/foundry/cheatcodes/assets/cheatcodes.json
@@ -101,6 +101,24 @@
           "description": "Unknown execution context."
         }
       ]
+    },
+    {
+      "name": "BroadcastTxType",
+      "description": "The transaction type (`txType`) of the broadcast.",
+      "variants": [
+        {
+          "name": "Call",
+          "description": ""
+        },
+        {
+          "name": "Create",
+          "description": ""
+        },
+        {
+          "name": "Create2",
+          "description": ""
+        }
+      ]
     }
   ],
   "structs": [
@@ -535,6 +553,94 @@
           "name": "storageKeys",
           "ty": "bytes32[]",
           "description": "The storage keys to be added in access list."
+        }
+      ]
+    },
+    {
+      "name": "BroadcastTxSummary",
+      "description": "Represents a transaction's broadcast details.",
+      "fields": [
+        {
+          "name": "txHash",
+          "ty": "bytes32",
+          "description": ""
+        },
+        {
+          "name": "txType",
+          "ty": "BroadcastTxType",
+          "description": ""
+        },
+        {
+          "name": "contractAddress",
+          "ty": "address",
+          "description": ""
+        },
+        {
+          "name": "blockNumber",
+          "ty": "uint64",
+          "description": ""
+        },
+        {
+          "name": "success",
+          "ty": "bool",
+          "description": ""
+        }
+      ]
+    },
+    {
+      "name": "SignedDelegation",
+      "description": "Holds a signed EIP-7702 authorization for an authority account to delegate to an implementation.",
+      "fields": [
+        {
+          "name": "v",
+          "ty": "uint8",
+          "description": "The y-parity of the recovered secp256k1 signature (0 or 1)."
+        },
+        {
+          "name": "r",
+          "ty": "bytes32",
+          "description": "First 32 bytes of the signature."
+        },
+        {
+          "name": "s",
+          "ty": "bytes32",
+          "description": "Second 32 bytes of the signature."
+        },
+        {
+          "name": "nonce",
+          "ty": "uint64",
+          "description": "The current nonce of the authority account at signing time.\n Used to ensure signature can't be replayed after account nonce changes."
+        },
+        {
+          "name": "implementation",
+          "ty": "address",
+          "description": "Address of the contract implementation that will be delegated to.\n Gets encoded into delegation code: 0xef0100 || implementation."
+        }
+      ]
+    },
+    {
+      "name": "Wallet",
+      "description": "A wallet with a public and private key.",
+      "fields": [
+        {
+          "name": "addr",
+          "ty": "address",
+          "description": ""
+        },
+        {
+          "name": "publicKeyX",
+          "ty": "uint256",
+          "description": ""
+        },
+        {
+          "name": "publicKeyY",
+          "ty": "uint256",
+          "description": ""
+        },
+        {
+          "name": "privateKey",
+          "ty": "uint256",
+          "description": ""
         }
       ]
     }
@@ -3122,6 +3228,66 @@
     },
     {
       "func": {
+        "id": "attachBlob",
+        "description": "Attach an EIP-4844 blob to the next call",
+        "declaration": "function attachBlob(bytes calldata blob) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "attachBlob(bytes)",
+        "selector": "0x10cb385c",
+        "selectorBytes": [
+          16,
+          203,
+          56,
+          92
+        ]
+      },
+      "group": "scripting",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "attachDelegation_0",
+        "description": "Designate the next call as an EIP-7702 transaction",
+        "declaration": "function attachDelegation(SignedDelegation calldata signedDelegation) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "attachDelegation((uint8,bytes32,bytes32,uint64,address))",
+        "selector": "0x14ae3519",
+        "selectorBytes": [
+          20,
+          174,
+          53,
+          25
+        ]
+      },
+      "group": "scripting",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "attachDelegation_1",
+        "description": "Designate the next call as an EIP-7702 transaction, with optional cross-chain validity.",
+        "declaration": "function attachDelegation(SignedDelegation calldata signedDelegation, bool crossChain) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "attachDelegation((uint8,bytes32,bytes32,uint64,address),bool)",
+        "selector": "0xf4460d34",
+        "selectorBytes": [
+          244,
+          70,
+          13,
+          52
+        ]
+      },
+      "group": "scripting",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
         "id": "blobBaseFee",
         "description": "Sets `block.blobbasefee`",
         "declaration": "function blobBaseFee(uint256 newBlobBaseFee) external;",
@@ -3159,6 +3325,126 @@
       "group": "evm",
       "status": "stable",
       "safety": "unsafe"
+    },
+    {
+      "func": {
+        "id": "breakpoint_0",
+        "description": "Writes a breakpoint to jump to in the debugger.",
+        "declaration": "function breakpoint(string calldata char) external pure;",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "breakpoint(string)",
+        "selector": "0xf0259e92",
+        "selectorBytes": [
+          240,
+          37,
+          158,
+          146
+        ]
+      },
+      "group": "testing",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "breakpoint_1",
+        "description": "Writes a conditional breakpoint to jump to in the debugger.",
+        "declaration": "function breakpoint(string calldata char, bool value) external pure;",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "breakpoint(string,bool)",
+        "selector": "0xf7d39a8d",
+        "selectorBytes": [
+          247,
+          211,
+          154,
+          141
+        ]
+      },
+      "group": "testing",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "broadcastRawTransaction",
+        "description": "Takes a signed transaction and broadcasts it to the network.",
+        "declaration": "function broadcastRawTransaction(bytes calldata data) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "broadcastRawTransaction(bytes)",
+        "selector": "0x8c0c72e0",
+        "selectorBytes": [
+          140,
+          12,
+          114,
+          224
+        ]
+      },
+      "group": "scripting",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "broadcast_0",
+        "description": "Has the next call (at this call depth only) create transactions that can later be signed and sent onchain.\nBroadcasting address is determined by checking the following in order:\n1. If `--sender` argument was provided, that address is used.\n2. If exactly one signer (e.g. private key, hw wallet, keystore) is set when `forge broadcast` is invoked, that signer is used.\n3. Otherwise, default foundry sender (1804c8AB1F12E6bbf3894d4083f33e07309d1f38) is used.",
+        "declaration": "function broadcast() external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "broadcast()",
+        "selector": "0xafc98040",
+        "selectorBytes": [
+          175,
+          201,
+          128,
+          64
+        ]
+      },
+      "group": "scripting",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "broadcast_1",
+        "description": "Has the next call (at this call depth only) create a transaction with the address provided\nas the sender that can later be signed and sent onchain.",
+        "declaration": "function broadcast(address signer) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "broadcast(address)",
+        "selector": "0xe6962cdb",
+        "selectorBytes": [
+          230,
+          150,
+          44,
+          219
+        ]
+      },
+      "group": "scripting",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "broadcast_2",
+        "description": "Has the next call (at this call depth only) create a transaction with the private key\nprovided as the sender that can later be signed and sent onchain.",
+        "declaration": "function broadcast(uint256 privateKey) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "broadcast(uint256)",
+        "selector": "0xf67a965b",
+        "selectorBytes": [
+          246,
+          122,
+          150,
+          91
+        ]
+      },
+      "group": "scripting",
+      "status": "unsupported",
+      "safety": "safe"
     },
     {
       "func": {
@@ -3562,6 +3848,66 @@
     },
     {
       "func": {
+        "id": "createWallet_0",
+        "description": "Derives a private key from the name, labels the account with that name, and returns the wallet.",
+        "declaration": "function createWallet(string calldata walletLabel) external returns (Wallet memory wallet);",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "createWallet(string)",
+        "selector": "0x7404f1d2",
+        "selectorBytes": [
+          116,
+          4,
+          241,
+          210
+        ]
+      },
+      "group": "crypto",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "createWallet_1",
+        "description": "Generates a wallet from the private key and returns the wallet.",
+        "declaration": "function createWallet(uint256 privateKey) external returns (Wallet memory wallet);",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "createWallet(uint256)",
+        "selector": "0x7a675bb6",
+        "selectorBytes": [
+          122,
+          103,
+          91,
+          182
+        ]
+      },
+      "group": "crypto",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "createWallet_2",
+        "description": "Generates a wallet from the private key, labels the account with that name, and returns the wallet.",
+        "declaration": "function createWallet(uint256 privateKey, string calldata walletLabel) external returns (Wallet memory wallet);",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "createWallet(uint256,string)",
+        "selector": "0xed7c5462",
+        "selectorBytes": [
+          237,
+          124,
+          84,
+          98
+        ]
+      },
+      "group": "crypto",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
         "id": "deal",
         "description": "Sets an address' balance.",
         "declaration": "function deal(address account, uint256 newBalance) external;",
@@ -3666,6 +4012,246 @@
     },
     {
       "func": {
+        "id": "deployCode_0",
+        "description": "Deploys a contract from an artifact file. Takes in the relative path to the json file or the path to the\nartifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.",
+        "declaration": "function deployCode(string calldata artifactPath) external returns (address deployedAddress);",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "deployCode(string)",
+        "selector": "0x9a8325a0",
+        "selectorBytes": [
+          154,
+          131,
+          37,
+          160
+        ]
+      },
+      "group": "filesystem",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "deployCode_1",
+        "description": "Deploys a contract from an artifact file. Takes in the relative path to the json file or the path to the\nartifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.\nAdditionally accepts abi-encoded constructor arguments.",
+        "declaration": "function deployCode(string calldata artifactPath, bytes calldata constructorArgs) external returns (address deployedAddress);",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "deployCode(string,bytes)",
+        "selector": "0x29ce9dde",
+        "selectorBytes": [
+          41,
+          206,
+          157,
+          222
+        ]
+      },
+      "group": "filesystem",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "deployCode_2",
+        "description": "Deploys a contract from an artifact file. Takes in the relative path to the json file or the path to the\nartifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.\nAdditionally accepts `msg.value`.",
+        "declaration": "function deployCode(string calldata artifactPath, uint256 value) external returns (address deployedAddress);",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "deployCode(string,uint256)",
+        "selector": "0x0af6a701",
+        "selectorBytes": [
+          10,
+          246,
+          167,
+          1
+        ]
+      },
+      "group": "filesystem",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "deployCode_3",
+        "description": "Deploys a contract from an artifact file. Takes in the relative path to the json file or the path to the\nartifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.\nAdditionally accepts abi-encoded constructor arguments and `msg.value`.",
+        "declaration": "function deployCode(string calldata artifactPath, bytes calldata constructorArgs, uint256 value) external returns (address deployedAddress);",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "deployCode(string,bytes,uint256)",
+        "selector": "0xff5d64e4",
+        "selectorBytes": [
+          255,
+          93,
+          100,
+          228
+        ]
+      },
+      "group": "filesystem",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "deployCode_4",
+        "description": "Deploys a contract from an artifact file, using the CREATE2 salt. Takes in the relative path to the json file or the path to the\nartifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.",
+        "declaration": "function deployCode(string calldata artifactPath, bytes32 salt) external returns (address deployedAddress);",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "deployCode(string,bytes32)",
+        "selector": "0x17ab1d79",
+        "selectorBytes": [
+          23,
+          171,
+          29,
+          121
+        ]
+      },
+      "group": "filesystem",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "deployCode_5",
+        "description": "Deploys a contract from an artifact file, using the CREATE2 salt. Takes in the relative path to the json file or the path to the\nartifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.\nAdditionally accepts abi-encoded constructor arguments.",
+        "declaration": "function deployCode(string calldata artifactPath, bytes calldata constructorArgs, bytes32 salt) external returns (address deployedAddress);",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "deployCode(string,bytes,bytes32)",
+        "selector": "0x016155bf",
+        "selectorBytes": [
+          1,
+          97,
+          85,
+          191
+        ]
+      },
+      "group": "filesystem",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "deployCode_6",
+        "description": "Deploys a contract from an artifact file, using the CREATE2 salt. Takes in the relative path to the json file or the path to the\nartifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.\nAdditionally accepts `msg.value`.",
+        "declaration": "function deployCode(string calldata artifactPath, uint256 value, bytes32 salt) external returns (address deployedAddress);",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "deployCode(string,uint256,bytes32)",
+        "selector": "0x002cb687",
+        "selectorBytes": [
+          0,
+          44,
+          182,
+          135
+        ]
+      },
+      "group": "filesystem",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "deployCode_7",
+        "description": "Deploys a contract from an artifact file, using the CREATE2 salt. Takes in the relative path to the json file or the path to the\nartifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.\nAdditionally accepts abi-encoded constructor arguments and `msg.value`.",
+        "declaration": "function deployCode(string calldata artifactPath, bytes calldata constructorArgs, uint256 value, bytes32 salt) external returns (address deployedAddress);",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "deployCode(string,bytes,uint256,bytes32)",
+        "selector": "0x3aa773ea",
+        "selectorBytes": [
+          58,
+          167,
+          115,
+          234
+        ]
+      },
+      "group": "filesystem",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "deriveKey_0",
+        "description": "Derive a private key from a provided mnemonic string (or mnemonic file path)\nat the derivation path `m/44'/60'/0'/0/{index}`.",
+        "declaration": "function deriveKey(string calldata mnemonic, uint32 index) external pure returns (uint256 privateKey);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "deriveKey(string,uint32)",
+        "selector": "0x6229498b",
+        "selectorBytes": [
+          98,
+          41,
+          73,
+          139
+        ]
+      },
+      "group": "crypto",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "deriveKey_1",
+        "description": "Derive a private key from a provided mnemonic string (or mnemonic file path)\nat `{derivationPath}{index}`.",
+        "declaration": "function deriveKey(string calldata mnemonic, string calldata derivationPath, uint32 index) external pure returns (uint256 privateKey);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "deriveKey(string,string,uint32)",
+        "selector": "0x6bcb2c1b",
+        "selectorBytes": [
+          107,
+          203,
+          44,
+          27
+        ]
+      },
+      "group": "crypto",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "deriveKey_2",
+        "description": "Derive a private key from a provided mnemonic string (or mnemonic file path) in the specified language\nat the derivation path `m/44'/60'/0'/0/{index}`.",
+        "declaration": "function deriveKey(string calldata mnemonic, uint32 index, string calldata language) external pure returns (uint256 privateKey);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "deriveKey(string,uint32,string)",
+        "selector": "0x32c8176d",
+        "selectorBytes": [
+          50,
+          200,
+          23,
+          109
+        ]
+      },
+      "group": "crypto",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "deriveKey_3",
+        "description": "Derive a private key from a provided mnemonic string (or mnemonic file path) in the specified language\nat `{derivationPath}{index}`.",
+        "declaration": "function deriveKey(string calldata mnemonic, string calldata derivationPath, uint32 index, string calldata language) external pure returns (uint256 privateKey);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "deriveKey(string,string,uint32,string)",
+        "selector": "0x29233b1f",
+        "selectorBytes": [
+          41,
+          35,
+          59,
+          31
+        ]
+      },
+      "group": "crypto",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
         "id": "difficulty",
         "description": "Sets `block.difficulty`.\nNot available on EVM versions from Paris onwards. Use `prevrandao` instead.\nReverts if used on unsupported EVM versions.",
         "declaration": "function difficulty(uint256 newDifficulty) external;",
@@ -3703,6 +4289,106 @@
       "group": "evm",
       "status": "stable",
       "safety": "unsafe"
+    },
+    {
+      "func": {
+        "id": "eip712HashStruct_0",
+        "description": "Generates the struct hash of the canonical EIP-712 type representation and its abi-encoded data.\nSupports 2 different inputs:\n 1. Name of the type (i.e. \"PermitSingle\"):\n    * requires previous binding generation with `forge bind-json`.\n    * bindings will be retrieved from the path configured in `foundry.toml`.\n 2. String representation of the type (i.e. \"Foo(Bar bar) Bar(uint256 baz)\").\n    * Note: the cheatcode will use the canonical type even if the input is malformated\n            with the wrong order of elements or with extra whitespaces.",
+        "declaration": "function eip712HashStruct(string calldata typeNameOrDefinition, bytes calldata abiEncodedData) external pure returns (bytes32 typeHash);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "eip712HashStruct(string,bytes)",
+        "selector": "0xaedeaebc",
+        "selectorBytes": [
+          174,
+          222,
+          174,
+          188
+        ]
+      },
+      "group": "utilities",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "eip712HashStruct_1",
+        "description": "Generates the struct hash of the canonical EIP-712 type representation and its abi-encoded data.\nRequires previous binding generation with `forge bind-json`.\nParams:\n * `bindingsPath`: path where the output of `forge bind-json` is stored.\n * `typeName`: Name of the type (i.e. \"PermitSingle\").\n * `abiEncodedData`: ABI-encoded data for the struct that is being hashed.",
+        "declaration": "function eip712HashStruct(string calldata bindingsPath, string calldata typeName, bytes calldata abiEncodedData) external pure returns (bytes32 typeHash);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "eip712HashStruct(string,string,bytes)",
+        "selector": "0x6d06c57c",
+        "selectorBytes": [
+          109,
+          6,
+          197,
+          124
+        ]
+      },
+      "group": "utilities",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "eip712HashType_0",
+        "description": "Generates the hash of the canonical EIP-712 type representation.\nSupports 2 different inputs:\n 1. Name of the type (i.e. \"Transaction\"):\n    * requires previous binding generation with `forge bind-json`.\n    * bindings will be retrieved from the path configured in `foundry.toml`.\n 2. String representation of the type (i.e. \"Foo(Bar bar) Bar(uint256 baz)\").\n    * Note: the cheatcode will output the canonical type even if the input is malformated\n            with the wrong order of elements or with extra whitespaces.",
+        "declaration": "function eip712HashType(string calldata typeNameOrDefinition) external pure returns (bytes32 typeHash);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "eip712HashType(string)",
+        "selector": "0x6792e9e2",
+        "selectorBytes": [
+          103,
+          146,
+          233,
+          226
+        ]
+      },
+      "group": "utilities",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "eip712HashType_1",
+        "description": "Generates the hash of the canonical EIP-712 type representation.\nRequires previous binding generation with `forge bind-json`.\nParams:\n * `bindingsPath`: path where the output of `forge bind-json` is stored.\n * `typeName`: Name of the type (i.e. \"Transaction\").",
+        "declaration": "function eip712HashType(string calldata bindingsPath, string calldata typeName) external pure returns (bytes32 typeHash);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "eip712HashType(string,string)",
+        "selector": "0x18fb6406",
+        "selectorBytes": [
+          24,
+          251,
+          100,
+          6
+        ]
+      },
+      "group": "utilities",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "eip712HashTypedData",
+        "description": "Generates a ready-to-sign digest of human-readable typed data following the EIP-712 standard.",
+        "declaration": "function eip712HashTypedData(string calldata jsonData) external pure returns (bytes32 digest);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "eip712HashTypedData(string)",
+        "selector": "0xea25e615",
+        "selectorBytes": [
+          234,
+          37,
+          230,
+          21
+        ]
+      },
+      "group": "utilities",
+      "status": "unsupported",
+      "safety": "safe"
     },
     {
       "func": {
@@ -5166,6 +5852,46 @@
     },
     {
       "func": {
+        "id": "foundryVersionAtLeast",
+        "description": "Returns true if the current Foundry version is greater than or equal to the given version.\nThe given version string must be in the format `major.minor.patch`.\nThis is equivalent to `foundryVersionCmp(version) >= 0`.",
+        "declaration": "function foundryVersionAtLeast(string calldata version) external view returns (bool);",
+        "visibility": "external",
+        "mutability": "view",
+        "signature": "foundryVersionAtLeast(string)",
+        "selector": "0x6248be1f",
+        "selectorBytes": [
+          98,
+          72,
+          190,
+          31
+        ]
+      },
+      "group": "testing",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "foundryVersionCmp",
+        "description": "Compares the current Foundry version with the given version string.\nThe given version string must be in the format `major.minor.patch`.\nReturns:\n-1 if current Foundry version is less than the given version\n0 if current Foundry version equals the given version\n1 if current Foundry version is greater than the given version\nThis result can then be used with a comparison operator against `0`.\nFor example, to check if the current Foundry version is greater than or equal to `1.0.0`:\n`if (foundryVersionCmp(\"1.0.0\") >= 0) { ... }`",
+        "declaration": "function foundryVersionCmp(string calldata version) external view returns (int256);",
+        "visibility": "external",
+        "mutability": "view",
+        "signature": "foundryVersionCmp(string)",
+        "selector": "0xca7b0a09",
+        "selectorBytes": [
+          202,
+          123,
+          10,
+          9
+        ]
+      },
+      "group": "testing",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
         "id": "fsMetadata",
         "description": "Given a path, query the file system to get information about a file, directory, etc.",
         "declaration": "function fsMetadata(string calldata path) external view returns (FsMetadata memory metadata);",
@@ -5182,6 +5908,46 @@
       },
       "group": "filesystem",
       "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "getArtifactPathByCode",
+        "description": "Gets the artifact path from code (aka. creation code).",
+        "declaration": "function getArtifactPathByCode(bytes calldata code) external view returns (string memory path);",
+        "visibility": "external",
+        "mutability": "view",
+        "signature": "getArtifactPathByCode(bytes)",
+        "selector": "0xeb74848c",
+        "selectorBytes": [
+          235,
+          116,
+          132,
+          140
+        ]
+      },
+      "group": "filesystem",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "getArtifactPathByDeployedCode",
+        "description": "Gets the artifact path from deployed code (aka. runtime code).",
+        "declaration": "function getArtifactPathByDeployedCode(bytes calldata deployedCode) external view returns (string memory path);",
+        "visibility": "external",
+        "mutability": "view",
+        "signature": "getArtifactPathByDeployedCode(bytes)",
+        "selector": "0x6d853ba5",
+        "selectorBytes": [
+          109,
+          133,
+          59,
+          165
+        ]
+      },
+      "group": "filesystem",
+      "status": "unsupported",
       "safety": "safe"
     },
     {
@@ -5266,6 +6032,66 @@
     },
     {
       "func": {
+        "id": "getBroadcast",
+        "description": "Returns the most recent broadcast for the given contract on `chainId` matching `txType`.\nFor example:\nThe most recent deployment can be fetched by passing `txType` as `CREATE` or `CREATE2`.\nThe most recent call can be fetched by passing `txType` as `CALL`.",
+        "declaration": "function getBroadcast(string calldata contractName, uint64 chainId, BroadcastTxType txType) external view returns (BroadcastTxSummary memory);",
+        "visibility": "external",
+        "mutability": "view",
+        "signature": "getBroadcast(string,uint64,uint8)",
+        "selector": "0x3dc90cb3",
+        "selectorBytes": [
+          61,
+          201,
+          12,
+          179
+        ]
+      },
+      "group": "filesystem",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "getBroadcasts_0",
+        "description": "Returns all broadcasts for the given contract on `chainId` with the specified `txType`.\nSorted such that the most recent broadcast is the first element, and the oldest is the last. i.e descending order of BroadcastTxSummary.blockNumber.",
+        "declaration": "function getBroadcasts(string calldata contractName, uint64 chainId, BroadcastTxType txType) external view returns (BroadcastTxSummary[] memory);",
+        "visibility": "external",
+        "mutability": "view",
+        "signature": "getBroadcasts(string,uint64,uint8)",
+        "selector": "0xf7afe919",
+        "selectorBytes": [
+          247,
+          175,
+          233,
+          25
+        ]
+      },
+      "group": "filesystem",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "getBroadcasts_1",
+        "description": "Returns all broadcasts for the given contract on `chainId`.\nSorted such that the most recent broadcast is the first element, and the oldest is the last. i.e descending order of BroadcastTxSummary.blockNumber.",
+        "declaration": "function getBroadcasts(string calldata contractName, uint64 chainId) external view returns (BroadcastTxSummary[] memory);",
+        "visibility": "external",
+        "mutability": "view",
+        "signature": "getBroadcasts(string,uint64)",
+        "selector": "0xf2fa4a26",
+        "selectorBytes": [
+          242,
+          250,
+          74,
+          38
+        ]
+      },
+      "group": "filesystem",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
         "id": "getChain_0",
         "description": "Returns a Chain struct for specific alias",
         "declaration": "function getChain(string calldata chainAlias) external view returns (Chain memory chain);",
@@ -5342,6 +6168,86 @@
       },
       "group": "filesystem",
       "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "getDeployment_0",
+        "description": "Returns the most recent deployment for the current `chainId`.",
+        "declaration": "function getDeployment(string calldata contractName) external view returns (address deployedAddress);",
+        "visibility": "external",
+        "mutability": "view",
+        "signature": "getDeployment(string)",
+        "selector": "0xa8091d97",
+        "selectorBytes": [
+          168,
+          9,
+          29,
+          151
+        ]
+      },
+      "group": "filesystem",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "getDeployment_1",
+        "description": "Returns the most recent deployment for the given contract on `chainId`",
+        "declaration": "function getDeployment(string calldata contractName, uint64 chainId) external view returns (address deployedAddress);",
+        "visibility": "external",
+        "mutability": "view",
+        "signature": "getDeployment(string,uint64)",
+        "selector": "0x0debd5d6",
+        "selectorBytes": [
+          13,
+          235,
+          213,
+          214
+        ]
+      },
+      "group": "filesystem",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "getDeployments",
+        "description": "Returns all deployments for the given contract on `chainId`\nSorted in descending order of deployment time i.e descending order of BroadcastTxSummary.blockNumber.\nThe most recent deployment is the first element, and the oldest is the last.",
+        "declaration": "function getDeployments(string calldata contractName, uint64 chainId) external view returns (address[] memory deployedAddresses);",
+        "visibility": "external",
+        "mutability": "view",
+        "signature": "getDeployments(string,uint64)",
+        "selector": "0x74e133dd",
+        "selectorBytes": [
+          116,
+          225,
+          51,
+          221
+        ]
+      },
+      "group": "filesystem",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "getFoundryVersion",
+        "description": "Returns the Foundry version.\nFormat: <cargo_version>-<tag>+<git_sha_short>.<unix_build_timestamp>.<profile>\nSample output: 0.3.0-nightly+3cb96bde9b.1737036656.debug\nNote: Build timestamps may vary slightly across platforms due to separate CI jobs.\nFor reliable version comparisons, use UNIX format (e.g., >= 1700000000)\nto compare timestamps while ignoring minor time differences.",
+        "declaration": "function getFoundryVersion() external view returns (string memory version);",
+        "visibility": "external",
+        "mutability": "view",
+        "signature": "getFoundryVersion()",
+        "selector": "0xea991bb5",
+        "selectorBytes": [
+          234,
+          153,
+          27,
+          181
+        ]
+      },
+      "group": "testing",
+      "status": "unsupported",
       "safety": "safe"
     },
     {
@@ -5522,6 +6428,26 @@
       },
       "group": "evm",
       "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "getWallets",
+        "description": "Returns addresses of available unlocked wallets in the script environment.",
+        "declaration": "function getWallets() external returns (address[] memory wallets);",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "getWallets()",
+        "selector": "0xdb7a4605",
+        "selectorBytes": [
+          219,
+          122,
+          70,
+          5
+        ]
+      },
+      "group": "scripting",
+      "status": "unsupported",
       "safety": "safe"
     },
     {
@@ -7728,6 +8654,66 @@
     },
     {
       "func": {
+        "id": "rememberKey",
+        "description": "Adds a private key to the local forge wallet and returns the address.",
+        "declaration": "function rememberKey(uint256 privateKey) external returns (address keyAddr);",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "rememberKey(uint256)",
+        "selector": "0x22100064",
+        "selectorBytes": [
+          34,
+          16,
+          0,
+          100
+        ]
+      },
+      "group": "crypto",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "rememberKeys_0",
+        "description": "Derive a set number of wallets from a mnemonic at the derivation path `m/44'/60'/0'/0/{0..count}`.\nThe respective private keys are saved to the local forge wallet for later use and their addresses are returned.",
+        "declaration": "function rememberKeys(string calldata mnemonic, string calldata derivationPath, uint32 count) external returns (address[] memory keyAddrs);",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "rememberKeys(string,string,uint32)",
+        "selector": "0x97cb9189",
+        "selectorBytes": [
+          151,
+          203,
+          145,
+          137
+        ]
+      },
+      "group": "crypto",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "rememberKeys_1",
+        "description": "Derive a set number of wallets from a mnemonic in the specified language at the derivation path `m/44'/60'/0'/0/{0..count}`.\nThe respective private keys are saved to the local forge wallet for later use and their addresses are returned.",
+        "declaration": "function rememberKeys(string calldata mnemonic, string calldata derivationPath, string calldata language, uint32 count) external returns (address[] memory keyAddrs);",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "rememberKeys(string,string,string,uint32)",
+        "selector": "0xf8d58eaf",
+        "selectorBytes": [
+          248,
+          213,
+          142,
+          175
+        ]
+      },
+      "group": "crypto",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
         "id": "removeDir",
         "description": "Removes a directory at the provided path.\nThis cheatcode will revert in the following situations, but is not limited to just these cases:\n- `path` doesn't exist.\n- `path` isn't a directory.\n- User lacks permissions to modify `path`.\n- The directory is not empty and `recursive` is false.\n`path` is relative to the project root.",
         "declaration": "function removeDir(string calldata path, bool recursive) external;",
@@ -8752,6 +9738,66 @@
     },
     {
       "func": {
+        "id": "signAndAttachDelegation_0",
+        "description": "Sign an EIP-7702 authorization and designate the next call as an EIP-7702 transaction",
+        "declaration": "function signAndAttachDelegation(address implementation, uint256 privateKey) external returns (SignedDelegation memory signedDelegation);",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "signAndAttachDelegation(address,uint256)",
+        "selector": "0xc7fa7288",
+        "selectorBytes": [
+          199,
+          250,
+          114,
+          136
+        ]
+      },
+      "group": "scripting",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "signAndAttachDelegation_1",
+        "description": "Sign an EIP-7702 authorization and designate the next call as an EIP-7702 transaction for specific nonce",
+        "declaration": "function signAndAttachDelegation(address implementation, uint256 privateKey, uint64 nonce) external returns (SignedDelegation memory signedDelegation);",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "signAndAttachDelegation(address,uint256,uint64)",
+        "selector": "0xcde3e5be",
+        "selectorBytes": [
+          205,
+          227,
+          229,
+          190
+        ]
+      },
+      "group": "scripting",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "signAndAttachDelegation_2",
+        "description": "Sign an EIP-7702 authorization and designate the next call as an EIP-7702 transaction, with optional cross-chain validity.",
+        "declaration": "function signAndAttachDelegation(address implementation, uint256 privateKey, bool crossChain) external returns (SignedDelegation memory signedDelegation);",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "signAndAttachDelegation(address,uint256,bool)",
+        "selector": "0xd936e146",
+        "selectorBytes": [
+          217,
+          54,
+          225,
+          70
+        ]
+      },
+      "group": "scripting",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
         "id": "signCompact",
         "description": "Signs `digest` with `privateKey` using the secp256k1 curve.\nReturns a compact signature (`r`, `vs`) as per EIP-2098, where `vs` encodes both the\nsignature's `s` value, and the recovery id `v` in a single bytes32.\nThis format reduces the signature size from 65 to 64 bytes.",
         "declaration": "function signCompact(uint256 privateKey, bytes32 digest) external pure returns (bytes32 r, bytes32 vs);",
@@ -8768,6 +9814,66 @@
       },
       "group": "crypto",
       "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "signDelegation_0",
+        "description": "Sign an EIP-7702 authorization for delegation",
+        "declaration": "function signDelegation(address implementation, uint256 privateKey) external returns (SignedDelegation memory signedDelegation);",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "signDelegation(address,uint256)",
+        "selector": "0x5b593c7b",
+        "selectorBytes": [
+          91,
+          89,
+          60,
+          123
+        ]
+      },
+      "group": "scripting",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "signDelegation_1",
+        "description": "Sign an EIP-7702 authorization for delegation for specific nonce",
+        "declaration": "function signDelegation(address implementation, uint256 privateKey, uint64 nonce) external returns (SignedDelegation memory signedDelegation);",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "signDelegation(address,uint256,uint64)",
+        "selector": "0xceba2ec3",
+        "selectorBytes": [
+          206,
+          186,
+          46,
+          195
+        ]
+      },
+      "group": "scripting",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "signDelegation_2",
+        "description": "Sign an EIP-7702 authorization for delegation, with optional cross-chain validity.",
+        "declaration": "function signDelegation(address implementation, uint256 privateKey, bool crossChain) external returns (SignedDelegation memory signedDelegation);",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "signDelegation(address,uint256,bool)",
+        "selector": "0xcdd7563d",
+        "selectorBytes": [
+          205,
+          215,
+          86,
+          61
+        ]
+      },
+      "group": "scripting",
+      "status": "unsupported",
       "safety": "safe"
     },
     {
@@ -9014,6 +10120,66 @@
     },
     {
       "func": {
+        "id": "startBroadcast_0",
+        "description": "Has all subsequent calls (at this call depth only) create transactions that can later be signed and sent onchain.\nBroadcasting address is determined by checking the following in order:\n1. If `--sender` argument was provided, that address is used.\n2. If exactly one signer (e.g. private key, hw wallet, keystore) is set when `forge broadcast` is invoked, that signer is used.\n3. Otherwise, default foundry sender (1804c8AB1F12E6bbf3894d4083f33e07309d1f38) is used.",
+        "declaration": "function startBroadcast() external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "startBroadcast()",
+        "selector": "0x7fb5297f",
+        "selectorBytes": [
+          127,
+          181,
+          41,
+          127
+        ]
+      },
+      "group": "scripting",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "startBroadcast_1",
+        "description": "Has all subsequent calls (at this call depth only) create transactions with the address\nprovided that can later be signed and sent onchain.",
+        "declaration": "function startBroadcast(address signer) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "startBroadcast(address)",
+        "selector": "0x7fec2a8d",
+        "selectorBytes": [
+          127,
+          236,
+          42,
+          141
+        ]
+      },
+      "group": "scripting",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "startBroadcast_2",
+        "description": "Has all subsequent calls (at this call depth only) create transactions with the private key\nprovided that can later be signed and sent onchain.",
+        "declaration": "function startBroadcast(uint256 privateKey) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "startBroadcast(uint256)",
+        "selector": "0xce817d47",
+        "selectorBytes": [
+          206,
+          129,
+          125,
+          71
+        ]
+      },
+      "group": "scripting",
+      "status": "unsupported",
+      "safety": "safe"
+    },
+    {
+      "func": {
         "id": "startDebugTraceRecording",
         "description": "Records the debug trace during the run.",
         "declaration": "function startDebugTraceRecording() external;",
@@ -9230,6 +10396,26 @@
       },
       "group": "evm",
       "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "stopBroadcast",
+        "description": "Stops collecting onchain transactions.",
+        "declaration": "function stopBroadcast() external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "stopBroadcast()",
+        "selector": "0x76eadd36",
+        "selectorBytes": [
+          118,
+          234,
+          221,
+          54
+        ]
+      },
+      "group": "scripting",
+      "status": "unsupported",
       "safety": "safe"
     },
     {

--- a/crates/foundry/cheatcodes/assets/cheatcodes.schema.json
+++ b/crates/foundry/cheatcodes/assets/cheatcodes.schema.json
@@ -412,6 +412,13 @@
           "enum": [
             "internal"
           ]
+        },
+        {
+          "description": "The cheatcode is not supported.",
+          "type": "string",
+          "enum": [
+            "unsupported"
+          ]
         }
       ]
     },

--- a/crates/foundry/cheatcodes/spec/src/cheatcode.rs
+++ b/crates/foundry/cheatcodes/spec/src/cheatcode.rs
@@ -62,6 +62,8 @@ pub enum Status<'a> {
     ///
     /// Use of internal cheatcodes is discouraged and will result in a warning.
     Internal,
+    /// The cheatcode is not supported.
+    Unsupported,
 }
 
 /// Cheatcode groups.

--- a/crates/foundry/cheatcodes/spec/src/lib.rs
+++ b/crates/foundry/cheatcodes/spec/src/lib.rs
@@ -94,6 +94,8 @@ impl Cheatcodes<'static> {
                 Vm::PotentialRevert::STRUCT.clone(),
                 Vm::AccessListItem::STRUCT.clone(),
                 Vm::BroadcastTxSummary::STRUCT.clone(),
+                Vm::SignedDelegation::STRUCT.clone(),
+                Vm::Wallet::STRUCT.clone(),
             ]),
             enums: Cow::Owned(vec![
                 Vm::CallerMode::ENUM.clone(),

--- a/crates/foundry/cheatcodes/spec/src/lib.rs
+++ b/crates/foundry/cheatcodes/spec/src/lib.rs
@@ -93,11 +93,13 @@ impl Cheatcodes<'static> {
                 Vm::DebugStep::STRUCT.clone(),
                 Vm::PotentialRevert::STRUCT.clone(),
                 Vm::AccessListItem::STRUCT.clone(),
+                Vm::BroadcastTxSummary::STRUCT.clone(),
             ]),
             enums: Cow::Owned(vec![
                 Vm::CallerMode::ENUM.clone(),
                 Vm::AccountAccessKind::ENUM.clone(),
                 Vm::ExecutionContext::ENUM.clone(),
+                Vm::BroadcastTxType::ENUM.clone(),
             ]),
             errors: Vm::VM_ERRORS.iter().copied().cloned().collect(),
             events: Cow::Borrowed(&[]),

--- a/crates/foundry/cheatcodes/spec/src/vm.rs
+++ b/crates/foundry/cheatcodes/spec/src/vm.rs
@@ -2516,6 +2516,384 @@ interface Vm {
     /// catch (bytes memory interceptedInitcode) { initcode = interceptedInitcode; }
     #[cheatcode(group = Utilities, safety = Unsafe)]
     function interceptInitcode() external;
+
+    // ======== Unsupported Cheatcodes ========
+
+    // -------- Data Structures --------
+
+    /// A wallet with a public and private key.
+    struct Wallet {
+        // The wallet's address.
+        address addr;
+        // The wallet's public key `X`.
+        uint256 publicKeyX;
+        // The wallet's public key `Y`.
+        uint256 publicKeyY;
+        // The wallet's private key.
+        uint256 privateKey;
+    }
+
+    /// Represents a transaction's broadcast details.
+    struct BroadcastTxSummary {
+        // The hash of the transaction that was broadcasted
+        bytes32 txHash;
+        // Represent the type of transaction among CALL, CREATE, CREATE2
+        BroadcastTxType txType;
+        // The address of the contract that was called or created.
+        // This is the address of the contract that is created if the txType is CREATE or CREATE2.
+        address contractAddress;
+        // The block number the transaction landed in.
+        uint64 blockNumber;
+        // Status of the transaction, retrieved from the transaction receipt.
+        bool success;
+    }
+
+    /// The transaction type (`txType`) of the broadcast.
+    enum BroadcastTxType {
+        // Represents a CALL broadcast tx.
+        Call,
+        // Represents a CREATE broadcast tx.
+        Create,
+        // Represents a CREATE2 broadcast tx.
+        Create2
+    }
+
+    // -------- Scripting --------
+
+    /// Has the next call (at this call depth only) create transactions that can later be signed and sent onchain.
+    ///
+    /// Broadcasting address is determined by checking the following in order:
+    /// 1. If `--sender` argument was provided, that address is used.
+    /// 2. If exactly one signer (e.g. private key, hw wallet, keystore) is set when `forge broadcast` is invoked, that signer is used.
+    /// 3. Otherwise, default foundry sender (1804c8AB1F12E6bbf3894d4083f33e07309d1f38) is used.
+    #[cheatcode(group = Scripting, status = Unsupported)]
+    function broadcast() external;
+
+    /// Has the next call (at this call depth only) create a transaction with the address provided
+    /// as the sender that can later be signed and sent onchain.
+    #[cheatcode(group = Scripting, status = Unsupported)]
+    function broadcast(address signer) external;
+
+    /// Has the next call (at this call depth only) create a transaction with the private key
+    /// provided as the sender that can later be signed and sent onchain.
+    #[cheatcode(group = Scripting, status = Unsupported)]
+    function broadcast(uint256 privateKey) external;
+
+    /// Has all subsequent calls (at this call depth only) create transactions that can later be signed and sent onchain.
+    ///
+    /// Broadcasting address is determined by checking the following in order:
+    /// 1. If `--sender` argument was provided, that address is used.
+    /// 2. If exactly one signer (e.g. private key, hw wallet, keystore) is set when `forge broadcast` is invoked, that signer is used.
+    /// 3. Otherwise, default foundry sender (1804c8AB1F12E6bbf3894d4083f33e07309d1f38) is used.
+    #[cheatcode(group = Scripting, status = Unsupported)]
+    function startBroadcast() external;
+
+    /// Has all subsequent calls (at this call depth only) create transactions with the address
+    /// provided that can later be signed and sent onchain.
+    #[cheatcode(group = Scripting, status = Unsupported)]
+    function startBroadcast(address signer) external;
+
+    /// Has all subsequent calls (at this call depth only) create transactions with the private key
+    /// provided that can later be signed and sent onchain.
+    #[cheatcode(group = Scripting, status = Unsupported)]
+    function startBroadcast(uint256 privateKey) external;
+
+    /// Stops collecting onchain transactions.
+    #[cheatcode(group = Scripting, status = Unsupported)]
+    function stopBroadcast() external;
+
+    /// Takes a signed transaction and broadcasts it to the network.
+    #[cheatcode(group = Scripting, status = Unsupported)]
+    function broadcastRawTransaction(bytes calldata data) external;
+
+    /// Sign an EIP-7702 authorization for delegation
+    #[cheatcode(group = Scripting, status = Unsupported)]
+    function signDelegation(address implementation, uint256 privateKey) external returns (SignedDelegation memory signedDelegation);
+
+    /// Sign an EIP-7702 authorization for delegation for specific nonce
+    #[cheatcode(group = Scripting, status = Unsupported)]
+    function signDelegation(address implementation, uint256 privateKey, uint64 nonce) external returns (SignedDelegation memory signedDelegation);
+
+    /// Sign an EIP-7702 authorization for delegation, with optional cross-chain validity.
+    #[cheatcode(group = Scripting, status = Unsupported)]
+    function signDelegation(address implementation, uint256 privateKey, bool crossChain) external returns (SignedDelegation memory signedDelegation);
+
+    /// Designate the next call as an EIP-7702 transaction
+    #[cheatcode(group = Scripting, status = Unsupported)]
+    function attachDelegation(SignedDelegation calldata signedDelegation) external;
+
+    /// Designate the next call as an EIP-7702 transaction, with optional cross-chain validity.
+    #[cheatcode(group = Scripting, status = Unsupported)]
+    function attachDelegation(SignedDelegation calldata signedDelegation, bool crossChain) external;
+
+    /// Sign an EIP-7702 authorization and designate the next call as an EIP-7702 transaction
+    #[cheatcode(group = Scripting, status = Unsupported)]
+    function signAndAttachDelegation(address implementation, uint256 privateKey) external returns (SignedDelegation memory signedDelegation);
+
+    /// Sign an EIP-7702 authorization and designate the next call as an EIP-7702 transaction for specific nonce
+    #[cheatcode(group = Scripting, status = Unsupported)]
+    function signAndAttachDelegation(address implementation, uint256 privateKey, uint64 nonce) external returns (SignedDelegation memory signedDelegation);
+
+    /// Sign an EIP-7702 authorization and designate the next call as an EIP-7702 transaction, with optional cross-chain validity.
+    #[cheatcode(group = Scripting, status = Unsupported)]
+    function signAndAttachDelegation(address implementation, uint256 privateKey, bool crossChain) external returns (SignedDelegation memory signedDelegation);
+
+    /// Attach an EIP-4844 blob to the next call
+    #[cheatcode(group = Scripting, status = Unsupported)]
+    function attachBlob(bytes calldata blob) external;
+
+    /// Returns addresses of available unlocked wallets in the script environment.
+    #[cheatcode(group = Scripting, status = Unsupported)]
+    function getWallets() external returns (address[] memory wallets);
+
+    // -------- Filesystem --------
+
+    /// Gets the artifact path from code (aka. creation code).
+    #[cheatcode(group = Filesystem, status = Unsupported)]
+    function getArtifactPathByCode(bytes calldata code) external view returns (string memory path);
+
+    /// Gets the artifact path from deployed code (aka. runtime code).
+    #[cheatcode(group = Filesystem, status = Unsupported)]
+    function getArtifactPathByDeployedCode(bytes calldata deployedCode) external view returns (string memory path);
+
+    /// Deploys a contract from an artifact file. Takes in the relative path to the json file or the path to the
+    /// artifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.
+    #[cheatcode(group = Filesystem, status = Unsupported)]
+    function deployCode(string calldata artifactPath) external returns (address deployedAddress);
+
+    /// Deploys a contract from an artifact file. Takes in the relative path to the json file or the path to the
+    /// artifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.
+    ///
+    /// Additionally accepts abi-encoded constructor arguments.
+    #[cheatcode(group = Filesystem, status = Unsupported)]
+    function deployCode(string calldata artifactPath, bytes calldata constructorArgs) external returns (address deployedAddress);
+
+    /// Deploys a contract from an artifact file. Takes in the relative path to the json file or the path to the
+    /// artifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.
+    ///
+    /// Additionally accepts `msg.value`.
+    #[cheatcode(group = Filesystem, status = Unsupported)]
+    function deployCode(string calldata artifactPath, uint256 value) external returns (address deployedAddress);
+
+    /// Deploys a contract from an artifact file. Takes in the relative path to the json file or the path to the
+    /// artifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.
+    ///
+    /// Additionally accepts abi-encoded constructor arguments and `msg.value`.
+    #[cheatcode(group = Filesystem, status = Unsupported)]
+    function deployCode(string calldata artifactPath, bytes calldata constructorArgs, uint256 value) external returns (address deployedAddress);
+
+    /// Deploys a contract from an artifact file, using the CREATE2 salt. Takes in the relative path to the json file or the path to the
+    /// artifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.
+    #[cheatcode(group = Filesystem, status = Unsupported)]
+    function deployCode(string calldata artifactPath, bytes32 salt) external returns (address deployedAddress);
+
+    /// Deploys a contract from an artifact file, using the CREATE2 salt. Takes in the relative path to the json file or the path to the
+    /// artifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.
+    ///
+    /// Additionally accepts abi-encoded constructor arguments.
+    #[cheatcode(group = Filesystem, status = Unsupported)]
+    function deployCode(string calldata artifactPath, bytes calldata constructorArgs, bytes32 salt) external returns (address deployedAddress);
+
+    /// Deploys a contract from an artifact file, using the CREATE2 salt. Takes in the relative path to the json file or the path to the
+    /// artifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.
+    ///
+    /// Additionally accepts `msg.value`.
+    #[cheatcode(group = Filesystem, status = Unsupported)]
+    function deployCode(string calldata artifactPath, uint256 value, bytes32 salt) external returns (address deployedAddress);
+
+    /// Deploys a contract from an artifact file, using the CREATE2 salt. Takes in the relative path to the json file or the path to the
+    /// artifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.
+    ///
+    /// Additionally accepts abi-encoded constructor arguments and `msg.value`.
+    #[cheatcode(group = Filesystem, status = Unsupported)]
+    function deployCode(string calldata artifactPath, bytes calldata constructorArgs, uint256 value, bytes32 salt) external returns (address deployedAddress);
+
+    /// Returns the most recent broadcast for the given contract on `chainId` matching `txType`.
+    ///
+    /// For example:
+    ///
+    /// The most recent deployment can be fetched by passing `txType` as `CREATE` or `CREATE2`.
+    ///
+    /// The most recent call can be fetched by passing `txType` as `CALL`.
+    #[cheatcode(group = Filesystem, status = Unsupported)]
+    function getBroadcast(string calldata contractName, uint64 chainId, BroadcastTxType txType) external view returns (BroadcastTxSummary memory);
+
+    /// Returns all broadcasts for the given contract on `chainId` with the specified `txType`.
+    ///
+    /// Sorted such that the most recent broadcast is the first element, and the oldest is the last. i.e descending order of BroadcastTxSummary.blockNumber.
+    #[cheatcode(group = Filesystem, status = Unsupported)]
+    function getBroadcasts(string calldata contractName, uint64 chainId, BroadcastTxType txType) external view returns (BroadcastTxSummary[] memory);
+
+    /// Returns all broadcasts for the given contract on `chainId`.
+    ///
+    /// Sorted such that the most recent broadcast is the first element, and the oldest is the last. i.e descending order of BroadcastTxSummary.blockNumber.
+    #[cheatcode(group = Filesystem, status = Unsupported)]
+    function getBroadcasts(string calldata contractName, uint64 chainId) external view returns (BroadcastTxSummary[] memory);
+
+    /// Returns the most recent deployment for the current `chainId`.
+    #[cheatcode(group = Filesystem, status = Unsupported)]
+    function getDeployment(string calldata contractName) external view returns (address deployedAddress);
+
+    /// Returns the most recent deployment for the given contract on `chainId`
+    #[cheatcode(group = Filesystem, status = Unsupported)]
+    function getDeployment(string calldata contractName, uint64 chainId) external view returns (address deployedAddress);
+
+    /// Returns all deployments for the given contract on `chainId`
+    ///
+    /// Sorted in descending order of deployment time i.e descending order of BroadcastTxSummary.blockNumber.
+    ///
+    /// The most recent deployment is the first element, and the oldest is the last.
+    #[cheatcode(group = Filesystem, status = Unsupported)]
+    function getDeployments(string calldata contractName, uint64 chainId) external view returns (address[] memory deployedAddresses);
+
+    // -------- Key management --------
+
+    /// Derives a private key from the name, labels the account with that name, and returns the wallet.
+    #[cheatcode(group = Crypto, status = Unsupported)]
+    function createWallet(string calldata walletLabel) external returns (Wallet memory wallet);
+
+    /// Generates a wallet from the private key and returns the wallet.
+    #[cheatcode(group = Crypto, status = Unsupported)]
+    function createWallet(uint256 privateKey) external returns (Wallet memory wallet);
+
+    /// Generates a wallet from the private key, labels the account with that name, and returns the wallet.
+    #[cheatcode(group = Crypto, status = Unsupported)]
+    function createWallet(uint256 privateKey, string calldata walletLabel) external returns (Wallet memory wallet);
+
+    /// Derive a private key from a provided mnemonic string (or mnemonic file path)
+    /// at the derivation path `m/44'/60'/0'/0/{index}`.
+    #[cheatcode(group = Crypto, status = Unsupported)]
+    function deriveKey(string calldata mnemonic, uint32 index) external pure returns (uint256 privateKey);
+    /// Derive a private key from a provided mnemonic string (or mnemonic file path)
+    /// at `{derivationPath}{index}`.
+    #[cheatcode(group = Crypto, status = Unsupported)]
+    function deriveKey(string calldata mnemonic, string calldata derivationPath, uint32 index)
+        external
+        pure
+        returns (uint256 privateKey);
+    /// Derive a private key from a provided mnemonic string (or mnemonic file path) in the specified language
+    /// at the derivation path `m/44'/60'/0'/0/{index}`.
+    #[cheatcode(group = Crypto, status = Unsupported)]
+    function deriveKey(string calldata mnemonic, uint32 index, string calldata language)
+        external
+        pure
+        returns (uint256 privateKey);
+    /// Derive a private key from a provided mnemonic string (or mnemonic file path) in the specified language
+    /// at `{derivationPath}{index}`.
+    #[cheatcode(group = Crypto, status = Unsupported)]
+    function deriveKey(string calldata mnemonic, string calldata derivationPath, uint32 index, string calldata language)
+        external
+        pure
+        returns (uint256 privateKey);
+
+    /// Adds a private key to the local forge wallet and returns the address.
+    #[cheatcode(group = Crypto, status = Unsupported)]
+    function rememberKey(uint256 privateKey) external returns (address keyAddr);
+
+    /// Derive a set number of wallets from a mnemonic at the derivation path `m/44'/60'/0'/0/{0..count}`.
+    ///
+    /// The respective private keys are saved to the local forge wallet for later use and their addresses are returned.
+    #[cheatcode(group = Crypto, status = Unsupported)]
+    function rememberKeys(string calldata mnemonic, string calldata derivationPath, uint32 count) external returns (address[] memory keyAddrs);
+
+    /// Derive a set number of wallets from a mnemonic in the specified language at the derivation path `m/44'/60'/0'/0/{0..count}`.
+    ///
+    /// The respective private keys are saved to the local forge wallet for later use and their addresses are returned.
+    #[cheatcode(group = Crypto, status = Unsupported)]
+    function rememberKeys(string calldata mnemonic, string calldata derivationPath, string calldata language, uint32 count)
+        external
+        returns (address[] memory keyAddrs);
+
+    // -------- Utilities --------
+
+    /// Generates the hash of the canonical EIP-712 type representation.
+    ///
+    /// Supports 2 different inputs:
+    ///  1. Name of the type (i.e. "Transaction"):
+    ///     * requires previous binding generation with `forge bind-json`.
+    ///     * bindings will be retrieved from the path configured in `foundry.toml`.
+    ///
+    ///  2. String representation of the type (i.e. "Foo(Bar bar) Bar(uint256 baz)").
+    ///     * Note: the cheatcode will output the canonical type even if the input is malformated
+    ///             with the wrong order of elements or with extra whitespaces.
+    #[cheatcode(group = Utilities, status = Unsupported)]
+    function eip712HashType(string calldata typeNameOrDefinition) external pure returns (bytes32 typeHash);
+
+    /// Generates the hash of the canonical EIP-712 type representation.
+    /// Requires previous binding generation with `forge bind-json`.
+    ///
+    /// Params:
+    ///  * `bindingsPath`: path where the output of `forge bind-json` is stored.
+    ///  * `typeName`: Name of the type (i.e. "Transaction").
+    #[cheatcode(group = Utilities, status = Unsupported)]
+    function eip712HashType(string calldata bindingsPath, string calldata typeName) external pure returns (bytes32 typeHash);
+
+    /// Generates the struct hash of the canonical EIP-712 type representation and its abi-encoded data.
+    ///
+    /// Supports 2 different inputs:
+    ///  1. Name of the type (i.e. "PermitSingle"):
+    ///     * requires previous binding generation with `forge bind-json`.
+    ///     * bindings will be retrieved from the path configured in `foundry.toml`.
+    ///
+    ///  2. String representation of the type (i.e. "Foo(Bar bar) Bar(uint256 baz)").
+    ///     * Note: the cheatcode will use the canonical type even if the input is malformated
+    ///             with the wrong order of elements or with extra whitespaces.
+    #[cheatcode(group = Utilities, status = Unsupported)]
+    function eip712HashStruct(string calldata typeNameOrDefinition, bytes calldata abiEncodedData) external pure returns (bytes32 typeHash);
+
+    /// Generates the struct hash of the canonical EIP-712 type representation and its abi-encoded data.
+    /// Requires previous binding generation with `forge bind-json`.
+    ///
+    /// Params:
+    ///  * `bindingsPath`: path where the output of `forge bind-json` is stored.
+    ///  * `typeName`: Name of the type (i.e. "PermitSingle").
+    ///  * `abiEncodedData`: ABI-encoded data for the struct that is being hashed.
+    #[cheatcode(group = Utilities, status = Unsupported)]
+    function eip712HashStruct(string calldata bindingsPath, string calldata typeName, bytes calldata abiEncodedData) external pure returns (bytes32 typeHash);
+
+    /// Generates a ready-to-sign digest of human-readable typed data following the EIP-712 standard.
+    #[cheatcode(group = Utilities, status = Unsupported)]
+    function eip712HashTypedData(string calldata jsonData) external pure returns (bytes32 digest);
+
+    // -------- Testing --------
+
+    /// Writes a breakpoint to jump to in the debugger.
+    #[cheatcode(group = Testing, safety = Safe, status = Unsupported)]
+    function breakpoint(string calldata char) external pure;
+
+    /// Writes a conditional breakpoint to jump to in the debugger.
+    #[cheatcode(group = Testing, safety = Safe, status = Unsupported)]
+    function breakpoint(string calldata char, bool value) external pure;
+
+    /// Returns true if the current Foundry version is greater than or equal to the given version.
+    /// The given version string must be in the format `major.minor.patch`.
+    ///
+    /// This is equivalent to `foundryVersionCmp(version) >= 0`.
+    #[cheatcode(group = Testing, safety = Safe, status = Unsupported)]
+    function foundryVersionAtLeast(string calldata version) external view returns (bool);
+
+    /// Compares the current Foundry version with the given version string.
+    /// The given version string must be in the format `major.minor.patch`.
+    ///
+    /// Returns:
+    /// -1 if current Foundry version is less than the given version
+    /// 0 if current Foundry version equals the given version
+    /// 1 if current Foundry version is greater than the given version
+    ///
+    /// This result can then be used with a comparison operator against `0`.
+    /// For example, to check if the current Foundry version is greater than or equal to `1.0.0`:
+    /// `if (foundryVersionCmp("1.0.0") >= 0) { ... }`
+    #[cheatcode(group = Testing, safety = Safe, status = Unsupported)]
+    function foundryVersionCmp(string calldata version) external view returns (int256);
+
+    /// Returns the Foundry version.
+    /// Format: <cargo_version>-<tag>+<git_sha_short>.<unix_build_timestamp>.<profile>
+    /// Sample output: 0.3.0-nightly+3cb96bde9b.1737036656.debug
+    /// Note: Build timestamps may vary slightly across platforms due to separate CI jobs.
+    /// For reliable version comparisons, use UNIX format (e.g., >= 1700000000)
+    /// to compare timestamps while ignoring minor time differences.
+    #[cheatcode(group = Testing, safety = Safe, status = Unsupported)]
+    function getFoundryVersion() external view returns (string memory version);
 }
 }
 

--- a/crates/foundry/cheatcodes/spec/src/vm.rs
+++ b/crates/foundry/cheatcodes/spec/src/vm.rs
@@ -282,22 +282,6 @@ interface Vm {
         address contractAddr;
     }
 
-    /// Holds a signed EIP-7702 authorization for an authority account to delegate to an implementation.
-    struct SignedDelegation {
-        /// The y-parity of the recovered secp256k1 signature (0 or 1).
-        uint8 v;
-        /// First 32 bytes of the signature.
-        bytes32 r;
-        /// Second 32 bytes of the signature.
-        bytes32 s;
-        /// The current nonce of the authority account at signing time.
-        /// Used to ensure signature can't be replayed after account nonce changes.
-        uint64 nonce;
-        /// Address of the contract implementation that will be delegated to.
-        /// Gets encoded into delegation code: 0xef0100 || implementation.
-        address implementation;
-    }
-
     /// Represents a "potential" revert reason from a single subsequent call when using `vm.assumeNoReverts`.
     /// Reverts that match will result in a FOUNDRY::ASSUME rejection, whereas unmatched reverts will be surfaced
     /// as normal.
@@ -2521,18 +2505,6 @@ interface Vm {
 
     // -------- Data Structures --------
 
-    /// A wallet with a public and private key.
-    struct Wallet {
-        // The wallet's address.
-        address addr;
-        // The wallet's public key `X`.
-        uint256 publicKeyX;
-        // The wallet's public key `Y`.
-        uint256 publicKeyY;
-        // The wallet's private key.
-        uint256 privateKey;
-    }
-
     /// Represents a transaction's broadcast details.
     struct BroadcastTxSummary {
         // The hash of the transaction that was broadcasted
@@ -2556,6 +2528,34 @@ interface Vm {
         Create,
         // Represents a CREATE2 broadcast tx.
         Create2
+    }
+
+    /// Holds a signed EIP-7702 authorization for an authority account to delegate to an implementation.
+    struct SignedDelegation {
+        /// The y-parity of the recovered secp256k1 signature (0 or 1).
+        uint8 v;
+        /// First 32 bytes of the signature.
+        bytes32 r;
+        /// Second 32 bytes of the signature.
+        bytes32 s;
+        /// The current nonce of the authority account at signing time.
+        /// Used to ensure signature can't be replayed after account nonce changes.
+        uint64 nonce;
+        /// Address of the contract implementation that will be delegated to.
+        /// Gets encoded into delegation code: 0xef0100 || implementation.
+        address implementation;
+    }
+
+    /// A wallet with a public and private key.
+    struct Wallet {
+        // The wallet's address.
+        address addr;
+        // The wallet's public key `X`.
+        uint256 publicKeyX;
+        // The wallet's public key `Y`.
+        uint256 publicKeyY;
+        // The wallet's private key.
+        uint256 privateKey;
     }
 
     // -------- Scripting --------

--- a/crates/foundry/cheatcodes/spec/src/vm.rs
+++ b/crates/foundry/cheatcodes/spec/src/vm.rs
@@ -2560,212 +2560,163 @@ interface Vm {
 
     // -------- Scripting --------
 
-    /// Has the next call (at this call depth only) create transactions that can later be signed and sent onchain.
-    ///
-    /// Broadcasting address is determined by checking the following in order:
-    /// 1. If `--sender` argument was provided, that address is used.
-    /// 2. If exactly one signer (e.g. private key, hw wallet, keystore) is set when `forge broadcast` is invoked, that signer is used.
-    /// 3. Otherwise, default foundry sender (1804c8AB1F12E6bbf3894d4083f33e07309d1f38) is used.
+    /// Scripting cheatcodes are not supported.
     #[cheatcode(group = Scripting, status = Unsupported)]
     function broadcast() external;
 
-    /// Has the next call (at this call depth only) create a transaction with the address provided
-    /// as the sender that can later be signed and sent onchain.
+    /// Scripting cheatcodes are not supported.
     #[cheatcode(group = Scripting, status = Unsupported)]
     function broadcast(address signer) external;
 
-    /// Has the next call (at this call depth only) create a transaction with the private key
-    /// provided as the sender that can later be signed and sent onchain.
+    /// Scripting cheatcodes are not supported.
     #[cheatcode(group = Scripting, status = Unsupported)]
     function broadcast(uint256 privateKey) external;
 
-    /// Has all subsequent calls (at this call depth only) create transactions that can later be signed and sent onchain.
-    ///
-    /// Broadcasting address is determined by checking the following in order:
-    /// 1. If `--sender` argument was provided, that address is used.
-    /// 2. If exactly one signer (e.g. private key, hw wallet, keystore) is set when `forge broadcast` is invoked, that signer is used.
-    /// 3. Otherwise, default foundry sender (1804c8AB1F12E6bbf3894d4083f33e07309d1f38) is used.
+    /// Scripting cheatcodes are not supported.
     #[cheatcode(group = Scripting, status = Unsupported)]
     function startBroadcast() external;
 
-    /// Has all subsequent calls (at this call depth only) create transactions with the address
-    /// provided that can later be signed and sent onchain.
+    /// Scripting cheatcodes are not supported.
     #[cheatcode(group = Scripting, status = Unsupported)]
     function startBroadcast(address signer) external;
 
-    /// Has all subsequent calls (at this call depth only) create transactions with the private key
-    /// provided that can later be signed and sent onchain.
+    /// Scripting cheatcodes are not supported.
     #[cheatcode(group = Scripting, status = Unsupported)]
     function startBroadcast(uint256 privateKey) external;
 
-    /// Stops collecting onchain transactions.
+    /// Scripting cheatcodes are not supported.
     #[cheatcode(group = Scripting, status = Unsupported)]
     function stopBroadcast() external;
 
-    /// Takes a signed transaction and broadcasts it to the network.
+    /// Scripting cheatcodes are not supported.
     #[cheatcode(group = Scripting, status = Unsupported)]
     function broadcastRawTransaction(bytes calldata data) external;
 
-    /// Sign an EIP-7702 authorization for delegation
+    /// EIP-7702 cheatcodes are not supported.
     #[cheatcode(group = Scripting, status = Unsupported)]
     function signDelegation(address implementation, uint256 privateKey) external returns (SignedDelegation memory signedDelegation);
 
-    /// Sign an EIP-7702 authorization for delegation for specific nonce
+    /// EIP-7702 cheatcodes are not supported.
     #[cheatcode(group = Scripting, status = Unsupported)]
     function signDelegation(address implementation, uint256 privateKey, uint64 nonce) external returns (SignedDelegation memory signedDelegation);
 
-    /// Sign an EIP-7702 authorization for delegation, with optional cross-chain validity.
+    /// EIP-7702 cheatcodes are not supported.
     #[cheatcode(group = Scripting, status = Unsupported)]
     function signDelegation(address implementation, uint256 privateKey, bool crossChain) external returns (SignedDelegation memory signedDelegation);
 
-    /// Designate the next call as an EIP-7702 transaction
+    /// EIP-7702 cheatcodes are not supported.
     #[cheatcode(group = Scripting, status = Unsupported)]
     function attachDelegation(SignedDelegation calldata signedDelegation) external;
 
-    /// Designate the next call as an EIP-7702 transaction, with optional cross-chain validity.
+    /// EIP-7702 cheatcodes are not supported.
     #[cheatcode(group = Scripting, status = Unsupported)]
     function attachDelegation(SignedDelegation calldata signedDelegation, bool crossChain) external;
 
-    /// Sign an EIP-7702 authorization and designate the next call as an EIP-7702 transaction
+    /// EIP-7702 cheatcodes are not supported.
     #[cheatcode(group = Scripting, status = Unsupported)]
     function signAndAttachDelegation(address implementation, uint256 privateKey) external returns (SignedDelegation memory signedDelegation);
 
-    /// Sign an EIP-7702 authorization and designate the next call as an EIP-7702 transaction for specific nonce
+    /// EIP-7702 cheatcodes are not supported.
     #[cheatcode(group = Scripting, status = Unsupported)]
     function signAndAttachDelegation(address implementation, uint256 privateKey, uint64 nonce) external returns (SignedDelegation memory signedDelegation);
 
-    /// Sign an EIP-7702 authorization and designate the next call as an EIP-7702 transaction, with optional cross-chain validity.
+    /// EIP-7702 cheatcodes are not supported.
     #[cheatcode(group = Scripting, status = Unsupported)]
     function signAndAttachDelegation(address implementation, uint256 privateKey, bool crossChain) external returns (SignedDelegation memory signedDelegation);
 
-    /// Attach an EIP-4844 blob to the next call
+    /// Scripting cheatcodes are not supported.
     #[cheatcode(group = Scripting, status = Unsupported)]
     function attachBlob(bytes calldata blob) external;
 
-    /// Returns addresses of available unlocked wallets in the script environment.
+    /// Scripting cheatcodes are not supported.
     #[cheatcode(group = Scripting, status = Unsupported)]
     function getWallets() external returns (address[] memory wallets);
 
     // -------- Filesystem --------
 
-    /// Gets the artifact path from code (aka. creation code).
+    /// Contract deployment cheatcodes are not supported.
     #[cheatcode(group = Filesystem, status = Unsupported)]
     function getArtifactPathByCode(bytes calldata code) external view returns (string memory path);
 
-    /// Gets the artifact path from deployed code (aka. runtime code).
+    /// Contract deployment cheatcodes are not supported.
     #[cheatcode(group = Filesystem, status = Unsupported)]
     function getArtifactPathByDeployedCode(bytes calldata deployedCode) external view returns (string memory path);
 
-    /// Deploys a contract from an artifact file. Takes in the relative path to the json file or the path to the
-    /// artifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.
+    /// Contract deployment cheatcodes are not supported.
     #[cheatcode(group = Filesystem, status = Unsupported)]
     function deployCode(string calldata artifactPath) external returns (address deployedAddress);
 
-    /// Deploys a contract from an artifact file. Takes in the relative path to the json file or the path to the
-    /// artifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.
-    ///
-    /// Additionally accepts abi-encoded constructor arguments.
+    /// Contract deployment cheatcodes are not supported.
     #[cheatcode(group = Filesystem, status = Unsupported)]
     function deployCode(string calldata artifactPath, bytes calldata constructorArgs) external returns (address deployedAddress);
 
-    /// Deploys a contract from an artifact file. Takes in the relative path to the json file or the path to the
-    /// artifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.
-    ///
-    /// Additionally accepts `msg.value`.
+    /// Contract deployment cheatcodes are not supported.
     #[cheatcode(group = Filesystem, status = Unsupported)]
     function deployCode(string calldata artifactPath, uint256 value) external returns (address deployedAddress);
 
-    /// Deploys a contract from an artifact file. Takes in the relative path to the json file or the path to the
-    /// artifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.
-    ///
-    /// Additionally accepts abi-encoded constructor arguments and `msg.value`.
+    /// Contract deployment cheatcodes are not supported.
     #[cheatcode(group = Filesystem, status = Unsupported)]
     function deployCode(string calldata artifactPath, bytes calldata constructorArgs, uint256 value) external returns (address deployedAddress);
 
-    /// Deploys a contract from an artifact file, using the CREATE2 salt. Takes in the relative path to the json file or the path to the
-    /// artifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.
+    /// Contract deployment cheatcodes are not supported.
     #[cheatcode(group = Filesystem, status = Unsupported)]
     function deployCode(string calldata artifactPath, bytes32 salt) external returns (address deployedAddress);
 
-    /// Deploys a contract from an artifact file, using the CREATE2 salt. Takes in the relative path to the json file or the path to the
-    /// artifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.
-    ///
-    /// Additionally accepts abi-encoded constructor arguments.
+    /// Contract deployment cheatcodes are not supported.
     #[cheatcode(group = Filesystem, status = Unsupported)]
     function deployCode(string calldata artifactPath, bytes calldata constructorArgs, bytes32 salt) external returns (address deployedAddress);
 
-    /// Deploys a contract from an artifact file, using the CREATE2 salt. Takes in the relative path to the json file or the path to the
-    /// artifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.
-    ///
-    /// Additionally accepts `msg.value`.
+    /// Contract deployment cheatcodes are not supported.
     #[cheatcode(group = Filesystem, status = Unsupported)]
     function deployCode(string calldata artifactPath, uint256 value, bytes32 salt) external returns (address deployedAddress);
 
-    /// Deploys a contract from an artifact file, using the CREATE2 salt. Takes in the relative path to the json file or the path to the
-    /// artifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.
-    ///
-    /// Additionally accepts abi-encoded constructor arguments and `msg.value`.
+    /// Contract deployment cheatcodes are not supported.
     #[cheatcode(group = Filesystem, status = Unsupported)]
     function deployCode(string calldata artifactPath, bytes calldata constructorArgs, uint256 value, bytes32 salt) external returns (address deployedAddress);
 
-    /// Returns the most recent broadcast for the given contract on `chainId` matching `txType`.
-    ///
-    /// For example:
-    ///
-    /// The most recent deployment can be fetched by passing `txType` as `CREATE` or `CREATE2`.
-    ///
-    /// The most recent call can be fetched by passing `txType` as `CALL`.
+    /// Contract deployment cheatcodes are not supported.
     #[cheatcode(group = Filesystem, status = Unsupported)]
     function getBroadcast(string calldata contractName, uint64 chainId, BroadcastTxType txType) external view returns (BroadcastTxSummary memory);
 
-    /// Returns all broadcasts for the given contract on `chainId` with the specified `txType`.
-    ///
-    /// Sorted such that the most recent broadcast is the first element, and the oldest is the last. i.e descending order of BroadcastTxSummary.blockNumber.
+    /// Contract deployment cheatcodes are not supported.
     #[cheatcode(group = Filesystem, status = Unsupported)]
     function getBroadcasts(string calldata contractName, uint64 chainId, BroadcastTxType txType) external view returns (BroadcastTxSummary[] memory);
 
-    /// Returns all broadcasts for the given contract on `chainId`.
-    ///
-    /// Sorted such that the most recent broadcast is the first element, and the oldest is the last. i.e descending order of BroadcastTxSummary.blockNumber.
+    /// Contract deployment cheatcodes are not supported.
     #[cheatcode(group = Filesystem, status = Unsupported)]
     function getBroadcasts(string calldata contractName, uint64 chainId) external view returns (BroadcastTxSummary[] memory);
 
-    /// Returns the most recent deployment for the current `chainId`.
+    /// Contract deployment cheatcodes are not supported.
     #[cheatcode(group = Filesystem, status = Unsupported)]
     function getDeployment(string calldata contractName) external view returns (address deployedAddress);
 
-    /// Returns the most recent deployment for the given contract on `chainId`
+    /// Contract deployment cheatcodes are not supported.
     #[cheatcode(group = Filesystem, status = Unsupported)]
     function getDeployment(string calldata contractName, uint64 chainId) external view returns (address deployedAddress);
 
-    /// Returns all deployments for the given contract on `chainId`
-    ///
-    /// Sorted in descending order of deployment time i.e descending order of BroadcastTxSummary.blockNumber.
-    ///
-    /// The most recent deployment is the first element, and the oldest is the last.
+    /// Contract deployment cheatcodes are not supported.
     #[cheatcode(group = Filesystem, status = Unsupported)]
     function getDeployments(string calldata contractName, uint64 chainId) external view returns (address[] memory deployedAddresses);
 
     // -------- Key management --------
 
-    /// Derives a private key from the name, labels the account with that name, and returns the wallet.
+    /// Key management cheatcodes are not supported.
     #[cheatcode(group = Crypto, status = Unsupported)]
     function createWallet(string calldata walletLabel) external returns (Wallet memory wallet);
 
-    /// Generates a wallet from the private key and returns the wallet.
+    /// Key management cheatcodes are not supported.
     #[cheatcode(group = Crypto, status = Unsupported)]
     function createWallet(uint256 privateKey) external returns (Wallet memory wallet);
 
-    /// Generates a wallet from the private key, labels the account with that name, and returns the wallet.
+    /// Key management cheatcodes are not supported.
     #[cheatcode(group = Crypto, status = Unsupported)]
     function createWallet(uint256 privateKey, string calldata walletLabel) external returns (Wallet memory wallet);
 
-    /// Derive a private key from a provided mnemonic string (or mnemonic file path)
-    /// at the derivation path `m/44'/60'/0'/0/{index}`.
+    /// Key management cheatcodes are not supported.
     #[cheatcode(group = Crypto, status = Unsupported)]
     function deriveKey(string calldata mnemonic, uint32 index) external pure returns (uint256 privateKey);
-    /// Derive a private key from a provided mnemonic string (or mnemonic file path)
-    /// at `{derivationPath}{index}`.
+
+    /// Key management cheatcodes are not supported.
     #[cheatcode(group = Crypto, status = Unsupported)]
     function deriveKey(string calldata mnemonic, string calldata derivationPath, uint32 index)
         external
@@ -2790,15 +2741,11 @@ interface Vm {
     #[cheatcode(group = Crypto, status = Unsupported)]
     function rememberKey(uint256 privateKey) external returns (address keyAddr);
 
-    /// Derive a set number of wallets from a mnemonic at the derivation path `m/44'/60'/0'/0/{0..count}`.
-    ///
-    /// The respective private keys are saved to the local forge wallet for later use and their addresses are returned.
+    /// Key management cheatcodes are not supported.
     #[cheatcode(group = Crypto, status = Unsupported)]
     function rememberKeys(string calldata mnemonic, string calldata derivationPath, uint32 count) external returns (address[] memory keyAddrs);
 
-    /// Derive a set number of wallets from a mnemonic in the specified language at the derivation path `m/44'/60'/0'/0/{0..count}`.
-    ///
-    /// The respective private keys are saved to the local forge wallet for later use and their addresses are returned.
+    /// Key management cheatcodes are not supported.
     #[cheatcode(group = Crypto, status = Unsupported)]
     function rememberKeys(string calldata mnemonic, string calldata derivationPath, string calldata language, uint32 count)
         external
@@ -2806,92 +2753,45 @@ interface Vm {
 
     // -------- Utilities --------
 
-    /// Generates the hash of the canonical EIP-712 type representation.
-    ///
-    /// Supports 2 different inputs:
-    ///  1. Name of the type (i.e. "Transaction"):
-    ///     * requires previous binding generation with `forge bind-json`.
-    ///     * bindings will be retrieved from the path configured in `foundry.toml`.
-    ///
-    ///  2. String representation of the type (i.e. "Foo(Bar bar) Bar(uint256 baz)").
-    ///     * Note: the cheatcode will output the canonical type even if the input is malformated
-    ///             with the wrong order of elements or with extra whitespaces.
+    /// EIP-712 cheatcodes are not supported.
     #[cheatcode(group = Utilities, status = Unsupported)]
     function eip712HashType(string calldata typeNameOrDefinition) external pure returns (bytes32 typeHash);
 
-    /// Generates the hash of the canonical EIP-712 type representation.
-    /// Requires previous binding generation with `forge bind-json`.
-    ///
-    /// Params:
-    ///  * `bindingsPath`: path where the output of `forge bind-json` is stored.
-    ///  * `typeName`: Name of the type (i.e. "Transaction").
+    /// EIP-712 cheatcodes are not supported.
     #[cheatcode(group = Utilities, status = Unsupported)]
     function eip712HashType(string calldata bindingsPath, string calldata typeName) external pure returns (bytes32 typeHash);
 
-    /// Generates the struct hash of the canonical EIP-712 type representation and its abi-encoded data.
-    ///
-    /// Supports 2 different inputs:
-    ///  1. Name of the type (i.e. "PermitSingle"):
-    ///     * requires previous binding generation with `forge bind-json`.
-    ///     * bindings will be retrieved from the path configured in `foundry.toml`.
-    ///
-    ///  2. String representation of the type (i.e. "Foo(Bar bar) Bar(uint256 baz)").
-    ///     * Note: the cheatcode will use the canonical type even if the input is malformated
-    ///             with the wrong order of elements or with extra whitespaces.
+    /// EIP-712 cheatcodes are not supported.
     #[cheatcode(group = Utilities, status = Unsupported)]
     function eip712HashStruct(string calldata typeNameOrDefinition, bytes calldata abiEncodedData) external pure returns (bytes32 typeHash);
 
-    /// Generates the struct hash of the canonical EIP-712 type representation and its abi-encoded data.
-    /// Requires previous binding generation with `forge bind-json`.
-    ///
-    /// Params:
-    ///  * `bindingsPath`: path where the output of `forge bind-json` is stored.
-    ///  * `typeName`: Name of the type (i.e. "PermitSingle").
-    ///  * `abiEncodedData`: ABI-encoded data for the struct that is being hashed.
+    /// EIP-712 cheatcodes are not supported.
     #[cheatcode(group = Utilities, status = Unsupported)]
     function eip712HashStruct(string calldata bindingsPath, string calldata typeName, bytes calldata abiEncodedData) external pure returns (bytes32 typeHash);
 
-    /// Generates a ready-to-sign digest of human-readable typed data following the EIP-712 standard.
+    /// EIP-712 cheatcodes are not supported.
     #[cheatcode(group = Utilities, status = Unsupported)]
     function eip712HashTypedData(string calldata jsonData) external pure returns (bytes32 digest);
 
     // -------- Testing --------
 
-    /// Writes a breakpoint to jump to in the debugger.
+    /// Debugging cheatcodes are not supported.
     #[cheatcode(group = Testing, safety = Safe, status = Unsupported)]
     function breakpoint(string calldata char) external pure;
 
-    /// Writes a conditional breakpoint to jump to in the debugger.
+    /// Debugging cheatcodes are not supported.
     #[cheatcode(group = Testing, safety = Safe, status = Unsupported)]
     function breakpoint(string calldata char, bool value) external pure;
 
-    /// Returns true if the current Foundry version is greater than or equal to the given version.
-    /// The given version string must be in the format `major.minor.patch`.
-    ///
-    /// This is equivalent to `foundryVersionCmp(version) >= 0`.
+    /// Foundry-specific version cheatcodes are not supported.
     #[cheatcode(group = Testing, safety = Safe, status = Unsupported)]
     function foundryVersionAtLeast(string calldata version) external view returns (bool);
 
-    /// Compares the current Foundry version with the given version string.
-    /// The given version string must be in the format `major.minor.patch`.
-    ///
-    /// Returns:
-    /// -1 if current Foundry version is less than the given version
-    /// 0 if current Foundry version equals the given version
-    /// 1 if current Foundry version is greater than the given version
-    ///
-    /// This result can then be used with a comparison operator against `0`.
-    /// For example, to check if the current Foundry version is greater than or equal to `1.0.0`:
-    /// `if (foundryVersionCmp("1.0.0") >= 0) { ... }`
+    /// Foundry-specific version cheatcodes are not supported.
     #[cheatcode(group = Testing, safety = Safe, status = Unsupported)]
     function foundryVersionCmp(string calldata version) external view returns (int256);
 
-    /// Returns the Foundry version.
-    /// Format: <cargo_version>-<tag>+<git_sha_short>.<unix_build_timestamp>.<profile>
-    /// Sample output: 0.3.0-nightly+3cb96bde9b.1737036656.debug
-    /// Note: Build timestamps may vary slightly across platforms due to separate CI jobs.
-    /// For reliable version comparisons, use UNIX format (e.g., >= 1700000000)
-    /// to compare timestamps while ignoring minor time differences.
+    /// Foundry-specific version cheatcodes are not supported.
     #[cheatcode(group = Testing, safety = Safe, status = Unsupported)]
     function getFoundryVersion() external view returns (string memory version);
 }

--- a/crates/foundry/cheatcodes/src/lib.rs
+++ b/crates/foundry/cheatcodes/src/lib.rs
@@ -62,6 +62,8 @@ mod test;
 
 mod toml;
 
+mod unsupported;
+
 mod utils;
 
 pub use cache::{CachedChains, CachedEndpoints, StorageCachingConfig};

--- a/crates/foundry/cheatcodes/src/unsupported.rs
+++ b/crates/foundry/cheatcodes/src/unsupported.rs
@@ -37,8 +37,8 @@ use crate::{
 /// Macro to implement unsupported cheatcodes that return an error when called.
 ///
 /// Use `pure` for cheatcodes marked as `pure` in the cheatcode spec,
-/// and `non_pure` for all others. This is done for correctness, it does not
-/// affect behavior since the cheatcodes are unsupported.
+/// and `non_pure` for all others. This is done for correctness, it has no
+/// effect since the cheatcodes are unsupported.
 macro_rules! impl_unsupported_cheatcode {
     (pure: $($call_type:ident => $cheatcode_name:literal),* $(,)?) => {
         $(
@@ -74,7 +74,7 @@ macro_rules! impl_unsupported_cheatcode {
                         TransactionErrorT,
                     >,
                 ) -> Result {
-                    bail!(concat!("cheatcode `", $cheatcode_name, "` is not supported"));
+                    bail!(concat!("cheatcode '", $cheatcode_name, "' is not supported"));
                 }
             }
         )*
@@ -113,7 +113,7 @@ macro_rules! impl_unsupported_cheatcode {
                         TransactionErrorT,
                     >,
                 ) -> Result {
-                    bail!(concat!("cheatcode `", $cheatcode_name, "` is not supported"));
+                    bail!(concat!("cheatcode '", $cheatcode_name, "' is not supported"));
                 }
             }
         )*
@@ -141,7 +141,7 @@ impl_unsupported_cheatcode! {
     breakpoint_1Call => "breakpoint(string,bool)",
 }
 
-// Non-pure cheatcodes (view or state-modifying)
+// Non-pure cheatcodes
 impl_unsupported_cheatcode! {
     non_pure:
     // Broadcasting cheatcodes

--- a/crates/foundry/cheatcodes/src/unsupported.rs
+++ b/crates/foundry/cheatcodes/src/unsupported.rs
@@ -130,10 +130,10 @@ impl_unsupported_cheatcode! {
     deriveKey_3Call => "deriveKey(string,string,uint32,string)",
 
     // EIP-712 cheatcodes
-    eip712HashType_0Call => "eip712HashType(string,string)",
-    eip712HashType_1Call => "eip712HashType(string,string,string)",
-    eip712HashStruct_0Call => "eip712HashStruct(string,string,bytes)",
-    eip712HashStruct_1Call => "eip712HashStruct(string,string,string,bytes)",
+    eip712HashType_0Call => "eip712HashType(string)",
+    eip712HashType_1Call => "eip712HashType(string,string)",
+    eip712HashStruct_0Call => "eip712HashStruct(string,bytes)",
+    eip712HashStruct_1Call => "eip712HashStruct(string,string,bytes)",
     eip712HashTypedDataCall => "eip712HashTypedData(string)",
 
     // Debugger cheatcodes
@@ -156,19 +156,19 @@ impl_unsupported_cheatcode! {
 
     // EIP-7702 delegation cheatcodes
     signDelegation_0Call => "signDelegation(address,uint256)",
-    signDelegation_1Call => "signDelegation(address,uint256,uint256)",
-    signDelegation_2Call => "signDelegation(address,uint256,uint64)",
-    attachDelegation_0Call => "attachDelegation((uint8,bytes32,bytes32,uint64,address))",
-    attachDelegation_1Call => "attachDelegation((uint8,bytes32,bytes32,uint64,address),address)",
+    signDelegation_1Call => "signDelegation(address,uint256,uint64)",
+    signDelegation_2Call => "signDelegation(address,uint256,bool)",
+    attachDelegation_0Call => "attachDelegation(SignedDelegation)",
+    attachDelegation_1Call => "attachDelegation(SignedDelegation,bool)",
     signAndAttachDelegation_0Call => "signAndAttachDelegation(address,uint256)",
-    signAndAttachDelegation_1Call => "signAndAttachDelegation(address,uint256,uint256)",
-    signAndAttachDelegation_2Call => "signAndAttachDelegation(address,uint256,uint64)",
+    signAndAttachDelegation_1Call => "signAndAttachDelegation(address,uint256,uint64)",
+    signAndAttachDelegation_2Call => "signAndAttachDelegation(address,uint256,bool)",
 
     // Blob cheatcodes (EIP-4844)
     attachBlobCall => "attachBlob(bytes)",
 
     // Wallet management cheatcodes
-    getWalletsCall => "getWallets()",
+    getWalletsCall => "getWallets(address[])",
     createWallet_0Call => "createWallet(string)",
     createWallet_1Call => "createWallet(uint256)",
     createWallet_2Call => "createWallet(uint256,string)",
@@ -183,19 +183,19 @@ impl_unsupported_cheatcode! {
     deployCode_1Call => "deployCode(string,bytes)",
     deployCode_2Call => "deployCode(string,uint256)",
     deployCode_3Call => "deployCode(string,bytes,uint256)",
-    deployCode_4Call => "deployCode(string,address)",
-    deployCode_5Call => "deployCode(string,bytes,address)",
-    deployCode_6Call => "deployCode(string,uint256,address)",
-    deployCode_7Call => "deployCode(string,bytes,uint256,address)",
-    getBroadcastCall => "getBroadcast(string,uint64,uint8)",
-    getBroadcasts_0Call => "getBroadcasts(string,uint64)",
-    getBroadcasts_1Call => "getBroadcasts(string,uint64,uint8)",
+    deployCode_4Call => "deployCode(string,bytes32)",
+    deployCode_5Call => "deployCode(string,bytes,bytes32)",
+    deployCode_6Call => "deployCode(string,uint256,bytes32)",
+    deployCode_7Call => "deployCode(string,bytes,uint256,bytes32)",
+    getBroadcastCall => "getBroadcast(string,uint64,BroadcastTxType)",
+    getBroadcasts_0Call => "getBroadcasts(string,uint64,BroadcastTxType)",
+    getBroadcasts_1Call => "getBroadcasts(string,uint64)",
     getDeployment_0Call => "getDeployment(string)",
     getDeployment_1Call => "getDeployment(string,uint64)",
     getDeploymentsCall => "getDeployments(string,uint64)",
 
     // Foundry version cheatcodes
-    foundryVersionAtLeastCall => "foundryVersionAtLeast(uint256,uint256,uint256)",
-    foundryVersionCmpCall => "foundryVersionCmp(uint256,uint256,uint256)",
+    foundryVersionAtLeastCall => "foundryVersionAtLeast(string)",
+    foundryVersionCmpCall => "foundryVersionCmp(string)",
     getFoundryVersionCall => "getFoundryVersion()",
 }

--- a/crates/foundry/cheatcodes/src/unsupported.rs
+++ b/crates/foundry/cheatcodes/src/unsupported.rs
@@ -1,0 +1,201 @@
+//! Stub implementations for cheatcodes that are not supported in EDR.
+//!
+//! These cheatcodes exist in Foundry but are not implemented in EDR.
+//! Calling them will result in an error explaining that the cheatcode is not
+//! supported.
+
+use foundry_evm_core::{
+    backend::CheatcodeBackend,
+    evm_context::{
+        BlockEnvTr, ChainContextTr, EvmBuilderTrait, HardforkTr, TransactionEnvTr,
+        TransactionErrorTrait,
+    },
+};
+use revm::context::result::HaltReasonTr;
+
+use crate::{
+    impl_is_pure_false, impl_is_pure_true, Cheatcode, Cheatcodes, Result,
+    Vm::{
+        attachBlobCall, attachDelegation_0Call, attachDelegation_1Call, breakpoint_0Call,
+        breakpoint_1Call, broadcastRawTransactionCall, broadcast_0Call, broadcast_1Call,
+        broadcast_2Call, createWallet_0Call, createWallet_1Call, createWallet_2Call,
+        deployCode_0Call, deployCode_1Call, deployCode_2Call, deployCode_3Call, deployCode_4Call,
+        deployCode_5Call, deployCode_6Call, deployCode_7Call, deriveKey_0Call, deriveKey_1Call,
+        deriveKey_2Call, deriveKey_3Call, eip712HashStruct_0Call, eip712HashStruct_1Call,
+        eip712HashType_0Call, eip712HashType_1Call, eip712HashTypedDataCall,
+        foundryVersionAtLeastCall, foundryVersionCmpCall, getArtifactPathByCodeCall,
+        getArtifactPathByDeployedCodeCall, getBroadcastCall, getBroadcasts_0Call,
+        getBroadcasts_1Call, getDeployment_0Call, getDeployment_1Call, getDeploymentsCall,
+        getFoundryVersionCall, getWalletsCall, rememberKeyCall, rememberKeys_0Call,
+        rememberKeys_1Call, signAndAttachDelegation_0Call, signAndAttachDelegation_1Call,
+        signAndAttachDelegation_2Call, signDelegation_0Call, signDelegation_1Call,
+        signDelegation_2Call, startBroadcast_0Call, startBroadcast_1Call, startBroadcast_2Call,
+        stopBroadcastCall,
+    },
+};
+
+/// Macro to implement unsupported cheatcodes that return an error when called.
+///
+/// Use `pure` for cheatcodes marked as `pure` in the cheatcode spec,
+/// and `non_pure` for all others. This is done for correctness, it does not
+/// affect behavior since the cheatcodes are unsupported.
+macro_rules! impl_unsupported_cheatcode {
+    (pure: $($call_type:ident => $cheatcode_name:literal),* $(,)?) => {
+        $(
+            impl_is_pure_true!($call_type);
+
+            impl Cheatcode for $call_type {
+                fn apply<
+                    BlockT: BlockEnvTr,
+                    TxT: TransactionEnvTr,
+                    EvmBuilderT: EvmBuilderTrait<BlockT, ChainContextT, HaltReasonT, HardforkT, TransactionErrorT, TxT>,
+                    HaltReasonT: HaltReasonTr,
+                    HardforkT: HardforkTr,
+                    TransactionErrorT: TransactionErrorTrait,
+                    ChainContextT: ChainContextTr,
+                    DatabaseT: CheatcodeBackend<
+                        BlockT,
+                        TxT,
+                        EvmBuilderT,
+                        HaltReasonT,
+                        HardforkT,
+                        TransactionErrorT,
+                        ChainContextT,
+                    >,
+                >(
+                    &self,
+                    _state: &mut Cheatcodes<
+                        BlockT,
+                        TxT,
+                        ChainContextT,
+                        EvmBuilderT,
+                        HaltReasonT,
+                        HardforkT,
+                        TransactionErrorT,
+                    >,
+                ) -> Result {
+                    bail!(concat!("cheatcode `", $cheatcode_name, "` is not supported"));
+                }
+            }
+        )*
+    };
+    (non_pure: $($call_type:ident => $cheatcode_name:literal),* $(,)?) => {
+        $(
+            impl_is_pure_false!($call_type);
+
+            impl Cheatcode for $call_type {
+                fn apply<
+                    BlockT: BlockEnvTr,
+                    TxT: TransactionEnvTr,
+                    EvmBuilderT: EvmBuilderTrait<BlockT, ChainContextT, HaltReasonT, HardforkT, TransactionErrorT, TxT>,
+                    HaltReasonT: HaltReasonTr,
+                    HardforkT: HardforkTr,
+                    TransactionErrorT: TransactionErrorTrait,
+                    ChainContextT: ChainContextTr,
+                    DatabaseT: CheatcodeBackend<
+                        BlockT,
+                        TxT,
+                        EvmBuilderT,
+                        HaltReasonT,
+                        HardforkT,
+                        TransactionErrorT,
+                        ChainContextT,
+                    >,
+                >(
+                    &self,
+                    _state: &mut Cheatcodes<
+                        BlockT,
+                        TxT,
+                        ChainContextT,
+                        EvmBuilderT,
+                        HaltReasonT,
+                        HardforkT,
+                        TransactionErrorT,
+                    >,
+                ) -> Result {
+                    bail!(concat!("cheatcode `", $cheatcode_name, "` is not supported"));
+                }
+            }
+        )*
+    };
+}
+
+// Pure cheatcodes (marked as `pure` in the Foundry spec)
+impl_unsupported_cheatcode! {
+    pure:
+    // Key derivation cheatcodes
+    deriveKey_0Call => "deriveKey(string,uint32)",
+    deriveKey_1Call => "deriveKey(string,string,uint32)",
+    deriveKey_2Call => "deriveKey(string,uint32,string)",
+    deriveKey_3Call => "deriveKey(string,string,uint32,string)",
+
+    // EIP-712 cheatcodes
+    eip712HashType_0Call => "eip712HashType(string,string)",
+    eip712HashType_1Call => "eip712HashType(string,string,string)",
+    eip712HashStruct_0Call => "eip712HashStruct(string,string,bytes)",
+    eip712HashStruct_1Call => "eip712HashStruct(string,string,string,bytes)",
+    eip712HashTypedDataCall => "eip712HashTypedData(string)",
+
+    // Debugger cheatcodes
+    breakpoint_0Call => "breakpoint(string)",
+    breakpoint_1Call => "breakpoint(string,bool)",
+}
+
+// Non-pure cheatcodes (view or state-modifying)
+impl_unsupported_cheatcode! {
+    non_pure:
+    // Broadcasting cheatcodes
+    broadcast_0Call => "broadcast()",
+    broadcast_1Call => "broadcast(address)",
+    broadcast_2Call => "broadcast(uint256)",
+    startBroadcast_0Call => "startBroadcast()",
+    startBroadcast_1Call => "startBroadcast(address)",
+    startBroadcast_2Call => "startBroadcast(uint256)",
+    stopBroadcastCall => "stopBroadcast()",
+    broadcastRawTransactionCall => "broadcastRawTransaction(bytes)",
+
+    // EIP-7702 delegation cheatcodes
+    signDelegation_0Call => "signDelegation(address,uint256)",
+    signDelegation_1Call => "signDelegation(address,uint256,uint256)",
+    signDelegation_2Call => "signDelegation(address,uint256,uint64)",
+    attachDelegation_0Call => "attachDelegation((uint8,bytes32,bytes32,uint64,address))",
+    attachDelegation_1Call => "attachDelegation((uint8,bytes32,bytes32,uint64,address),address)",
+    signAndAttachDelegation_0Call => "signAndAttachDelegation(address,uint256)",
+    signAndAttachDelegation_1Call => "signAndAttachDelegation(address,uint256,uint256)",
+    signAndAttachDelegation_2Call => "signAndAttachDelegation(address,uint256,uint64)",
+
+    // Blob cheatcodes (EIP-4844)
+    attachBlobCall => "attachBlob(bytes)",
+
+    // Wallet management cheatcodes
+    getWalletsCall => "getWallets()",
+    createWallet_0Call => "createWallet(string)",
+    createWallet_1Call => "createWallet(uint256)",
+    createWallet_2Call => "createWallet(uint256,string)",
+    rememberKeyCall => "rememberKey(uint256)",
+    rememberKeys_0Call => "rememberKeys(string,string,uint32)",
+    rememberKeys_1Call => "rememberKeys(string,string,string,uint32)",
+
+    // Artifact/deployment cheatcodes
+    getArtifactPathByCodeCall => "getArtifactPathByCode(bytes)",
+    getArtifactPathByDeployedCodeCall => "getArtifactPathByDeployedCode(bytes)",
+    deployCode_0Call => "deployCode(string)",
+    deployCode_1Call => "deployCode(string,bytes)",
+    deployCode_2Call => "deployCode(string,uint256)",
+    deployCode_3Call => "deployCode(string,bytes,uint256)",
+    deployCode_4Call => "deployCode(string,address)",
+    deployCode_5Call => "deployCode(string,bytes,address)",
+    deployCode_6Call => "deployCode(string,uint256,address)",
+    deployCode_7Call => "deployCode(string,bytes,uint256,address)",
+    getBroadcastCall => "getBroadcast(string,uint64,uint8)",
+    getBroadcasts_0Call => "getBroadcasts(string,uint64)",
+    getBroadcasts_1Call => "getBroadcasts(string,uint64,uint8)",
+    getDeployment_0Call => "getDeployment(string)",
+    getDeployment_1Call => "getDeployment(string,uint64)",
+    getDeploymentsCall => "getDeployments(string,uint64)",
+
+    // Foundry version cheatcodes
+    foundryVersionAtLeastCall => "foundryVersionAtLeast(uint256,uint256,uint256)",
+    foundryVersionCmpCall => "foundryVersionCmp(uint256,uint256,uint256)",
+    getFoundryVersionCall => "getFoundryVersion()",
+}


### PR DESCRIPTION
This PR introduces support for a new type of cheatcode in the `Vm` cheatcode interface: `Unsupported`. Unsupported cheatcodes from Foundry v1.3.0 are added to the `Vm` interface, with corresponding stubs.

This is the first step towards implementing structured errors for unsupported cheatcodes and provides the ability to distinguish between "unsupported" and "missing" (newer, not integrated) cheatcodes.

The unsupported cheatcodes currently have short, generic documentation that states the unsupported status. This may be revisited in a future PR to add more detailed information.

Changes in `foundry/cheatcodes/assets` are auto-generated from `vm.rs` and can be ignored when reviewing.