### PR TITLE
fix: resolve proxied calls against the implementation's ABI

### DIFF
--- a/.changeset/chubby-masks-fall.md
+++ b/.changeset/chubby-masks-fall.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+universal proxy support for function identifier lookup#1327

--- a/.changeset/chubby-masks-fall.md
+++ b/.changeset/chubby-masks-fall.md
@@ -2,4 +2,4 @@
 "@nomicfoundation/edr": patch
 ---
 
-universal proxy support for function identifier lookup#1327
+Fixed calls through proxy contracts being reported as `<unrecognized-selector>` in logged transactions and calls. When a function selector is not found in the called contract's ABI, it is now resolved against the ABI of the implementation behind the proxy, and the call is labeled with the full delegation chain, e.g. `Proxy>Implementation#setValue`. This works for any proxy that forwards the selector via `DELEGATECALL`.

--- a/crates/edr_napi/test/proxyCalls.ts
+++ b/crates/edr_napi/test/proxyCalls.ts
@@ -1,0 +1,226 @@
+import { assert } from "chai";
+import * as fs from "fs";
+import {
+  ContractDecoder,
+  GENERIC_CHAIN_TYPE,
+  Provider,
+  SubscriptionEvent,
+  TracingConfigWithBuffers,
+} from "..";
+import {
+  DEFAULT_GENESIS_ADDRESS,
+  deployContract,
+  fundedGenesisState,
+  getContext,
+  l1ProviderConfig,
+  registerGenericProviderFactory,
+  sendTransaction,
+} from "./helpers";
+
+// Contract code in edr/data/contracts/ProxyMultipleImplementations.sol.
+// The proxies delegate through their fallback functions, so their ABIs do not
+// contain the implementations' functions. This makes calls through them hit
+// the proxy chain resolution in `ContractDecoder::populate_call_trace_arena`.
+const proxyBuildInfo: Buffer = fs.readFileSync(
+  `${__dirname}/data/artifacts/default/ProxyMultipleImplementations.json`
+);
+
+const proxyContracts = JSON.parse(proxyBuildInfo.toString()).output.contracts[
+  "project/contracts/ProxyMultipleImplementations.sol"
+];
+
+// Selector of `one()`, from `evm.methodIdentifiers` in the build info.
+const ONE_CALLDATA = "0x901717d1";
+
+const tracingConfig: TracingConfigWithBuffers = {
+  buildInfos: [Uint8Array.from(proxyBuildInfo)],
+};
+
+/** ABI-encodes an address as a 32-byte constructor argument. */
+function encodeAddressArg(address: string): string {
+  return address.slice(2).toLowerCase().padStart(64, "0");
+}
+
+describe("Proxy call logging", function () {
+  const context = getContext();
+
+  before(async function () {
+    await registerGenericProviderFactory(context);
+  });
+
+  let lines: string[];
+  let provider: Provider;
+
+  beforeEach(async function () {
+    lines = [];
+
+    provider = await context.createProvider(
+      GENERIC_CHAIN_TYPE,
+      l1ProviderConfig({ genesisState: fundedGenesisState() }),
+      {
+        enable: true,
+        decodeConsoleLogInputsCallback: (
+          _inputs: ArrayBuffer[]
+        ): string[] => [],
+        printLineCallback: (message: string, replace: boolean): void => {
+          if (replace) {
+            lines[lines.length - 1] = message;
+          } else {
+            lines.push(message);
+          }
+        },
+      },
+      {
+        subscriptionCallback: (_event: SubscriptionEvent) => {},
+      },
+      ContractDecoder.withContracts(tracingConfig)
+    );
+  });
+
+  function assertContractCallLine(expected: string) {
+    const line = lines.find((entry) => entry.includes("Contract call:"));
+    assert.isDefined(
+      line,
+      `Expected a "Contract call:" line in the logs:\n${lines.join("\n")}`
+    );
+    assert.match(
+      line,
+      new RegExp(`Contract call:\\s+${expected}$`),
+      `Unexpected contract call line in the logs:\n${lines.join("\n")}`
+    );
+  }
+
+  async function deployImpl1(): Promise<string> {
+    return deployContract(
+      provider,
+      `0x${proxyContracts.Impl1.evm.bytecode.object}`,
+      DEFAULT_GENESIS_ADDRESS
+    );
+  }
+
+  async function deployProxy(
+    contractName: "Proxy" | "Proxy2",
+    implementationAddress: string
+  ): Promise<string> {
+    const bytecode: string =
+      proxyContracts[contractName].evm.bytecode.object +
+      encodeAddressArg(implementationAddress);
+
+    return deployContract(provider, `0x${bytecode}`, DEFAULT_GENESIS_ADDRESS);
+  }
+
+  it("logs the function of a directly called contract", async function () {
+    const implAddress = await deployImpl1();
+
+    lines = [];
+    await sendTransaction(provider, {
+      from: DEFAULT_GENESIS_ADDRESS,
+      to: implAddress,
+      gas: 1_000_000,
+      data: ONE_CALLDATA,
+    });
+
+    assertContractCallLine("Impl1#one");
+  });
+
+  it("logs the implementation's function for a call through a proxy", async function () {
+    const implAddress = await deployImpl1();
+    const proxyAddress = await deployProxy("Proxy", implAddress);
+
+    lines = [];
+    await sendTransaction(provider, {
+      from: DEFAULT_GENESIS_ADDRESS,
+      to: proxyAddress,
+      gas: 1_000_000,
+      data: ONE_CALLDATA,
+    });
+
+    assertContractCallLine("Proxy>Impl1#one");
+    assert.isUndefined(
+      lines.find((entry) => entry.includes("<unrecognized-selector>")),
+      `Expected no unrecognized selector in the logs:\n${lines.join("\n")}`
+    );
+  });
+
+  it("logs the full proxy chain for a call through chained proxies", async function () {
+    const implAddress = await deployImpl1();
+    const innerProxyAddress = await deployProxy("Proxy2", implAddress);
+    const outerProxyAddress = await deployProxy("Proxy", innerProxyAddress);
+
+    // `Proxy2`'s code reads its implementation from storage slot 1. Under
+    // DELEGATECALL it reads the outer proxy's storage, so wire the outer
+    // proxy's slot 1 to the implementation, mirroring the `vm.store` usage in
+    // edr/js/integration-tests/solidity-tests/test-contracts/ProxyGasReport.t.sol.
+    await provider.handleRequest(
+      JSON.stringify({
+        id: 1,
+        jsonrpc: "2.0",
+        method: "hardhat_setStorageAt",
+        params: [
+          outerProxyAddress,
+          "0x1",
+          `0x${encodeAddressArg(implAddress)}`,
+        ],
+      })
+    );
+
+    lines = [];
+    await sendTransaction(provider, {
+      from: DEFAULT_GENESIS_ADDRESS,
+      to: outerProxyAddress,
+      gas: 1_000_000,
+      data: ONE_CALLDATA,
+    });
+
+    assertContractCallLine("Proxy>Proxy2>Impl1#one");
+  });
+
+  it("logs the implementation's function for an eth_call through a proxy", async function () {
+    const implAddress = await deployImpl1();
+    const proxyAddress = await deployProxy("Proxy", implAddress);
+
+    lines = [];
+    await provider.handleRequest(
+      JSON.stringify({
+        id: 1,
+        jsonrpc: "2.0",
+        method: "eth_call",
+        params: [
+          {
+            from: DEFAULT_GENESIS_ADDRESS,
+            to: proxyAddress,
+            gas: "0xf4240", // 1,000,000
+            data: ONE_CALLDATA,
+          },
+        ],
+      })
+    );
+
+    assertContractCallLine("Proxy>Impl1#one");
+  });
+
+  it("falls back to an unrecognized selector for a proxied call to an unknown function", async function () {
+    const implAddress = await deployImpl1();
+    const proxyAddress = await deployProxy("Proxy", implAddress);
+
+    lines = [];
+    // A selector that is neither in the proxy's nor the implementation's ABI.
+    await provider.handleRequest(
+      JSON.stringify({
+        id: 1,
+        jsonrpc: "2.0",
+        method: "eth_call",
+        params: [
+          {
+            from: DEFAULT_GENESIS_ADDRESS,
+            to: proxyAddress,
+            gas: "0xf4240", // 1,000,000
+            data: "0xdeadbeef",
+          },
+        ],
+      })
+    );
+
+    assertContractCallLine("Proxy#<unrecognized-selector>");
+  });
+});

--- a/crates/edr_solidity/src/contract_decoder.rs
+++ b/crates/edr_solidity/src/contract_decoder.rs
@@ -386,8 +386,8 @@ impl ContractDecoder {
     /// bytecode and tries to find the function in the implementation's ABI.
     ///
     /// Returns a [`DecodedCallTrace`] with:
-    /// - The resolved function signature with implementation info if found via
-    ///   proxy
+    /// - The resolved function signature with proxy chain info if found via
+    ///   proxy (e.g., "EIP173Proxy>GreetingsRegistry")
     /// - The unrecognized-selector fallback if not resolvable
     fn resolve_via_proxy_chain_or_unrecognized(
         &mut self,
@@ -398,8 +398,6 @@ impl ContractDecoder {
         proxy_chain: &[Address],
         address_to_executed_code: &HashMap<Address, Bytes>,
     ) -> Result<DecodedCallTrace, serde_json::Error> {
-        let label = Some(contract_name.clone());
-
         // Try to resolve via proxy chain if we have one with at least 2 addresses
         // (proxy + implementation)
         if proxy_chain.len() >= 2 {
@@ -431,16 +429,18 @@ impl ContractDecoder {
                             Vec::new()
                         };
 
-                        // Format signature with implementation info:
-                        // "functionName(args) (impl: ImplContractName @ 0x...)"
-                        let signature = format!(
-                            "{} (impl: {} @ {:#x})",
-                            abi.signature(),
-                            impl_contract.name,
-                            impl_address
+                        // Build the proxy chain label: "Proxy1>Proxy2>...>Implementation"
+                        // Start with the first contract name (already known)
+                        let chain_label = self.build_proxy_chain_label(
+                            &contract_name,
+                            proxy_chain,
+                            address_to_executed_code,
                         );
 
-                        let call_data = Some(DecodedCallData { signature, args });
+                        let call_data = Some(DecodedCallData {
+                            signature: abi.signature(),
+                            args,
+                        });
 
                         let return_data = decode_function_output(
                             call_trace,
@@ -450,7 +450,7 @@ impl ContractDecoder {
                         );
 
                         return Ok(DecodedCallTrace {
-                            label,
+                            label: Some(chain_label),
                             return_data,
                             call_data,
                         });
@@ -478,7 +478,7 @@ impl ContractDecoder {
         };
 
         Ok(DecodedCallTrace {
-            label,
+            label: Some(contract_name),
             return_data,
             call_data: Some(DecodedCallData {
                 signature: UNRECOGNIZED_FUNCTION_NAME.to_owned(),
@@ -489,6 +489,41 @@ impl ContractDecoder {
                 },
             }),
         })
+    }
+
+    /// Builds a proxy chain label from a list of addresses.
+    ///
+    /// Returns a string like "EIP173Proxy>Router>GreetingsRegistry" where each
+    /// contract in the proxy chain is represented by its name, joined by `>`.
+    ///
+    /// If a contract name cannot be resolved for an address, it falls back to
+    /// using the truncated address.
+    fn build_proxy_chain_label(
+        &mut self,
+        first_contract_name: &str,
+        proxy_chain: &[Address],
+        address_to_executed_code: &HashMap<Address, Bytes>,
+    ) -> String {
+        let mut chain_names = vec![first_contract_name.to_string()];
+
+        // Skip the first address (we already have its name) and resolve the rest
+        for &addr in proxy_chain.iter().skip(1) {
+            let name = if let Some(code) = address_to_executed_code.get(&addr) {
+                if let Some(metadata) = self.contracts_identifier.get_bytecode_for_call(code, false)
+                {
+                    metadata.contract.read().name.clone()
+                } else {
+                    // Fallback to truncated address if contract not found
+                    format!("{:#x}", addr)
+                }
+            } else {
+                // Fallback to truncated address if code not found
+                format!("{:#x}", addr)
+            };
+            chain_names.push(name);
+        }
+
+        chain_names.join(">")
     }
 }
 

--- a/crates/edr_solidity/src/contract_decoder.rs
+++ b/crates/edr_solidity/src/contract_decoder.rs
@@ -28,6 +28,7 @@ use crate::{
     compiler::create_models_and_decode_bytecodes,
     contracts_identifier::ContractsIdentifier,
     nested_trace::{NestedTrace, NestedTraceStep},
+    proxy_detection::detect_proxy_chain,
 };
 
 /// Errors that can occur during the decoding of the nested trace.
@@ -255,8 +256,16 @@ impl ContractDecoder {
         address_to_executed_code: &HashMap<Address, Bytes>,
         precompile_addresses: &HashSet<Address>,
     ) -> Result<(), serde_json::Error> {
-        for node in call_trace_arena.nodes_mut() {
+        // Pre-compute all proxy chains (immutable borrow) before mutating nodes.
+        // This is needed because detect_proxy_chain requires immutable access to the
+        // arena, but we need mutable access to update node.trace.decoded.
+        let proxy_chains: Vec<Vec<Address>> = (0..call_trace_arena.nodes().len())
+            .map(|idx| detect_proxy_chain(call_trace_arena, idx))
+            .collect();
+
+        for (idx, node) in call_trace_arena.nodes_mut().iter_mut().enumerate() {
             let call_trace = &mut node.trace;
+            let proxy_chain = &proxy_chains[idx];
 
             let decoded = if precompile_addresses.contains(&call_trace.address)
                 && let Some(decoded) = foundry_evm_traces::decoder::precompiles::decode(call_trace)
@@ -323,38 +332,16 @@ impl ContractDecoder {
                                 call_data,
                             }
                         } else {
-                            let return_data = if !call_trace.success {
-                                let revert_msg = self
-                                    .revert_decoder
-                                    .decode(&call_trace.output, call_trace.status);
-
-                                if call_trace.output.is_empty()
-                                    || revert_msg.contains("EvmError: Revert")
-                                {
-                                    Some(format!(
-                                    "unrecognized function selector {selector} for contract {contract_name} ({contract_address}).",
-                                    contract_name = contract.name,
-                                    contract_address = call_trace.address,
-                                ))
-                                } else {
-                                    Some(revert_msg)
-                                }
-                            } else {
-                                None
-                            };
-
-                            DecodedCallTrace {
-                                label,
-                                return_data,
-                                call_data: Some(DecodedCallData {
-                                    signature: UNRECOGNIZED_FUNCTION_NAME.to_owned(),
-                                    args: if calldata.is_empty() {
-                                        Vec::new()
-                                    } else {
-                                        vec![calldata.to_string()]
-                                    },
-                                }),
-                            }
+                            // Selector not found in the called contract's ABI.
+                            // Try to resolve via proxy chain detection.
+                            self.resolve_via_proxy_chain_or_unrecognized(
+                                call_trace,
+                                calldata,
+                                &selector,
+                                contract.name.clone(),
+                                proxy_chain,
+                                address_to_executed_code,
+                            )?
                         }
                     } else {
                         DecodedCallTrace {
@@ -389,6 +376,119 @@ impl ContractDecoder {
             call_trace.decoded = Some(Box::new(decoded));
         }
         Ok(())
+    }
+
+    /// Attempts to resolve a function selector via proxy chain detection.
+    ///
+    /// When a selector is not found in the called contract's ABI, this method
+    /// checks if the call trace exhibits a proxy pattern (DELEGATECALL with
+    /// matching selector). If so, it looks up the implementation contract's
+    /// bytecode and tries to find the function in the implementation's ABI.
+    ///
+    /// Returns a [`DecodedCallTrace`] with:
+    /// - The resolved function signature with implementation info if found via
+    ///   proxy
+    /// - The unrecognized-selector fallback if not resolvable
+    fn resolve_via_proxy_chain_or_unrecognized(
+        &mut self,
+        call_trace: &CallTrace,
+        calldata: &Bytes,
+        selector: &Selector,
+        contract_name: String,
+        proxy_chain: &[Address],
+        address_to_executed_code: &HashMap<Address, Bytes>,
+    ) -> Result<DecodedCallTrace, serde_json::Error> {
+        let label = Some(contract_name.clone());
+
+        // Try to resolve via proxy chain if we have one with at least 2 addresses
+        // (proxy + implementation)
+        if proxy_chain.len() >= 2 {
+            // Get implementation address (last in chain)
+            let impl_address = *proxy_chain.last().unwrap();
+
+            // Get implementation bytecode
+            if let Some(impl_code) = address_to_executed_code.get(&impl_address) {
+                // Find contract metadata for implementation
+                if let Some(impl_metadata) = self
+                    .contracts_identifier
+                    .get_bytecode_for_call(impl_code, false)
+                {
+                    let impl_contract = impl_metadata.contract.read();
+
+                    // Look up selector in implementation ABI
+                    if let Some(function) =
+                        impl_contract.get_function_from_selector(selector.as_slice())
+                    {
+                        let abi = alloy_json_abi::Function::try_from(function.as_ref())?;
+
+                        let args = if let Some(input_data) = calldata.get(SELECTOR_LEN..)
+                            && let Ok(args) = abi.abi_decode_input(input_data)
+                        {
+                            args.iter()
+                                .map(|value| format_value(value, &impl_contract.name))
+                                .collect()
+                        } else {
+                            Vec::new()
+                        };
+
+                        // Format signature with implementation info:
+                        // "functionName(args) (impl: ImplContractName @ 0x...)"
+                        let signature = format!(
+                            "{} (impl: {} @ {:#x})",
+                            abi.signature(),
+                            impl_contract.name,
+                            impl_address
+                        );
+
+                        let call_data = Some(DecodedCallData { signature, args });
+
+                        let return_data = decode_function_output(
+                            call_trace,
+                            &abi,
+                            &impl_contract.name,
+                            &self.revert_decoder,
+                        );
+
+                        return Ok(DecodedCallTrace {
+                            label,
+                            return_data,
+                            call_data,
+                        });
+                    }
+                }
+            }
+        }
+
+        // Fallback: selector not resolved via proxy chain
+        let return_data = if !call_trace.success {
+            let revert_msg = self
+                .revert_decoder
+                .decode(&call_trace.output, call_trace.status);
+
+            if call_trace.output.is_empty() || revert_msg.contains("EvmError: Revert") {
+                Some(format!(
+                    "unrecognized function selector {selector} for contract {contract_name} ({contract_address}).",
+                    contract_address = call_trace.address,
+                ))
+            } else {
+                Some(revert_msg)
+            }
+        } else {
+            None
+        };
+
+        Ok(DecodedCallTrace {
+            label,
+            return_data,
+            call_data: Some(DecodedCallData {
+                signature: UNRECOGNIZED_FUNCTION_NAME.to_owned(),
+                args: if calldata.is_empty() {
+                    Vec::new()
+                } else {
+                    vec![calldata.to_string()]
+                },
+            }),
+        })
     }
 }
 

--- a/crates/edr_solidity/src/contract_decoder.rs
+++ b/crates/edr_solidity/src/contract_decoder.rs
@@ -254,112 +254,112 @@ impl ContractDecoder {
         address_to_executed_code: &HashMap<Address, Bytes>,
         precompile_addresses: &HashSet<Address>,
     ) -> Result<(), serde_json::Error> {
-        // Pre-compute all proxy chains (immutable borrow) before mutating nodes.
-        // This is needed because detect_proxy_chain requires immutable access to the
-        // arena, but we need mutable access to update node.trace.decoded.
-        let proxy_chains: Vec<Vec<Address>> = (0..call_trace_arena.nodes().len())
-            .map(|idx| {
-                // `detect_proxy_chain` returns the chain ordered from the
-                // final implementation to the outermost proxy; reverse it so
-                // that the implementation is last.
-                detect_proxy_chain(call_trace_arena, idx).map_or_else(Vec::new, |chain| {
-                    chain.iter().rev().map(|trace| trace.address).collect()
+        // Decoding is done in two passes: the first pass computes the decoded
+        // call traces with only immutable access to the arena, because calls
+        // whose function selector is not found in the called contract's ABI
+        // are resolved through proxy chain detection, which inspects other
+        // nodes in the arena. The second pass assigns the results to the
+        // nodes.
+        let decoded_traces = {
+            let arena: &CallTraceArena = call_trace_arena;
+            arena
+                .nodes()
+                .iter()
+                .enumerate()
+                .map(|(node_idx, node)| {
+                    self.decode_call_trace(
+                        arena,
+                        node_idx,
+                        &node.trace,
+                        address_to_executed_code,
+                        precompile_addresses,
+                    )
                 })
-            })
-            .collect();
+                .collect::<Result<Vec<_>, serde_json::Error>>()?
+        };
 
-        for (idx, node) in call_trace_arena.nodes_mut().iter_mut().enumerate() {
-            let call_trace = &mut node.trace;
-            let proxy_chain = &proxy_chains[idx];
+        for (node, decoded) in call_trace_arena.nodes_mut().iter_mut().zip(decoded_traces) {
+            node.trace.decoded = Some(Box::new(decoded));
+        }
 
-            let decoded = if precompile_addresses.contains(&call_trace.address)
-                && let Some(decoded) = foundry_evm_traces::decoder::precompiles::decode(call_trace)
-            {
-                decoded
-            } else if call_trace.kind.is_any_create() {
-                let identified = self
-                    .contracts_identifier
-                    .get_bytecode_for_call(&call_trace.data, true);
+        Ok(())
+    }
 
-                let contract_identifier = identified
-                    .map_or(UNRECOGNIZED_CONTRACT_NAME.to_string(), |i| {
-                        i.contract_metadata.contract.read().name.clone()
-                    });
+    /// Decodes a single call trace of the arena, identifying the contract and
+    /// the called function from the executed code.
+    fn decode_call_trace(
+        &mut self,
+        call_trace_arena: &CallTraceArena,
+        node_idx: usize,
+        call_trace: &CallTrace,
+        address_to_executed_code: &HashMap<Address, Bytes>,
+        precompile_addresses: &HashSet<Address>,
+    ) -> Result<DecodedCallTrace, serde_json::Error> {
+        let decoded = if precompile_addresses.contains(&call_trace.address)
+            && let Some(decoded) = foundry_evm_traces::decoder::precompiles::decode(call_trace)
+        {
+            decoded
+        } else if call_trace.kind.is_any_create() {
+            let identified = self
+                .contracts_identifier
+                .get_bytecode_for_call(&call_trace.data, true);
 
-                DecodedCallTrace {
-                    label: Some(contract_identifier),
-                    ..DecodedCallTrace::default()
-                }
-            } else {
-                let calldata = &call_trace.data;
-                let code = address_to_executed_code
-                    .get(&call_trace.address)
-                    .unwrap_or_default();
+            let contract_identifier = identified
+                .map_or(UNRECOGNIZED_CONTRACT_NAME.to_string(), |i| {
+                    i.contract_metadata.contract.read().name.clone()
+                });
 
-                let identified = self.contracts_identifier.get_bytecode_for_call(code, false);
+            DecodedCallTrace {
+                label: Some(contract_identifier),
+                ..DecodedCallTrace::default()
+            }
+        } else {
+            let calldata = &call_trace.data;
+            let code = address_to_executed_code
+                .get(&call_trace.address)
+                .unwrap_or_default();
 
-                if let Some(identified) = identified {
-                    if let Some(Ok(selector)) = calldata.get(..SELECTOR_LEN).map(Selector::try_from)
+            let identified = self.contracts_identifier.get_bytecode_for_call(code, false);
+
+            if let Some(identified) = identified {
+                if let Some(Ok(selector)) = calldata.get(..SELECTOR_LEN).map(Selector::try_from) {
+                    let contract = identified.contract_metadata.contract.read();
+                    let label = Some(contract.name.clone());
+                    if let Some(function) = contract.get_function_from_selector(selector.as_slice())
                     {
-                        let contract = identified.contract_metadata.contract.read();
-                        let label = Some(contract.name.clone());
-                        if let Some(function) =
-                            contract.get_function_from_selector(selector.as_slice())
-                        {
-                            let abi = alloy_json_abi::Function::try_from(function.as_ref())?;
+                        let abi = alloy_json_abi::Function::try_from(function.as_ref())?;
 
-                            let args = if let Some(input_data) = calldata.get(SELECTOR_LEN..)
-                                && let Ok(args) = abi.abi_decode_input(input_data)
-                            {
-                                args.iter()
-                                    .map(|value| format_value(value, &contract.name))
-                                    .collect()
-                            } else {
-                                Vec::new()
-                            };
+                        let args =
+                            decode_input_args(&abi, calldata, &contract.name).unwrap_or_default();
 
-                            let call_data = Some(DecodedCallData {
-                                signature: abi.signature(),
-                                args,
-                            });
+                        let call_data = Some(DecodedCallData {
+                            signature: abi.signature(),
+                            args,
+                        });
 
-                            let return_data = decode_function_output(
-                                call_trace,
-                                &abi,
-                                &contract.name,
-                                &self.revert_decoder,
-                            );
+                        let return_data = decode_function_output(
+                            call_trace,
+                            &abi,
+                            &contract.name,
+                            &self.revert_decoder,
+                        );
 
-                            DecodedCallTrace {
-                                label,
-                                return_data,
-                                call_data,
-                            }
-                        } else {
-                            // Selector not found in the called contract's ABI.
-                            // Try to resolve via proxy chain detection.
-                            self.resolve_via_proxy_chain_or_unrecognized(
-                                call_trace,
-                                calldata,
-                                &selector,
-                                contract.name.clone(),
-                                proxy_chain,
-                                address_to_executed_code,
-                            )?
+                        DecodedCallTrace {
+                            label,
+                            return_data,
+                            call_data,
                         }
                     } else {
-                        DecodedCallTrace {
-                            label: Some(UNRECOGNIZED_CONTRACT_NAME.to_string()),
-                            return_data: default_return_data(call_trace, &self.revert_decoder),
-                            call_data: if call_trace.data.is_empty() {
-                                None
-                            } else {
-                                Some(DecodedCallData {
-                                    signature: UNRECOGNIZED_FUNCTION_NAME.to_owned(),
-                                    args: vec![call_trace.data.to_string()],
-                                })
-                            },
-                        }
+                        // Selector not found in the called contract's ABI.
+                        // Try to resolve via proxy chain detection.
+                        self.resolve_via_proxy_chain_or_unrecognized(
+                            call_trace_arena,
+                            node_idx,
+                            call_trace,
+                            &selector,
+                            contract.name.clone(),
+                            address_to_executed_code,
+                        )?
                     }
                 } else {
                     DecodedCallTrace {
@@ -369,17 +369,29 @@ impl ContractDecoder {
                             None
                         } else {
                             Some(DecodedCallData {
-                                signature: "".to_owned(),
+                                signature: UNRECOGNIZED_FUNCTION_NAME.to_owned(),
                                 args: vec![call_trace.data.to_string()],
                             })
                         },
                     }
                 }
-            };
+            } else {
+                DecodedCallTrace {
+                    label: Some(UNRECOGNIZED_CONTRACT_NAME.to_string()),
+                    return_data: default_return_data(call_trace, &self.revert_decoder),
+                    call_data: if call_trace.data.is_empty() {
+                        None
+                    } else {
+                        Some(DecodedCallData {
+                            signature: "".to_owned(),
+                            args: vec![call_trace.data.to_string()],
+                        })
+                    },
+                }
+            }
+        };
 
-            call_trace.decoded = Some(Box::new(decoded));
-        }
-        Ok(())
+        Ok(decoded)
     }
 
     /// Attempts to resolve a function selector via proxy chain detection.
@@ -395,71 +407,61 @@ impl ContractDecoder {
     /// - The unrecognized-selector fallback if not resolvable
     fn resolve_via_proxy_chain_or_unrecognized(
         &mut self,
+        call_trace_arena: &CallTraceArena,
+        node_idx: usize,
         call_trace: &CallTrace,
-        calldata: &Bytes,
         selector: &Selector,
         contract_name: String,
-        proxy_chain: &[Address],
         address_to_executed_code: &HashMap<Address, Bytes>,
     ) -> Result<DecodedCallTrace, serde_json::Error> {
-        // Try to resolve via proxy chain if we have one with at least 2 addresses
-        // (proxy + implementation)
-        if proxy_chain.len() >= 2 {
-            // Get implementation address (last in chain)
-            let impl_address = *proxy_chain.last().unwrap();
+        // `detect_proxy_chain` returns the chain ordered from the final
+        // implementation to the outermost proxy.
+        if let Some(proxy_chain) = detect_proxy_chain(call_trace_arena, node_idx)
+            && let Some(implementation) = proxy_chain.first()
+            && let Some(impl_code) = address_to_executed_code.get(&implementation.address)
+            && let Some(impl_identified) = self
+                .contracts_identifier
+                .get_bytecode_for_call(impl_code, false)
+        {
+            let impl_contract = impl_identified.contract_metadata.contract.read();
 
-            // Get implementation bytecode
-            if let Some(impl_code) = address_to_executed_code.get(&impl_address) {
-                // Find contract metadata for implementation
-                if let Some(impl_identified) = self
-                    .contracts_identifier
-                    .get_bytecode_for_call(impl_code, false)
-                {
-                    let impl_contract = impl_identified.contract_metadata.contract.read();
+            // Look up selector in implementation ABI
+            if let Some(function) = impl_contract.get_function_from_selector(selector.as_slice()) {
+                let abi = alloy_json_abi::Function::try_from(function.as_ref())?;
 
-                    // Look up selector in implementation ABI
-                    if let Some(function) =
-                        impl_contract.get_function_from_selector(selector.as_slice())
-                    {
-                        let abi = alloy_json_abi::Function::try_from(function.as_ref())?;
+                // The proxy may forward modified calldata (e.g.
+                // clones-with-immutable-args appends immutable arguments), so
+                // fall back to the calldata that the implementation actually
+                // received.
+                let args = decode_input_args(&abi, &call_trace.data, &impl_contract.name)
+                    .or_else(|| decode_input_args(&abi, &implementation.data, &impl_contract.name))
+                    .unwrap_or_default();
 
-                        let args = if let Some(input_data) = calldata.get(SELECTOR_LEN..)
-                            && let Ok(args) = abi.abi_decode_input(input_data)
-                        {
-                            args.iter()
-                                .map(|value| format_value(value, &impl_contract.name))
-                                .collect()
-                        } else {
-                            Vec::new()
-                        };
+                // Build the proxy chain label: "Proxy1>Proxy2>...>Implementation"
+                // Start with the first contract name (already known)
+                let chain_label = self.build_proxy_chain_label(
+                    &contract_name,
+                    &proxy_chain,
+                    address_to_executed_code,
+                );
 
-                        // Build the proxy chain label: "Proxy1>Proxy2>...>Implementation"
-                        // Start with the first contract name (already known)
-                        let chain_label = self.build_proxy_chain_label(
-                            &contract_name,
-                            proxy_chain,
-                            address_to_executed_code,
-                        );
+                let call_data = Some(DecodedCallData {
+                    signature: abi.signature(),
+                    args,
+                });
 
-                        let call_data = Some(DecodedCallData {
-                            signature: abi.signature(),
-                            args,
-                        });
+                let return_data = decode_function_output(
+                    call_trace,
+                    &abi,
+                    &impl_contract.name,
+                    &self.revert_decoder,
+                );
 
-                        let return_data = decode_function_output(
-                            call_trace,
-                            &abi,
-                            &impl_contract.name,
-                            &self.revert_decoder,
-                        );
-
-                        return Ok(DecodedCallTrace {
-                            label: Some(chain_label),
-                            return_data,
-                            call_data,
-                        });
-                    }
-                }
+                return Ok(DecodedCallTrace {
+                    label: Some(chain_label),
+                    return_data,
+                    call_data,
+                });
             }
         }
 
@@ -486,50 +488,67 @@ impl ContractDecoder {
             return_data,
             call_data: Some(DecodedCallData {
                 signature: UNRECOGNIZED_FUNCTION_NAME.to_owned(),
-                args: if calldata.is_empty() {
+                args: if call_trace.data.is_empty() {
                     Vec::new()
                 } else {
-                    vec![calldata.to_string()]
+                    vec![call_trace.data.to_string()]
                 },
             }),
         })
     }
 
-    /// Builds a proxy chain label from a list of addresses.
+    /// Builds a proxy chain label from a proxy chain ordered from the final
+    /// implementation to the outermost proxy.
     ///
     /// Returns a string like "EIP173Proxy>Router>GreetingsRegistry" where each
-    /// contract in the proxy chain is represented by its name, joined by `>`.
+    /// contract in the proxy chain is represented by its name, joined by `>`,
+    /// starting with the outermost proxy.
     ///
     /// If a contract name cannot be resolved for an address, it falls back to
-    /// using the truncated address.
+    /// using the address.
     fn build_proxy_chain_label(
         &mut self,
-        first_contract_name: &str,
-        proxy_chain: &[Address],
+        outermost_contract_name: &str,
+        proxy_chain: &[&CallTrace],
         address_to_executed_code: &HashMap<Address, Bytes>,
     ) -> String {
-        let mut chain_names = vec![first_contract_name.to_string()];
+        let mut chain_names = vec![outermost_contract_name.to_string()];
 
-        // Skip the first address (we already have its name) and resolve the rest
-        for &addr in proxy_chain.iter().skip(1) {
-            let name = if let Some(code) = address_to_executed_code.get(&addr) {
-                if let Some(identified) =
-                    self.contracts_identifier.get_bytecode_for_call(code, false)
-                {
-                    identified.contract_metadata.contract.read().name.clone()
-                } else {
-                    // Fallback to truncated address if contract not found
-                    format!("{:#x}", addr)
-                }
-            } else {
-                // Fallback to truncated address if code not found
-                format!("{:#x}", addr)
-            };
+        // Skip the outermost call, whose name is already known, and resolve
+        // the rest.
+        for call_trace in proxy_chain.iter().rev().skip(1) {
+            let name = address_to_executed_code
+                .get(&call_trace.address)
+                .and_then(|code| self.contracts_identifier.get_bytecode_for_call(code, false))
+                .map_or_else(
+                    || format!("{:#x}", call_trace.address),
+                    |identified| identified.contract_metadata.contract.read().name.clone(),
+                );
             chain_names.push(name);
         }
 
         chain_names.join(">")
     }
+}
+
+/// Decodes the input arguments of the provided calldata using the function
+/// ABI, formatting the values with the provided contract name.
+///
+/// Returns `None` if the calldata does not contain input data or if decoding
+/// fails.
+fn decode_input_args(
+    function: &alloy_json_abi::Function,
+    calldata: &Bytes,
+    contract_name: &str,
+) -> Option<Vec<String>> {
+    let input_data = calldata.get(SELECTOR_LEN..)?;
+    let args = function.abi_decode_input(input_data).ok()?;
+
+    Some(
+        args.iter()
+            .map(|value| format_value(value, contract_name))
+            .collect(),
+    )
 }
 
 /// Decodes the function output from the call trace using the provided function

--- a/crates/edr_solidity/src/contract_decoder.rs
+++ b/crates/edr_solidity/src/contract_decoder.rs
@@ -27,6 +27,7 @@ use crate::{
     build_model::ContractFunctionType,
     contracts_identifier::{ContractsIdentifier, IdentifiedContract},
     nested_trace::{NestedTrace, NestedTraceStep},
+    proxy_detection::detect_proxy_chain,
 };
 
 /// Errors that can occur during the decoding of the nested trace.
@@ -253,8 +254,23 @@ impl ContractDecoder {
         address_to_executed_code: &HashMap<Address, Bytes>,
         precompile_addresses: &HashSet<Address>,
     ) -> Result<(), serde_json::Error> {
-        for node in call_trace_arena.nodes_mut() {
+        // Pre-compute all proxy chains (immutable borrow) before mutating nodes.
+        // This is needed because detect_proxy_chain requires immutable access to the
+        // arena, but we need mutable access to update node.trace.decoded.
+        let proxy_chains: Vec<Vec<Address>> = (0..call_trace_arena.nodes().len())
+            .map(|idx| {
+                // `detect_proxy_chain` returns the chain ordered from the
+                // final implementation to the outermost proxy; reverse it so
+                // that the implementation is last.
+                detect_proxy_chain(call_trace_arena, idx).map_or_else(Vec::new, |chain| {
+                    chain.iter().rev().map(|trace| trace.address).collect()
+                })
+            })
+            .collect();
+
+        for (idx, node) in call_trace_arena.nodes_mut().iter_mut().enumerate() {
             let call_trace = &mut node.trace;
+            let proxy_chain = &proxy_chains[idx];
 
             let decoded = if precompile_addresses.contains(&call_trace.address)
                 && let Some(decoded) = foundry_evm_traces::decoder::precompiles::decode(call_trace)
@@ -320,38 +336,16 @@ impl ContractDecoder {
                                 call_data,
                             }
                         } else {
-                            let return_data = if !call_trace.success {
-                                let revert_msg = self
-                                    .revert_decoder
-                                    .decode(&call_trace.output, call_trace.status);
-
-                                if call_trace.output.is_empty()
-                                    || revert_msg.contains("EvmError: Revert")
-                                {
-                                    Some(format!(
-                                    "unrecognized function selector {selector} for contract {contract_name} ({contract_address}).",
-                                    contract_name = contract.name,
-                                    contract_address = call_trace.address,
-                                ))
-                                } else {
-                                    Some(revert_msg)
-                                }
-                            } else {
-                                None
-                            };
-
-                            DecodedCallTrace {
-                                label,
-                                return_data,
-                                call_data: Some(DecodedCallData {
-                                    signature: UNRECOGNIZED_FUNCTION_NAME.to_owned(),
-                                    args: if calldata.is_empty() {
-                                        Vec::new()
-                                    } else {
-                                        vec![calldata.to_string()]
-                                    },
-                                }),
-                            }
+                            // Selector not found in the called contract's ABI.
+                            // Try to resolve via proxy chain detection.
+                            self.resolve_via_proxy_chain_or_unrecognized(
+                                call_trace,
+                                calldata,
+                                &selector,
+                                contract.name.clone(),
+                                proxy_chain,
+                                address_to_executed_code,
+                            )?
                         }
                     } else {
                         DecodedCallTrace {
@@ -386,6 +380,119 @@ impl ContractDecoder {
             call_trace.decoded = Some(Box::new(decoded));
         }
         Ok(())
+    }
+
+    /// Attempts to resolve a function selector via proxy chain detection.
+    ///
+    /// When a selector is not found in the called contract's ABI, this method
+    /// checks if the call trace exhibits a proxy pattern (DELEGATECALL with
+    /// matching selector). If so, it looks up the implementation contract's
+    /// bytecode and tries to find the function in the implementation's ABI.
+    ///
+    /// Returns a [`DecodedCallTrace`] with:
+    /// - The resolved function signature with implementation info if found via
+    ///   proxy
+    /// - The unrecognized-selector fallback if not resolvable
+    fn resolve_via_proxy_chain_or_unrecognized(
+        &mut self,
+        call_trace: &CallTrace,
+        calldata: &Bytes,
+        selector: &Selector,
+        contract_name: String,
+        proxy_chain: &[Address],
+        address_to_executed_code: &HashMap<Address, Bytes>,
+    ) -> Result<DecodedCallTrace, serde_json::Error> {
+        let label = Some(contract_name.clone());
+
+        // Try to resolve via proxy chain if we have one with at least 2 addresses
+        // (proxy + implementation)
+        if proxy_chain.len() >= 2 {
+            // Get implementation address (last in chain)
+            let impl_address = *proxy_chain.last().unwrap();
+
+            // Get implementation bytecode
+            if let Some(impl_code) = address_to_executed_code.get(&impl_address) {
+                // Find contract metadata for implementation
+                if let Some(impl_identified) = self
+                    .contracts_identifier
+                    .get_bytecode_for_call(impl_code, false)
+                {
+                    let impl_contract = impl_identified.contract_metadata.contract.read();
+
+                    // Look up selector in implementation ABI
+                    if let Some(function) =
+                        impl_contract.get_function_from_selector(selector.as_slice())
+                    {
+                        let abi = alloy_json_abi::Function::try_from(function.as_ref())?;
+
+                        let args = if let Some(input_data) = calldata.get(SELECTOR_LEN..)
+                            && let Ok(args) = abi.abi_decode_input(input_data)
+                        {
+                            args.iter()
+                                .map(|value| format_value(value, &impl_contract.name))
+                                .collect()
+                        } else {
+                            Vec::new()
+                        };
+
+                        // Format signature with implementation info:
+                        // "functionName(args) (impl: ImplContractName @ 0x...)"
+                        let signature = format!(
+                            "{} (impl: {} @ {:#x})",
+                            abi.signature(),
+                            impl_contract.name,
+                            impl_address
+                        );
+
+                        let call_data = Some(DecodedCallData { signature, args });
+
+                        let return_data = decode_function_output(
+                            call_trace,
+                            &abi,
+                            &impl_contract.name,
+                            &self.revert_decoder,
+                        );
+
+                        return Ok(DecodedCallTrace {
+                            label,
+                            return_data,
+                            call_data,
+                        });
+                    }
+                }
+            }
+        }
+
+        // Fallback: selector not resolved via proxy chain
+        let return_data = if !call_trace.success {
+            let revert_msg = self
+                .revert_decoder
+                .decode(&call_trace.output, call_trace.status);
+
+            if call_trace.output.is_empty() || revert_msg.contains("EvmError: Revert") {
+                Some(format!(
+                    "unrecognized function selector {selector} for contract {contract_name} ({contract_address}).",
+                    contract_address = call_trace.address,
+                ))
+            } else {
+                Some(revert_msg)
+            }
+        } else {
+            None
+        };
+
+        Ok(DecodedCallTrace {
+            label,
+            return_data,
+            call_data: Some(DecodedCallData {
+                signature: UNRECOGNIZED_FUNCTION_NAME.to_owned(),
+                args: if calldata.is_empty() {
+                    Vec::new()
+                } else {
+                    vec![calldata.to_string()]
+                },
+            }),
+        })
     }
 }
 

--- a/crates/edr_solidity/src/contract_decoder.rs
+++ b/crates/edr_solidity/src/contract_decoder.rs
@@ -513,9 +513,10 @@ impl ContractDecoder {
         // Skip the first address (we already have its name) and resolve the rest
         for &addr in proxy_chain.iter().skip(1) {
             let name = if let Some(code) = address_to_executed_code.get(&addr) {
-                if let Some(metadata) = self.contracts_identifier.get_bytecode_for_call(code, false)
+                if let Some(identified) =
+                    self.contracts_identifier.get_bytecode_for_call(code, false)
                 {
-                    metadata.contract.read().name.clone()
+                    identified.contract_metadata.contract.read().name.clone()
                 } else {
                     // Fallback to truncated address if contract not found
                     format!("{:#x}", addr)

--- a/crates/edr_solidity/src/contract_decoder.rs
+++ b/crates/edr_solidity/src/contract_decoder.rs
@@ -403,7 +403,7 @@ impl ContractDecoder {
     ///
     /// Returns a [`DecodedCallTrace`] with:
     /// - The resolved function signature with proxy chain info if found via
-    ///   proxy (e.g., "EIP173Proxy>GreetingsRegistry")
+    ///   proxy (e.g., "Proxy1>Proxy2>...>Implementation")
     /// - The unrecognized-selector fallback if not resolvable
     fn resolve_via_proxy_chain_or_unrecognized(
         &mut self,
@@ -500,7 +500,7 @@ impl ContractDecoder {
     /// Builds a proxy chain label from a proxy chain ordered from the final
     /// implementation to the outermost proxy.
     ///
-    /// Returns a string like "EIP173Proxy>Router>GreetingsRegistry" where each
+    /// Returns a string like "Proxy1>Proxy2>...>Implementation" where each
     /// contract in the proxy chain is represented by its name, joined by `>`,
     /// starting with the outermost proxy.
     ///

--- a/crates/edr_solidity/src/contract_decoder.rs
+++ b/crates/edr_solidity/src/contract_decoder.rs
@@ -390,8 +390,8 @@ impl ContractDecoder {
     /// bytecode and tries to find the function in the implementation's ABI.
     ///
     /// Returns a [`DecodedCallTrace`] with:
-    /// - The resolved function signature with implementation info if found via
-    ///   proxy
+    /// - The resolved function signature with proxy chain info if found via
+    ///   proxy (e.g., "EIP173Proxy>GreetingsRegistry")
     /// - The unrecognized-selector fallback if not resolvable
     fn resolve_via_proxy_chain_or_unrecognized(
         &mut self,
@@ -402,8 +402,6 @@ impl ContractDecoder {
         proxy_chain: &[Address],
         address_to_executed_code: &HashMap<Address, Bytes>,
     ) -> Result<DecodedCallTrace, serde_json::Error> {
-        let label = Some(contract_name.clone());
-
         // Try to resolve via proxy chain if we have one with at least 2 addresses
         // (proxy + implementation)
         if proxy_chain.len() >= 2 {
@@ -435,16 +433,18 @@ impl ContractDecoder {
                             Vec::new()
                         };
 
-                        // Format signature with implementation info:
-                        // "functionName(args) (impl: ImplContractName @ 0x...)"
-                        let signature = format!(
-                            "{} (impl: {} @ {:#x})",
-                            abi.signature(),
-                            impl_contract.name,
-                            impl_address
+                        // Build the proxy chain label: "Proxy1>Proxy2>...>Implementation"
+                        // Start with the first contract name (already known)
+                        let chain_label = self.build_proxy_chain_label(
+                            &contract_name,
+                            proxy_chain,
+                            address_to_executed_code,
                         );
 
-                        let call_data = Some(DecodedCallData { signature, args });
+                        let call_data = Some(DecodedCallData {
+                            signature: abi.signature(),
+                            args,
+                        });
 
                         let return_data = decode_function_output(
                             call_trace,
@@ -454,7 +454,7 @@ impl ContractDecoder {
                         );
 
                         return Ok(DecodedCallTrace {
-                            label,
+                            label: Some(chain_label),
                             return_data,
                             call_data,
                         });
@@ -482,7 +482,7 @@ impl ContractDecoder {
         };
 
         Ok(DecodedCallTrace {
-            label,
+            label: Some(contract_name),
             return_data,
             call_data: Some(DecodedCallData {
                 signature: UNRECOGNIZED_FUNCTION_NAME.to_owned(),
@@ -493,6 +493,41 @@ impl ContractDecoder {
                 },
             }),
         })
+    }
+
+    /// Builds a proxy chain label from a list of addresses.
+    ///
+    /// Returns a string like "EIP173Proxy>Router>GreetingsRegistry" where each
+    /// contract in the proxy chain is represented by its name, joined by `>`.
+    ///
+    /// If a contract name cannot be resolved for an address, it falls back to
+    /// using the truncated address.
+    fn build_proxy_chain_label(
+        &mut self,
+        first_contract_name: &str,
+        proxy_chain: &[Address],
+        address_to_executed_code: &HashMap<Address, Bytes>,
+    ) -> String {
+        let mut chain_names = vec![first_contract_name.to_string()];
+
+        // Skip the first address (we already have its name) and resolve the rest
+        for &addr in proxy_chain.iter().skip(1) {
+            let name = if let Some(code) = address_to_executed_code.get(&addr) {
+                if let Some(metadata) = self.contracts_identifier.get_bytecode_for_call(code, false)
+                {
+                    metadata.contract.read().name.clone()
+                } else {
+                    // Fallback to truncated address if contract not found
+                    format!("{:#x}", addr)
+                }
+            } else {
+                // Fallback to truncated address if code not found
+                format!("{:#x}", addr)
+            };
+            chain_names.push(name);
+        }
+
+        chain_names.join(">")
     }
 }
 

--- a/crates/edr_solidity/src/proxy_detection.rs
+++ b/crates/edr_solidity/src/proxy_detection.rs
@@ -36,8 +36,12 @@ pub fn detect_proxy_chain(arena: &CallTraceArena, node_idx: usize) -> Vec<Addres
             continue;
         }
 
-        // Proxy pattern: same calldata forwarded and same returndata returned
-        if child.trace.data != node.trace.data {
+        // Proxy pattern: same function selector forwarded and same returndata returned
+        // We only compare the first 4 bytes (selector) instead of the entire calldata
+        // to support patterns like clones-with-immutable-args where the proxy may
+        // append additional data to the calldata.
+        const SELECTOR_LEN: usize = 4;
+        if node.trace.data.get(..SELECTOR_LEN) != child.trace.data.get(..SELECTOR_LEN) {
             continue;
         }
         if child.trace.output != node.trace.output {
@@ -201,6 +205,68 @@ mod tests {
                 CallKind::Call,
                 Address::repeat_byte(2),
                 calldata,
+                output,
+                vec![],
+            ),
+        ]);
+        let chain = detect_proxy_chain(&arena, 0);
+        assert!(chain.is_empty());
+    }
+
+    #[test]
+    fn test_clones_with_immutable_args_proxy() {
+        // Proxy pattern where selector matches but calldata differs
+        // (e.g., clones-with-immutable-args appends data)
+        let proxy_addr = Address::repeat_byte(1);
+        let impl_addr = Address::repeat_byte(2);
+        // Parent calldata is just the selector + some args
+        let parent_calldata = Bytes::from_static(b"SELC_args");
+        // Child calldata has the same selector but extra data appended
+        let child_calldata = Bytes::from_static(b"SELC_args_and_extra_immutable_data");
+        let output = Bytes::from_static(b"output");
+
+        let arena = build_arena(vec![
+            (
+                CallKind::Call,
+                proxy_addr,
+                parent_calldata,
+                output.clone(),
+                vec![1],
+            ),
+            (
+                CallKind::DelegateCall,
+                impl_addr,
+                child_calldata,
+                output,
+                vec![],
+            ),
+        ]);
+        let chain = detect_proxy_chain(&arena, 0);
+        assert_eq!(chain, vec![proxy_addr, impl_addr]);
+    }
+
+    #[test]
+    fn test_different_selector_not_proxy() {
+        // DELEGATECALL with different first 4 bytes should not be detected as proxy
+        let proxy_addr = Address::repeat_byte(1);
+        let impl_addr = Address::repeat_byte(2);
+        // Different selectors (first 4 bytes)
+        let parent_calldata = Bytes::from_static(b"AABBrest_of_data");
+        let child_calldata = Bytes::from_static(b"CCDDrest_of_data");
+        let output = Bytes::from_static(b"output");
+
+        let arena = build_arena(vec![
+            (
+                CallKind::Call,
+                proxy_addr,
+                parent_calldata,
+                output.clone(),
+                vec![1],
+            ),
+            (
+                CallKind::DelegateCall,
+                impl_addr,
+                child_calldata,
                 output,
                 vec![],
             ),

--- a/crates/edr_solidity/src/proxy_detection.rs
+++ b/crates/edr_solidity/src/proxy_detection.rs
@@ -239,4 +239,69 @@ mod tests {
         let chain = detect_proxy_chain(&arena, 0);
         assert!(chain.is_none());
     }
+
+    #[test]
+    fn test_clones_with_immutable_args_proxy() {
+        // Proxy pattern where selector matches but calldata differs
+        // (e.g., clones-with-immutable-args appends data)
+        let proxy_addr = Address::repeat_byte(1);
+        let impl_addr = Address::repeat_byte(2);
+        // Parent calldata is just the selector + some args
+        let parent_calldata = Bytes::from_static(b"SELC_args");
+        // Child calldata has the same selector but extra data appended
+        let child_calldata = Bytes::from_static(b"SELC_args_and_extra_immutable_data");
+        let output = Bytes::from_static(b"output");
+
+        let arena = build_arena(vec![
+            (
+                CallKind::Call,
+                proxy_addr,
+                parent_calldata,
+                output.clone(),
+                vec![1],
+            ),
+            (
+                CallKind::DelegateCall,
+                impl_addr,
+                child_calldata,
+                output,
+                vec![],
+            ),
+        ]);
+        let proxy_call = &arena.nodes()[0].trace;
+        let impl_call = &arena.nodes()[1].trace;
+
+        let chain = detect_proxy_chain(&arena, 0);
+        assert_eq!(chain, Some(vec![impl_call, proxy_call]));
+    }
+
+    #[test]
+    fn test_different_selector_not_proxy() {
+        // DELEGATECALL with different first 4 bytes should not be detected as proxy
+        let proxy_addr = Address::repeat_byte(1);
+        let impl_addr = Address::repeat_byte(2);
+        // Different selectors (first 4 bytes)
+        let parent_calldata = Bytes::from_static(b"AABBrest_of_data");
+        let child_calldata = Bytes::from_static(b"CCDDrest_of_data");
+        let output = Bytes::from_static(b"output");
+
+        let arena = build_arena(vec![
+            (
+                CallKind::Call,
+                proxy_addr,
+                parent_calldata,
+                output.clone(),
+                vec![1],
+            ),
+            (
+                CallKind::DelegateCall,
+                impl_addr,
+                child_calldata,
+                output,
+                vec![],
+            ),
+        ]);
+        let chain = detect_proxy_chain(&arena, 0);
+        assert!(chain.is_none());
+    }
 }


### PR DESCRIPTION
fix https://github.com/NomicFoundation/hardhat/issues/7434

better than https://github.com/NomicFoundation/edr/pull/1324 as it supports any proxy, diamond ...

it is also simpler

Note that I modified the proxy chain detection logic to only match for the first 4 bytes so it supports things like clone-with-immutable-args that append data to the calldata