### PR TITLE
fix(op): update Base Mainnet dynamic eip1559 params

### DIFF
--- a/crates/edr_op/src/hardfork/base.rs
+++ b/crates/edr_op/src/hardfork/base.rs
@@ -45,6 +45,10 @@ pub(crate) static MAINNET_BASE_FEE_PARAMS: LazyLock<BaseFeeParams<OpSpecId>> =
                 BaseFeeActivation::BlockNumber(41_711_238),
                 ConstantBaseFeeParams::new(125, 6),
             ),
+            (
+                BaseFeeActivation::BlockNumber(43_841_215),
+                ConstantBaseFeeParams::new(100, 5),
+            ),
         ]))
     });
 

--- a/crates/edr_op/tests/integration/dynamic_base_fee_params.rs
+++ b/crates/edr_op/tests/integration/dynamic_base_fee_params.rs
@@ -90,6 +90,7 @@ impl_test_dynamic_base_fee_params! {
         38_951_425, // jovian activated block
         39_647_879, // SystemConfig EIP-1559 update 2025-12-18
         41_711_238, // SystemConfig EIP-1559 update 2026-02-04
+        43_841_215, // SystemConfig EIP-1559 update 2026-03-25
     ],
     op_sepolia: json_rpc_url_provider::op_sepolia() => [
         26_806_602,


### PR DESCRIPTION
## Main change
Update Base Mainnet EIP dynamic base fee params after yesterday's `SystemConfig` update  (2026-03-25)

For details see  `tx: 0xa0e2f62a2867858350ff32a7943a23ddb872571eeacee7bc0453b46948a5c372` on SystemConfig contract [event list](https://etherscan.io/address/0x73a79Fab69143498Ed3712e519A88a918e1f4072#events) 