### PR TITLE
fix: validate gas snapshot names

### DIFF
--- a/.changeset/thin-pillows-retire.md
+++ b/.changeset/thin-pillows-retire.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Added validation checks for names provided in gas snapshot cheatcodes

--- a/crates/foundry/cheatcodes/src/evm.rs
+++ b/crates/foundry/cheatcodes/src/evm.rs
@@ -3323,7 +3323,7 @@ fn inner_value_snapshot<
     name: Option<String>,
     value: String,
 ) -> Result {
-    let (group, name) = derive_snapshot_name(ccx, group, name);
+    let (group, name) = derive_snapshot_name(ccx, group, name)?;
 
     ccx.state
         .gas_snapshots
@@ -3366,7 +3366,7 @@ fn inner_last_gas_snapshot<
     name: Option<String>,
     value: u64,
 ) -> Result {
-    let (group, name) = derive_snapshot_name(ccx, group, name);
+    let (group, name) = derive_snapshot_name(ccx, group, name)?;
 
     ccx.state
         .gas_snapshots
@@ -3421,7 +3421,7 @@ fn inner_start_gas_snapshot<
         bail!("gas snapshot was already started with group: {group} and name: {name}");
     }
 
-    let (group, name) = derive_snapshot_name(ccx, group, name);
+    let (group, name) = derive_snapshot_name(ccx, group, name)?;
 
     ccx.state.gas_metering.gas_records.push(GasRecord {
         group: group.clone(),
@@ -3529,6 +3529,24 @@ fn inner_stop_gas_snapshot<
     }
 }
 
+/// Validates that a snapshot group name or entry name is safe for use as a
+/// filename component. Rejects path separators, `..`, and other special
+/// characters to prevent directory traversal.
+fn validate_snapshot_name(value: &str, is_group_name: bool) -> Result {
+    let is_valid = !value.is_empty()
+        && value
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | ' '));
+    let kind = if is_group_name { "group name" } else { "name" };
+
+    ensure!(
+        is_valid,
+        "invalid snapshot {kind}: \"{value}\". Only alphanumeric characters, hyphens, underscores, and spaces are allowed."
+    );
+
+    Ok(Vec::default())
+}
+
 // Derives the snapshot group and name from the provided group and name or the
 // running contract.
 fn derive_snapshot_name<
@@ -3561,7 +3579,7 @@ fn derive_snapshot_name<
     >,
     group: Option<String>,
     name: Option<String>,
-) -> (String, String) {
+) -> Result<(String, String)> {
     let group = group.unwrap_or_else(|| {
         ccx.state
             .config
@@ -3571,7 +3589,10 @@ fn derive_snapshot_name<
             .name
     });
     let name = name.unwrap_or_else(|| "default".to_string());
-    (group, name)
+    validate_snapshot_name(&group, true)?;
+    validate_snapshot_name(&name, false)?;
+
+    Ok((group, name))
 }
 
 /// Reads the current caller information and returns the current [`CallerMode`],

--- a/crates/foundry/cheatcodes/src/evm.rs
+++ b/crates/foundry/cheatcodes/src/evm.rs
@@ -3530,8 +3530,9 @@ fn inner_stop_gas_snapshot<
 }
 
 /// Validates that a snapshot group name or entry name is safe for use as a
-/// filename component. Rejects path separators, `..`, and other special
-/// characters to prevent directory traversal.
+/// filename component. Allows only ASCII alphanumeric characters, hyphens,
+/// underscores, and spaces, which prevents names containing path
+/// separators or traversal sequences (such as `..`) from being used.
 fn validate_snapshot_name(value: &str, is_group_name: bool) -> Result<()> {
     let is_valid = !value.is_empty()
         && value

--- a/crates/foundry/cheatcodes/src/evm.rs
+++ b/crates/foundry/cheatcodes/src/evm.rs
@@ -3532,7 +3532,7 @@ fn inner_stop_gas_snapshot<
 /// Validates that a snapshot group name or entry name is safe for use as a
 /// filename component. Rejects path separators, `..`, and other special
 /// characters to prevent directory traversal.
-fn validate_snapshot_name(value: &str, is_group_name: bool) -> Result {
+fn validate_snapshot_name(value: &str, is_group_name: bool) -> Result<()> {
     let is_valid = !value.is_empty()
         && value
             .chars()
@@ -3544,7 +3544,7 @@ fn validate_snapshot_name(value: &str, is_group_name: bool) -> Result {
         "invalid snapshot {kind}: \"{value}\". Only alphanumeric characters, hyphens, underscores, and spaces are allowed."
     );
 
-    Ok(Vec::default())
+    Ok(())
 }
 
 // Derives the snapshot group and name from the provided group and name or the

--- a/js/integration-tests/solidity-tests/test-contracts/ScopedSnapshot.sol
+++ b/js/integration-tests/solidity-tests/test-contracts/ScopedSnapshot.sol
@@ -170,6 +170,32 @@ contract GasSnapshotTest is Test {
         slot0 = 1;
         vm.stopSnapshotGas("testGroup", "testMissingStartSnapshot");
     }
+
+    // snapshotValue with a group name containing path separators should revert.
+    function testInvalidGroupNameSlash() public {
+        vm.snapshotValue("../../evil", "a", 1);
+    }
+
+    // snapshotValue with a group name containing backslash should revert.
+    function testInvalidGroupNameBackslash() public {
+        vm.snapshotValue("foo\\bar", "a", 1);
+    }
+
+    // snapshotValue with an empty group name should revert.
+    function testInvalidGroupNameEmpty() public {
+        vm.snapshotValue("", "a", 1);
+    }
+
+    // snapshotGasLastCall with a group name containing a dot-dot should revert.
+    function testInvalidGroupNameDotDot() public {
+        flare.run(1);
+        vm.snapshotGasLastCall("group..name", "a");
+    }
+
+    // startSnapshotGas with a name containing special characters should revert.
+    function testInvalidSnapshotName() public {
+        vm.startSnapshotGas("validGroup", "name/with/slashes");
+    }
 }
 
 contract Flare {

--- a/js/integration-tests/solidity-tests/test/unit.ts
+++ b/js/integration-tests/solidity-tests/test/unit.ts
@@ -342,8 +342,8 @@ describe("Unit tests", () => {
     const { totalTests, failedTests, suiteResults } =
       await testContext.runTestsWithStats("GasSnapshotTest", {}, L1_CHAIN_TYPE);
 
-    assert.equal(totalTests, 15);
-    assert.equal(failedTests, 3);
+    assert.equal(totalTests, 20);
+    assert.equal(failedTests, 8);
 
     let snapshots = new Map<string, Map<string, string>>();
 
@@ -375,6 +375,49 @@ describe("Unit tests", () => {
           );
           continue;
         }
+
+        if (testResult.name === "testInvalidGroupNameSlash()") {
+          assert.equal(testResult.status, "Failure");
+          assert.match(
+            testResult.reason!,
+            /invalid snapshot group name: "\.\.\/\.\.\/evil"/
+          );
+          continue;
+        }
+
+        if (testResult.name === "testInvalidGroupNameBackslash()") {
+          assert.equal(testResult.status, "Failure");
+          assert.match(
+            testResult.reason!,
+            /invalid snapshot group name: "foo\\bar"/
+          );
+          continue;
+        }
+
+        if (testResult.name === "testInvalidGroupNameEmpty()") {
+          assert.equal(testResult.status, "Failure");
+          assert.match(testResult.reason!, /invalid snapshot group name: ""/);
+          continue;
+        }
+
+        if (testResult.name === "testInvalidGroupNameDotDot()") {
+          assert.equal(testResult.status, "Failure");
+          assert.match(
+            testResult.reason!,
+            /invalid snapshot group name: "group\.\.name"/
+          );
+          continue;
+        }
+
+        if (testResult.name === "testInvalidSnapshotName()") {
+          assert.equal(testResult.status, "Failure");
+          assert.match(
+            testResult.reason!,
+            /invalid snapshot name: "name\/with\/slashes"/
+          );
+          continue;
+        }
+
         assert.notEqual(testResult.valueSnapshotGroups, undefined);
 
         const snapshotGroups = testResult.valueSnapshotGroups!;


### PR DESCRIPTION
This PR adds checks to validate both snapshot group names and snapshot names. This is to prevent malicious use of names to traverse directories (e.g. by including `../` in the name).

Not adhering to the pattern results in the following error being returned:
`vm.snapshotValue: invalid snapshot group name: "foo\bar". Only alphanumeric characters, hyphens, underscores, and spaces are allowed.`

closes #1326 