### PR TITLE
ci: fix release workflow

### DIFF
--- a/.github/workflows/edr-npm-release.yml
+++ b/.github/workflows/edr-npm-release.yml
@@ -134,7 +134,7 @@ jobs:
         shell: bash
 
       - name: Build in docker (gnu)
-        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # v3
+        uses: NomicFoundation/docker-run-action@63f044457cfb71a5c63fa589218c89a418565d9c # Fork of v3 with updated Docker (https://github.com/addnab/docker-run-action/issues/62)
         if: ${{ matrix.settings.docker && matrix.settings.flavor == 'gnu'}}
         with:
           image: ${{ matrix.settings.docker }}
@@ -157,7 +157,7 @@ jobs:
       # SFW is not provided on musl versions of Linux
       # https://github.com/NomicFoundation/edr/issues/1198
       - name: Build in docker (musl)
-        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # v3
+        uses: NomicFoundation/docker-run-action@63f044457cfb71a5c63fa589218c89a418565d9c # Fork of v3 with updated Docker (https://github.com/addnab/docker-run-action/issues/62)
         if: ${{ matrix.settings.docker && matrix.settings.flavor == 'musl' }}
         with:
           image: ${{ matrix.settings.docker }}


### PR DESCRIPTION
Fixes [CI release workflow failures](https://github.com/NomicFoundation/edr/actions/runs/21957607460/job/63425983634) due to https://github.com/addnab/docker-run-action/issues/62 by using a fork of the original GitHub action.