### PR TITLE
chore: upgrade `setup-node` action version

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -11,7 +11,7 @@ runs:
   using: composite
   steps:
     - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
-    - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+    - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
       id: setup-node
       with:
         node-version: ${{ inputs.node-version }}

--- a/.github/workflows/edr-npm-release.yml
+++ b/.github/workflows/edr-npm-release.yml
@@ -515,7 +515,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
       - name: Setup node
-        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         id: setup-node
         with:
           node-version: 22
@@ -625,7 +625,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
       - name: Setup node
-        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         id: setup-node
         with:
           node-version: 22


### PR DESCRIPTION
Upgrade to version `6.2.0` since this version includes a fix for `The 'punycode' module is deprecated` error we experienced on the "Post setup node" step (see https://github.com/actions/setup-node/issues/1364).

EDR failures:
 - https://github.com/NomicFoundation/edr/actions/runs/21289056355/job/61280027216 
 - https://github.com/NomicFoundation/edr/actions/runs/20579076063/job/59103907985
