### PR TITLE
chore: fix changeset before release

### DIFF
--- a/.changeset/olive-signs-cough.md
+++ b/.changeset/olive-signs-cough.md
@@ -1,6 +1,5 @@
 ---
 "@nomicfoundation/edr": minor
-"solidity-tests": minor
 ---
 
 Added `Broadcast` and `RecurrentBroadcast` variants to the `CallerMode` enum. These variants are unsupported by EDR cheatcodes implementation but are needed to ensure ABI compatibility with forge-std.


### PR DESCRIPTION
Remove reference to `solidity-tests` module. 
This module is just for integration-tests, it makes no sense to track a changelog for it