### PR TITLE
fix: return error for mismatched names in gas snapshot cheatcodes

### DIFF
--- a/.changeset/mighty-geckos-change.md
+++ b/.changeset/mighty-geckos-change.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Fixed error handling for mismatched names in gas snapshot cheatcodes

--- a/js/integration-tests/solidity-tests/test-contracts/ScopedSnapshot.sol
+++ b/js/integration-tests/solidity-tests/test-contracts/ScopedSnapshot.sol
@@ -151,6 +151,13 @@ contract GasSnapshotTest is Test {
         );
         assertGt(gasUsed, 0);
     }
+
+    // Calls stopSnapshotGas with a name that doesn't match the startSnapshotGas call.
+    function testMismatchedStartStopSnapshot() public {
+        vm.startSnapshotGas("testMismatchedStartSnapshot");
+        slot0 = 1;
+        vm.stopSnapshotGas("testMismatchedStopSnapshot");
+    }
 }
 
 contract Flare {

--- a/js/integration-tests/solidity-tests/test/unit.ts
+++ b/js/integration-tests/solidity-tests/test/unit.ts
@@ -342,13 +342,21 @@ describe("Unit tests", () => {
     const { totalTests, failedTests, suiteResults } =
       await testContext.runTestsWithStats("GasSnapshotTest", {}, L1_CHAIN_TYPE);
 
-    assert.equal(totalTests, 12);
-    assert.equal(failedTests, 0);
+    assert.equal(totalTests, 13);
+    assert.equal(failedTests, 1);
 
     let snapshots = new Map<string, Map<string, string>>();
 
     for (const suiteResult of suiteResults) {
       for (const testResult of suiteResult.testResults) {
+        if (testResult.name === "testMismatchedStartStopSnapshot()") {
+          assert.equal(testResult.status, "Failure");
+          assert.equal(
+            testResult.reason,
+            "vm.stopSnapshotGas: no gas snapshot was started with the name: testMismatchedStopSnapshot in group: GasSnapshotTest"
+          );
+          continue;
+        }
         assert.notEqual(testResult.valueSnapshotGroups, undefined);
 
         const snapshotGroups = testResult.valueSnapshotGroups!;


### PR DESCRIPTION
This PR modifies the way `group` and `name` is handled for  the `stopGasSnapshot` cheatcode. Previously, when either one of the parameters was missing, both values would default to the currently active gas snapshot.

However, for `stopSnapshotGas` this was not correct for cases where only one of the parameters is missing. For example, when using

```rust
function stopSnapshotGas(string calldata name)
```

the group is derived from the contract name, but the snapshot name should be the one provided in the cheatcode. In the previous implementation, the name would be overridden with the active snapshot name, resulting in the generation of a snapshot even for mismatched names.

This PR fixes this by using the active snapshot group & name values only for missing components, allowing us to identify mismatched snapshot names and produce an error as expected.

closes #1291