### PR TITLE
ci(dependabot): add github-actions ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,12 @@ updates:
     cooldown:
       default-days: 7
       semver-major-days: 30
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "build"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Keep GitHub Actions pinned versions up to date automatically, matching the configuration already in place for solx. (7 days cooldown)

Note that this will be good to slowly update now, as June 2nd node runner will switch to using Node 24 and switching yourself will hopefully prevent a sudden breakage. See https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/