### PR TITLE
fix: add missing `show_logs` field to global fuzz config

### DIFF
--- a/.changeset/stupid-apes-accept.md
+++ b/.changeset/stupid-apes-accept.md
@@ -2,4 +2,4 @@
 "@nomicfoundation/edr": patch
 ---
 
-Added `show_logs` field to global fuzz test configuration
+Added `showLogs` field to global fuzz test configuration

--- a/.changeset/stupid-apes-accept.md
+++ b/.changeset/stupid-apes-accept.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Added `show_logs` field to global fuzz test configuration

--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -841,6 +841,11 @@ export interface FuzzConfigArgs {
    */
   includePushBytes?: boolean
   /**
+   * Show `console.log` in fuzz test.
+   * Defaults to false.
+   */
+  showLogs?: boolean
+  /**
    * Optional timeout (in seconds) for each property test.
    * Defaults to none (no timeout).
    */

--- a/crates/edr_napi/src/solidity_tests/config.rs
+++ b/crates/edr_napi/src/solidity_tests/config.rs
@@ -392,6 +392,9 @@ pub struct FuzzConfigArgs {
     /// The flag indicating whether to include push bytes values.
     /// Defaults to true.
     pub include_push_bytes: Option<bool>,
+    /// Show `console.log` in fuzz test.
+    /// Defaults to false.
+    pub show_logs: Option<bool>,
     /// Optional timeout (in seconds) for each property test.
     /// Defaults to none (no timeout).
     pub timeout: Option<u32>,
@@ -410,6 +413,7 @@ impl TryFrom<FuzzConfigArgs> for FuzzConfig {
             dictionary_weight,
             include_storage,
             include_push_bytes,
+            show_logs,
             timeout,
         } = value;
 
@@ -451,6 +455,10 @@ impl TryFrom<FuzzConfigArgs> for FuzzConfig {
 
         if let Some(include_push_bytes) = include_push_bytes {
             fuzz.dictionary.include_push_bytes = include_push_bytes;
+        }
+
+        if let Some(show_logs) = show_logs {
+            fuzz.show_logs = show_logs;
         }
 
         Ok(fuzz)
@@ -528,6 +536,7 @@ impl InvariantConfigArgs {
             failure_persist_file: _,
             max_test_rejects: _,
             seed: _,
+            show_logs: _,
             timeout,
         } = fuzz;
 

--- a/crates/edr_solidity_tests/tests/it/fuzz.rs
+++ b/crates/edr_solidity_tests/tests/it/fuzz.rs
@@ -293,6 +293,57 @@ async fn test_fuzz_can_scrape_bytecode() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_fuzz_show_logs() {
+    let filter = SolidityTestFilter::new("testSuccessfulFuzz", ".*", ".*fuzz/Fuzz.t.sol");
+
+    // With show_logs enabled, decoded_logs should contain the fuzz test's log
+    // messages.
+    let mut config = TEST_DATA_DEFAULT.config_with_mock_rpc();
+    config.fuzz.show_logs = true;
+
+    let runner = TEST_DATA_DEFAULT.runner_with_fuzz_persistence(config).await;
+    let suite_result = runner.test_collect(filter.clone()).await.suite_results;
+
+    for SuiteResult { test_results, .. } in suite_result.values() {
+        let result = test_results
+            .get("testSuccessfulFuzz(uint128,uint128)")
+            .expect("test result should exist");
+        assert_eq!(result.status, TestStatus::Success);
+        assert!(
+            result
+                .decoded_logs
+                .iter()
+                .any(|log| log.contains("testSuccessfulFuzz")),
+            "Expected logs to contain 'testSuccessfulFuzz' when show_logs is true, got: {:?}",
+            result.decoded_logs,
+        );
+    }
+
+    // With show_logs disabled (default), decoded_logs from successful fuzz runs
+    // should not be collected.
+    let mut config = TEST_DATA_DEFAULT.config_with_mock_rpc();
+    config.fuzz.show_logs = false;
+
+    let runner = TEST_DATA_DEFAULT.runner_with_fuzz_persistence(config).await;
+    let suite_result = runner.test_collect(filter).await.suite_results;
+
+    for SuiteResult { test_results, .. } in suite_result.values() {
+        let result = test_results
+            .get("testSuccessfulFuzz(uint128,uint128)")
+            .expect("test result should exist");
+        assert_eq!(result.status, TestStatus::Success);
+        assert!(
+            !result
+                .decoded_logs
+                .iter()
+                .any(|log| log.contains("testSuccessfulFuzz")),
+            "Expected no 'testSuccessfulFuzz' logs when show_logs is false, got: {:?}",
+            result.decoded_logs,
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_fuzz_timeout() {
     let filter = SolidityTestFilter::new(".*", ".*", ".*fuzz/FuzzTimeout.t.sol");
     let mut config = TEST_DATA_DEFAULT.config_with_mock_rpc();

--- a/crates/edr_solidity_tests/tests/it/helpers.rs
+++ b/crates/edr_solidity_tests/tests/it/helpers.rs
@@ -215,6 +215,7 @@ pub struct TestFuzzConfig {
     pub gas_report_samples: u32,
     pub failure_persist_dir: Option<PathBuf>,
     pub failure_persist_file: String,
+    pub show_logs: bool,
 }
 
 impl TestFuzzConfig {
@@ -237,6 +238,7 @@ impl Default for TestFuzzConfig {
             gas_report_samples: 256,
             failure_persist_dir: None,
             failure_persist_file: "testfailure".into(),
+            show_logs: false,
         }
     }
 }
@@ -252,7 +254,7 @@ impl From<TestFuzzConfig> for FuzzConfig {
             gas_report_samples: value.gas_report_samples,
             failure_persist_dir: value.failure_persist_dir,
             failure_persist_file: value.failure_persist_file,
-            show_logs: false,
+            show_logs: value.show_logs,
             timeout: None,
         }
     }


### PR DESCRIPTION
This PR adds `show_logs` to the global fuzz config which is exposed through NAPI. The field is already present on the Rust side of the configuration , but it couldn't be set through JS global config.