### PR TITLE
fix: allow commas and non-consecutive dots in gas snapshot names

### DIFF
--- a/.changeset/mean-regions-obey.md
+++ b/.changeset/mean-regions-obey.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Added support for commas and non-consecutive dots in names provided in gas snapshot cheatcodes

--- a/crates/foundry/cheatcodes/src/evm.rs
+++ b/crates/foundry/cheatcodes/src/evm.rs
@@ -3536,10 +3536,11 @@ fn inner_stop_gas_snapshot<
 /// from being used.
 fn validate_snapshot_name(value: &str, is_group_name: bool) -> Result<()> {
     let is_valid = !value.is_empty()
+        && value != "."
+        && !value.contains("..")
         && value
             .chars()
-            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | ' ' | ',' | '.'))
-        && !value.contains("..");
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | ' ' | ',' | '.'));
     let kind = if is_group_name { "group name" } else { "name" };
 
     ensure!(

--- a/crates/foundry/cheatcodes/src/evm.rs
+++ b/crates/foundry/cheatcodes/src/evm.rs
@@ -3531,18 +3531,20 @@ fn inner_stop_gas_snapshot<
 
 /// Validates that a snapshot group name or entry name is safe for use as a
 /// filename component. Allows only ASCII alphanumeric characters, hyphens,
-/// underscores, and spaces, which prevents names containing path
-/// separators or traversal sequences (such as `..`) from being used.
+/// underscores, spaces, commas, and non-consecutive dots, which prevents
+/// names containing path separators or traversal sequences (such as `..`)
+/// from being used.
 fn validate_snapshot_name(value: &str, is_group_name: bool) -> Result<()> {
     let is_valid = !value.is_empty()
         && value
             .chars()
-            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | ' '));
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | ' ' | ',' | '.'))
+        && !value.contains("..");
     let kind = if is_group_name { "group name" } else { "name" };
 
     ensure!(
         is_valid,
-        "invalid snapshot {kind}: \"{value}\". Only alphanumeric characters, hyphens, underscores, and spaces are allowed."
+        "invalid snapshot {kind}: \"{value}\". Only alphanumeric characters, hyphens, underscores, spaces, commas, and non-consecutive dots are allowed."
     );
 
     Ok(())

--- a/js/integration-tests/solidity-tests/test-contracts/ScopedSnapshot.sol
+++ b/js/integration-tests/solidity-tests/test-contracts/ScopedSnapshot.sol
@@ -196,6 +196,16 @@ contract GasSnapshotTest is Test {
     function testInvalidSnapshotName() public {
         vm.startSnapshotGas("validGroup", "name/with/slashes");
     }
+
+    // snapshotValue with a snapshot name containing a comma should succeed.
+    function testValidSnapshotNameWithComma() public {
+        vm.snapshotValue("GasSnapshotTest", "name,with,comma", 789);
+    }
+
+    // snapshotValue with a snapshot name containing non-consecutive dots should succeed.
+    function testValidSnapshotNameWithDot() public {
+        vm.snapshotValue("GasSnapshotTest", "name.with.dot", 101);
+    }
 }
 
 contract Flare {

--- a/js/integration-tests/solidity-tests/test/unit.ts
+++ b/js/integration-tests/solidity-tests/test/unit.ts
@@ -342,7 +342,7 @@ describe("Unit tests", () => {
     const { totalTests, failedTests, suiteResults } =
       await testContext.runTestsWithStats("GasSnapshotTest", {}, L1_CHAIN_TYPE);
 
-    assert.equal(totalTests, 20);
+    assert.equal(totalTests, 22);
     assert.equal(failedTests, 8);
 
     let snapshots = new Map<string, Map<string, string>>();
@@ -468,6 +468,8 @@ describe("Unit tests", () => {
             ["d", "123"],
             ["e", "456"],
             ["f", "789"],
+            ["name,with,comma", "789"],
+            ["name.with.dot", "101"],
             ["testAssertGasExternal", "50260"],
             ["testAssertGasInternalA", "22047"],
             ["testAssertGasInternalB", "1011"],


### PR DESCRIPTION
This PR allows usage of `,` and non-consecutive `.` in names provided for gas snapshot cheatcodes, since they do not interfere with OS file name restrictions and cannot be leveraged to traverse the filesystem.

Follow-up to #1337 