### PR TITLE
chore: document spec compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ EDR finds its origins in Hardhat Network but incorporates the lessons we have le
 - **Source-level code coverage** via Solidity instrumentation.
 - **Per-function and per-deployment gas reports** with proxy delegation chain tracking.
 
+## Spec Compliance
+
+For a list of EIPs and chain specifications that EDR does not fully support, including workarounds, see [spec-compliance/](spec-compliance/README.md).
+
 ## Production Usage
 
 - [Hardhat 3](https://hardhat.org/)

--- a/spec-compliance/README.md
+++ b/spec-compliance/README.md
@@ -1,0 +1,23 @@
+# Spec Compliance
+
+This directory documents EIPs and chain specifications that EDR does not support or only partially supports. Each entry links to a detailed document describing what the spec requires, how EDR deviates, and any available workarounds.
+
+## Status definitions
+
+| Status | Meaning |
+| --- | --- |
+| **Unsupported** | EDR has no implementation related to this spec. |
+| **Structural** | EDR includes the required fields defined by the spec to produce valid blocks, but does not simulate the underlying behavior. There are no plans to fully implement this. Workarounds may be available. |
+| **Partial** | EDR has adapted tooling or provides workarounds, but the core logic is not yet implemented. |
+
+## L1 Ethereum
+
+| EIP | Hardfork | Status | Details |
+| --- | --- | --- | --- |
+| [EIP-4788](https://eips.ethereum.org/EIPS/eip-4788) | Cancun | Structural | [l1/eip-4788.md](l1/eip-4788.md) |
+
+## OP Stack
+
+| Spec | Hardfork | Status | Details |
+| --- | --- | --- | --- |
+| [`blob_gas_used` / DA Footprint](https://specs.optimism.io/protocol/jovian/exec-engine.html) | Jovian | Partial | [op/jovian_da_footprint.md](op/jovian_da_footprint.md) |

--- a/spec-compliance/l1/eip-4788.md
+++ b/spec-compliance/l1/eip-4788.md
@@ -1,0 +1,60 @@
+# EIP-4788: Beacon block root in the EVM
+
+**Spec**: <https://eips.ethereum.org/EIPS/eip-4788> **Hardfork**: Cancun **Status**: Structural
+
+## What the spec requires
+
+EIP-4788 introduces a stateful precompile at `0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02` that stores parent beacon block roots. At the start of each block (Cancun+), a system-level call writes two storage slots into the contract's ring buffer:
+
+- Slot `timestamp % 8191` = block timestamp
+- Slot `(timestamp % 8191) + 8191` = parent beacon block root
+
+Contracts can then query the oracle by providing a timestamp to retrieve the corresponding beacon root.
+
+## What EDR does
+
+EDR assigns deterministic pseudo-random `parent_beacon_block_root` values to locally mined block headers, ensuring unique non-zero values per block. However, these values have no relation to any actual consensus layer, and the pre-block system call that populates the oracle contract's storage is not executed.
+
+The beacon root contract bytecode is deployed to state — in local mode by Hardhat via `l1_genesis_state`, and in forked mode it is either fetched from the remote chain (Cancun+ fork point) or injected by EDR (pre-Cancun fork point). In all cases, its storage is not populated by EDR via the system call.
+
+## Impact
+
+- **Local mode**: The oracle contract's storage is empty. Any query will revert, as the ring buffer will never match the requested timestamp.
+- **Forked mode**: Historical storage is lazily fetched from the remote chain, so queries for timestamps that were populated before the fork point will work. However, blocks mined locally after the fork will not have their beacon roots written to storage, so queries for those timestamps will revert.
+
+## Workarounds
+
+You can manually populate the oracle's storage using `hardhat_setStorageAt`. The two slots to set for a given block timestamp are:
+
+- **Timestamp slot**: index `timestamp % 8191`, value = the timestamp
+- **Root slot**: index `(timestamp % 8191) + 8191`, value = the desired parent beacon block root
+
+Example using ethers.js:
+
+```javascript
+const BEACON_ROOTS_ADDRESS = "0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02";
+const HISTORY_BUFFER_LENGTH = 8191n;
+
+const block = await ethers.provider.getBlock("latest");
+const timestamp = BigInt(block.timestamp);
+const timestampSlot = timestamp % HISTORY_BUFFER_LENGTH;
+const rootSlot = timestampSlot + HISTORY_BUFFER_LENGTH;
+
+// Set the timestamp entry
+await ethers.provider.send("hardhat_setStorageAt", [
+  BEACON_ROOTS_ADDRESS,
+  ethers.toBeHex(timestampSlot, 32),
+  ethers.toBeHex(timestamp, 32),
+]);
+
+// Set the beacon root entry
+await ethers.provider.send("hardhat_setStorageAt", [
+  BEACON_ROOTS_ADDRESS,
+  ethers.toBeHex(rootSlot, 32),
+  desiredBeaconRoot,
+]);
+```
+
+## Related issues
+
+- [#1346 — Bug: EDR replay-block tool failing to replay EIP-4788 dependent transactions](https://github.com/NomicFoundation/edr/issues/1346): block replay tool was not populating the beacon root contract's storage from the remote chain.

--- a/spec-compliance/l1/eip-4788.md
+++ b/spec-compliance/l1/eip-4788.md
@@ -4,7 +4,7 @@
 
 ## What the spec requires
 
-EIP-4788 introduces a stateful precompile at `0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02` that stores parent beacon block roots. At the start of each block (Cancun+), a system-level call writes two storage slots into the contract's ring buffer:
+EIP-4788 introduces a system contract — the beacon roots contract at `0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02` — that stores parent beacon block roots in a ring buffer. At the start of each block (Cancun+), a system-level call populates two storage slots:
 
 - Slot `timestamp % 8191` = block timestamp
 - Slot `(timestamp % 8191) + 8191` = parent beacon block root
@@ -13,9 +13,9 @@ Contracts can then query the oracle by providing a timestamp to retrieve the cor
 
 ## What EDR does
 
-EDR assigns deterministic pseudo-random `parent_beacon_block_root` values to locally mined block headers, ensuring unique non-zero values per block. However, these values have no relation to any actual consensus layer, and the pre-block system call that populates the oracle contract's storage is not executed.
+EDR assigns deterministic pseudo-random `parent_beacon_block_root` values to locally mined block headers. However, these values have no relation to any actual consensus layer, and the pre-block system call that populates the oracle contract's storage is not executed.
 
-The beacon root contract bytecode is deployed to state — in local mode by Hardhat via `l1_genesis_state`, and in forked mode it is either fetched from the remote chain (Cancun+ fork point) or injected by EDR (pre-Cancun fork point). In all cases, its storage is not populated by EDR via the system call.
+The beacon root contract bytecode is deployed to state — in local mode by Hardhat via `l1_genesis_state`, and in forked mode it is either fetched from the remote chain (Cancun+ fork point) or injected by EDR (pre-Cancun fork point). EDR does not execute the system call that populates the contract's storage for newly mined blocks.
 
 ## Impact
 

--- a/spec-compliance/op/jovian_da_footprint.md
+++ b/spec-compliance/op/jovian_da_footprint.md
@@ -2,9 +2,19 @@
 
 **Spec**: <https://specs.optimism.io/protocol/jovian/exec-engine.html> **Hardfork**: Jovian **Status**: Partial
 
+## Terminology
+
+The spec, JSON-RPC, and EDR internals use different names for the field affected by this spec gap:
+
+| Spec / JSON-RPC | EDR internal (`BlobGas` struct) |
+| --------------- | ------------------------------- |
+| `blobGasUsed`   | `blob_gas.gas_used`             |
+
+This document uses `blobGasUsed` (the JSON-RPC / spec name) throughout.
+
 ## What the spec requires
 
-Starting with the Jovian hardfork, the OP Stack repurposes the `blobGasUsed` block header field to store the block's DA (Data Availability) footprint. The DA footprint is computed from the estimated compressed size of each non-deposit transaction:
+Starting with the Jovian hardfork, the OP Stack repurposes `blobGasUsed` to store the block's DA (Data Availability) footprint. The DA footprint is computed from the estimated compressed size of each non-deposit transaction:
 
 ```
 daUsageEstimate = max(
@@ -19,7 +29,7 @@ The block's `blobGasUsed` is then set to its total `daFootprint`. This value als
 
 ## What EDR does
 
-EDR does not currently compute `blob_gas_used` using the `daFootprint` calculation. The DA footprint estimation (FastLZ compression, scalar parameters) is not implemented.
+EDR does not currently compute `blobGasUsed` using the `daFootprint` calculation. The DA footprint estimation (FastLZ compression, scalar parameters) is not implemented.
 
 ## Impact
 
@@ -28,9 +38,9 @@ EDR does not currently compute `blob_gas_used` using the `daFootprint` calculati
 
 ## Workarounds
 
-The block replay tool works around this by overriding the `blob_gas` header field with the remote block's value via header overrides. This ensures replayed blocks have the correct `blobGasUsed` without EDR needing to compute the DA footprint locally.
+The block replay tool works around this by overriding the `blob_gas` header field with the remote block's value via header overrides (see `jovian_header_overrides` in `crates/edr_op/src/test_utils.rs`). This ensures replayed blocks have the correct `blobGasUsed` without EDR needing to compute the DA footprint locally.
 
-The same approach can be used at the provider level: override the `blob_gas` field with the expected value when mining blocks.
+The same approach can be used at the provider level: override the `blob_gas` header field with the expected value when mining blocks.
 
 ## Related issues
 

--- a/spec-compliance/op/jovian_da_footprint.md
+++ b/spec-compliance/op/jovian_da_footprint.md
@@ -1,0 +1,37 @@
+# Jovian: `blob_gas_used` / DA Footprint
+
+**Spec**: <https://specs.optimism.io/protocol/jovian/exec-engine.html> **Hardfork**: Jovian **Status**: Partial
+
+## What the spec requires
+
+Starting with the Jovian hardfork, the OP Stack repurposes the `blobGasUsed` block header field to store the block's DA (Data Availability) footprint. The DA footprint is computed from the estimated compressed size of each non-deposit transaction:
+
+```
+daUsageEstimate = max(
+    minTransactionSize,
+    (intercept + fastlzCoef * tx.fastlzSize) // 1e6
+)
+
+daFootprint += daUsageEstimate * daFootprintGasScalar
+```
+
+The block's `blobGasUsed` is then set to its total `daFootprint`. This value also affects base fee calculations: `gasMetered = max(gasUsed, blobGasUsed)` replaces the previous `gasUsed` in the EIP-1559 base fee formula.
+
+## What EDR does
+
+EDR does not currently compute `blob_gas_used` using the `daFootprint` calculation. The DA footprint estimation (FastLZ compression, scalar parameters) is not implemented.
+
+## Impact
+
+- `blobGasUsed` in block headers will not reflect the DA footprint as specified
+- Base fee calculations for subsequent blocks may diverge from the spec, since `gasMetered` depends on `blobGasUsed`
+
+## Workarounds
+
+The block replay tool works around this by overriding the `blob_gas` header field with the remote block's value via header overrides. This ensures replayed blocks have the correct `blobGasUsed` without EDR needing to compute the DA footprint locally.
+
+The same approach can be used at the provider level: override the `blob_gas` field with the expected value when mining blocks.
+
+## Related issues
+
+- [#1212 — Fully support OP Jovian hardfork](https://github.com/NomicFoundation/edr/issues/1212): implementing the DA footprint calculation would change this status from Partial to fully supported.


### PR DESCRIPTION
## Summary

Add a `spec-compliance/` directory documenting EIPs and chain specifications that EDR does not support or only partially supports.

The main goal is to have public records of what's not supported in EDR and why, serving as a reference for EDR contributors, Hardhat power users, and future EDR-library consumers who integrate EDR outside of Hardhat. This is a starting point, not an exhaustive list. Rhe expectation is that it grows alongside EDR as new hardforks and chain specs are adopted.

## Structure

- `spec-compliance/README.md` — index with status definitions and tables grouped by chain type (L1 Ethereum, OP Stack) and ordered by hardfork
- `spec-compliance/l1/` — detailed docs for L1 Ethereum specs
- `spec-compliance/op/` — detailed docs for OP Stack specs
