### PR TITLE
build: upgrade Slang to v1.3.3

### DIFF
--- a/.changeset/famous-plums-sort.md
+++ b/.changeset/famous-plums-sort.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Added support for instrumentation of Solidity 0.8.34

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5635,8 +5635,8 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "metaslang_bindings"
-version = "1.3.2"
-source = "git+https://github.com/NomicFoundation/slang?tag=v1.3.2#71d628c76f9e7ba00e73ae95364f5e099ec9fb04"
+version = "1.3.3"
+source = "git+https://github.com/NomicFoundation/slang?tag=v1.3.3#3ad185704aa8d7f638f3d574317ece89ab66d818"
 dependencies = [
  "metaslang_cst",
  "metaslang_graph_builder",
@@ -5647,8 +5647,8 @@ dependencies = [
 
 [[package]]
 name = "metaslang_cst"
-version = "1.3.2"
-source = "git+https://github.com/NomicFoundation/slang?tag=v1.3.2#71d628c76f9e7ba00e73ae95364f5e099ec9fb04"
+version = "1.3.3"
+source = "git+https://github.com/NomicFoundation/slang?tag=v1.3.3#3ad185704aa8d7f638f3d574317ece89ab66d818"
 dependencies = [
  "nom",
  "serde",
@@ -5657,8 +5657,8 @@ dependencies = [
 
 [[package]]
 name = "metaslang_graph_builder"
-version = "1.3.2"
-source = "git+https://github.com/NomicFoundation/slang?tag=v1.3.2#71d628c76f9e7ba00e73ae95364f5e099ec9fb04"
+version = "1.3.3"
+source = "git+https://github.com/NomicFoundation/slang?tag=v1.3.3#3ad185704aa8d7f638f3d574317ece89ab66d818"
 dependencies = [
  "log",
  "metaslang_cst",
@@ -5671,8 +5671,8 @@ dependencies = [
 
 [[package]]
 name = "metaslang_stack_graphs"
-version = "1.3.2"
-source = "git+https://github.com/NomicFoundation/slang?tag=v1.3.2#71d628c76f9e7ba00e73ae95364f5e099ec9fb04"
+version = "1.3.3"
+source = "git+https://github.com/NomicFoundation/slang?tag=v1.3.3#3ad185704aa8d7f638f3d574317ece89ab66d818"
 dependencies = [
  "bitvec",
  "controlled-option",
@@ -7900,8 +7900,8 @@ dependencies = [
 
 [[package]]
 name = "slang_solidity"
-version = "1.3.2"
-source = "git+https://github.com/NomicFoundation/slang?tag=v1.3.2#71d628c76f9e7ba00e73ae95364f5e099ec9fb04"
+version = "1.3.3"
+source = "git+https://github.com/NomicFoundation/slang?tag=v1.3.3#3ad185704aa8d7f638f3d574317ece89ab66d818"
 dependencies = [
  "metaslang_bindings",
  "metaslang_cst",

--- a/crates/edr_instrument/Cargo.toml
+++ b/crates/edr_instrument/Cargo.toml
@@ -8,7 +8,7 @@ edr_primitives.workspace = true
 semver.workspace = true
 serde = { workspace = true, features = ["derive"] }
 sha3.workspace = true
-slang_solidity = { git = "https://github.com/NomicFoundation/slang", tag = "v1.3.2" }
+slang_solidity = { git = "https://github.com/NomicFoundation/slang", tag = "v1.3.3" }
 thiserror.workspace = true
 
 [lints]

--- a/hardhat-tests/test/internal/hardhat-network/stack-traces/compilers-list.ts
+++ b/hardhat-tests/test/internal/hardhat-network/stack-traces/compilers-list.ts
@@ -366,11 +366,23 @@ export const solidityCompilers: SolidityCompiler[] = [
   {
     solidityVersion: "0.8.33",
     compilerPath: "soljson-v0.8.33+commit.64118f21.js",
-    latestSolcVersion: true,
   },
   {
     solidityVersion: "0.8.33",
     compilerPath: "soljson-v0.8.33+commit.64118f21.js",
+    optimizer: {
+      runs: 200,
+      viaIR: true,
+    },
+  },
+  {
+    solidityVersion: "0.8.34",
+    compilerPath: "soljson-v0.8.34+commit.80d5c536.js",
+    latestSolcVersion: true,
+  },
+  {
+    solidityVersion: "0.8.34",
+    compilerPath: "soljson-v0.8.34+commit.80d5c536.js",
     optimizer: {
       runs: 200,
       viaIR: true,


### PR DESCRIPTION
Upgrades Slang to [v1.3.3](https://github.com/NomicFoundation/slang/releases/tag/v1.3.3), with support for Solidity 0.8.34