### PR TITLE
feat: add the ability to specify the hardfork when running Solidity tests

### DIFF
--- a/.changeset/chatty-radios-draw.md
+++ b/.changeset/chatty-radios-draw.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": minor
+---
+
+Added the ability to specify the hardfork when running Solidity tests. Added support for the Osaka hardfork in Solidity tests.

--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -660,11 +660,8 @@ export interface SolidityTestRunnerConfigArgs {
    * Defaults to `31337`.
    */
   chainId?: bigint
-  /**
-   * The hardfork to use for EVM execution.
-   * Defaults to the chain's default hardfork if not provided.
-   */
-  hardfork?: string
+  /** The hardfork to use for EVM execution. */
+  hardfork: string
   /**
    * The gas limit for each test case.
    * Defaults to `9_223_372_036_854_775_807` (`i64::MAX`).

--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -661,6 +661,11 @@ export interface SolidityTestRunnerConfigArgs {
    */
   chainId?: bigint
   /**
+   * The hardfork to use for EVM execution.
+   * Defaults to the chain's default hardfork if not provided.
+   */
+  hardfork?: string
+  /**
    * The gas limit for each test case.
    * Defaults to `9_223_372_036_854_775_807` (`i64::MAX`).
    */
@@ -700,6 +705,11 @@ export interface SolidityTestRunnerConfigArgs {
    * Defaults to false.
    */
   disableBlockGasLimit?: boolean
+  /**
+   * Whether to enable the EIP-7825 (Osaka) transaction gas limit cap.
+   * Defaults to false.
+   */
+  enableTxGasLimitCap?: boolean
   /**
    * The memory limit of the EVM in bytes.
    * Defaults to `33_554_432` (2^25 = 32MiB).

--- a/crates/edr_napi/src/solidity_tests/config.rs
+++ b/crates/edr_napi/src/solidity_tests/config.rs
@@ -75,6 +75,9 @@ pub struct SolidityTestRunnerConfigArgs {
     /// Defaults to `31337`.
     #[serde(serialize_with = "serialize_optional_bigint_as_struct")]
     pub chain_id: Option<BigInt>,
+    /// The hardfork to use for EVM execution.
+    /// Defaults to the chain's default hardfork if not provided.
+    pub hardfork: Option<String>,
     /// The gas limit for each test case.
     /// Defaults to `9_223_372_036_854_775_807` (`i64::MAX`).
     #[serde(serialize_with = "serialize_optional_bigint_as_struct")]
@@ -107,6 +110,9 @@ pub struct SolidityTestRunnerConfigArgs {
     /// Whether to disable the block gas limit.
     /// Defaults to false.
     pub disable_block_gas_limit: Option<bool>,
+    /// Whether to enable the EIP-7825 (Osaka) transaction gas limit cap.
+    /// Defaults to false.
+    pub enable_tx_gas_limit_cap: Option<bool>,
     /// The memory limit of the EVM in bytes.
     /// Defaults to `33_554_432` (2^25 = 32MiB).
     #[serde(serialize_with = "serialize_optional_bigint_as_struct")]
@@ -184,6 +190,7 @@ impl SolidityTestRunnerConfigArgs {
             initial_balance,
             block_number,
             chain_id,
+            hardfork,
             gas_limit,
             gas_price,
             block_base_fee_per_gas,
@@ -192,6 +199,7 @@ impl SolidityTestRunnerConfigArgs {
             block_difficulty,
             block_gas_limit,
             disable_block_gas_limit,
+            enable_tx_gas_limit_cap,
             memory_limit,
             local_predeploys,
             eth_rpc_url,
@@ -308,6 +316,7 @@ impl SolidityTestRunnerConfigArgs {
             initial_balance: initial_balance.map(TryCast::try_cast).transpose()?,
             block_number: block_number.map(TryCast::try_cast).transpose()?,
             chain_id: chain_id.map(TryCast::try_cast).transpose()?,
+            hardfork,
             gas_limit: gas_limit.map(TryCast::try_cast).transpose()?,
             gas_price: gas_price.map(TryCast::try_cast).transpose()?,
             block_base_fee_per_gas: block_base_fee_per_gas.map(TryCast::try_cast).transpose()?,
@@ -316,6 +325,7 @@ impl SolidityTestRunnerConfigArgs {
             block_difficulty: block_difficulty.map(TryCast::try_cast).transpose()?,
             block_gas_limit: block_gas_limit.map(TryCast::try_cast).transpose()?,
             disable_block_gas_limit,
+            enable_tx_gas_limit_cap,
             memory_limit: memory_limit.map(TryCast::try_cast).transpose()?,
             local_predeploys,
             fork_url: eth_rpc_url,

--- a/crates/edr_napi/src/solidity_tests/config.rs
+++ b/crates/edr_napi/src/solidity_tests/config.rs
@@ -76,8 +76,7 @@ pub struct SolidityTestRunnerConfigArgs {
     #[serde(serialize_with = "serialize_optional_bigint_as_struct")]
     pub chain_id: Option<BigInt>,
     /// The hardfork to use for EVM execution.
-    /// Defaults to the chain's default hardfork if not provided.
-    pub hardfork: Option<String>,
+    pub hardfork: String,
     /// The gas limit for each test case.
     /// Defaults to `9_223_372_036_854_775_807` (`i64::MAX`).
     #[serde(serialize_with = "serialize_optional_bigint_as_struct")]

--- a/crates/edr_napi/test/coverage.ts
+++ b/crates/edr_napi/test/coverage.ts
@@ -248,6 +248,7 @@ describe("Code coverage", () => {
       const testSuites = artifacts.map((artifact) => artifact.id);
       const config = {
         projectRoot: __dirname,
+        hardfork: l1HardforkToString(l1HardforkLatest()),
         observability: {
           codeCoverage: {
             onCollectedCoverageCallback: async (coverage: Uint8Array[]) => {
@@ -279,6 +280,7 @@ describe("Code coverage", () => {
       const testSuites = artifacts.map((artifact) => artifact.id);
       const config = {
         projectRoot: __dirname,
+        hardfork: l1HardforkToString(l1HardforkLatest()),
         observability: {
           codeCoverage: {
             onCollectedCoverageCallback: async (_coverage: Uint8Array[]) => {

--- a/crates/edr_napi/test/op.ts
+++ b/crates/edr_napi/test/op.ts
@@ -325,6 +325,7 @@ describe("Multi-chain", () => {
         const testSuites = artifacts.map((artifact) => artifact.id);
         const config = {
           projectRoot: __dirname,
+          hardfork: opHardforkToString(opLatestHardfork()),
         };
 
         const [, results] = await runAllSolidityTests(

--- a/crates/edr_napi/test/solidity-tests.ts
+++ b/crates/edr_napi/test/solidity-tests.ts
@@ -1,6 +1,12 @@
 import { assert } from "chai";
 
-import { EdrContext, L1_CHAIN_TYPE, l1SolidityTestRunnerFactory } from "..";
+import {
+  EdrContext,
+  L1_CHAIN_TYPE,
+  l1HardforkLatest,
+  l1HardforkToString,
+  l1SolidityTestRunnerFactory,
+} from "..";
 import { loadContract, runAllSolidityTests } from "./helpers";
 
 describe("Solidity Tests", () => {
@@ -22,6 +28,7 @@ describe("Solidity Tests", () => {
     const testSuites = artifacts.map((artifact) => artifact.id);
     const config = {
       projectRoot: __dirname,
+      hardfork: l1HardforkToString(l1HardforkLatest()),
     };
 
     const [, results] = await runAllSolidityTests(
@@ -57,6 +64,7 @@ describe("Solidity Tests", () => {
     const testSuites = artifacts.map((artifact) => artifact.id);
     const config = {
       projectRoot: __dirname,
+      hardfork: l1HardforkToString(l1HardforkLatest()),
       // Memory limit is too large
       memoryLimit: 2n ** 65n,
     };
@@ -82,6 +90,7 @@ describe("Solidity Tests", () => {
     const testSuites = artifacts.map((artifact) => artifact.id);
     const config = {
       projectRoot: __dirname,
+      hardfork: l1HardforkToString(l1HardforkLatest()),
     };
 
     artifacts[0].contract.bytecode = "invalid bytecode";
@@ -112,6 +121,7 @@ describe("Solidity Tests", () => {
       testSuites,
       {
         projectRoot: __dirname,
+        hardfork: l1HardforkToString(l1HardforkLatest()),
         testPattern: "Multiply",
       }
     );

--- a/crates/edr_napi_core/src/solidity/config.rs
+++ b/crates/edr_napi_core/src/solidity/config.rs
@@ -189,7 +189,7 @@ pub struct TestRunnerConfig {
 
 fn parse_hardfork<HardforkT>(hardfork: String) -> napi::Result<HardforkT>
 where
-    HardforkT: FromStr<Err = UnknownHardfork> + Default + Into<EvmSpecId>,
+    HardforkT: FromStr<Err = UnknownHardfork> + Into<EvmSpecId>,
 {
     hardfork.parse().map_err(|UnknownHardfork| {
         napi::Error::new(

--- a/crates/edr_napi_core/src/solidity/config.rs
+++ b/crates/edr_napi_core/src/solidity/config.rs
@@ -119,8 +119,7 @@ pub struct TestRunnerConfig {
     /// Defaults to `31337`.
     pub chain_id: Option<u64>,
     /// The hardfork to use for EVM execution.
-    /// Defaults to the chain's default hardfork if not provided.
-    pub hardfork: Option<String>,
+    pub hardfork: String,
     /// The gas limit for each test case.
     /// Defaults to `9_223_372_036_854_775_807` (`i64::MAX`).
     pub gas_limit: Option<u64>,
@@ -247,9 +246,8 @@ where
         }
 
         evm_opts.env.chain_id = chain_id;
-        if let Some(hardfork) = hardfork {
-            evm_opts.spec = parse_hardfork(hardfork)?;
-        }
+
+        evm_opts.spec = parse_hardfork(hardfork)?;
 
         evm_opts.env.gas_price = gas_price;
 

--- a/crates/edr_solidity_tests/src/config.rs
+++ b/crates/edr_solidity_tests/src/config.rs
@@ -139,6 +139,7 @@ impl<HardforkT: HardforkTr> SolidityTestRunnerConfig<HardforkT> {
             memory_limit: 1 << 25, // 2**25 = 32MiB
             isolate: false,
             disable_block_gas_limit: false,
+            enable_tx_gas_limit_cap: false,
             fork_headers: None,
         }
     }

--- a/crates/foundry/evm/core/src/opts.rs
+++ b/crates/foundry/evm/core/src/opts.rs
@@ -67,6 +67,9 @@ pub struct EvmOpts<HardforkT> {
 
     /// Whether to disable block gas limit checks.
     pub disable_block_gas_limit: bool,
+
+    /// Whether to enable the EIP-7825 (Osaka) transaction gas limit cap.
+    pub enable_tx_gas_limit_cap: bool,
 }
 
 impl<HardforkT> Default for EvmOpts<HardforkT>
@@ -90,6 +93,7 @@ where
             memory_limit: 0,
             isolate: false,
             disable_block_gas_limit: false,
+            enable_tx_gas_limit_cap: false,
         }
     }
 }
@@ -137,6 +141,7 @@ where
             self.fork_block_number,
             self.sender,
             self.disable_block_gas_limit,
+            self.enable_tx_gas_limit_cap,
         )
         .await
         .wrap_err_with(|| {
@@ -160,6 +165,7 @@ where
             self.env.chain_id.unwrap_or(edr_defaults::DEV_CHAIN_ID),
             self.memory_limit,
             self.disable_block_gas_limit,
+            self.enable_tx_gas_limit_cap,
         );
 
         crate::Env {

--- a/crates/foundry/evm/core/src/precompiles.rs
+++ b/crates/foundry/evm/core/src/precompiles.rs
@@ -30,6 +30,30 @@ pub const BLAKE_2F: Address = address!("0x00000000000000000000000000000000000000
 /// The `PointEvaluation` precompile address.
 pub const POINT_EVALUATION: Address = address!("0x000000000000000000000000000000000000000a");
 
+/// The BLS12-381 G1ADD precompile address.
+pub const BLS12_G1ADD: Address = address!("0x000000000000000000000000000000000000000b");
+
+/// The BLS12-381 G1MSM precompile address.
+pub const BLS12_G1MSM: Address = address!("0x000000000000000000000000000000000000000c");
+
+/// The BLS12-381 G2ADD precompile address.
+pub const BLS12_G2ADD: Address = address!("0x000000000000000000000000000000000000000d");
+
+/// The BLS12-381 G2MSM precompile address.
+pub const BLS12_G2MSM: Address = address!("0x000000000000000000000000000000000000000e");
+
+/// The BLS12-381 pairing check precompile address.
+pub const BLS12_PAIRING_CHECK: Address = address!("0x000000000000000000000000000000000000000f");
+
+/// The BLS12-381 map Fp to G1 precompile address.
+pub const BLS12_MAP_FP_TO_G1: Address = address!("0x0000000000000000000000000000000000000010");
+
+/// The BLS12-381 map Fp2 to G2 precompile address.
+pub const BLS12_MAP_FP2_TO_G2: Address = address!("0x0000000000000000000000000000000000000011");
+
+/// The P256VERIFY precompile address.
+pub const P256_VERIFY: Address = address!("0x0000000000000000000000000000000000000100");
+
 /// Precompile addresses.
 pub const PRECOMPILES: &[Address] = &[
     EC_RECOVER,
@@ -42,4 +66,12 @@ pub const PRECOMPILES: &[Address] = &[
     EC_PAIRING,
     BLAKE_2F,
     POINT_EVALUATION,
+    BLS12_G1ADD,
+    BLS12_G1MSM,
+    BLS12_G2ADD,
+    BLS12_G2MSM,
+    BLS12_PAIRING_CHECK,
+    BLS12_MAP_FP_TO_G1,
+    BLS12_MAP_FP2_TO_G2,
+    P256_VERIFY,
 ];

--- a/crates/foundry/evm/traces/src/decoder/mod.rs
+++ b/crates/foundry/evm/traces/src/decoder/mod.rs
@@ -17,8 +17,9 @@ use foundry_evm_core::{
     contracts::ContractsByArtifact,
     decode::RevertDecoder,
     precompiles::{
-        BLAKE_2F, EC_ADD, EC_MUL, EC_PAIRING, EC_RECOVER, IDENTITY, MOD_EXP, POINT_EVALUATION,
-        RIPEMD_160, SHA_256,
+        BLAKE_2F, BLS12_G1ADD, BLS12_G1MSM, BLS12_G2ADD, BLS12_G2MSM, BLS12_MAP_FP2_TO_G2,
+        BLS12_MAP_FP_TO_G1, BLS12_PAIRING_CHECK, EC_ADD, EC_MUL, EC_PAIRING, EC_RECOVER, IDENTITY,
+        MOD_EXP, P256_VERIFY, POINT_EVALUATION, RIPEMD_160, SHA_256,
     },
 };
 use itertools::Itertools;
@@ -175,6 +176,14 @@ impl CallTraceDecoder {
                 (EC_PAIRING, "ECPairing".to_string()),
                 (BLAKE_2F, "Blake2F".to_string()),
                 (POINT_EVALUATION, "PointEvaluation".to_string()),
+                (BLS12_G1ADD, "BLS12_G1ADD".to_string()),
+                (BLS12_G1MSM, "BLS12_G1MSM".to_string()),
+                (BLS12_G2ADD, "BLS12_G2ADD".to_string()),
+                (BLS12_G2MSM, "BLS12_G2MSM".to_string()),
+                (BLS12_PAIRING_CHECK, "BLS12_PAIRING_CHECK".to_string()),
+                (BLS12_MAP_FP_TO_G1, "BLS12_MAP_FP_TO_G1".to_string()),
+                (BLS12_MAP_FP2_TO_G2, "BLS12_MAP_FP2_TO_G2".to_string()),
+                (P256_VERIFY, "P256VERIFY".to_string()),
             ]),
             receive_contracts: HashSet::default(),
             fallback_contracts: HashMap::default(),

--- a/crates/foundry/evm/traces/src/decoder/precompiles.rs
+++ b/crates/foundry/evm/traces/src/decoder/precompiles.rs
@@ -1,8 +1,9 @@
 use alloy_primitives::{hex, Address, B256, U256};
 use alloy_sol_types::{abi, sol, SolCall};
 use foundry_evm_core::precompiles::{
-    BLAKE_2F, EC_ADD, EC_MUL, EC_PAIRING, EC_RECOVER, IDENTITY, MOD_EXP, POINT_EVALUATION,
-    RIPEMD_160, SHA_256,
+    BLAKE_2F, BLS12_G1ADD, BLS12_G1MSM, BLS12_G2ADD, BLS12_G2MSM, BLS12_MAP_FP2_TO_G2,
+    BLS12_MAP_FP_TO_G1, BLS12_PAIRING_CHECK, EC_ADD, EC_MUL, EC_PAIRING, EC_RECOVER, IDENTITY,
+    MOD_EXP, P256_VERIFY, POINT_EVALUATION, RIPEMD_160, SHA_256,
 };
 use itertools::Itertools;
 use revm_inspectors::tracing::types::DecodedCallTrace;
@@ -34,11 +35,25 @@ interface Precompiles {
     /* 0x08 */ function ecpairing(EcPairingInput[] input) returns (bool success);
     /* 0x09 */ function blake2f(uint32 rounds, uint64[8] h, uint64[16] m, uint64[2] t, bool f) returns (uint64[8] h);
     /* 0x0a */ function pointEvaluation(bytes32 versionedHash, bytes32 z, bytes32 y, bytes1[48] commitment, bytes1[48] proof) returns (bytes value);
+
+    // Prague BLS12-381 precompiles (EIP-2537)
+    /* 0x0b */ function bls12G1Add(bytes p1, bytes p2) returns (bytes result);
+    /* 0x0c */ function bls12G1Msm(bytes[] scalarsAndPoints) returns (bytes result);
+    /* 0x0d */ function bls12G2Add(bytes p1, bytes p2) returns (bytes result);
+    /* 0x0e */ function bls12G2Msm(bytes[] scalarsAndPoints) returns (bytes result);
+    /* 0x0f */ function bls12PairingCheck(bytes[] pairs) returns (bool success);
+    /* 0x10 */ function bls12MapFpToG1(bytes fp) returns (bytes result);
+    /* 0x11 */ function bls12MapFp2ToG2(bytes fp2) returns (bytes result);
+
+    // Osaka precompiles (EIP-7212)
+    /* 0x100 */ function p256Verify(bytes32 hash, uint256 r, uint256 s, uint256 qx, uint256 qy) returns (bool success);
 }
 }
 use Precompiles::{
-    blake2fCall, ecaddCall, ecaddReturn, ecmulCall, ecmulReturn, ecpairingCall, ecrecoverCall,
-    identityCall, modexpCall, pointEvaluationCall, ripemdCall, sha256Call,
+    blake2fCall, bls12G1AddCall, bls12G1MsmCall, bls12G2AddCall, bls12G2MsmCall,
+    bls12MapFp2ToG2Call, bls12MapFpToG1Call, bls12PairingCheckCall, ecaddCall, ecaddReturn,
+    ecmulCall, ecmulReturn, ecpairingCall, ecrecoverCall, identityCall, modexpCall, p256VerifyCall,
+    pointEvaluationCall, ripemdCall, sha256Call,
 };
 
 pub(super) fn is_known_precompile(address: Address, _chain_id: u64) -> bool {
@@ -57,6 +72,14 @@ pub(super) fn is_known_precompile(address: Address, _chain_id: u64) -> bool {
                 | EC_PAIRING
                 | BLAKE_2F
                 | POINT_EVALUATION
+                | BLS12_G1ADD
+                | BLS12_G1MSM
+                | BLS12_G2ADD
+                | BLS12_G2MSM
+                | BLS12_PAIRING_CHECK
+                | BLS12_MAP_FP_TO_G1
+                | BLS12_MAP_FP2_TO_G2
+                | P256_VERIFY
         )
 }
 
@@ -68,7 +91,7 @@ pub(super) fn decode(trace: &CallTrace, _chain_id: u64) -> Option<DecodedCallTra
 
     for &precompile in PRECOMPILES {
         if trace.address == precompile.address() {
-            let signature = precompile.signature();
+            let signature = precompile.signature(&trace.data);
 
             let args = precompile
                 .decode_call(&trace.data)
@@ -99,7 +122,7 @@ pub(super) fn decode(trace: &CallTrace, _chain_id: u64) -> Option<DecodedCallTra
 
 pub(super) trait Precompile {
     fn address(&self) -> Address;
-    fn signature(&self) -> &'static str;
+    fn signature(&self, data: &[u8]) -> &'static str;
 
     fn decode_call(&self, data: &[u8]) -> alloy_sol_types::Result<Vec<String>> {
         Ok(vec![hex::encode_prefixed(data)])
@@ -124,6 +147,14 @@ const PRECOMPILES: &[&dyn Precompile] = &[
     &Ecpairing,
     &Blake2f,
     &PointEvaluation,
+    &Bls12G1Add,
+    &Bls12G1Msm,
+    &Bls12G2Add,
+    &Bls12G2Msm,
+    &Bls12PairingCheck,
+    &Bls12MapFpToG1,
+    &Bls12MapFp2ToG2,
+    &P256Verify,
 ];
 
 struct Ecrecover;
@@ -132,7 +163,7 @@ impl Precompile for Ecrecover {
         EC_RECOVER
     }
 
-    fn signature(&self) -> &'static str {
+    fn signature(&self, _: &[u8]) -> &'static str {
         ecrecoverCall::SIGNATURE
     }
 
@@ -158,7 +189,7 @@ impl Precompile for Sha256 {
         SHA_256
     }
 
-    fn signature(&self) -> &'static str {
+    fn signature(&self, _: &[u8]) -> &'static str {
         sha256Call::SIGNATURE
     }
 
@@ -174,7 +205,7 @@ impl Precompile for Ripemd160 {
         RIPEMD_160
     }
 
-    fn signature(&self) -> &'static str {
+    fn signature(&self, _: &[u8]) -> &'static str {
         ripemdCall::SIGNATURE
     }
 
@@ -190,7 +221,7 @@ impl Precompile for Identity {
         IDENTITY
     }
 
-    fn signature(&self) -> &'static str {
+    fn signature(&self, _: &[u8]) -> &'static str {
         identityCall::SIGNATURE
     }
 }
@@ -201,7 +232,7 @@ impl Precompile for ModExp {
         MOD_EXP
     }
 
-    fn signature(&self) -> &'static str {
+    fn signature(&self, _: &[u8]) -> &'static str {
         modexpCall::SIGNATURE
     }
 
@@ -230,7 +261,7 @@ impl Precompile for EcAdd {
         EC_ADD
     }
 
-    fn signature(&self) -> &'static str {
+    fn signature(&self, _: &[u8]) -> &'static str {
         ecaddCall::SIGNATURE
     }
 
@@ -256,7 +287,7 @@ impl Precompile for Ecmul {
         EC_MUL
     }
 
-    fn signature(&self) -> &'static str {
+    fn signature(&self, _: &[u8]) -> &'static str {
         ecmulCall::SIGNATURE
     }
 
@@ -277,7 +308,7 @@ impl Precompile for Ecpairing {
         EC_PAIRING
     }
 
-    fn signature(&self) -> &'static str {
+    fn signature(&self, _: &[u8]) -> &'static str {
         ecpairingCall::SIGNATURE
     }
 
@@ -307,7 +338,7 @@ impl Precompile for Blake2f {
         BLAKE_2F
     }
 
-    fn signature(&self) -> &'static str {
+    fn signature(&self, _: &[u8]) -> &'static str {
         blake2fCall::SIGNATURE
     }
 
@@ -345,7 +376,7 @@ impl Precompile for PointEvaluation {
         POINT_EVALUATION
     }
 
-    fn signature(&self) -> &'static str {
+    fn signature(&self, _: &[u8]) -> &'static str {
         pointEvaluationCall::SIGNATURE
     }
 
@@ -368,6 +399,162 @@ impl Precompile for PointEvaluation {
 
 fn iter_to_string<I: Iterator<Item = T>, T: std::fmt::Display>(iter: I) -> String {
     format!("[{}]", iter.format(", "))
+}
+
+const G1_POINT_SIZE: usize = 128;
+const G2_POINT_SIZE: usize = 256;
+const SCALAR_SIZE: usize = 32;
+const FP_SIZE: usize = 64;
+
+struct Bls12G1Add;
+impl Precompile for Bls12G1Add {
+    fn address(&self) -> Address {
+        BLS12_G1ADD
+    }
+
+    fn signature(&self, _: &[u8]) -> &'static str {
+        bls12G1AddCall::SIGNATURE
+    }
+
+    fn decode_call(&self, data: &[u8]) -> alloy_sol_types::Result<Vec<String>> {
+        let (p1, rest) = take_at_most(data, G1_POINT_SIZE);
+        let (p2, _) = take_at_most(rest, G1_POINT_SIZE);
+        Ok(vec![hex::encode_prefixed(p1), hex::encode_prefixed(p2)])
+    }
+}
+
+struct Bls12G1Msm;
+impl Precompile for Bls12G1Msm {
+    fn address(&self) -> Address {
+        BLS12_G1MSM
+    }
+
+    fn signature(&self, _: &[u8]) -> &'static str {
+        bls12G1MsmCall::SIGNATURE
+    }
+
+    fn decode_call(&self, data: &[u8]) -> alloy_sol_types::Result<Vec<String>> {
+        let pair_size = G1_POINT_SIZE + SCALAR_SIZE;
+        Ok(data.chunks(pair_size).map(hex::encode_prefixed).collect())
+    }
+}
+
+struct Bls12G2Add;
+impl Precompile for Bls12G2Add {
+    fn address(&self) -> Address {
+        BLS12_G2ADD
+    }
+
+    fn signature(&self, _: &[u8]) -> &'static str {
+        bls12G2AddCall::SIGNATURE
+    }
+
+    fn decode_call(&self, data: &[u8]) -> alloy_sol_types::Result<Vec<String>> {
+        let (p1, rest) = take_at_most(data, G2_POINT_SIZE);
+        let (p2, _) = take_at_most(rest, G2_POINT_SIZE);
+        Ok(vec![hex::encode_prefixed(p1), hex::encode_prefixed(p2)])
+    }
+}
+
+struct Bls12G2Msm;
+impl Precompile for Bls12G2Msm {
+    fn address(&self) -> Address {
+        BLS12_G2MSM
+    }
+
+    fn signature(&self, _: &[u8]) -> &'static str {
+        bls12G2MsmCall::SIGNATURE
+    }
+
+    fn decode_call(&self, data: &[u8]) -> alloy_sol_types::Result<Vec<String>> {
+        let pair_size = G2_POINT_SIZE + SCALAR_SIZE;
+        Ok(data.chunks(pair_size).map(hex::encode_prefixed).collect())
+    }
+}
+
+struct Bls12PairingCheck;
+impl Precompile for Bls12PairingCheck {
+    fn address(&self) -> Address {
+        BLS12_PAIRING_CHECK
+    }
+
+    fn signature(&self, _: &[u8]) -> &'static str {
+        bls12PairingCheckCall::SIGNATURE
+    }
+
+    fn decode_call(&self, data: &[u8]) -> alloy_sol_types::Result<Vec<String>> {
+        let pair_size = G1_POINT_SIZE + G2_POINT_SIZE;
+        Ok(data.chunks(pair_size).map(hex::encode_prefixed).collect())
+    }
+
+    fn decode_return(&self, data: &[u8]) -> alloy_sol_types::Result<Vec<String>> {
+        let ret = bls12PairingCheckCall::abi_decode_returns(data)?;
+        Ok(vec![ret.to_string()])
+    }
+}
+
+struct Bls12MapFpToG1;
+impl Precompile for Bls12MapFpToG1 {
+    fn address(&self) -> Address {
+        BLS12_MAP_FP_TO_G1
+    }
+
+    fn signature(&self, _: &[u8]) -> &'static str {
+        bls12MapFpToG1Call::SIGNATURE
+    }
+
+    fn decode_call(&self, data: &[u8]) -> alloy_sol_types::Result<Vec<String>> {
+        let (fp, _) = take_at_most(data, FP_SIZE);
+        Ok(vec![hex::encode_prefixed(fp)])
+    }
+}
+
+struct Bls12MapFp2ToG2;
+impl Precompile for Bls12MapFp2ToG2 {
+    fn address(&self) -> Address {
+        BLS12_MAP_FP2_TO_G2
+    }
+
+    fn signature(&self, _: &[u8]) -> &'static str {
+        bls12MapFp2ToG2Call::SIGNATURE
+    }
+
+    fn decode_call(&self, data: &[u8]) -> alloy_sol_types::Result<Vec<String>> {
+        let (fp2, _) = take_at_most(data, G1_POINT_SIZE);
+        Ok(vec![hex::encode_prefixed(fp2)])
+    }
+}
+
+struct P256Verify;
+impl Precompile for P256Verify {
+    fn address(&self) -> Address {
+        P256_VERIFY
+    }
+
+    fn signature(&self, _: &[u8]) -> &'static str {
+        p256VerifyCall::SIGNATURE
+    }
+
+    fn decode_call(&self, data: &[u8]) -> alloy_sol_types::Result<Vec<String>> {
+        let p256VerifyCall { hash, r, s, qx, qy } = p256VerifyCall::abi_decode_raw(data)?;
+        Ok(vec![
+            hash.to_string(),
+            r.to_string(),
+            s.to_string(),
+            qx.to_string(),
+            qy.to_string(),
+        ])
+    }
+
+    fn decode_return(&self, data: &[u8]) -> alloy_sol_types::Result<Vec<String>> {
+        let ret = p256VerifyCall::abi_decode_returns(data)?;
+        Ok(vec![ret.to_string()])
+    }
+}
+
+fn take_at_most(data: &[u8], n: usize) -> (&[u8], &[u8]) {
+    let n = n.min(data.len());
+    data.split_at(n)
 }
 
 #[cfg(test)]

--- a/crates/foundry/evm/traces/src/decoder/precompiles.rs
+++ b/crates/foundry/evm/traces/src/decoder/precompiles.rs
@@ -37,18 +37,9 @@ interface Precompiles {
 }
 }
 use Precompiles::{
-    blake2fCall, ecaddCall, ecmulCall, ecpairingCall, ecrecoverCall, identityCall, modexpCall,
-    pointEvaluationCall, ripemdCall, sha256Call,
+    blake2fCall, ecaddCall, ecaddReturn, ecmulCall, ecmulReturn, ecpairingCall, ecrecoverCall,
+    identityCall, modexpCall, pointEvaluationCall, ripemdCall, sha256Call,
 };
-
-macro_rules! tri {
-    ($e:expr) => {
-        match $e {
-            Ok(x) => x,
-            Err(_) => return None,
-        }
-    };
-}
 
 pub(super) fn is_known_precompile(address: Address, _chain_id: u64) -> bool {
     address
@@ -75,91 +66,254 @@ pub(super) fn decode(trace: &CallTrace, _chain_id: u64) -> Option<DecodedCallTra
         return None;
     }
 
-    let data = &trace.data;
+    for &precompile in PRECOMPILES {
+        if trace.address == precompile.address() {
+            let signature = precompile.signature();
 
-    let (signature, args) = match trace.address {
-        EC_RECOVER => {
-            let (sig, ecrecoverCall { hash, v, r, s }) = tri!(abi_decode_call(data));
-            (
-                sig,
-                vec![
-                    hash.to_string(),
-                    v.to_string(),
-                    r.to_string(),
-                    s.to_string(),
-                ],
-            )
-        }
-        SHA_256 => (sha256Call::SIGNATURE, vec![data.to_string()]),
-        RIPEMD_160 => (ripemdCall::SIGNATURE, vec![data.to_string()]),
-        IDENTITY => (identityCall::SIGNATURE, vec![data.to_string()]),
-        MOD_EXP => (modexpCall::SIGNATURE, tri!(decode_modexp(data))),
-        EC_ADD => {
-            let (sig, ecaddCall { x1, y1, x2, y2 }) = tri!(abi_decode_call(data));
-            (
-                sig,
-                vec![
-                    x1.to_string(),
-                    y1.to_string(),
-                    x2.to_string(),
-                    y2.to_string(),
-                ],
-            )
-        }
-        EC_MUL => {
-            let (sig, ecmulCall { x1, y1, s }) = tri!(abi_decode_call(data));
-            (sig, vec![x1.to_string(), y1.to_string(), s.to_string()])
-        }
-        EC_PAIRING => (ecpairingCall::SIGNATURE, tri!(decode_ecpairing(data))),
-        BLAKE_2F => (blake2fCall::SIGNATURE, tri!(decode_blake2f(data))),
-        POINT_EVALUATION => (pointEvaluationCall::SIGNATURE, tri!(decode_kzg(data))),
-        _ => return None,
-    };
+            let args = precompile
+                .decode_call(&trace.data)
+                .unwrap_or_else(|_| vec![trace.data.to_string()]);
 
-    Some(DecodedCallTrace {
-        label: Some("PRECOMPILES".to_string()),
-        call_data: Some(DecodedCallData {
-            signature: signature.to_string(),
-            args,
-        }),
-        // TODO: Decode return data too.
-        return_data: None,
-    })
+            let return_data = precompile
+                .decode_return(&trace.output)
+                .unwrap_or_else(|_| vec![trace.output.to_string()]);
+            let return_data = if return_data.len() == 1 {
+                return_data.into_iter().next().unwrap()
+            } else {
+                format!("({})", return_data.join(", "))
+            };
+
+            return Some(DecodedCallTrace {
+                label: Some("PRECOMPILES".to_string()),
+                call_data: Some(DecodedCallData {
+                    signature: signature.to_string(),
+                    args,
+                }),
+                return_data: Some(return_data),
+            });
+        }
+    }
+
+    None
+}
+
+pub(super) trait Precompile {
+    fn address(&self) -> Address;
+    fn signature(&self) -> &'static str;
+
+    fn decode_call(&self, data: &[u8]) -> alloy_sol_types::Result<Vec<String>> {
+        Ok(vec![hex::encode_prefixed(data)])
+    }
+
+    fn decode_return(&self, data: &[u8]) -> alloy_sol_types::Result<Vec<String>> {
+        Ok(vec![hex::encode_prefixed(data)])
+    }
 }
 
 // Note: we use the ABI decoder, but this is not necessarily ABI-encoded data.
 // It's just a convenient way to decode the data.
 
-fn decode_modexp(data: &[u8]) -> alloy_sol_types::Result<Vec<String>> {
-    let mut decoder = abi::Decoder::new(data);
-    let b_size = decoder.take_offset()?;
-    let e_size = decoder.take_offset()?;
-    let m_size = decoder.take_offset()?;
-    let b = decoder.take_slice(b_size)?;
-    let e = decoder.take_slice(e_size)?;
-    let m = decoder.take_slice(m_size)?;
-    Ok(vec![
-        b_size.to_string(),
-        e_size.to_string(),
-        m_size.to_string(),
-        hex::encode_prefixed(b),
-        hex::encode_prefixed(e),
-        hex::encode_prefixed(m),
-    ])
+const PRECOMPILES: &[&dyn Precompile] = &[
+    &Ecrecover,
+    &Sha256,
+    &Ripemd160,
+    &Identity,
+    &ModExp,
+    &EcAdd,
+    &Ecmul,
+    &Ecpairing,
+    &Blake2f,
+    &PointEvaluation,
+];
+
+struct Ecrecover;
+impl Precompile for Ecrecover {
+    fn address(&self) -> Address {
+        EC_RECOVER
+    }
+
+    fn signature(&self) -> &'static str {
+        ecrecoverCall::SIGNATURE
+    }
+
+    fn decode_call(&self, data: &[u8]) -> alloy_sol_types::Result<Vec<String>> {
+        let ecrecoverCall { hash, v, r, s } = ecrecoverCall::abi_decode_raw(data)?;
+        Ok(vec![
+            hash.to_string(),
+            v.to_string(),
+            r.to_string(),
+            s.to_string(),
+        ])
+    }
+
+    fn decode_return(&self, data: &[u8]) -> alloy_sol_types::Result<Vec<String>> {
+        let ret = ecrecoverCall::abi_decode_returns(data)?;
+        Ok(vec![ret.to_string()])
+    }
 }
 
-fn decode_ecpairing(data: &[u8]) -> alloy_sol_types::Result<Vec<String>> {
-    let mut decoder = abi::Decoder::new(data);
-    let mut values = Vec::new();
-    // input must be either empty or a multiple of 6 32-byte values
-    let mut tmp = <[&B256; 6]>::default();
-    while !decoder.is_empty() {
-        for tmp in &mut tmp {
-            *tmp = decoder.take_word()?;
-        }
-        values.push(iter_to_string(tmp.iter().map(|x| U256::from_be_bytes(x.0))));
+struct Sha256;
+impl Precompile for Sha256 {
+    fn address(&self) -> Address {
+        SHA_256
     }
-    Ok(values)
+
+    fn signature(&self) -> &'static str {
+        sha256Call::SIGNATURE
+    }
+
+    fn decode_return(&self, data: &[u8]) -> alloy_sol_types::Result<Vec<String>> {
+        let ret = sha256Call::abi_decode_returns(data)?;
+        Ok(vec![ret.to_string()])
+    }
+}
+
+struct Ripemd160;
+impl Precompile for Ripemd160 {
+    fn address(&self) -> Address {
+        RIPEMD_160
+    }
+
+    fn signature(&self) -> &'static str {
+        ripemdCall::SIGNATURE
+    }
+
+    fn decode_return(&self, data: &[u8]) -> alloy_sol_types::Result<Vec<String>> {
+        let ret = ripemdCall::abi_decode_returns(data)?;
+        Ok(vec![ret.to_string()])
+    }
+}
+
+struct Identity;
+impl Precompile for Identity {
+    fn address(&self) -> Address {
+        IDENTITY
+    }
+
+    fn signature(&self) -> &'static str {
+        identityCall::SIGNATURE
+    }
+}
+
+struct ModExp;
+impl Precompile for ModExp {
+    fn address(&self) -> Address {
+        MOD_EXP
+    }
+
+    fn signature(&self) -> &'static str {
+        modexpCall::SIGNATURE
+    }
+
+    fn decode_call(&self, data: &[u8]) -> alloy_sol_types::Result<Vec<String>> {
+        let mut decoder = abi::Decoder::new(data);
+        let b_size = decoder.take_offset()?;
+        let e_size = decoder.take_offset()?;
+        let m_size = decoder.take_offset()?;
+        let b = decoder.take_slice(b_size)?;
+        let e = decoder.take_slice(e_size)?;
+        let m = decoder.take_slice(m_size)?;
+        Ok(vec![
+            b_size.to_string(),
+            e_size.to_string(),
+            m_size.to_string(),
+            hex::encode_prefixed(b),
+            hex::encode_prefixed(e),
+            hex::encode_prefixed(m),
+        ])
+    }
+}
+
+struct EcAdd;
+impl Precompile for EcAdd {
+    fn address(&self) -> Address {
+        EC_ADD
+    }
+
+    fn signature(&self) -> &'static str {
+        ecaddCall::SIGNATURE
+    }
+
+    fn decode_call(&self, data: &[u8]) -> alloy_sol_types::Result<Vec<String>> {
+        let ecaddCall { x1, y1, x2, y2 } = ecaddCall::abi_decode_raw(data)?;
+        Ok(vec![
+            x1.to_string(),
+            y1.to_string(),
+            x2.to_string(),
+            y2.to_string(),
+        ])
+    }
+
+    fn decode_return(&self, data: &[u8]) -> alloy_sol_types::Result<Vec<String>> {
+        let ecaddReturn { x, y } = ecaddCall::abi_decode_returns(data)?;
+        Ok(vec![x.to_string(), y.to_string()])
+    }
+}
+
+struct Ecmul;
+impl Precompile for Ecmul {
+    fn address(&self) -> Address {
+        EC_MUL
+    }
+
+    fn signature(&self) -> &'static str {
+        ecmulCall::SIGNATURE
+    }
+
+    fn decode_call(&self, data: &[u8]) -> alloy_sol_types::Result<Vec<String>> {
+        let ecmulCall { x1, y1, s } = ecmulCall::abi_decode_raw(data)?;
+        Ok(vec![x1.to_string(), y1.to_string(), s.to_string()])
+    }
+
+    fn decode_return(&self, data: &[u8]) -> alloy_sol_types::Result<Vec<String>> {
+        let ecmulReturn { x, y } = ecmulCall::abi_decode_returns(data)?;
+        Ok(vec![x.to_string(), y.to_string()])
+    }
+}
+
+struct Ecpairing;
+impl Precompile for Ecpairing {
+    fn address(&self) -> Address {
+        EC_PAIRING
+    }
+
+    fn signature(&self) -> &'static str {
+        ecpairingCall::SIGNATURE
+    }
+
+    fn decode_call(&self, data: &[u8]) -> alloy_sol_types::Result<Vec<String>> {
+        let mut decoder = abi::Decoder::new(data);
+        let mut values = Vec::new();
+        // input must be either empty or a multiple of 6 32-byte values
+        let mut tmp = <[&B256; 6]>::default();
+        while !decoder.is_empty() {
+            for tmp in &mut tmp {
+                *tmp = decoder.take_word()?;
+            }
+            values.push(iter_to_string(tmp.iter().map(|x| U256::from_be_bytes(x.0))));
+        }
+        Ok(values)
+    }
+
+    fn decode_return(&self, data: &[u8]) -> alloy_sol_types::Result<Vec<String>> {
+        let ret = ecpairingCall::abi_decode_returns(data)?;
+        Ok(vec![ret.to_string()])
+    }
+}
+
+struct Blake2f;
+impl Precompile for Blake2f {
+    fn address(&self) -> Address {
+        BLAKE_2F
+    }
+
+    fn signature(&self) -> &'static str {
+        blake2fCall::SIGNATURE
+    }
+
+    fn decode_call(&self, data: &[u8]) -> alloy_sol_types::Result<Vec<String>> {
+        decode_blake2f(data)
+    }
 }
 
 fn decode_blake2f<'a>(data: &'a [u8]) -> alloy_sol_types::Result<Vec<String>> {
@@ -185,25 +339,31 @@ fn decode_blake2f<'a>(data: &'a [u8]) -> alloy_sol_types::Result<Vec<String>> {
     ])
 }
 
-fn decode_kzg(data: &[u8]) -> alloy_sol_types::Result<Vec<String>> {
-    let mut decoder = abi::Decoder::new(data);
-    let versioned_hash = decoder.take_word()?;
-    let z = decoder.take_word()?;
-    let y = decoder.take_word()?;
-    let commitment = decoder.take_slice(48)?;
-    let proof = decoder.take_slice(48)?;
-    Ok(vec![
-        versioned_hash.to_string(),
-        z.to_string(),
-        y.to_string(),
-        hex::encode_prefixed(commitment),
-        hex::encode_prefixed(proof),
-    ])
-}
+struct PointEvaluation;
+impl Precompile for PointEvaluation {
+    fn address(&self) -> Address {
+        POINT_EVALUATION
+    }
 
-fn abi_decode_call<T: SolCall>(data: &[u8]) -> alloy_sol_types::Result<(&'static str, T)> {
-    // raw because there are no selectors here
-    Ok((T::SIGNATURE, T::abi_decode_raw(data)?))
+    fn signature(&self) -> &'static str {
+        pointEvaluationCall::SIGNATURE
+    }
+
+    fn decode_call(&self, data: &[u8]) -> alloy_sol_types::Result<Vec<String>> {
+        let mut decoder = abi::Decoder::new(data);
+        let versioned_hash = decoder.take_word()?;
+        let z = decoder.take_word()?;
+        let y = decoder.take_word()?;
+        let commitment = decoder.take_slice(48)?;
+        let proof = decoder.take_slice(48)?;
+        Ok(vec![
+            versioned_hash.to_string(),
+            z.to_string(),
+            y.to_string(),
+            hex::encode_prefixed(commitment),
+            hex::encode_prefixed(proof),
+        ])
+    }
 }
 
 fn iter_to_string<I: Iterator<Item = T>, T: std::fmt::Display>(iter: I) -> String {
@@ -247,7 +407,7 @@ mod tests {
             30364cd4f8a293b1a04f0153548d3e01baad091c69097ca4e9f26be63e4095b5
         "
         );
-        let decoded = decode_ecpairing(&data).unwrap();
+        let decoded = Ecpairing.decode_call(&data).unwrap();
         // 4 arrays of 6 32-byte values
         assert_eq!(decoded.len(), 4);
     }

--- a/js/benchmark/src/solidity-tests.ts
+++ b/js/benchmark/src/solidity-tests.ts
@@ -37,6 +37,8 @@ import {
   InvariantTestKind,
   L1_CHAIN_TYPE,
   l1SolidityTestRunnerFactory,
+  l1HardforkLatest,
+  l1HardforkToString,
 } from "@nomicfoundation/edr";
 import { createHardhatRuntimeEnvironment } from "hardhat/hre";
 import { solidityTestConfigToSolidityTestRunnerConfigArgs } from "hardhat/internal/builtin-plugins/solidity-test/helpers";
@@ -673,6 +675,8 @@ async function createSolidityTestsInput(repoPath: string) {
       testPattern: undefined,
       generateGasReport: false,
     });
+  // TODO: move to solidityTestConfigToSolidityTestRunnerConfigArgs after it's updated in Hardhat
+  solidityTestsConfig.hardfork = l1HardforkToString(l1HardforkLatest());
   // Temporary workaround for `testFuzz_AssumeNotPrecompile` in forge-std which assumes no predeploys on mainnet.
   solidityTestsConfig.localPredeploys = undefined;
 

--- a/js/integration-tests/solidity-tests/test-contracts/EIP7212Test.sol
+++ b/js/integration-tests/solidity-tests/test-contracts/EIP7212Test.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import "hardhat/console.sol";
+
+contract EIP7212Test {
+    address constant P256_PRECOMPILE = address(0x100);
+
+    function testP256Precompile() public {
+        bytes32 msgHash = 0x7547e7989971d6c63cf140647fefc5c3043460ea96763f529feef8bc83b67680;
+        bytes32 r = 0x4456df631c55951140b184cc1b4db60e78f1ae4b003e336348bc7d3c1cc8daab;
+        bytes32 s = 0xfd26094146960c9f1df540c823a3c44d969b48fd42da2142450772ce2d45c064;
+        bytes32 x = 0x703bbc0830e0238b0030e03cff350561ae96ac5f00edc3be1c72bbc04e0f0180;
+        bytes32 y = 0x958533939e7571d60f6e895709ab5d3f9f339e0a26cc8baaf61200340d8e6c90;
+        // ----------------------------------------
+
+        // Pack the 160 bytes of input
+        bytes memory input = abi.encodePacked(msgHash, r, s, x, y);
+
+        // Call the precompile
+        (bool success, bytes memory ret) = P256_PRECOMPILE.staticcall(input);
+
+        // CHECK 1: The precompile must exist
+        require(success, "EIP-7212 Precompile call failed");
+        require(
+            ret.length == 32,
+            "EIP-7212 Precompile missing: Returned 0 bytes"
+        );
+
+        // CHECK 2: The signature must be valid
+        // If the precompile exists, this should return 1
+        uint256 result = abi.decode(ret, (uint256));
+        require(result == 1, "Signature verification failed");
+    }
+}

--- a/js/integration-tests/solidity-tests/test-contracts/EIP7212Test.sol
+++ b/js/integration-tests/solidity-tests/test-contracts/EIP7212Test.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
 
-import "hardhat/console.sol";
-
 contract EIP7212Test {
     address constant P256_PRECOMPILE = address(0x100);
 
@@ -12,7 +10,6 @@ contract EIP7212Test {
         bytes32 s = 0xfd26094146960c9f1df540c823a3c44d969b48fd42da2142450772ce2d45c064;
         bytes32 x = 0x703bbc0830e0238b0030e03cff350561ae96ac5f00edc3be1c72bbc04e0f0180;
         bytes32 y = 0x958533939e7571d60f6e895709ab5d3f9f339e0a26cc8baaf61200340d8e6c90;
-        // ----------------------------------------
 
         // Pack the 160 bytes of input
         bytes memory input = abi.encodePacked(msgHash, r, s, x, y);

--- a/js/integration-tests/solidity-tests/test/testContext.ts
+++ b/js/integration-tests/solidity-tests/test/testContext.ts
@@ -20,6 +20,8 @@ import {
   SuiteResult,
   SolidityTestResult,
   CheatcodeErrorDetails,
+  l1HardforkToString,
+  opHardforkToString,
 } from "@nomicfoundation/edr";
 import {
   buildSolidityTestsInput,
@@ -90,6 +92,10 @@ export class TestContext {
       projectRoot: hre.config.paths.root,
       rpcCachePath: this.rpcCachePath,
       localPredeploys: localPredeploys,
+      hardfork:
+        chainType === L1_CHAIN_TYPE
+          ? l1HardforkToString(l1HardforkLatest())
+          : opHardforkToString(opLatestHardfork()),
     };
   }
 

--- a/js/integration-tests/solidity-tests/test/testContext.ts
+++ b/js/integration-tests/solidity-tests/test/testContext.ts
@@ -101,7 +101,7 @@ export class TestContext {
 
   async runTestsWithStats(
     contractName: string,
-    config?: Omit<SolidityTestRunnerConfigArgs, "projectRoot">,
+    config?: Omit<SolidityTestRunnerConfigArgs, "projectRoot" | "hardfork">,
     chainType: string = L1_CHAIN_TYPE
   ): Promise<SolidityTestsRunResult> {
     let totalTests = 0;

--- a/js/integration-tests/solidity-tests/test/unit.ts
+++ b/js/integration-tests/solidity-tests/test/unit.ts
@@ -8,6 +8,7 @@ import {
 import {
   CheatcodeErrorCode,
   CollectStackTraces,
+  IncludeTraces,
   L1_CHAIN_TYPE,
   OP_CHAIN_TYPE,
   SuiteResult,
@@ -665,6 +666,17 @@ describe("Unit tests", () => {
 
       assert.equal(result.totalTests, 1);
       assert.equal(result.failedTests, 0);
+    });
+  });
+
+  describe("Precompiles", function () {
+    it("EIP7212 Precompile", async function () {
+      const { totalTests, failedTests } =
+        await testContext.runTestsWithStats("EIP7212Test");
+
+      // Checks are done in the test. Just check that the test passed.
+      assert.equal(failedTests, 0);
+      assert.equal(totalTests, 1);
     });
   });
 });

--- a/js/integration-tests/solidity-tests/test/unit.ts
+++ b/js/integration-tests/solidity-tests/test/unit.ts
@@ -8,7 +8,6 @@ import {
 import {
   CheatcodeErrorCode,
   CollectStackTraces,
-  IncludeTraces,
   L1_CHAIN_TYPE,
   OP_CHAIN_TYPE,
   SuiteResult,


### PR DESCRIPTION
This PR adds the ability to specify the hardfork when running Solidity tests using the Typescript interface. It also adds support for the Osaka hardfork in Solidity tests.