### PR TITLE
fix(cheatcodes): ensure `CallerMode` compatibility with `forge-std`

### DIFF
--- a/.changeset/olive-signs-cough.md
+++ b/.changeset/olive-signs-cough.md
@@ -1,0 +1,7 @@
+---
+"@nomicfoundation/edr": minor
+"solidity-tests": minor
+---
+
+Added `Broadcast` and `RecurrentBroadcast` variants to the `CallerMode` enum. These variants are unsupported by EDR cheatcodes implementation but are needed to  
+

--- a/.changeset/olive-signs-cough.md
+++ b/.changeset/olive-signs-cough.md
@@ -3,5 +3,4 @@
 "solidity-tests": minor
 ---
 
-Added `Broadcast` and `RecurrentBroadcast` variants to the `CallerMode` enum. These variants are unsupported by EDR cheatcodes implementation but are needed to  
-
+Added `Broadcast` and `RecurrentBroadcast` variants to the `CallerMode` enum. These variants are unsupported by EDR cheatcodes implementation but are needed to ensure ABI compatibility with forge-std.

--- a/book/src/02_development/08_cheatcodes.md
+++ b/book/src/02_development/08_cheatcodes.md
@@ -148,6 +148,7 @@ The initial execution of this command, following the addition of a new cheat cod
 3. If a struct, enum, error, or event was added to `Vm`, update [`spec::Cheatcodes::new`]
 4. Update the JSON interface by running `cargo generate-cheats-interface` twice. This is expected to fail the first time that this is run after adding a new cheatcode; see [JSON interface](#json-interface)
 5. Write an integration test for the cheatcode in [`testdata/cheats/`]
+6. Update the documentation in the [hardhat-website](https://github.com/NomicFoundation/hardhat-website) repository to reflect the cheatcode changes. Signatures, enum variants, and doc comments in the website docs should match [`cheatcodes/spec/src/vm.rs`] 1:1. Any additional context (e.g., why something is unsupported) should live only in the website docs (e.g., as note blocks), not in `vm.rs`
 
 [`sol!`]: https://docs.rs/alloy-sol-macro/latest/alloy_sol_macro/macro.sol.html
 [`cheatcodes/spec/src/vm.rs`]: ../../../crates/foundry/cheatcodes/spec/src/vm.rs

--- a/crates/edr_solidity_tests/tests/testdata/cheats/Vm.sol
+++ b/crates/edr_solidity_tests/tests/testdata/cheats/Vm.sol
@@ -7,7 +7,7 @@ pragma experimental ABIEncoderV2;
 
 interface Vm {
     enum CheatcodeErrorCode { UnsupportedCheatcode, MissingCheatcode }
-    enum CallerMode { None, Prank, RecurrentPrank }
+    enum CallerMode { None, Broadcast, RecurrentBroadcast, Prank, RecurrentPrank }
     enum AccountAccessKind { Call, DelegateCall, CallCode, StaticCall, Create, SelfDestruct, Resume, Balance, Extcodesize, Extcodehash, Extcodecopy }
     enum ExecutionContext { TestGroup, Test, Coverage, Snapshot, Unknown }
     enum BroadcastTxType { Call, Create, Create2 }

--- a/crates/edr_solidity_tests/tests/testdata/default/cheats/ReadCallers.t.sol
+++ b/crates/edr_solidity_tests/tests/testdata/default/cheats/ReadCallers.t.sol
@@ -130,4 +130,26 @@ contract ReadCallersTest is DSTest {
         assertEq(newSender, expectedSender);
         assertEq(newOrigin, expectedTxOrigin);
     }
+
+    // Tests that CallerMode enum values match forge-std's 5-variant enum:
+    // None=0, Broadcast=1, RecurrentBroadcast=2, Prank=3, RecurrentPrank=4
+    // Broadcast (1) and RecurrentBroadcast (2) are not tested here because
+    // EDR does not support broadcast functionality. However, the enum values
+    // for Prank and RecurrentPrank must still match forge-std's definitions.
+    function testReadCallersEnumValueNone() public {
+        (Vm.CallerMode mode,,) = vm.readCallers();
+        assertEq(uint256(mode), 0, "CallerMode.None should be 0");
+    }
+
+    function testReadCallersEnumValuePrank(address sender) public {
+        vm.prank(sender);
+        (Vm.CallerMode mode,,) = vm.readCallers();
+        assertEq(uint256(mode), 3, "CallerMode.Prank should be 3");
+    }
+
+    function testReadCallersEnumValueRecurrentPrank(address sender) public {
+        vm.startPrank(sender);
+        (Vm.CallerMode mode,,) = vm.readCallers();
+        assertEq(uint256(mode), 4, "CallerMode.RecurrentPrank should be 4");
+    }
 }

--- a/crates/foundry/cheatcodes/assets/cheatcodes.json
+++ b/crates/foundry/cheatcodes/assets/cheatcodes.json
@@ -29,11 +29,19 @@
     },
     {
       "name": "CallerMode",
-      "description": "A modification applied to either `msg.sender` or `tx.origin`. Returned by `readCallers`.",
+      "description": "A modification applied to either `msg.sender` or `tx.origin`. Returned by `readCallers`.\n Variant order must match forge-std's `CallerMode` enum for ABI compatibility.",
       "variants": [
         {
           "name": "None",
           "description": "No caller modification is currently active."
+        },
+        {
+          "name": "Broadcast",
+          "description": "Not supported in EDR. Present for forge-std ABI compatibility."
+        },
+        {
+          "name": "RecurrentBroadcast",
+          "description": "Not supported in EDR. Present for forge-std ABI compatibility."
         },
         {
           "name": "Prank",

--- a/crates/foundry/cheatcodes/assets/cheatcodes.json
+++ b/crates/foundry/cheatcodes/assets/cheatcodes.json
@@ -37,11 +37,11 @@
         },
         {
           "name": "Broadcast",
-          "description": "Not supported in EDR. Present for forge-std ABI compatibility."
+          "description": "Unsupported. Present for forge-std ABI compatibility."
         },
         {
           "name": "RecurrentBroadcast",
-          "description": "Not supported in EDR. Present for forge-std ABI compatibility."
+          "description": "Unsupported. Present for forge-std ABI compatibility."
         },
         {
           "name": "Prank",

--- a/crates/foundry/cheatcodes/spec/src/vm.rs
+++ b/crates/foundry/cheatcodes/spec/src/vm.rs
@@ -52,9 +52,9 @@ interface Vm {
     enum CallerMode {
         /// No caller modification is currently active.
         None,
-        /// Not supported in EDR. Present for forge-std ABI compatibility.
+        /// Unsupported. Present for forge-std ABI compatibility.
         Broadcast,
-        /// Not supported in EDR. Present for forge-std ABI compatibility.
+        /// Unsupported. Present for forge-std ABI compatibility.
         RecurrentBroadcast,
         /// A one time prank triggered by a `vm.prank()` call is currently active.
         Prank,

--- a/crates/foundry/cheatcodes/spec/src/vm.rs
+++ b/crates/foundry/cheatcodes/spec/src/vm.rs
@@ -48,9 +48,14 @@ interface Vm {
     error StructuredCheatcodeError(CheatcodeErrorDetails details);
 
     /// A modification applied to either `msg.sender` or `tx.origin`. Returned by `readCallers`.
+    /// Variant order must match forge-std's `CallerMode` enum for ABI compatibility.
     enum CallerMode {
         /// No caller modification is currently active.
         None,
+        /// Not supported in EDR. Present for forge-std ABI compatibility.
+        Broadcast,
+        /// Not supported in EDR. Present for forge-std ABI compatibility.
+        RecurrentBroadcast,
         /// A one time prank triggered by a `vm.prank()` call is currently active.
         Prank,
         /// A recurrent prank triggered by a `vm.startPrank()` call is currently active.


### PR DESCRIPTION
## Summary

- Brought back `Broadcast` and `RecurrentBroadcast` variants to the `CallerMode` enum, which were removed in #1206.
  - Their absence broke ABI compatibility with forge-std
  - The side effect: `Prank (3)` and `RecurrentPrank (4)` were decoded as `Broadcast (1)` and `RecurrentBroadcast (2)` by test contracts using `forge-std`, breaking  standard Foundry test patterns that rely on pausePrank-style modifiers
- Added tests verifying the enum ordinals (`None=0, Prank=3, RecurrentPrank=4`)
- Updated the cheatcodes book to remind developers to keep hardhat-website docs in sync with `crates/foundry/cheatcodes/spec/src/vm.rs`

## Evidence
I validate that previously-failing aave-v4 tests now pass, by linking `aave-v4 -> local hardhat -> local edr_napi (with changes)`


https://github.com/user-attachments/assets/dccda0fa-4cf0-4351-8774-fbfd074c7a36



closes #1319 