### PR TITLE
fix(op): Jovian+ `base_fee` calculation

### DIFF
--- a/.changeset/bright-chicken-travel.md
+++ b/.changeset/bright-chicken-travel.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Fixed OP stack Jovian base fee calculation to use `max(gasUsed, blobGasUsed)`

--- a/crates/block/header/src/lib.rs
+++ b/crates/block/header/src/lib.rs
@@ -346,6 +346,7 @@ impl PartialHeader {
                 Some(if let Some(parent) = &parent {
                     calculate_next_base_fee_per_gas(
                         parent,
+                        u128::from(parent.gas_used),
                         overrides
                             .base_fee_params
                             .as_ref()
@@ -594,6 +595,7 @@ pub fn overridden_block_number<HardforkT>(
 /// Panics if the parent header does not contain a base fee.
 pub fn calculate_next_base_fee_per_gas<HardforkT: PartialOrd>(
     parent: &BlockHeader,
+    gas_used: u128,
     base_fee_params: &BaseFeeParams<HardforkT>,
     hardfork: HardforkT,
 ) -> u128 {
@@ -605,7 +607,6 @@ pub fn calculate_next_base_fee_per_gas<HardforkT: PartialOrd>(
     // Adapted from https://github.com/alloy-rs/alloy/blob/main/crates/eips/src/eip1559/helpers.rs#L41
     // modifying it to support `u128`.
     // TODO: Remove once https://github.com/alloy-rs/alloy/issues/2181 has been addressed.
-    let gas_used = u128::from(parent.gas_used);
     let gas_limit = u128::from(parent.gas_limit);
 
     // In reality, [EIP-1559] specifies an initial base fee block number at which to

--- a/crates/block/header/src/lib.rs
+++ b/crates/block/header/src/lib.rs
@@ -587,8 +587,15 @@ pub fn overridden_block_number<HardforkT>(
     })
 }
 
-/// Calculates the next base fee for a post-London block, given the parent's
-/// header.
+/// Calculates the next base fee for a post-London block.
+///
+/// Inputs to the EIP-1559 update formula:
+/// - `gas_used` — from the `gas_used` parameter
+/// - `gas_limit` and `base_fee_per_gas` — from `parent`
+/// - elasticity multiplier and max change denominator — from `base_fee_params`
+///
+/// `gas_used` is a parameter to support non-standard calculations; for
+/// standard EIP-1559, pass `u128::from(parent.gas_used)`.
 ///
 /// # Panics
 ///

--- a/crates/block/header/tests/integration/base_fee.rs
+++ b/crates/block/header/tests/integration/base_fee.rs
@@ -175,6 +175,7 @@ fn test_partial_header_uses_override_with_parent_after_london() {
         partial_header.base_fee,
         Some(calculate_next_base_fee_per_gas(
             &parent_header,
+            u128::from(parent_header.gas_used),
             &base_fee_params,
             edr_chain_l1::Hardfork::LONDON
         ))

--- a/crates/edr_chain_l1/src/spec.rs
+++ b/crates/edr_chain_l1/src/spec.rs
@@ -219,7 +219,12 @@ impl ProviderChainSpec for L1ChainSpec {
         hardfork: Self::Hardfork,
         default_base_fee_params: &BaseFeeParams<Self::Hardfork>,
     ) -> u128 {
-        calculate_next_base_fee_per_gas(header, default_base_fee_params, hardfork)
+        calculate_next_base_fee_per_gas(
+            header,
+            u128::from(header.gas_used),
+            default_base_fee_params,
+            hardfork,
+        )
     }
 
     fn default_schedulded_blob_params() -> Option<ScheduledBlobParams> {

--- a/crates/edr_op/src/spec.rs
+++ b/crates/edr_op/src/spec.rs
@@ -295,11 +295,14 @@ pub(crate) fn op_next_base_fee(
             .blob_gas
             .as_ref()
             .map_or(0, |blob_gas| u128::from(blob_gas.gas_used));
+
         let gas_metered = core::cmp::max(u128::from(parent_header.gas_used), parent_blob_gas_used);
         let base_fee_per_gas =
             calculate_next_base_fee_per_gas(parent_header, gas_metered, base_fee_params, hardfork);
+
         let min_base_fee = decode_min_base_fee(&parent_header.extra_data)
             .expect("Jovian should have min base fee defined in extra data");
+
         core::cmp::max(base_fee_per_gas, min_base_fee)
     } else {
         calculate_next_base_fee_per_gas(
@@ -523,7 +526,7 @@ mod tests {
             // gas_used == target → no-change under standard EIP-1559 if blob is ignored.
             let parent = parent_with(GAS_TARGET, Some(10_000_000), Bytes::default());
 
-            let result = super::super::op_next_base_fee(
+            let result = op_next_base_fee(
                 &parent,
                 Hardfork::HOLOCENE,
                 &BaseFeeParams::Constant(BASE_FEE_PARAMS),
@@ -539,7 +542,7 @@ mod tests {
             let extra_data = encode_dynamic_base_fee_params_jovian(&BASE_FEE_PARAMS, 1);
             let parent = parent_with(GAS_TARGET, Some(2 * GAS_TARGET), extra_data);
 
-            let result = super::super::op_next_base_fee(
+            let result = op_next_base_fee(
                 &parent,
                 Hardfork::JOVIAN,
                 &BaseFeeParams::Constant(BASE_FEE_PARAMS),
@@ -554,7 +557,7 @@ mod tests {
             // the same next base fee.
             let extra_data = encode_dynamic_base_fee_params_jovian(&BASE_FEE_PARAMS, 1);
             let equivalent_parent = parent_with(2 * GAS_TARGET, None, extra_data);
-            let equivalent_result = super::super::op_next_base_fee(
+            let equivalent_result = op_next_base_fee(
                 &equivalent_parent,
                 Hardfork::JOVIAN,
                 &BaseFeeParams::Constant(BASE_FEE_PARAMS),
@@ -568,7 +571,7 @@ mod tests {
             // gas_used > target, blob_gas_used tiny → gas_metered = gas_used.
             let parent = parent_with(2 * GAS_TARGET, Some(1_000), extra_data);
 
-            let jovian_result = super::super::op_next_base_fee(
+            let jovian_result = op_next_base_fee(
                 &parent,
                 Hardfork::JOVIAN,
                 &BaseFeeParams::Constant(BASE_FEE_PARAMS),
@@ -576,7 +579,7 @@ mod tests {
 
             // Pre-Jovian result for the same header should match, since gas_used dominates.
             let pre_jovian_parent = parent_with(2 * GAS_TARGET, Some(1_000), Bytes::default());
-            let pre_jovian_result = super::super::op_next_base_fee(
+            let pre_jovian_result = op_next_base_fee(
                 &pre_jovian_parent,
                 Hardfork::HOLOCENE,
                 &BaseFeeParams::Constant(BASE_FEE_PARAMS),
@@ -590,12 +593,12 @@ mod tests {
             let with_blob_zero = parent_with(2 * GAS_TARGET, Some(0), extra_data.clone());
             let without_blob = parent_with(2 * GAS_TARGET, None, extra_data);
 
-            let result_with_blob_zero = super::super::op_next_base_fee(
+            let result_with_blob_zero = op_next_base_fee(
                 &with_blob_zero,
                 Hardfork::JOVIAN,
                 &BaseFeeParams::Constant(BASE_FEE_PARAMS),
             );
-            let result_without_blob = super::super::op_next_base_fee(
+            let result_without_blob = op_next_base_fee(
                 &without_blob,
                 Hardfork::JOVIAN,
                 &BaseFeeParams::Constant(BASE_FEE_PARAMS),
@@ -614,7 +617,7 @@ mod tests {
             // gas_used well under target → base fee decreases below min_base_fee.
             let parent = parent_with(1_000_000, None, extra_data);
 
-            let result = super::super::op_next_base_fee(
+            let result = op_next_base_fee(
                 &parent,
                 Hardfork::HOLOCENE,
                 &BaseFeeParams::Constant(BASE_FEE_PARAMS),
@@ -640,7 +643,7 @@ mod tests {
             // gas_used well under target → unclamped base fee decreases below min_base_fee.
             let parent = parent_with(GAS_TARGET / 5, None, extra_data);
 
-            let result = super::super::op_next_base_fee(
+            let result = op_next_base_fee(
                 &parent,
                 Hardfork::JOVIAN,
                 &BaseFeeParams::Constant(BASE_FEE_PARAMS),
@@ -663,7 +666,7 @@ mod tests {
             let extra_data = encode_dynamic_base_fee_params_jovian(&BASE_FEE_PARAMS, min_base_fee);
             let parent = parent_with(1_000_000, None, extra_data);
 
-            let result = super::super::op_next_base_fee(
+            let result = op_next_base_fee(
                 &parent,
                 Hardfork::JOVIAN,
                 &BaseFeeParams::Constant(BASE_FEE_PARAMS),

--- a/crates/edr_op/src/spec.rs
+++ b/crates/edr_op/src/spec.rs
@@ -485,4 +485,198 @@ mod tests {
             .expect("Blob excess gas should be set");
         assert_eq!(blob_excess_gas.excess_blob_gas, excess_gas);
     }
+
+    mod op_next_base_fee {
+        use edr_eip1559::ConstantBaseFeeParams;
+
+        use super::*;
+
+        // With these parameters, `gas_target = gas_limit / elasticity = 5M`.
+        const GAS_LIMIT: u64 = 30_000_000;
+        const GAS_TARGET: u64 = 5_000_000;
+        const PARENT_BASE_FEE: u128 = 1_000_000_000;
+        const BASE_FEE_PARAMS: ConstantBaseFeeParams = ConstantBaseFeeParams {
+            max_change_denominator: 300,
+            elasticity_multiplier: 6,
+        };
+
+        fn parent_with(
+            gas_used: u64,
+            blob_gas_used: Option<u64>,
+            extra_data: Bytes,
+        ) -> BlockHeader {
+            BlockHeader {
+                gas_limit: GAS_LIMIT,
+                gas_used,
+                base_fee_per_gas: Some(PARENT_BASE_FEE),
+                blob_gas: blob_gas_used.map(|gas_used| BlobGas {
+                    gas_used,
+                    excess_gas: 0,
+                }),
+                extra_data,
+                ..BlockHeader::default()
+            }
+        }
+
+        #[test]
+        fn pre_jovian_ignores_blob_gas_used() {
+            // gas_used == target → no-change under standard EIP-1559 if blob is ignored.
+            let parent = parent_with(GAS_TARGET, Some(10_000_000), Bytes::default());
+
+            let result = super::super::op_next_base_fee(
+                &parent,
+                Hardfork::HOLOCENE,
+                &BaseFeeParams::Constant(BASE_FEE_PARAMS),
+            );
+
+            assert_eq!(result, PARENT_BASE_FEE);
+        }
+
+        #[test]
+        fn jovian_uses_blob_gas_when_larger_than_gas_used() {
+            // gas_used == target (would be no-change alone); blob_gas_used = 2 * target
+            // should drive the base fee up via gas_metered = max(gas_used, blob_gas_used).
+            let extra_data = encode_dynamic_base_fee_params_jovian(&BASE_FEE_PARAMS, 1);
+            let parent = parent_with(GAS_TARGET, Some(2 * GAS_TARGET), extra_data);
+
+            let result = super::super::op_next_base_fee(
+                &parent,
+                Hardfork::JOVIAN,
+                &BaseFeeParams::Constant(BASE_FEE_PARAMS),
+            );
+
+            assert!(
+                result > PARENT_BASE_FEE,
+                "base fee should increase when blob_gas_used exceeds the target"
+            );
+
+            // Equivalent parent with the blob usage moved into gas_used should yield
+            // the same next base fee.
+            let extra_data = encode_dynamic_base_fee_params_jovian(&BASE_FEE_PARAMS, 1);
+            let equivalent_parent = parent_with(2 * GAS_TARGET, None, extra_data);
+            let equivalent_result = super::super::op_next_base_fee(
+                &equivalent_parent,
+                Hardfork::JOVIAN,
+                &BaseFeeParams::Constant(BASE_FEE_PARAMS),
+            );
+            assert_eq!(result, equivalent_result);
+        }
+
+        #[test]
+        fn jovian_uses_gas_used_when_larger_than_blob_gas() {
+            let extra_data = encode_dynamic_base_fee_params_jovian(&BASE_FEE_PARAMS, 1);
+            // gas_used > target, blob_gas_used tiny → gas_metered = gas_used.
+            let parent = parent_with(2 * GAS_TARGET, Some(1_000), extra_data);
+
+            let jovian_result = super::super::op_next_base_fee(
+                &parent,
+                Hardfork::JOVIAN,
+                &BaseFeeParams::Constant(BASE_FEE_PARAMS),
+            );
+
+            // Pre-Jovian result for the same header should match, since gas_used dominates.
+            let pre_jovian_parent = parent_with(2 * GAS_TARGET, Some(1_000), Bytes::default());
+            let pre_jovian_result = super::super::op_next_base_fee(
+                &pre_jovian_parent,
+                Hardfork::HOLOCENE,
+                &BaseFeeParams::Constant(BASE_FEE_PARAMS),
+            );
+            assert_eq!(jovian_result, pre_jovian_result);
+        }
+
+        #[test]
+        fn jovian_treats_missing_blob_gas_as_zero() {
+            let extra_data = encode_dynamic_base_fee_params_jovian(&BASE_FEE_PARAMS, 1);
+            let with_blob_zero = parent_with(2 * GAS_TARGET, Some(0), extra_data.clone());
+            let without_blob = parent_with(2 * GAS_TARGET, None, extra_data);
+
+            let result_with_blob_zero = super::super::op_next_base_fee(
+                &with_blob_zero,
+                Hardfork::JOVIAN,
+                &BaseFeeParams::Constant(BASE_FEE_PARAMS),
+            );
+            let result_without_blob = super::super::op_next_base_fee(
+                &without_blob,
+                Hardfork::JOVIAN,
+                &BaseFeeParams::Constant(BASE_FEE_PARAMS),
+            );
+
+            assert_eq!(result_with_blob_zero, result_without_blob);
+        }
+
+        #[test]
+        fn pre_jovian_does_not_clamp_to_min_base_fee() {
+            // Even with a Jovian-encoded extra_data carrying a high min_base_fee, the
+            // pre-Jovian path must not apply the clamp — it should ignore extra_data
+            // entirely.
+            let min_base_fee = 999_000_000u128;
+            let extra_data = encode_dynamic_base_fee_params_jovian(&BASE_FEE_PARAMS, min_base_fee);
+            // gas_used well under target → base fee decreases below min_base_fee.
+            let parent = parent_with(1_000_000, None, extra_data);
+
+            let result = super::super::op_next_base_fee(
+                &parent,
+                Hardfork::HOLOCENE,
+                &BaseFeeParams::Constant(BASE_FEE_PARAMS),
+            );
+
+            let expected = calculate_next_base_fee_per_gas(
+                &parent,
+                u128::from(parent.gas_used),
+                &BaseFeeParams::Constant(BASE_FEE_PARAMS),
+                Hardfork::HOLOCENE,
+            );
+            assert_eq!(result, expected);
+            assert!(
+                result < min_base_fee,
+                "pre-Jovian result should be below min_base_fee (i.e. un-clamped)"
+            );
+        }
+
+        #[test]
+        fn jovian_clamps_to_min_base_fee() {
+            let min_base_fee = 999_000_000u128;
+            let extra_data = encode_dynamic_base_fee_params_jovian(&BASE_FEE_PARAMS, min_base_fee);
+            // gas_used well under target → unclamped base fee decreases below min_base_fee.
+            let parent = parent_with(GAS_TARGET / 5, None, extra_data);
+
+            let result = super::super::op_next_base_fee(
+                &parent,
+                Hardfork::JOVIAN,
+                &BaseFeeParams::Constant(BASE_FEE_PARAMS),
+            );
+
+            // Sanity: the un-clamped result would be below min_base_fee.
+            let unclamped = calculate_next_base_fee_per_gas(
+                &parent,
+                u128::from(parent.gas_used),
+                &BaseFeeParams::Constant(BASE_FEE_PARAMS),
+                Hardfork::JOVIAN,
+            );
+            assert!(unclamped < min_base_fee);
+            assert_eq!(result, min_base_fee);
+        }
+
+        #[test]
+        fn jovian_does_not_clamp_when_above_min_base_fee() {
+            let min_base_fee = 1u128;
+            let extra_data = encode_dynamic_base_fee_params_jovian(&BASE_FEE_PARAMS, min_base_fee);
+            let parent = parent_with(1_000_000, None, extra_data);
+
+            let result = super::super::op_next_base_fee(
+                &parent,
+                Hardfork::JOVIAN,
+                &BaseFeeParams::Constant(BASE_FEE_PARAMS),
+            );
+
+            let expected = calculate_next_base_fee_per_gas(
+                &parent,
+                u128::from(parent.gas_used),
+                &BaseFeeParams::Constant(BASE_FEE_PARAMS),
+                Hardfork::JOVIAN,
+            );
+            assert_eq!(result, expected);
+            assert!(result > min_base_fee);
+        }
+    }
 }

--- a/crates/edr_op/src/spec.rs
+++ b/crates/edr_op/src/spec.rs
@@ -273,27 +273,41 @@ pub(crate) fn op_base_fee_params_for_block(
     }
 }
 
-/// Calculate next `base_fee` for OP stack block
+/// Calculates the next block's `base_fee` for an OP stack chain.
 ///
-/// If Jovian is activated, clamps the standard EVM calculation result to the
-/// minimum encoded in `extra_data` field See <https://specs.optimism.io/protocol/jovian/exec-engine.html#minimum-base-fee-in-block-header>
+/// Pre-Jovian: applies the standard EIP-1559 update over the parent's
+/// `gas_used`.
+///
+/// From Jovian onward, two changes apply:
+/// - `gasMetered := max(gasUsed, blobGasUsed)` is used in place of `gasUsed`,
+///   where `blobGasUsed` carries the parent block's DA footprint. See
+///   <https://specs.optimism.io/protocol/jovian/exec-engine.html#da-footprint-block-limit>.
+/// - The result is clamped to the minimum base fee encoded in the parent's
+///   `extra_data`. See
+///   <https://specs.optimism.io/protocol/jovian/exec-engine.html#minimum-base-fee-in-block-header>.
 pub(crate) fn op_next_base_fee(
     parent_header: &BlockHeader,
     hardfork: Hardfork,
     base_fee_params: &BaseFeeParams<Hardfork>,
 ) -> u128 {
-    let base_fee_per_gas =
-        calculate_next_base_fee_per_gas(parent_header, base_fee_params, hardfork);
     if hardfork >= Hardfork::JOVIAN {
+        let parent_blob_gas_used = parent_header
+            .blob_gas
+            .as_ref()
+            .map_or(0, |blob_gas| u128::from(blob_gas.gas_used));
+        let gas_metered = core::cmp::max(u128::from(parent_header.gas_used), parent_blob_gas_used);
+        let base_fee_per_gas =
+            calculate_next_base_fee_per_gas(parent_header, gas_metered, base_fee_params, hardfork);
         let min_base_fee = decode_min_base_fee(&parent_header.extra_data)
             .expect("Jovian should have min base fee defined in extra data");
-        if base_fee_per_gas < min_base_fee {
-            min_base_fee
-        } else {
-            base_fee_per_gas
-        }
+        core::cmp::max(base_fee_per_gas, min_base_fee)
     } else {
-        base_fee_per_gas
+        calculate_next_base_fee_per_gas(
+            parent_header,
+            u128::from(parent_header.gas_used),
+            base_fee_params,
+            hardfork,
+        )
     }
 }
 

--- a/crates/edr_op/tests/integration/dynamic_base_fee_params.rs
+++ b/crates/edr_op/tests/integration/dynamic_base_fee_params.rs
@@ -91,6 +91,7 @@ impl_test_dynamic_base_fee_params! {
         39_647_879, // SystemConfig EIP-1559 update 2025-12-18
         41_711_238, // SystemConfig EIP-1559 update 2026-02-04
         43_841_215, // SystemConfig EIP-1559 update 2026-03-25
+        44_467_358, // Jovian+ Block with exceeding `blobGasUsed`
     ],
     op_sepolia: json_rpc_url_provider::op_sepolia() => [
         26_806_602,


### PR DESCRIPTION
## Context 
When implementing #1213 I missed the impact the following sentence had in the `base_fee` calculation

> Furthermore, from Jovian, the base fee update calculation now uses `gasMetered := max(gasUsed, blobGasUsed)` in place of the `gasUsed` value used before. As a result, blocks with high DA usage may cause the base fee to increase in subsequent blocks.

source: [ Jovian spec da-footprint section](https://specs.optimism.io/protocol/jovian/exec-engine.html#da-footprint-block-limit) 

Niran pointed us to it on https://github.com/base/node/issues/883#issuecomment-4269635982

## Changes
This PR introduces the changes necessary for tweaking the OP base fee calculation to follow the spec accordingly. 

Note: Even if Jovian is still not fully implemented in EDR (`da_footprint` is not calculated), this change guarantees that if the `blob_gas` is overwritten properly (like in block-replay tool) the calculation matches Jovian spec