### PR TITLE
refactor: split execution and setup traces

### DIFF
--- a/crates/edr_napi/src/solidity_tests/test_results.rs
+++ b/crates/edr_napi/src/solidity_tests/test_results.rs
@@ -78,7 +78,14 @@ impl SuiteResult {
             test_results: suite_result
                 .test_results
                 .into_iter()
-                .map(|(name, test_result)| TestResult::new(name, test_result, include_traces))
+                .map(|(name, test_result)| {
+                    TestResult::new(
+                        name,
+                        test_result,
+                        &suite_result.setup_traces,
+                        include_traces,
+                    )
+                })
                 .collect(),
             warnings: suite_result.warnings,
         }
@@ -118,7 +125,7 @@ pub struct TestResult {
     pub value_snapshot_groups: Option<Vec<ValueSnapshotGroup>>,
 
     stack_trace_result: Option<Arc<SolidityTestStackTraceResult<String>>>,
-    call_trace_arenas: Vec<(traces::TraceKind, SparsedTraceArena)>,
+    call_trace_arenas: Vec<SparsedTraceArena>,
 }
 
 /// The stack trace result
@@ -221,8 +228,7 @@ impl TestResult {
     pub fn call_traces(&self) -> Vec<CallTrace> {
         self.call_trace_arenas
             .iter()
-            .filter(|(k, _)| *k != traces::TraceKind::Deployment)
-            .map(|(_, a)| CallTrace::from_arena_node(&a.resolve_arena(), 0))
+            .map(|arena| CallTrace::from_arena_node(&arena.resolve_arena(), 0))
             .collect()
     }
 }
@@ -231,6 +237,7 @@ impl TestResult {
     fn new(
         name: String,
         test_result: edr_solidity_tests::result::TestResult<String>,
+        setup_traces: &edr_solidity_tests::traces::SetupTraces,
         include_traces: IncludeTraces,
     ) -> Self {
         let include_trace = include_traces == IncludeTraces::All
@@ -319,9 +326,14 @@ impl TestResult {
             ),
             stack_trace_result: test_result.stack_trace_result.map(Arc::new),
             call_trace_arenas: if include_trace {
-                test_result.traces
+                setup_traces
+                    .iter()
+                    .filter(|(k, _)| *k != traces::SetupTraceKind::Deployment)
+                    .map(|(_, arena)| arena.clone())
+                    .chain(test_result.execution_traces)
+                    .collect()
             } else {
-                vec![]
+                Vec::new()
             },
         }
     }

--- a/crates/edr_solidity_tests/src/multi_runner.rs
+++ b/crates/edr_solidity_tests/src/multi_runner.rs
@@ -394,16 +394,16 @@ impl<
             let mut decoder = CallTraceDecoderBuilder::new().build();
             let mut trace_identifier = TraceIdentifiers::new().with_local(&self.known_contracts);
 
-            // Setup traces are shared across all tests in the suite, so analyze them only
-            // once.
-            if let Some(gas_report) = gas_report.as_mut() {
-                for (_, arena) in &mut r.setup_traces {
-                    decoder.identify(arena, &mut trace_identifier);
-                    tokio::task::block_in_place(|| {
-                        handle.block_on(decode_trace_arena(arena, &decoder));
-                    });
-                }
+            // Setup traces are shared across all tests in the suite, so decode and analyze
+            // them only once.
+            for (_, arena) in &mut r.setup_traces {
+                decoder.identify(arena, &mut trace_identifier);
+                tokio::task::block_in_place(|| {
+                    handle.block_on(decode_trace_arena(arena, &decoder));
+                });
+            }
 
+            if let Some(gas_report) = gas_report.as_mut() {
                 tokio::task::block_in_place(|| {
                     handle.block_on(
                         gas_report.analyze(r.setup_traces.iter().map(|(_, a)| &a.arena), &decoder),

--- a/crates/edr_solidity_tests/src/multi_runner.rs
+++ b/crates/edr_solidity_tests/src/multi_runner.rs
@@ -424,11 +424,9 @@ impl<
                         .map(|(k, v)| (*k, v.clone())),
                 );
 
+                // Re-execute setup traces to collect identities of deployed contracts.
                 for (_, arena) in &mut r.setup_traces {
                     decoder.identify(arena, &mut trace_identifier);
-                    tokio::task::block_in_place(|| {
-                        handle.block_on(decode_trace_arena(arena, &decoder));
-                    });
                 }
 
                 for arena in &mut result.execution_traces {
@@ -449,8 +447,7 @@ impl<
                     for trace in &result.gas_report_traces {
                         decoder.clear_addresses();
 
-                        // Re-execute setup and deployment traces to collect identities created in
-                        // setUp and constructor.
+                        // Re-execute setup traces to collect identities of deployed contracts.
                         for (_, arena) in &r.setup_traces {
                             decoder.identify(arena, &mut trace_identifier);
                         }

--- a/crates/edr_solidity_tests/src/multi_runner.rs
+++ b/crates/edr_solidity_tests/src/multi_runner.rs
@@ -31,8 +31,7 @@ use foundry_evm::{
     inspectors::{cheatcodes::CheatsConfigOptions, CheatsConfig},
     opts::EvmOpts,
     traces::{
-        decode_trace_arena, identifier::TraceIdentifiers, CallTraceDecoderBuilder, TraceKind,
-        TracingMode,
+        decode_trace_arena, identifier::TraceIdentifiers, CallTraceDecoderBuilder, TracingMode,
     },
 };
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
@@ -395,6 +394,23 @@ impl<
             let mut decoder = CallTraceDecoderBuilder::new().build();
             let mut trace_identifier = TraceIdentifiers::new().with_local(&self.known_contracts);
 
+            // Setup traces are shared across all tests in the suite, so analyze them only
+            // once.
+            if let Some(gas_report) = gas_report.as_mut() {
+                for (_, arena) in &mut r.setup_traces {
+                    decoder.identify(arena, &mut trace_identifier);
+                    tokio::task::block_in_place(|| {
+                        handle.block_on(decode_trace_arena(arena, &decoder));
+                    });
+                }
+
+                tokio::task::block_in_place(|| {
+                    handle.block_on(
+                        gas_report.analyze(r.setup_traces.iter().map(|(_, a)| &a.arena), &decoder),
+                    );
+                });
+            }
+
             for result in r.test_results.values_mut() {
                 if result.status.is_success() && self.include_traces != IncludeTraces::All {
                     continue;
@@ -408,7 +424,14 @@ impl<
                         .map(|(k, v)| (*k, v.clone())),
                 );
 
-                for (_, arena) in &mut result.traces {
+                for (_, arena) in &mut r.setup_traces {
+                    decoder.identify(arena, &mut trace_identifier);
+                    tokio::task::block_in_place(|| {
+                        handle.block_on(decode_trace_arena(arena, &decoder));
+                    });
+                }
+
+                for arena in &mut result.execution_traces {
                     decoder.identify(arena, &mut trace_identifier);
                     tokio::task::block_in_place(|| {
                         handle.block_on(decode_trace_arena(arena, &decoder));
@@ -417,10 +440,10 @@ impl<
 
                 if let Some(gas_report) = gas_report.as_mut() {
                     tokio::task::block_in_place(|| {
-                        handle.block_on(
-                            gas_report
-                                .analyze(result.traces.iter().map(|(_, a)| &a.arena), &decoder),
-                        );
+                        handle.block_on(gas_report.analyze(
+                            result.execution_traces.iter().map(|arena| &arena.arena),
+                            &decoder,
+                        ));
                     });
 
                     for trace in &result.gas_report_traces {
@@ -428,10 +451,8 @@ impl<
 
                         // Re-execute setup and deployment traces to collect identities created in
                         // setUp and constructor.
-                        for (kind, arena) in &result.traces {
-                            if !matches!(kind, TraceKind::Execution) {
-                                decoder.identify(arena, &mut trace_identifier);
-                            }
+                        for (_, arena) in &r.setup_traces {
+                            decoder.identify(arena, &mut trace_identifier);
                         }
 
                         for arena in trace {

--- a/crates/edr_solidity_tests/src/result.rs
+++ b/crates/edr_solidity_tests/src/result.rs
@@ -21,7 +21,7 @@ use foundry_evm::{
         invariant::InvariantFuzzError, stack_trace::SolidityTestStackTraceResult, RawCallResult,
     },
     fuzz::{CounterExample, FuzzFixtures},
-    traces::{CallTraceArena, CallTraceDecoder, TraceKind, Traces},
+    traces::{CallTraceArena, CallTraceDecoder, SetupTraceKind, SetupTraces, SparsedTraceArena},
 };
 use serde::{Deserialize, Serialize};
 use yansi::Paint;
@@ -168,6 +168,10 @@ pub struct SuiteResult<HaltReasonT> {
     /// Wall clock time it took to execute all tests in this suite.
     #[serde(with = "humantime_serde")]
     pub duration: Duration,
+    /// Traces from the setup phase of the test suite. These are shared across
+    /// all tests in the suite and should be printed alongside each test's
+    /// individual traces.
+    pub setup_traces: SetupTraces,
     /// Individual test results: `test fn signature -> TestResult`.
     pub test_results: BTreeMap<String, TestResult<HaltReasonT>>,
     /// Generated warnings.
@@ -192,6 +196,7 @@ where
             .collect();
         SuiteResult {
             duration: self.duration,
+            setup_traces: self.setup_traces,
             test_results,
             warnings: self.warnings,
         }
@@ -201,6 +206,7 @@ where
 impl<HaltReasonT: HaltReasonTrait> SuiteResult<HaltReasonT> {
     pub fn new(
         duration: Duration,
+        setup_traces: SetupTraces,
         test_results: BTreeMap<String, TestResult<HaltReasonT>>,
         mut warnings: Vec<String>,
     ) -> Self {
@@ -229,6 +235,7 @@ impl<HaltReasonT: HaltReasonTrait> SuiteResult<HaltReasonT> {
 
         Self {
             duration,
+            setup_traces,
             test_results,
             warnings,
         }
@@ -389,7 +396,7 @@ pub struct TestResult<HaltReasonT> {
 
     /// Traces
     #[serde(skip)]
-    pub traces: Traces,
+    pub execution_traces: Vec<SparsedTraceArena>,
 
     /// Additional traces to use for gas report.
     #[serde(skip)]
@@ -437,7 +444,7 @@ impl<HaltReasonT> TestResult<HaltReasonT> {
             logs: self.logs,
             decoded_logs: self.decoded_logs,
             kind: self.kind,
-            traces: self.traces,
+            execution_traces: self.execution_traces,
             gas_report_traces: self.gas_report_traces,
             line_coverage: self.line_coverage,
             labeled_addresses: self.labeled_addresses,
@@ -497,7 +504,6 @@ impl<HaltReasonT: HaltReasonTrait> TestResult<HaltReasonT> {
             labeled_addresses: setup.labels.clone(),
             logs: setup.logs.clone(),
             decoded_logs: decode_console_logs(&setup.logs),
-            traces: setup.traces.clone(),
             line_coverage: setup.coverage.clone(),
             stack_trace_result: setup.stack_trace_result.clone(),
             ..Default::default()
@@ -514,7 +520,7 @@ impl<HaltReasonT: HaltReasonTrait> TestResult<HaltReasonT> {
     }
 
     /// Creates a test setup result.
-    pub fn setup_result(setup: TestSetup<HaltReasonT>) -> Self {
+    pub fn setup_failure_result(setup: TestSetup<HaltReasonT>) -> Self {
         Self {
             status: if setup.skipped {
                 TestStatus::Skipped
@@ -524,7 +530,6 @@ impl<HaltReasonT: HaltReasonTrait> TestResult<HaltReasonT> {
             reason: setup.reason,
             decoded_logs: decode_console_logs(&setup.logs),
             logs: setup.logs,
-            traces: setup.traces,
             line_coverage: setup.coverage,
             labeled_addresses: setup.labels,
             stack_trace_result: setup.stack_trace_result,
@@ -580,11 +585,7 @@ impl<HaltReasonT: HaltReasonTrait> TestResult<HaltReasonT> {
         self.logs.extend(raw_call_result.logs);
         self.decoded_logs = decode_console_logs(&self.logs);
         self.labeled_addresses.extend(raw_call_result.labels);
-        self.traces.extend(
-            raw_call_result
-                .traces
-                .map(|traces| (TraceKind::Execution, traces)),
-        );
+        self.execution_traces.extend(raw_call_result.traces);
         self.merge_coverages(raw_call_result.line_coverage);
 
         self.status = match success {
@@ -615,8 +616,7 @@ impl<HaltReasonT: HaltReasonTrait> TestResult<HaltReasonT> {
         self.logs.extend(result.logs);
         self.decoded_logs = decode_console_logs(&self.logs);
         self.labeled_addresses.extend(result.labeled_addresses);
-        self.traces
-            .extend(result.traces.map(|traces| (TraceKind::Execution, traces)));
+        self.execution_traces.extend(result.traces);
         self.merge_coverages(result.line_coverage);
 
         self.status = if result.skipped {
@@ -758,11 +758,7 @@ impl<HaltReasonT: HaltReasonTrait> TestResult<HaltReasonT> {
         self.logs.extend(call_result.logs);
         self.decoded_logs = decode_console_logs(&self.logs);
         self.labeled_addresses.extend(call_result.labels);
-        self.traces.extend(
-            call_result
-                .traces
-                .map(|traces| (TraceKind::Execution, traces)),
-        );
+        self.execution_traces.extend(call_result.traces);
         self.merge_coverages(call_result.line_coverage);
     }
 
@@ -910,7 +906,7 @@ pub struct TestSetup<HaltReasonT> {
     /// Addresses labeled during setup.
     pub labels: AddressHashMap<String>,
     /// Call traces of the setup.
-    pub traces: Traces,
+    pub traces: SetupTraces,
     /// Coverage info during setup.
     pub coverage: Option<HitMaps>,
     /// Addresses of external libraries deployed during setup.
@@ -968,7 +964,7 @@ impl<HaltReasonT: HaltReasonTrait> TestSetup<HaltReasonT> {
             HardforkT,
             TransactionErrorT,
         >,
-        trace_kind: TraceKind,
+        trace_kind: SetupTraceKind,
     ) {
         self.logs.extend(raw.logs);
         self.labels.extend(raw.labels);

--- a/crates/edr_solidity_tests/src/runner.rs
+++ b/crates/edr_solidity_tests/src/runner.rs
@@ -44,7 +44,7 @@ use foundry_evm::{
         invariant::{CallDetails, InvariantContract},
         CounterExample, FuzzFixtures,
     },
-    traces::{load_contracts, TraceKind, TracingMode},
+    traces::{load_contracts, SetupTraceKind, TracingMode},
 };
 use itertools::Itertools;
 use proptest::test_runner::{FailurePersistence, RngAlgorithm, TestError, TestRng, TestRunner};
@@ -305,7 +305,7 @@ impl<
             }
 
             let (raw, reason) = RawCallResult::from_evm_result(deploy_result.map(Into::into))?;
-            result.extend(raw, TraceKind::Deployment);
+            result.extend(raw, SetupTraceKind::Deployment);
             if reason.is_some() {
                 result.reason = reason;
                 return Ok(result);
@@ -333,7 +333,7 @@ impl<
             debug_assert_eq!(dr.address, address);
         }
         let (raw, reason) = RawCallResult::from_evm_result(deploy_result.map(Into::into))?;
-        result.extend(raw, TraceKind::Deployment);
+        result.extend(raw, SetupTraceKind::Deployment);
         if reason.is_some() {
             result.reason = reason;
             return Ok(result);
@@ -351,7 +351,7 @@ impl<
             trace!("calling setUp");
             let res = executor.setup(None, address, Some(self.revert_decoder));
             let (raw, reason) = RawCallResult::from_evm_result(res)?;
-            result.extend(raw, TraceKind::Setup);
+            result.extend(raw, SetupTraceKind::Setup);
             result.reason = reason;
         }
 
@@ -505,6 +505,7 @@ impl<
         if setup_fns.len() > 1 {
             return Ok(SuiteResult::new(
                 start.elapsed(),
+                Vec::new(),
                 [(
                     "setUp()".to_string(),
                     TestResult::fail("multiple setUp functions".to_string()),
@@ -525,6 +526,7 @@ impl<
             // Return a single test result failure if multiple functions declared.
             return Ok(SuiteResult::new(
                 start.elapsed(),
+                Vec::new(),
                 [(
                     "afterInvariant()".to_string(),
                     TestResult::fail("multiple afterInvariant functions".to_string()),
@@ -559,7 +561,7 @@ impl<
         }
 
         let setup_time = Instant::now();
-        let mut setup = self.setup(&mut executor, call_setup);
+        let mut setup: TestSetup<HaltReasonT> = self.setup(&mut executor, call_setup);
         debug!("finished setting up in {:?}", setup_time.elapsed());
 
         executor.inspector_mut().tracer = prev_tracer;
@@ -610,7 +612,8 @@ impl<
             };
             return Ok(SuiteResult::new(
                 elapsed,
-                [(fail_msg, TestResult::setup_result(setup))].into(),
+                setup.traces.clone(),
+                [(fail_msg, TestResult::setup_failure_result(setup))].into(),
                 warnings,
             ));
         }
@@ -649,7 +652,12 @@ impl<
             let test_results = test_fail_functions
                 .map(|func| (func.signature(), fail()))
                 .collect();
-            return Ok(SuiteResult::new(start.elapsed(), test_results, warnings));
+            return Ok(SuiteResult::new(
+                start.elapsed(),
+                setup.traces,
+                test_results,
+                warnings,
+            ));
         }
 
         let test_results = functions
@@ -685,7 +693,7 @@ impl<
             .collect::<BTreeMap<_, _>>();
 
         let duration = start.elapsed();
-        let suite_result = SuiteResult::new(duration, test_results, warnings);
+        let suite_result = SuiteResult::new(duration, setup.traces, test_results, warnings);
         info!(
             duration=?suite_result.duration,
             "done. {}/{} successful",
@@ -871,7 +879,16 @@ impl<
                 if self.executor.tracer_records_steps() {
                     get_stack_trace(
                         &*self.cr.contract_decoder,
-                        self.result.traces.iter().map(|(_, arena)| &arena.arena),
+                        self.setup
+                            .traces
+                            .iter()
+                            .map(|(_, arena)| &arena.arena)
+                            .chain(
+                                self.result
+                                    .execution_traces
+                                    .iter()
+                                    .map(|arena| &arena.arena),
+                            ),
                         None,
                     )
                     .map_err(SolidityTestStackTraceError::from)
@@ -1025,7 +1042,16 @@ impl<
                     if self.executor.tracer_records_steps() {
                         get_stack_trace(
                             &*self.cr.contract_decoder,
-                            self.result.traces.iter().map(|(_, arena)| &arena.arena),
+                            self.setup
+                                .traces
+                                .iter()
+                                .map(|(_, arena)| &arena.arena)
+                                .chain(
+                                    self.result
+                                        .execution_traces
+                                        .iter()
+                                        .map(|arena| &arena.arena),
+                                ),
                             None,
                         )
                         .map_err(SolidityTestStackTraceError::from)
@@ -1180,11 +1206,12 @@ impl<
                 // exit without executing new runs.
                 let stack_trace_result = replay_run(ReplayRunArgs {
                     executor: self.clone_executor(),
+                    execution_traces: &mut self.result.execution_traces,
                     invariant_contract: &invariant_contract,
                     known_contracts: self.cr.known_contracts,
                     ided_contracts: identified_contracts.clone(),
                     logs: &mut self.result.logs,
-                    traces: &mut self.result.traces,
+                    setup_traces: &self.setup.traces,
                     line_coverage: &mut self.result.line_coverage,
                     deprecated_cheatcodes: &mut self.result.deprecated_cheatcodes,
                     inputs: &txes,
@@ -1218,7 +1245,16 @@ impl<
                     if self.executor.tracer_records_steps() {
                         get_stack_trace(
                             &*self.cr.contract_decoder,
-                            self.result.traces.iter().map(|(_, arena)| &arena.arena),
+                            self.setup
+                                .traces
+                                .iter()
+                                .map(|(_, arena)| &arena.arena)
+                                .chain(
+                                    self.result
+                                        .execution_traces
+                                        .iter()
+                                        .map(|arena| &arena.arena),
+                                ),
                             None,
                         )
                         .map_err(SolidityTestStackTraceError::from)
@@ -1257,12 +1293,13 @@ impl<
                     // coverage.
                     match replay_error(ReplayErrorArgs {
                         executor: self.clone_executor(),
+                        execution_traces: &mut self.result.execution_traces,
                         failed_case: &case_data,
                         invariant_contract: &invariant_contract,
                         known_contracts: self.cr.known_contracts,
                         ided_contracts: identified_contracts.clone(),
                         logs: &mut self.result.logs,
-                        traces: &mut self.result.traces,
+                        setup_traces: &self.setup.traces,
                         coverage: &mut None,
                         deprecated_cheatcodes: &mut self.result.deprecated_cheatcodes,
                         generate_stack_trace: true,
@@ -1330,11 +1367,12 @@ impl<
             _ => {
                 if let Err(err) = replay_run(ReplayRunArgs {
                     executor: self.clone_executor(),
+                    execution_traces: &mut self.result.execution_traces,
                     invariant_contract: &invariant_contract,
                     known_contracts: self.cr.known_contracts,
                     ided_contracts: identified_contracts.clone(),
                     logs: &mut self.result.logs,
-                    traces: &mut self.result.traces,
+                    setup_traces: &self.setup.traces,
                     line_coverage: &mut self.result.line_coverage,
                     deprecated_cheatcodes: &mut self.result.deprecated_cheatcodes,
                     inputs: &invariant_result.last_run_inputs,
@@ -1437,7 +1475,16 @@ impl<
                 if fuzzed_executor.tracer_records_steps() {
                     get_stack_trace(
                         &*self.cr.contract_decoder,
-                        self.result.traces.iter().map(|(_, arena)| &arena.arena),
+                        self.setup
+                            .traces
+                            .iter()
+                            .map(|(_, arena)| &arena.arena)
+                            .chain(
+                                self.result
+                                    .execution_traces
+                                    .iter()
+                                    .map(|arena| &arena.arena),
+                            ),
                         None,
                     )
                     .map_err(SolidityTestStackTraceError::from)
@@ -1551,7 +1598,7 @@ impl<
         executor.inspector_mut().tracing(TracingMode::WithSteps);
 
         // Run unit test
-        let new_traces = match executor.call(
+        let new_trace_arena = match executor.call(
             self.cr.sender,
             setup.address,
             func,
@@ -1565,12 +1612,13 @@ impl<
         }
         .expect("enabled tracing");
 
-        let mut traces = setup.traces;
-        traces.push((TraceKind::Execution, new_traces));
-
         get_stack_trace(
             &*self.cr.contract_decoder,
-            traces.iter().map(|(_, arena)| &arena.arena),
+            setup
+                .traces
+                .iter()
+                .map(|(_, arena)| &arena.arena)
+                .chain(std::iter::once(&new_trace_arena.arena)),
             None,
         )
         .transpose()
@@ -1633,12 +1681,15 @@ fn re_run_fuzz_counterexample_for_stack_traces<
         )
         .map_err(|err| SolidityTestStackTraceError::Evm(err.to_string()))?;
 
-    let mut traces = setup.traces;
-    traces.push((TraceKind::Execution, call.traces.expect("tracing is on")));
+    let new_trace_arena = call.traces.expect("tracing is on");
 
     get_stack_trace(
         &*contract_runner.contract_decoder,
-        traces.iter().map(|(_, arena)| &arena.arena),
+        setup
+            .traces
+            .iter()
+            .map(|(_, arena)| &arena.arena)
+            .chain(std::iter::once(&new_trace_arena.arena)),
         None,
     )
     .transpose()

--- a/crates/edr_solidity_tests/tests/it/core.rs
+++ b/crates/edr_solidity_tests/tests/it/core.rs
@@ -10,7 +10,7 @@ use edr_solidity_tests::{
     multi_runner::SolidityTestsRunResult,
     result::{SuiteResult, TestStatus},
 };
-use foundry_evm::traces::TraceKind;
+use foundry_evm::traces::SetupTraceKind;
 
 use crate::helpers::{assert_multiple, SolidityTestFilter, TEST_DATA_DEFAULT, TEST_DATA_PARIS};
 
@@ -755,31 +755,37 @@ async fn test_trace() {
 
     // TODO: This trace test is very basic - it is probably a good candidate for
     // snapshot testing.
-    for (_, SuiteResult { test_results, .. }) in suite_result {
+    for (
+        test_suite_name,
+        SuiteResult {
+            setup_traces,
+            test_results,
+            ..
+        },
+    ) in suite_result
+    {
+        let deployment_traces = setup_traces
+            .iter()
+            .filter(|(kind, _)| *kind == SetupTraceKind::Deployment);
+
+        assert_eq!(
+            deployment_traces.count(),
+            12, // includes libraries
+            "Test {test_suite_name} did not have exactly 12 deployment traces."
+        );
+
+        let setup_traces = setup_traces
+            .iter()
+            .filter(|(kind, _)| *kind == SetupTraceKind::Setup);
+
+        assert!(
+            setup_traces.count() <= 1,
+            "Test suite {test_suite_name} had more than 1 setup trace."
+        );
+
         for (test_name, result) in test_results {
-            let deployment_traces = result
-                .traces
-                .iter()
-                .filter(|(kind, _)| *kind == TraceKind::Deployment);
-            let setup_traces = result
-                .traces
-                .iter()
-                .filter(|(kind, _)| *kind == TraceKind::Setup);
-            let execution_traces = result
-                .traces
-                .iter()
-                .filter(|(kind, _)| *kind == TraceKind::Execution);
             assert_eq!(
-                deployment_traces.count(),
-                12, // includes libraries
-                "Test {test_name} did not have exactly 12 deployment trace."
-            );
-            assert!(
-                setup_traces.count() <= 1,
-                "Test {test_name} had more than 1 setup trace."
-            );
-            assert_eq!(
-                execution_traces.count(),
+                result.execution_traces.len(),
                 1,
                 "Test {test_name} did not not have exactly 1 execution trace."
             );

--- a/crates/edr_solidity_tests/tests/it/core.rs
+++ b/crates/edr_solidity_tests/tests/it/core.rs
@@ -787,7 +787,7 @@ async fn test_trace() {
             assert_eq!(
                 result.execution_traces.len(),
                 1,
-                "Test {test_name} did not not have exactly 1 execution trace."
+                "Test {test_name} did not have exactly 1 execution trace."
             );
         }
     }

--- a/crates/edr_solidity_tests/tests/it/helpers/config.rs
+++ b/crates/edr_solidity_tests/tests/it/helpers/config.rs
@@ -163,16 +163,17 @@ impl<
                     let call_trace_decoder = CallTraceDecoderBuilder::default()
                         .with_known_contracts(&known_contracts)
                         .build();
-                    let decoded_traces = join_all(result.traces.iter_mut().map(|(_, arena)| {
-                        let decoder = &call_trace_decoder;
-                        async move {
-                            decode_trace_arena(arena, decoder).await;
-                            render_trace_arena(arena)
-                        }
-                    }))
-                    .await
-                    .into_iter()
-                    .collect::<Vec<String>>();
+                    let decoded_traces =
+                        join_all(result.execution_traces.iter_mut().map(|arena| {
+                            let decoder = &call_trace_decoder;
+                            async move {
+                                decode_trace_arena(arena, decoder).await;
+                                render_trace_arena(arena)
+                            }
+                        }))
+                        .await
+                        .into_iter()
+                        .collect::<Vec<String>>();
                     eyre::bail!(
                         "Test {} did not {} as expected.\nReason: {:?}\nLogs:\n{}\n\nTraces:\n{}",
                         test_name,

--- a/crates/edr_solidity_tests/tests/it/repros.rs
+++ b/crates/edr_solidity_tests/tests/it/repros.rs
@@ -20,7 +20,7 @@ use foundry_evm::{
         BlockEnvTr, ChainContextTr, EvmBuilderTrait, HardforkTr, L1EvmBuilder, TransactionEnvTr,
         TransactionErrorTrait,
     },
-    traces::{CallKind, CallTraceDecoder, DecodedCallData, TraceKind},
+    traces::{CallKind, CallTraceDecoder, DecodedCallData},
 };
 
 use crate::helpers::{
@@ -411,9 +411,12 @@ test_repro!(6501, false, None, |res| {
         ["a".to_string(), "1".to_string(), "b 2".to_string()]
     );
 
-    let (kind, traces) = test.traces.last().expect("there are traces").clone();
-    let nodes = traces.arena.into_nodes();
-    assert_eq!(kind, TraceKind::Execution);
+    let execution_traces = test
+        .execution_traces
+        .last()
+        .expect("there are traces")
+        .clone();
+    let nodes = execution_traces.arena.into_nodes();
 
     let test_call = nodes.first().unwrap();
     assert_eq!(test_call.idx, 0);

--- a/crates/foundry/evm/evm/src/executors/invariant/replay.rs
+++ b/crates/foundry/evm/evm/src/executors/invariant/replay.rs
@@ -18,7 +18,7 @@ use foundry_evm_fuzz::{
     invariant::{BasicTxDetails, InvariantContract},
     BaseCounterExample,
 };
-use foundry_evm_traces::{load_contracts, TraceKind, Traces, TracingMode};
+use foundry_evm_traces::{load_contracts, SetupTraces, SparsedTraceArena, TracingMode};
 use parking_lot::RwLock;
 use proptest::test_runner::TestError;
 use revm::{
@@ -48,6 +48,7 @@ pub struct ReplayRunArgs<
     TransactionErrorT: TransactionErrorTrait,
     ChainContextT: ChainContextTr,
 > {
+    pub execution_traces: &'a mut Vec<SparsedTraceArena>,
     pub executor: Executor<
         BlockT,
         TxT,
@@ -61,7 +62,7 @@ pub struct ReplayRunArgs<
     pub known_contracts: &'a ContractsByArtifact,
     pub ided_contracts: ContractsByAddress,
     pub logs: &'a mut Vec<Log>,
-    pub traces: &'a mut Traces,
+    pub setup_traces: &'a SetupTraces,
     pub line_coverage: &'a mut Option<HitMaps>,
     pub deprecated_cheatcodes: &'a mut HashMap<&'static str, Option<&'static str>>,
     pub inputs: &'a [BasicTxDetails],
@@ -108,12 +109,13 @@ pub fn replay_run<
     >,
 ) -> Result<ReplayResult<HaltReasonT>> {
     let ReplayRunArgs {
+        execution_traces,
         mut executor,
         invariant_contract,
         known_contracts,
         mut ided_contracts,
         logs,
-        traces,
+        setup_traces,
         line_coverage: coverage,
         deprecated_cheatcodes,
         inputs,
@@ -142,10 +144,7 @@ pub fn replay_run<
             U256::ZERO,
         )?;
         logs.extend(call_result.logs);
-        traces.push((
-            TraceKind::Execution,
-            call_result.traces.clone().expect("enabled tracing"),
-        ));
+        execution_traces.push(call_result.traces.clone().expect("enabled tracing"));
         HitMaps::merge_opt(coverage, call_result.line_coverage);
 
         // Identify newly generated contracts, if they exist.
@@ -171,19 +170,25 @@ pub fn replay_run<
             .is_some_and(InstructionResult::is_ok)
             && (fail_on_revert || !call_result.reverted)
         {
-            let stack_trace_result = if let Some(indeterminism_reasons) =
-                call_result.indeterminism_reasons
-            {
-                Some(indeterminism_reasons.into())
-            } else {
-                contract_decoder
-                    .and_then(|decoder| {
-                        get_stack_trace(decoder, traces.iter().map(|(_, arena)| &arena.arena), None)
+            let stack_trace_result =
+                if let Some(indeterminism_reasons) = call_result.indeterminism_reasons {
+                    Some(indeterminism_reasons.into())
+                } else {
+                    contract_decoder
+                        .and_then(|decoder| {
+                            get_stack_trace(
+                                decoder,
+                                setup_traces
+                                    .iter()
+                                    .map(|(_, arena)| &arena.arena)
+                                    .chain(execution_traces.iter().map(|arena| &arena.arena)),
+                                None,
+                            )
                             .map_err(SolidityTestStackTraceError::from)
                             .transpose()
-                    })
-                    .map(SolidityTestStackTraceResult::from)
-            };
+                        })
+                        .map(SolidityTestStackTraceResult::from)
+                };
             let revert_reason =
                 revert_decoder.maybe_decode(call_result.result.as_ref(), call_result.exit_reason);
             return Ok(ReplayResult {
@@ -211,10 +216,7 @@ pub fn replay_run<
             .into(),
     )?;
 
-    traces.push((
-        TraceKind::Execution,
-        invariant_result.traces.expect("tracing is on"),
-    ));
+    execution_traces.push(invariant_result.traces.expect("tracing is on"));
     logs.extend(invariant_result.logs);
     deprecated_cheatcodes.extend(
         invariant_result
@@ -229,10 +231,7 @@ pub fn replay_run<
             call_result: after_invariant_result,
             success: _,
         } = call_after_invariant_function(&executor, invariant_contract.address)?;
-        traces.push((
-            TraceKind::Execution,
-            after_invariant_result.traces.clone().unwrap(),
-        ));
+        execution_traces.push(after_invariant_result.traces.clone().unwrap());
         logs.extend(after_invariant_result.logs);
     }
 
@@ -246,7 +245,10 @@ pub fn replay_run<
                         contract_decoder.and_then(|decoder| {
                             get_stack_trace(
                                 decoder,
-                                traces.iter().map(|(_, arena)| &arena.arena),
+                                setup_traces
+                                    .iter()
+                                    .map(|(_, arena)| &arena.arena)
+                                    .chain(execution_traces.iter().map(|arena| &arena.arena)),
                                 None,
                             )
                             .map_err(SolidityTestStackTraceError::from)
@@ -281,6 +283,7 @@ pub struct ReplayErrorArgs<
     TransactionErrorT: TransactionErrorTrait,
     ChainContextT: ChainContextTr,
 > {
+    pub execution_traces: &'a mut Vec<SparsedTraceArena>,
     pub executor: Executor<
         BlockT,
         TxT,
@@ -295,7 +298,7 @@ pub struct ReplayErrorArgs<
     pub known_contracts: &'a ContractsByArtifact,
     pub ided_contracts: ContractsByAddress,
     pub logs: &'a mut Vec<Log>,
-    pub traces: &'a mut Traces,
+    pub setup_traces: &'a SetupTraces,
     pub coverage: &'a mut Option<HitMaps>,
     pub deprecated_cheatcodes: &'a mut HashMap<&'static str, Option<&'static str>>,
     pub generate_stack_trace: bool,
@@ -330,13 +333,14 @@ pub fn replay_error<
     >,
 ) -> Result<ReplayResult<HaltReasonT>> {
     let ReplayErrorArgs {
+        execution_traces,
         mut executor,
         failed_case,
         invariant_contract,
         known_contracts,
         ided_contracts,
         logs,
-        traces,
+        setup_traces,
         coverage,
         deprecated_cheatcodes,
         generate_stack_trace,
@@ -361,12 +365,13 @@ pub fn replay_error<
             // Replay calls to get the counterexample and to collect logs, traces and
             // coverage.
             replay_run(ReplayRunArgs {
+                execution_traces,
                 invariant_contract,
                 executor,
                 known_contracts,
                 ided_contracts,
                 logs,
-                traces,
+                setup_traces,
                 line_coverage: coverage,
                 deprecated_cheatcodes,
                 inputs: &calls,

--- a/crates/foundry/evm/traces/src/lib.rs
+++ b/crates/foundry/evm/traces/src/lib.rs
@@ -236,7 +236,7 @@ pub enum SetupTraceKind {
 impl SetupTraceKind {
     /// Returns `true` if the trace kind is [`Deployment`].
     ///
-    /// [`Deployment`]: TraceKind::Deployment
+    /// [`Deployment`]: SetupTraceKind::Deployment
     #[must_use]
     pub fn is_deployment(self) -> bool {
         matches!(self, Self::Deployment)
@@ -244,7 +244,7 @@ impl SetupTraceKind {
 
     /// Returns `true` if the trace kind is [`Setup`].
     ///
-    /// [`Setup`]: TraceKind::Setup
+    /// [`Setup`]: SetupTraceKind::Setup
     #[must_use]
     pub fn is_setup(self) -> bool {
         matches!(self, Self::Setup)

--- a/crates/foundry/evm/traces/src/lib.rs
+++ b/crates/foundry/evm/traces/src/lib.rs
@@ -38,7 +38,9 @@ pub mod decoder;
 pub use decoder::{CallTraceDecoder, CallTraceDecoderBuilder};
 use foundry_evm_core::contracts::{ContractsByAddress, ContractsByArtifact};
 
-pub type Traces = Vec<(TraceKind, SparsedTraceArena)>;
+pub type SetupTraces = Vec<SetupTrace>;
+
+pub type SetupTrace = (SetupTraceKind, SparsedTraceArena);
 
 /// Trace arena keeping track of ignored trace items.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -226,13 +228,12 @@ pub fn render_trace_arena(arena: &CallTraceArena) -> String {
 
 /// Specifies the kind of trace.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum TraceKind {
+pub enum SetupTraceKind {
     Deployment,
     Setup,
-    Execution,
 }
 
-impl TraceKind {
+impl SetupTraceKind {
     /// Returns `true` if the trace kind is [`Deployment`].
     ///
     /// [`Deployment`]: TraceKind::Deployment
@@ -247,14 +248,6 @@ impl TraceKind {
     #[must_use]
     pub fn is_setup(self) -> bool {
         matches!(self, Self::Setup)
-    }
-
-    /// Returns `true` if the trace kind is [`Execution`].
-    ///
-    /// [`Execution`]: TraceKind::Execution
-    #[must_use]
-    pub fn is_execution(self) -> bool {
-        matches!(self, Self::Execution)
     }
 }
 


### PR DESCRIPTION
While fixing bugs outlined in #1325 and adding support for multiple deployments of the same contract, this small refactor was necessary. I decided to split it into a separate PR to keep reviewing easier.

The goal is to split setup traces (either deployment or calls to the `setUp()` function) from execution traces. They used to be tracked together, but setup traces are generated once per test suite, whereas execution traces are generated per test.

This refactor creates a clear distinction between the two. User-facing APIs still return a combination of both types of traces for each test, for backwards compatibility.