### PR TITLE
chore(CI): fix post-setup-node step "Path Validation Error"

### DIFF
--- a/.github/workflows/edr-npm-release.yml
+++ b/.github/workflows/edr-npm-release.yml
@@ -462,7 +462,7 @@ jobs:
         run: |
           FILENAME="${{ env.APP_NAME }}_bundle.tar.gz"
           NAPI_EXTRA_FILES=("npm/" "LICENSE" "README.md" "package.json" "Cargo.toml")
-          readarray -t FILES < <(cat package.json | jq -r .files[] ) 
+          readarray -t FILES < <(cat package.json | jq -r .files[] )
           ALL_FILES=("${FILES[@]}" "${NAPI_EXTRA_FILES[@]}")
           NAPI_FILES=()
           for file in "${ALL_FILES[@]}"; do
@@ -629,7 +629,7 @@ jobs:
         id: setup-node
         with:
           node-version: 22
-          cache: pnpm
+          package-manager-cache: false
       - name: Update npm to make sure it supports Trusted Publishing
         run: npm install -g npm@v11.6.2
       - name: Publish


### PR DESCRIPTION
## Context
The `publish` job has been failing during the `post-setup-node` step, as seen in [this workflow run](https://github.com/NomicFoundation/edr/actions/runs/22329057297/job/64609694896).

## Fix
The root cause is that `setup-node` was configured with `cache: pnpm`, but the job does not install dependencies (it only needs Node.js to run `npm publish`). Because `cache` was set, the `post-setup-node` step attempted to save the pnpm store cache, which failed since the store path was never created (no `pnpm install` runs in this job).

Removing `cache` should prevent the post step to skip cache saving altogether, fixing the error.

## Bonus
Additionally, I set `package-manager-cache: false` explicitly. The `setup-node` action [warns about a breaking change in v5](https://github.com/actions/setup-node/blob/main/README.md):

> For workflows with elevated privileges or access to sensitive information, we recommend disabling automatic caching by setting `package-manager-cache: false` when caching is not needed for secure operation.

Currently, the auto-caching feature [does not detect pnpm](https://github.com/actions/setup-node/blob/774c1d62961e73038a114d59c8847023c003194d/__tests__/main.test.ts#L364), so it wouldn't activate for this project's setup. Still, setting it to `false` explicitly opts out in case support is expanded in the future, and makes the intent clear.
