### PR TITLE
fix: replicate beacon root oracle state when replaying blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3595,6 +3595,7 @@ dependencies = [
  "edr_rpc_eth",
  "edr_state_api",
  "edr_utils",
+ "futures",
  "parking_lot 0.12.3",
  "serde",
  "tokio",

--- a/crates/blockchain/fork/src/eips/eip4788.rs
+++ b/crates/blockchain/fork/src/eips/eip4788.rs
@@ -1,4 +1,4 @@
-use edr_primitives::{address, bytes, Address, Bytecode, Bytes};
+use edr_primitives::{address, bytes, Address, Bytecode, Bytes, U256};
 use edr_state_api::{account::AccountInfo, StateDiff};
 
 /// The address of the beacon roots contract.
@@ -8,6 +8,40 @@ pub const BEACON_ROOTS_ADDRESS: Address = address!("0x000F3df6D732807Ef1319fB7B8
 pub const BEACON_ROOTS_BYTECODE: Bytes = bytes!(
     "0x3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500"
 );
+
+/// The history buffer length used by the beacon roots contract.
+const HISTORY_BUFFER_LENGTH: u64 = 8191;
+
+/// Storage slot indices for an entry in the EIP-4788 beacon root contract's
+/// ring buffer.
+///
+/// The contract uses two parallel ring buffers to store timestamps and the
+/// corresponfing parent beacon block roots
+///
+/// See: <https://eips.ethereum.org/EIPS/eip-4788>
+pub struct BeaconRootStorageSlots {
+    /// Slot index for the timestamp value.
+    pub timestamp_slot: U256,
+    /// Slot index for the parent beacon block root
+    pub beacon_root_slot: U256,
+}
+
+/// Computes the storage slot indices for the given block `timestamp` in the
+/// EIP-4788 beacon root contract's ring buffer.
+///
+/// The contract uses two parallel ring buffers of length
+/// [`HISTORY_BUFFER_LENGTH`]:
+/// - Slots `0..HISTORY_BUFFER_LENGTH` store timestamps.
+/// - Slots `HISTORY_BUFFER_LENGTH..HISTORY_BUFFER_LENGTH*2` store the
+///   corresponding parent beacon block roots.
+pub fn beacon_root_storage_slots(timestamp: u64) -> BeaconRootStorageSlots {
+    let timestamp_slot = U256::from(timestamp % HISTORY_BUFFER_LENGTH);
+    let beacon_root_slot = timestamp_slot + U256::from(HISTORY_BUFFER_LENGTH);
+    BeaconRootStorageSlots {
+        timestamp_slot,
+        beacon_root_slot,
+    }
+}
 
 pub(crate) fn beacon_roots_contract() -> AccountInfo {
     let code = Bytecode::new_raw(BEACON_ROOTS_BYTECODE);

--- a/crates/blockchain/fork/src/eips/eip4788.rs
+++ b/crates/blockchain/fork/src/eips/eip4788.rs
@@ -29,11 +29,9 @@ pub struct BeaconRootStorageSlots {
 /// Computes the storage slot indices for the given block `timestamp` in the
 /// EIP-4788 beacon root contract's ring buffer.
 ///
-/// The contract uses two parallel ring buffers of length
-/// [`HISTORY_BUFFER_LENGTH`]:
-/// - Slots `0..HISTORY_BUFFER_LENGTH` store timestamps.
-/// - Slots `HISTORY_BUFFER_LENGTH..HISTORY_BUFFER_LENGTH*2` store the
-///   corresponding parent beacon block roots.
+/// The contract uses two parallel ring buffers
+/// - First buffer to store timestamps.
+/// - Second buffer to store the corresponding parent beacon block roots.
 pub fn beacon_root_storage_slots(timestamp: u64) -> BeaconRootStorageSlots {
     let timestamp_slot = U256::from(timestamp % HISTORY_BUFFER_LENGTH);
     let beacon_root_slot = timestamp_slot + U256::from(HISTORY_BUFFER_LENGTH);

--- a/crates/blockchain/fork/src/eips/eip4788.rs
+++ b/crates/blockchain/fork/src/eips/eip4788.rs
@@ -16,7 +16,7 @@ const HISTORY_BUFFER_LENGTH: u64 = 8191;
 /// ring buffer.
 ///
 /// The contract uses two parallel ring buffers to store timestamps and the
-/// corresponfing parent beacon block roots
+/// corresponding parent beacon block roots
 ///
 /// See: <https://eips.ethereum.org/EIPS/eip-4788>
 pub struct BeaconRootStorageSlots {
@@ -54,4 +54,23 @@ pub(crate) fn beacon_roots_contract() -> AccountInfo {
 
 pub(crate) fn add_beacon_roots_contract_to_state_diff(state_diff: &mut StateDiff) {
     state_diff.apply_account_change(BEACON_ROOTS_ADDRESS, beacon_roots_contract());
+}
+
+#[cfg(test)]
+mod tests {
+    use edr_primitives::U256;
+
+    use super::*;
+
+    #[test]
+    fn beacon_root_storage_slots_follows_eip_spec() {
+        let timestamp = HISTORY_BUFFER_LENGTH - 1;
+        let slots = beacon_root_storage_slots(timestamp);
+
+        assert_eq!(slots.timestamp_slot, U256::from(timestamp));
+        assert_eq!(
+            slots.beacon_root_slot,
+            U256::from(timestamp + HISTORY_BUFFER_LENGTH)
+        );
+    }
 }

--- a/crates/edr_provider/src/data.rs
+++ b/crates/edr_provider/src/data.rs
@@ -4539,7 +4539,7 @@ mod tests {
                 url: json_rpc_url_provider::ethereum_mainnet(),
                 header_overrides_constructor: prague_header_overrides,
             },
-            mainnet_beacon_root_oracle_depending => L1ChainSpec {
+            mainnet_beacon_root_oracle_dependent => L1ChainSpec {
                 block_number: 24_735_736,
                 url: json_rpc_url_provider::ethereum_mainnet(),
                 header_overrides_constructor: prague_header_overrides,

--- a/crates/edr_provider/src/data.rs
+++ b/crates/edr_provider/src/data.rs
@@ -4539,6 +4539,11 @@ mod tests {
                 url: json_rpc_url_provider::ethereum_mainnet(),
                 header_overrides_constructor: prague_header_overrides,
             },
+            mainnet_beacon_root_oracle_depending => L1ChainSpec {
+                block_number: 24_735_736,
+                url: json_rpc_url_provider::ethereum_mainnet(),
+                header_overrides_constructor: prague_header_overrides,
+            },
 
         }
     }

--- a/crates/test/block_replay/Cargo.toml
+++ b/crates/test/block_replay/Cargo.toml
@@ -24,6 +24,7 @@ edr_receipt.workspace = true
 edr_rpc_eth.workspace = true
 edr_state_api.workspace = true
 edr_utils.workspace = true
+futures = "0.3"
 parking_lot.workspace = true
 serde.workspace = true
 tokio.workspace = true

--- a/crates/test/block_replay/src/lib.rs
+++ b/crates/test/block_replay/src/lib.rs
@@ -167,15 +167,11 @@ pub async fn run_full_block<
         >,
 >(
     runtime: tokio::runtime::Handle,
-    url: String,
+    rpc_client: EthRpcClientForChainSpec<ChainSpecT>,
     block_number: u64,
     header_overrides_constructor: impl FnOnce(&BlockHeader) -> HeaderOverrides<ChainSpecT::Hardfork>,
 ) -> anyhow::Result<()> {
-    let rpc_client = Arc::new(EthRpcClientForChainSpec::<ChainSpecT>::new(
-        &url,
-        edr_defaults::CACHE_DIR.into(),
-        None,
-    )?);
+    let rpc_client = Arc::new(rpc_client);
     let ForkedStateAndBlockchain {
         block_config,
         expected_block,
@@ -540,9 +536,8 @@ macro_rules! impl_full_block_tests {
                 #[tokio::test(flavor = "multi_thread")]
                 async fn [<full_block_ $name>]() -> anyhow::Result<()> {
                     let runtime = tokio::runtime::Handle::current();
-                    let url = $url;
-
-                    $crate::run_full_block::<$chain_spec>(runtime, url, $block_number, $header_overrides_constructor).await
+                    let rpc_client = edr_rpc_eth::client::EthRpcClientForChainSpec::<$chain_spec>::new(&$url, edr_defaults::CACHE_DIR.into(), None)?;
+                    $crate::run_full_block::<$chain_spec>(runtime, rpc_client, $block_number, $header_overrides_constructor).await
                 }
             }
         )+

--- a/crates/test/block_replay/src/lib.rs
+++ b/crates/test/block_replay/src/lib.rs
@@ -13,18 +13,21 @@ use edr_block_builder_api::{BlockBuilder as _, BlockInputs};
 use edr_block_header::{BlockConfig, BlockHeader, HeaderOverrides, PartialHeader, Withdrawal};
 use edr_block_remote::RemoteBlock;
 use edr_blockchain_api::{BlockchainMetadata as _, StateAtBlock as _};
-use edr_blockchain_fork::ForkedBlockchain;
+use edr_blockchain_fork::{
+    eips::eip4788::{beacon_root_storage_slots, BeaconRootStorageSlots, BEACON_ROOTS_ADDRESS},
+    ForkedBlockchain,
+};
 use edr_chain_spec::{ChainSpec, EvmSpecId, ExecutableTransaction, HardforkChainSpec};
 use edr_chain_spec_block::BlockChainSpec;
 use edr_chain_spec_evm::config::EvmConfig;
 use edr_chain_spec_provider::SyncProviderChainSpec;
 use edr_chain_spec_receipt::ReceiptChainSpec;
 use edr_chain_spec_rpc::{RpcBlockChainSpec, RpcChainSpec, RpcEthBlock};
-use edr_eth::{block::miner_reward, PreEip1898BlockSpec};
+use edr_eth::{block::miner_reward, BlockSpec, PreEip1898BlockSpec};
 use edr_primitives::{HashMap, B256};
 use edr_receipt::{log::FilterLog, AsExecutionReceipt, ExecutionReceipt as _, ReceiptTrait};
-use edr_rpc_eth::client::EthRpcClientForChainSpec;
-use edr_state_api::irregular::IrregularState;
+use edr_rpc_eth::client::{EthRpcClient, EthRpcClientForChainSpec};
+use edr_state_api::{irregular::IrregularState, DynState};
 use edr_utils::random::RandomHashGenerator;
 
 type ForkedStateAndBlockchainForChainSpec<ChainSpecT> = ForkedStateAndBlockchain<
@@ -84,14 +87,11 @@ async fn get_fork_state<
     >,
 >(
     runtime: tokio::runtime::Handle,
-    url: String,
+    rpc_client: Arc<EthRpcClient<ChainSpecT, ChainSpecT::RpcReceipt, ChainSpecT::RpcTransaction>>,
     block_number: u64,
 ) -> anyhow::Result<ForkedStateAndBlockchainForChainSpec<ChainSpecT>> {
-    let rpc_client =
-        EthRpcClientForChainSpec::<ChainSpecT>::new(&url, edr_defaults::CACHE_DIR.into(), None)?;
     let chain_id = rpc_client.chain_id().await?;
 
-    let rpc_client = Arc::new(rpc_client);
     let replay_block = {
         let block = rpc_client
             .get_block_by_number_with_transaction_data(PreEip1898BlockSpec::Number(block_number))
@@ -171,12 +171,17 @@ pub async fn run_full_block<
     block_number: u64,
     header_overrides_constructor: impl FnOnce(&BlockHeader) -> HeaderOverrides<ChainSpecT::Hardfork>,
 ) -> anyhow::Result<()> {
+    let rpc_client = Arc::new(EthRpcClientForChainSpec::<ChainSpecT>::new(
+        &url,
+        edr_defaults::CACHE_DIR.into(),
+        None,
+    )?);
     let ForkedStateAndBlockchain {
         block_config,
         expected_block,
         prior_blockchain,
         prior_irregular_state,
-    } = get_fork_state::<ChainSpecT>(runtime, url, block_number).await?;
+    } = get_fork_state::<ChainSpecT>(runtime, rpc_client.clone(), block_number).await?;
 
     let replay_header = expected_block.block_header();
     let hardfork = prior_blockchain.hardfork();
@@ -188,9 +193,21 @@ pub async fn run_full_block<
         transaction_gas_cap: None,
     };
 
-    let state = prior_blockchain
-        .state_at_block_number(block_number - 1, prior_irregular_state.state_overrides())?;
+    let state = {
+        let mut state = prior_blockchain
+            .state_at_block_number(block_number - 1, prior_irregular_state.state_overrides())?;
 
+        if hardfork.into() >= EvmSpecId::CANCUN {
+            replicate_beacon_block_root_oracle_state(
+                block_number,
+                rpc_client,
+                replay_header,
+                &mut state,
+            )
+            .await?;
+        }
+        state
+    };
     let custom_precompiles = HashMap::default();
 
     let mut builder = ChainSpecT::BlockBuilder::new_block_builder(
@@ -375,6 +392,53 @@ pub async fn run_full_block<
     Ok(())
 }
 
+async fn replicate_beacon_block_root_oracle_state<
+    ChainSpecT: 'static
+        + SyncProviderChainSpec<
+            ExecutionReceipt<FilterLog>: Debug + PartialEq,
+            Receipt: AsExecutionReceipt<ExecutionReceipt = ChainSpecT::ExecutionReceipt<FilterLog>>,
+            RpcBlock<<ChainSpecT as RpcChainSpec>::RpcTransaction>: TryInto<
+                EthBlockData<ChainSpecT::SignedTransaction>,
+                Error: 'static,
+            >,
+        >,
+>(
+    block_number: u64,
+    rpc_client: Arc<EthRpcClient<ChainSpecT, ChainSpecT::RpcReceipt, ChainSpecT::RpcTransaction>>,
+    replay_header: &BlockHeader,
+    state: &mut Box<dyn DynState>,
+) -> Result<(), anyhow::Error> {
+    let BeaconRootStorageSlots {
+        timestamp_slot,
+        beacon_root_slot,
+    } = beacon_root_storage_slots(replay_header.timestamp);
+    let timestamp_value = rpc_client
+        .get_storage_at(
+            BEACON_ROOTS_ADDRESS,
+            timestamp_slot,
+            Some(BlockSpec::Number(block_number)),
+        )
+        .await?;
+    let root_value = rpc_client
+        .get_storage_at(
+            BEACON_ROOTS_ADDRESS,
+            beacon_root_slot,
+            Some(BlockSpec::Number(block_number)),
+        )
+        .await?;
+    state.set_account_storage_slot(
+        BEACON_ROOTS_ADDRESS,
+        beacon_root_slot,
+        root_value.expect("BEACON_ROOT root slot storage should be defined"),
+    )?;
+    state.set_account_storage_slot(
+        BEACON_ROOTS_ADDRESS,
+        timestamp_slot,
+        timestamp_value.expect("BEACON_ROOT timestamp slot storage should be defined"),
+    )?;
+    Ok(())
+}
+
 /// Forks the block at the provided block number and compares it with the
 /// locally mined block header for that block without transactions.
 ///
@@ -398,12 +462,17 @@ pub async fn assert_replay_header<
     header_overrides_constructor: impl FnOnce(&BlockHeader) -> HeaderOverrides<ChainSpecT::Hardfork>,
     header_validation: impl FnOnce(&BlockHeader, &PartialHeader) -> anyhow::Result<()>,
 ) -> anyhow::Result<()> {
+    let rpc_client = Arc::new(EthRpcClientForChainSpec::<ChainSpecT>::new(
+        &url,
+        edr_defaults::CACHE_DIR.into(),
+        None,
+    )?);
     let ForkedStateAndBlockchain {
         block_config,
         expected_block,
         prior_blockchain,
         prior_irregular_state,
-    } = get_fork_state::<ChainSpecT>(runtime, url, block_number).await?;
+    } = get_fork_state::<ChainSpecT>(runtime, rpc_client.clone(), block_number).await?;
 
     let replay_header = expected_block.block_header();
 

--- a/crates/test/block_replay/src/lib.rs
+++ b/crates/test/block_replay/src/lib.rs
@@ -29,6 +29,7 @@ use edr_receipt::{log::FilterLog, AsExecutionReceipt, ExecutionReceipt as _, Rec
 use edr_rpc_eth::client::{EthRpcClient, EthRpcClientForChainSpec};
 use edr_state_api::{irregular::IrregularState, DynState};
 use edr_utils::random::RandomHashGenerator;
+use futures::try_join;
 
 type ForkedStateAndBlockchainForChainSpec<ChainSpecT> = ForkedStateAndBlockchain<
     <ChainSpecT as ReceiptChainSpec>::Receipt,
@@ -408,30 +409,27 @@ async fn replicate_beacon_block_root_oracle_state<
         timestamp_slot,
         beacon_root_slot,
     } = beacon_root_storage_slots(replay_header.timestamp);
-    let timestamp_value = rpc_client
-        .get_storage_at(
-            BEACON_ROOTS_ADDRESS,
-            timestamp_slot,
-            Some(BlockSpec::Number(block_number)),
-        )
-        .await?;
-    let root_value = rpc_client
-        .get_storage_at(
-            BEACON_ROOTS_ADDRESS,
-            beacon_root_slot,
-            Some(BlockSpec::Number(block_number)),
-        )
-        .await?;
-    state.set_account_storage_slot(
-        BEACON_ROOTS_ADDRESS,
-        beacon_root_slot,
-        root_value.expect("BEACON_ROOT root slot storage should be defined"),
-    )?;
-    state.set_account_storage_slot(
+
+    let timestamp_slot_fetch = rpc_client.get_storage_at(
         BEACON_ROOTS_ADDRESS,
         timestamp_slot,
-        timestamp_value.expect("BEACON_ROOT timestamp slot storage should be defined"),
-    )?;
+        Some(BlockSpec::Number(block_number)),
+    );
+    let beacon_root_slot_fetch = rpc_client.get_storage_at(
+        BEACON_ROOTS_ADDRESS,
+        beacon_root_slot,
+        Some(BlockSpec::Number(block_number)),
+    );
+    if let (Some(timestamp_value), Some(beacon_root_value)) =
+        try_join!(timestamp_slot_fetch, beacon_root_slot_fetch)?
+    {
+        state.set_account_storage_slot(
+            BEACON_ROOTS_ADDRESS,
+            beacon_root_slot,
+            beacon_root_value,
+        )?;
+        state.set_account_storage_slot(BEACON_ROOTS_ADDRESS, timestamp_slot, timestamp_value)?;
+    }
     Ok(())
 }
 

--- a/crates/tool/cli/src/remote_block.rs
+++ b/crates/tool/cli/src/remote_block.rs
@@ -79,5 +79,11 @@ where
     };
 
     println!("Testing block {block_number} for chain type {chain_type}");
-    run_full_block::<ChainSpecT>(runtime, url, block_number, header_overrides_constructor).await
+    run_full_block::<ChainSpecT>(
+        runtime,
+        rpc_client,
+        block_number,
+        header_overrides_constructor,
+    )
+    .await
 }


### PR DESCRIPTION
## Context
https://github.com/NomicFoundation/edr/issues/1346#issuecomment-4246035282

## Changes
Update `run_full_block` function so that the `replay-block` tool and `full_block` tests can replicate remote blocks that include transactions that query the EIP-4788 parent beacon block root oracle.

For Cancun+ blocks, before creating the block builder, the replay tool now fetches the beacon root contract's storage slots from the remote chain at the target block number and writes them into the local state. This ensures that any transaction querying the oracle reads the correct values, matching the remote chain's execution.

### Details
- Define `BeaconRootStorageSlots` and `beacon_root_storage_slots()` in the EIP-4788 module to compute the ring buffer slot indices for a given timestamp
- In `run_full_block`, fetch the two relevant storage slots from remote via `get_storage_at` rpc request and apply them to local state before block construction
- Add block replay test for mainnet block `24_735_736` (the block from the issue report)

Fixes #1346
