### PR TITLE
fix: return error instead of panic for missing `startSnapshotGas`

### DIFF
--- a/.changeset/swift-bees-enter.md
+++ b/.changeset/swift-bees-enter.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Fixed error reporting when calling `stopSnapshotGas` without an active snapshot

--- a/js/integration-tests/solidity-tests/test-contracts/ScopedSnapshot.sol
+++ b/js/integration-tests/solidity-tests/test-contracts/ScopedSnapshot.sol
@@ -158,6 +158,12 @@ contract GasSnapshotTest is Test {
         slot0 = 1;
         vm.stopSnapshotGas("testMismatchedStopSnapshot");
     }
+
+    // Calls stopSnapshotGas without a corresponding startSnapshotGas call.
+    function testMissingStartSnapshot() public {
+        slot0 = 1;
+        vm.stopSnapshotGas("testMissingStartSnapshot");
+    }
 }
 
 contract Flare {

--- a/js/integration-tests/solidity-tests/test-contracts/ScopedSnapshot.sol
+++ b/js/integration-tests/solidity-tests/test-contracts/ScopedSnapshot.sol
@@ -159,10 +159,16 @@ contract GasSnapshotTest is Test {
         vm.stopSnapshotGas("testMismatchedStopSnapshot");
     }
 
-    // Calls stopSnapshotGas without a corresponding startSnapshotGas call.
+    // Calls stopSnapshotGas(name) without a corresponding startSnapshotGas call.
     function testMissingStartSnapshot() public {
         slot0 = 1;
         vm.stopSnapshotGas("testMissingStartSnapshot");
+    }
+
+    // Calls stopSnapshotGas(group, name) without a corresponding startSnapshotGas call.
+    function testMissingStartSnapshotWithGroup() public {
+        slot0 = 1;
+        vm.stopSnapshotGas("testGroup", "testMissingStartSnapshot");
     }
 }
 

--- a/js/integration-tests/solidity-tests/test/unit.ts
+++ b/js/integration-tests/solidity-tests/test/unit.ts
@@ -342,8 +342,8 @@ describe("Unit tests", () => {
     const { totalTests, failedTests, suiteResults } =
       await testContext.runTestsWithStats("GasSnapshotTest", {}, L1_CHAIN_TYPE);
 
-    assert.equal(totalTests, 14);
-    assert.equal(failedTests, 2);
+    assert.equal(totalTests, 15);
+    assert.equal(failedTests, 3);
 
     let snapshots = new Map<string, Map<string, string>>();
 
@@ -363,6 +363,15 @@ describe("Unit tests", () => {
           assert.equal(
             testResult.reason,
             "vm.stopSnapshotGas: no gas snapshot was started; call startSnapshotGas() first"
+          );
+          continue;
+        }
+
+        if (testResult.name === "testMissingStartSnapshotWithGroup()") {
+          assert.equal(testResult.status, "Failure");
+          assert.equal(
+            testResult.reason,
+            "vm.stopSnapshotGas: no gas snapshot was started with the name: testMissingStartSnapshot in group: testGroup"
           );
           continue;
         }

--- a/js/integration-tests/solidity-tests/test/unit.ts
+++ b/js/integration-tests/solidity-tests/test/unit.ts
@@ -342,8 +342,8 @@ describe("Unit tests", () => {
     const { totalTests, failedTests, suiteResults } =
       await testContext.runTestsWithStats("GasSnapshotTest", {}, L1_CHAIN_TYPE);
 
-    assert.equal(totalTests, 13);
-    assert.equal(failedTests, 1);
+    assert.equal(totalTests, 14);
+    assert.equal(failedTests, 2);
 
     let snapshots = new Map<string, Map<string, string>>();
 
@@ -354,6 +354,15 @@ describe("Unit tests", () => {
           assert.equal(
             testResult.reason,
             "vm.stopSnapshotGas: no gas snapshot was started with the name: testMismatchedStopSnapshot in group: GasSnapshotTest"
+          );
+          continue;
+        }
+
+        if (testResult.name === "testMissingStartSnapshot()") {
+          assert.equal(testResult.status, "Failure");
+          assert.equal(
+            testResult.reason,
+            "vm.stopSnapshotGas: no gas snapshot was started; call startSnapshotGas() first"
           );
           continue;
         }


### PR DESCRIPTION
This PR changes the behavior when calling `stopSnapshotGas` without an active snapshot in Solidity tests. Previously, EDR would panic with an ambiguous message. Now the Solidity test fails with an appropriate message.