### PR TITLE
feat: add runtime bytecode size to DeploymentGasReport

### DIFF
--- a/.changeset/spicy-cities-ask.md
+++ b/.changeset/spicy-cities-ask.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": minor
+---
+
+Added runtime bytecode size information to contract deployment gas reports

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1733,17 +1733,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
-name = "comfy-table"
-version = "7.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
-dependencies = [
- "crossterm",
- "unicode-segmentation",
- "unicode-width",
-]
-
-[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1990,28 +1979,6 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crossterm"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
-dependencies = [
- "bitflags 2.10.0",
- "crossterm_winapi",
- "parking_lot 0.12.3",
- "rustix 0.38.44",
- "winapi",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "crunchy"
@@ -2902,7 +2869,6 @@ dependencies = [
 name = "edr_gas_report"
 version = "0.3.8"
 dependencies = [
- "comfy-table",
  "derive_more 2.0.1",
  "dyn-clone",
  "edr_chain_spec",
@@ -4020,7 +3986,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.59.0",
 ]
 
@@ -5539,12 +5505,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -7307,19 +7267,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.10.0",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -7327,7 +7274,7 @@ dependencies = [
  "bitflags 2.10.0",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -8298,7 +8245,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.2",
  "once_cell",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 

--- a/crates/edr_gas_report/Cargo.toml
+++ b/crates/edr_gas_report/Cargo.toml
@@ -16,8 +16,6 @@ revm-inspectors.workspace = true
 thiserror.workspace = true
 serde.workspace = true
 
-comfy-table = "7"
-
 [features]
 tracing = ["edr_solidity/tracing"]
 

--- a/crates/edr_gas_report/src/lib.rs
+++ b/crates/edr_gas_report/src/lib.rs
@@ -317,7 +317,12 @@ impl DeploymentGasReportAndIdentifiers {
             ExecutionResult::Success {
                 output: Output::Create(bytes, _),
                 ..
-            } => bytes.len() as u64,
+            } => bytes.len().try_into().unwrap_or_else(|_| {
+                panic!(
+                    "Length should be smaller than `u64::MAX`. Actual: {}",
+                    bytes.len()
+                )
+            }),
             _ => 0,
         };
 

--- a/crates/edr_gas_report/src/lib.rs
+++ b/crates/edr_gas_report/src/lib.rs
@@ -1,6 +1,3 @@
-use std::fmt::Display;
-
-use comfy_table::{presets::ASCII_MARKDOWN, Attribute, Cell, Color, Table};
 use derive_more::Debug;
 use dyn_clone::DynClone;
 use edr_chain_spec::HaltReasonTrait;
@@ -8,7 +5,7 @@ use edr_primitives::{
     hash_map::{self, HashMap},
     Address, Bytecode, Bytes,
 };
-use edr_receipt::ExecutionResult;
+use edr_receipt::{ExecutionResult, Output};
 use edr_solidity::{
     contract_decoder::{ContractDecoder, ContractIdentifierAndFunctionSignature},
     proxy_detection::detect_proxy_chain,
@@ -137,105 +134,6 @@ impl GasReport {
                 }
             }
         }
-    }
-}
-
-impl Display for GasReport {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-        // Sort contract names for consistent output
-        let mut sorted_contracts: Vec<_> = self.contracts.iter().collect();
-        sorted_contracts.sort_by(|a, b| a.0.cmp(b.0));
-
-        for (name, contract) in sorted_contracts {
-            if contract.deployments.is_empty() && contract.functions.is_empty() {
-                continue;
-            }
-
-            let mut table = Table::new();
-            table.load_preset(ASCII_MARKDOWN);
-            table.set_header([Cell::new(format!("{name} contract"))
-                .add_attribute(Attribute::Bold)
-                .fg(Color::Green)]);
-
-            // Add deployment information if available
-            if !contract.deployments.is_empty() {
-                table.add_row([
-                    Cell::new("Deployment Cost")
-                        .add_attribute(Attribute::Bold)
-                        .fg(Color::Cyan),
-                    Cell::new("Deployment Size")
-                        .add_attribute(Attribute::Bold)
-                        .fg(Color::Cyan),
-                    Cell::new("Status")
-                        .add_attribute(Attribute::Bold)
-                        .fg(Color::Cyan),
-                ]);
-
-                for deployment in &contract.deployments {
-                    let status_str = match deployment.status {
-                        GasReportExecutionStatus::Success => "Success",
-                        GasReportExecutionStatus::Revert => "Revert",
-                        GasReportExecutionStatus::Halt => "Halt",
-                    };
-                    table.add_row([
-                        Cell::new(deployment.gas.to_string()),
-                        Cell::new(deployment.size.to_string()),
-                        Cell::new(status_str).fg(match deployment.status {
-                            GasReportExecutionStatus::Success => Color::Green,
-                            GasReportExecutionStatus::Revert => Color::Yellow,
-                            GasReportExecutionStatus::Halt => Color::Red,
-                        }),
-                    ]);
-                }
-            }
-
-            // Add function information if available
-            if !contract.functions.is_empty() {
-                table.add_row([Cell::new("")]);
-                table.add_row([
-                    Cell::new("Function Name")
-                        .add_attribute(Attribute::Bold)
-                        .fg(Color::Magenta),
-                    Cell::new("Gas")
-                        .add_attribute(Attribute::Bold)
-                        .fg(Color::Magenta),
-                    Cell::new("Status")
-                        .add_attribute(Attribute::Bold)
-                        .fg(Color::Magenta),
-                ]);
-
-                // Sort function names for consistent output
-                let mut sorted_functions: Vec<_> = contract.functions.iter().collect();
-                sorted_functions.sort_by(|a, b| a.0.cmp(b.0));
-
-                for (function_signature, reports) in sorted_functions {
-                    if reports.is_empty() {
-                        continue;
-                    }
-
-                    for report in reports {
-                        let status_str = match report.status {
-                            GasReportExecutionStatus::Success => "Success",
-                            GasReportExecutionStatus::Revert => "Revert",
-                            GasReportExecutionStatus::Halt => "Halt",
-                        };
-                        table.add_row([
-                            Cell::new(function_signature.clone()).add_attribute(Attribute::Bold),
-                            Cell::new(report.gas.to_string()).fg(Color::Yellow),
-                            Cell::new(status_str).fg(match report.status {
-                                GasReportExecutionStatus::Success => Color::Green,
-                                GasReportExecutionStatus::Revert => Color::Yellow,
-                                GasReportExecutionStatus::Halt => Color::Red,
-                            }),
-                        ]);
-                    }
-                }
-            }
-
-            writeln!(f, "{table}")?;
-            writeln!(f)?;
-        }
-        Ok(())
     }
 }
 
@@ -382,6 +280,7 @@ impl<HaltReasonT: HaltReasonTrait> From<&ExecutionResult<HaltReasonT>>
 pub struct DeploymentGasReport {
     pub gas: u64,
     pub size: u64,
+    pub runtime_size: u64,
     pub status: GasReportExecutionStatus,
 }
 
@@ -414,12 +313,21 @@ impl DeploymentGasReportAndIdentifiers {
             return Err(DeploymentGasReportCreationError::UnrecognizedContract);
         }
 
+        let runtime_size = match execution_result {
+            ExecutionResult::Success {
+                output: Output::Create(bytes, _),
+                ..
+            } => bytes.len() as u64,
+            _ => 0,
+        };
+
         let report = DeploymentGasReport {
             gas: execution_result.gas_used(),
             size: code
                 .len()
                 .try_into()
                 .expect("Contract code size should fit into u64"),
+            runtime_size,
             status: execution_result.into(),
         };
 

--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -417,6 +417,7 @@ export enum GasReportExecutionStatus {
 export interface DeploymentGasReport {
   gas: bigint
   size: bigint
+  runtimeSize: bigint
   status: GasReportExecutionStatus
 }
 export interface FunctionGasReport {

--- a/crates/edr_napi/src/gas_report.rs
+++ b/crates/edr_napi/src/gas_report.rs
@@ -25,6 +25,7 @@ pub enum GasReportExecutionStatus {
 pub struct DeploymentGasReport {
     pub gas: BigInt,
     pub size: BigInt,
+    pub runtime_size: BigInt,
     pub status: GasReportExecutionStatus,
 }
 
@@ -82,6 +83,7 @@ impl From<edr_gas_report::DeploymentGasReport> for DeploymentGasReport {
         Self {
             gas: BigInt::from(value.gas),
             size: BigInt::from(value.size),
+            runtime_size: BigInt::from(value.runtime_size),
             status: value.status.into(),
         }
     }

--- a/crates/edr_solidity_tests/src/gas_report.rs
+++ b/crates/edr_solidity_tests/src/gas_report.rs
@@ -80,8 +80,22 @@ impl GasReport {
             trace!(contract_name, "adding create gas info");
             contract_info.deployments.push(DeploymentGasReport {
                 gas: trace.gas_used,
-                size: trace.data.len() as u64,
-                runtime_size: trace.output.len() as u64,
+                size: trace.data.len().try_into().unwrap_or_else(|_| {
+                    panic!(
+                        "Length should be smaller than `u64::MAX`. Actual: {}",
+                        trace.data.len()
+                    )
+                }),
+                runtime_size: if matches!(status, GasReportExecutionStatus::Success) {
+                    trace.output.len().try_into().unwrap_or_else(|_| {
+                        panic!(
+                            "Length should be smaller than `u64::MAX`. Actual: {}",
+                            trace.output.len()
+                        )
+                    })
+                } else {
+                    0
+                },
                 status,
             });
         } else if let Some(DecodedCallData { signature, .. }) = decoded().await.call_data {

--- a/crates/edr_solidity_tests/src/gas_report.rs
+++ b/crates/edr_solidity_tests/src/gas_report.rs
@@ -81,6 +81,7 @@ impl GasReport {
             contract_info.deployments.push(DeploymentGasReport {
                 gas: trace.gas_used,
                 size: trace.data.len() as u64,
+                runtime_size: trace.output.len() as u64,
                 status,
             });
         } else if let Some(DecodedCallData { signature, .. }) = decoded().await.call_data {

--- a/js/integration-tests/solidity-tests/contracts/Greeter.sol
+++ b/js/integration-tests/solidity-tests/contracts/Greeter.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+contract Greeter {
+    string public greeting;
+
+    constructor(string memory _greeting) {
+        greeting = _greeting;
+    }
+}

--- a/js/integration-tests/solidity-tests/test-contracts/RuntimeSize.t.sol
+++ b/js/integration-tests/solidity-tests/test-contracts/RuntimeSize.t.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {Greeter} from "../contracts/Greeter.sol";
+
+contract RuntimeSizeShortTest is Test {
+    Greeter public greeter;
+
+    function setUp() public {
+        greeter = new Greeter("Hi");
+    }
+
+    function test_greet() public view {
+        assertEq(greeter.greeting(), "Hi");
+    }
+}
+
+contract RuntimeSizeLongTest is Test {
+    Greeter public greeter;
+
+    function setUp() public {
+        greeter = new Greeter("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+    }
+
+    function test_greet() public view {
+        assertEq(greeter.greeting(), "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+    }
+}

--- a/js/integration-tests/solidity-tests/test/gas.ts
+++ b/js/integration-tests/solidity-tests/test/gas.ts
@@ -140,6 +140,7 @@ describe("Gas report tests", () => {
     assert.equal(contractReport.deployments.length, 1);
     assert(contractReport.deployments[0].gas > 0n);
     assert.equal(contractReport.deployments[0].size, 510n);
+    assert.equal(contractReport.deployments[0].runtimeSize, 481n);
     assert.equal(
       contractReport!.deployments[0].status,
       GasReportExecutionStatus.Success
@@ -302,6 +303,7 @@ describe("Gas report tests", () => {
     assert.equal(contractReport.deployments.length, 1);
     assert(contractReport.deployments[0].gas > 0n);
     assert.equal(contractReport.deployments[0].size, 783n);
+    assert.equal(contractReport.deployments[0].runtimeSize, 754n);
     assert.equal(
       contractReport!.deployments[0].status,
       GasReportExecutionStatus.Success
@@ -413,6 +415,49 @@ describe("Gas report tests", () => {
     assert(
       contractReport === undefined,
       "Deploy should not be included in the gas report since a revert in setUp causes Solidity test execution to terminate"
+    );
+  });
+
+  it("runtimeSize is constant across deployments with different constructor args", async function () {
+    const contractKey = "project/contracts/Greeter.sol:Greeter";
+
+    // Short greeting: ABI args = offset(32) + length(32) + data(32) = 96 bytes
+    const shortResult = await testContext.runTestsWithStats(
+      "RuntimeSizeShortTest",
+      { generateGasReport: true }
+    );
+    const shortReport =
+      shortResult.testResult!.gasReport!.contracts[contractKey];
+    assert(shortReport !== undefined, "Greeter should be in short test report");
+
+    // Long greeting (33 chars): ABI args = offset(32) + length(32) + data(64) = 128 bytes
+    const longResult = await testContext.runTestsWithStats(
+      "RuntimeSizeLongTest",
+      { generateGasReport: true }
+    );
+    const longReport = longResult.testResult!.gasReport!.contracts[contractKey];
+    assert(longReport !== undefined, "Greeter should be in long test report");
+
+    const shortDeploy = shortReport.deployments[0];
+    const longDeploy = longReport.deployments[0];
+
+    // Size includes constructor args, so it differs between deployments (one extra ABI slot for the longer string)
+    assert.equal(
+      longDeploy.size - shortDeploy.size,
+      32n,
+      `Expected size difference of 32 bytes for the additional constructor argument data, got ${longDeploy.size - shortDeploy.size} bytes`
+    );
+
+    assert(
+      shortDeploy.runtimeSize == 531n,
+      `Expected runtimeSize of 531 bytes, got ${shortDeploy.runtimeSize} bytes`
+    );
+
+    // runtimeSize must be identical
+    assert.equal(
+      shortDeploy.runtimeSize,
+      longDeploy.runtimeSize,
+      "runtimeSize should be the same regardless of constructor args"
     );
   });
 });

--- a/js/integration-tests/solidity-tests/test/gas.ts
+++ b/js/integration-tests/solidity-tests/test/gas.ts
@@ -448,8 +448,9 @@ describe("Gas report tests", () => {
       `Expected size difference of 32 bytes for the additional constructor argument data, got ${longDeploy.size - shortDeploy.size} bytes`
     );
 
-    assert(
-      shortDeploy.runtimeSize == 531n,
+    assert.equal(
+      shortDeploy.runtimeSize,
+      531n,
       `Expected runtimeSize of 531 bytes, got ${shortDeploy.runtimeSize} bytes`
     );
 


### PR DESCRIPTION
This PR adds runtime bytecode size information to contract deployment gas reports.

Other changes:
- removed `comfy-table` dependency since `Display` trait was not used for `edr_gas_report::GasReport`

closes #1329 