### PR TITLE
fix(op): update Base Mainnet `DynamicBaseFeeParams`

### DIFF
--- a/crates/edr_op/src/hardfork/base.rs
+++ b/crates/edr_op/src/hardfork/base.rs
@@ -41,6 +41,10 @@ pub(crate) static MAINNET_BASE_FEE_PARAMS: LazyLock<BaseFeeParams<OpSpecId>> =
                 BaseFeeActivation::BlockNumber(39_647_879),
                 ConstantBaseFeeParams::new(50, 6),
             ),
+            (
+                BaseFeeActivation::BlockNumber(41_711_238),
+                ConstantBaseFeeParams::new(125, 6),
+            ),
         ]))
     });
 

--- a/crates/edr_op/tests/integration/dynamic_base_fee_params.rs
+++ b/crates/edr_op/tests/integration/dynamic_base_fee_params.rs
@@ -42,6 +42,18 @@ async fn assert_base_fee_activation(
         assert_eq!(remote_header.base_fee_per_gas, local_header.base_fee);
         Ok(())
     };
+    // Two blocks before the activation point shouldn't see any modification
+    assert_replay_header::<OpChainSpec>(
+        runtime.clone(),
+        url.clone(),
+        block_number - 2,
+        header_overrides,
+        block_validation,
+    )
+    .await?;
+
+    // One block before the activation point should have a different `extra_data`
+    // field than its parent
     assert_replay_header::<OpChainSpec>(
         runtime.clone(),
         url.clone(),
@@ -51,6 +63,8 @@ async fn assert_base_fee_activation(
     )
     .await?;
 
+    // The activation point block should use the new values for calculating the base
+    // fee
     assert_replay_header::<OpChainSpec>(
         runtime,
         url,
@@ -75,6 +89,7 @@ impl_test_dynamic_base_fee_params! {
         38_088_319,
         38_951_425, // jovian activated block
         39_647_879, // SystemConfig EIP-1559 update 2025-12-18
+        41_711_238, // SystemConfig EIP-1559 update 2026-02-04
     ],
     op_sepolia: json_rpc_url_provider::op_sepolia() => [
         26_806_602,


### PR DESCRIPTION
## Main change
Update Base Mainnet EIP dynamic base fee params after today (2026-02-04) `SystemConfig` update

For details see  tx: 0x30bb34595b1536556112591bfd26b9b24096dbfb37d59cc13515101a5f8b4de5 on SystemConfig contract [event list](https://etherscan.io/address/0x73a79Fab69143498Ed3712e519A88a918e1f4072#events) 


## Bonus track
Add extra-validation and doc comments on `dynamic_base_fee_params.rs` tests