### PR TITLE
feat(solidity-tests): support EIP-712 cheatcodes

### DIFF
--- a/.changeset/fair-humans-fall.md
+++ b/.changeset/fair-humans-fall.md
@@ -1,0 +1,6 @@
+---
+"@nomicfoundation/edr": minor
+---
+
+- Added support for EIP-712 cheatcodes `eip712HashType`, `eip712HashStruct`, `eip712HashTypedData`.
+- Addded new `eip712CanonicalTypes` solidity runner config option for name-based type resolution.

--- a/.changeset/fair-humans-fall.md
+++ b/.changeset/fair-humans-fall.md
@@ -3,4 +3,4 @@
 ---
 
 - Added support for EIP-712 cheatcodes `eip712HashType`, `eip712HashStruct`, `eip712HashTypedData`.
-- Addded new `eip712CanonicalTypes` solidity runner config option for name-based type resolution.
+- Added new `eip712CanonicalTypes` solidity runner config option for name-based type resolution.

--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -1639,11 +1639,6 @@ export declare class EdrContext {
    *   with the results of each test suite as soon as it finished executing.
    */
   runSolidityTests(chainType: string, artifacts: Array<Artifact>, testSuites: Array<ArtifactId>, configArgs: SolidityTestRunnerConfigArgs, tracingConfig: TracingConfigWithBuffers, onTestSuiteCompletedCallback: (result: SuiteResult) => void): Promise<SolidityTestResult>
-  /**
-   *Creates a mock provider, which always returns the given response.
-   *For testing purposes.
-   */
-  createMockProvider(mockedResponse: any): Provider
 }
 export declare class ContractDecoder {
   /**Creates an empty instance. */

--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -795,6 +795,29 @@ export interface SolidityTestRunnerConfigArgs {
    * Defaults to none.
    */
   testFunctionOverrides?: Array<TestFunctionOverride>
+  /**
+   * A list of EIP-712 canonical type definitions that can be referenced
+   * by type name in the `eip712HashType` and `eip712HashStruct` cheatcodes.
+   *
+   * The type of a struct is encoded as:
+   *
+   * `name ‖ "(" ‖ member₁ ‖ "," ‖ member₂ ‖ "," ‖ … ‖ memberₙ ")"`
+   *
+   * where each member is written as `type ‖ " " ‖ name`.
+   *
+   * For example, the following struct:
+   *
+   * ```
+   *  struct Mail {
+   *    address from;
+   *    address to;
+   *    string contents;
+   *  }
+   * ```
+   *
+   * is encoded as `Mail(address from,address to,string contents)`.
+   */
+  eip712CanonicalTypes?: Array<string>
 }
 /** Fuzz testing configuration */
 export interface FuzzConfigArgs {

--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -796,8 +796,18 @@ export interface SolidityTestRunnerConfigArgs {
    */
   testFunctionOverrides?: Array<TestFunctionOverride>
   /**
-   * A list of EIP-712 canonical type definitions that can be referenced
-   * by type name in the `eip712HashType` and `eip712HashStruct` cheatcodes.
+   * A list of EIP-712 canonical type definitions that can be referenced by
+   * type name in the `eip712HashType` and `eip712HashStruct` cheatcodes.
+   *
+   * Each entry is an independent, self-contained type definition. A
+   * definition that references nested struct types must inline those
+   * struct definitions, per the EIP-712 `encodeType` spec.
+   *
+   * Only the primary (leftmost) type of each entry is registered by name.
+   * Nested struct types referenced inside an entry are *not* registered
+   * under their own names. To look up a nested struct by name from a
+   * cheatcode, add it as a separate top-level entry whose primary type
+   * is the nested struct.
    *
    * The type of a struct is encoded as:
    *
@@ -805,17 +815,18 @@ export interface SolidityTestRunnerConfigArgs {
    *
    * where each member is written as `type ‖ " " ‖ name`.
    *
-   * For example, the following struct:
+   * Entries that fail to parse cause a startup error listing every bad
+   * entry.
    *
-   * ```
-   *  struct Mail {
-   *    address from;
-   *    address to;
-   *    string contents;
-   *  }
+   * Example — to make both `Mail` and `Person` reachable by name:
+   *
+   * ```text
+   * "Mail(Person from,Person to,string contents)Person(address wallet,string name)"
+   * "Person(address wallet,string name)"
    * ```
    *
-   * is encoded as `Mail(address from,address to,string contents)`.
+   * With *only* the first entry, `vm.eip712HashType("Mail")` works but
+   * `vm.eip712HashType("Person")` fails with an unknown-type error.
    */
   eip712CanonicalTypes?: Array<string>
 }
@@ -1628,6 +1639,11 @@ export declare class EdrContext {
    *   with the results of each test suite as soon as it finished executing.
    */
   runSolidityTests(chainType: string, artifacts: Array<Artifact>, testSuites: Array<ArtifactId>, configArgs: SolidityTestRunnerConfigArgs, tracingConfig: TracingConfigWithBuffers, onTestSuiteCompletedCallback: (result: SuiteResult) => void): Promise<SolidityTestResult>
+  /**
+   *Creates a mock provider, which always returns the given response.
+   *For testing purposes.
+   */
+  createMockProvider(mockedResponse: any): Provider
 }
 export declare class ContractDecoder {
   /**Creates an empty instance. */

--- a/crates/edr_napi/src/solidity_tests/config.rs
+++ b/crates/edr_napi/src/solidity_tests/config.rs
@@ -167,6 +167,38 @@ pub struct SolidityTestRunnerConfigArgs {
     /// Test function level config overrides.
     /// Defaults to none.
     pub test_function_overrides: Option<Vec<TestFunctionOverride>>,
+    /// A list of EIP-712 canonical type definitions that can be referenced by
+    /// type name in the `eip712HashType` and `eip712HashStruct` cheatcodes.
+    ///
+    /// Each entry is an independent, self-contained type definition. A
+    /// definition that references nested struct types must inline those
+    /// struct definitions, per the EIP-712 `encodeType` spec.
+    ///
+    /// Only the primary (leftmost) type of each entry is registered by name.
+    /// Nested struct types referenced inside an entry are *not* registered
+    /// under their own names. To look up a nested struct by name from a
+    /// cheatcode, add it as a separate top-level entry whose primary type
+    /// is the nested struct.
+    ///
+    /// The type of a struct is encoded as:
+    ///
+    /// `name ‖ "(" ‖ member₁ ‖ "," ‖ member₂ ‖ "," ‖ … ‖ memberₙ ")"`
+    ///
+    /// where each member is written as `type ‖ " " ‖ name`.
+    ///
+    /// Entries that fail to parse cause a startup error listing every bad
+    /// entry.
+    ///
+    /// Example — to make both `Mail` and `Person` reachable by name:
+    ///
+    /// ```text
+    /// "Mail(Person from,Person to,string contents)Person(address wallet,string name)"
+    /// "Person(address wallet,string name)"
+    /// ```
+    ///
+    /// With *only* the first entry, `vm.eip712HashType("Mail")` works but
+    /// `vm.eip712HashType("Person")` fails with an unknown-type error.
+    pub eip712_canonical_types: Option<Vec<String>>,
 }
 
 impl SolidityTestRunnerConfigArgs {
@@ -215,6 +247,7 @@ impl SolidityTestRunnerConfigArgs {
             test_pattern,
             generate_gas_report,
             test_function_overrides,
+            eip712_canonical_types,
         } = self;
 
         let test_pattern = TestFilterConfig {
@@ -294,6 +327,17 @@ impl SolidityTestRunnerConfigArgs {
                 })
                 .transpose()?
                 .unwrap_or_default(),
+            eip712_types_by_name: foundry_cheatcodes::parse_eip712_canonical_types(
+                eip712_canonical_types.unwrap_or_default(),
+            )
+            .map_err(|errors| {
+                let msg = errors
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
+                    .join("; ");
+                napi::Error::new(Status::InvalidArg, msg)
+            })?,
         };
 
         let on_collected_coverage_fn = observability.map_or_else(

--- a/crates/edr_napi/test/solidity-tests.ts
+++ b/crates/edr_napi/test/solidity-tests.ts
@@ -107,6 +107,38 @@ describe("Solidity Tests", () => {
     );
   });
 
+  it("rejects invalid eip712CanonicalTypes as InvalidArg", async function () {
+    // Boundary check only: an invalid eip712CanonicalTypes entry must
+    // reject with an InvalidArg error. The exhaustive semantics
+    // (collecting every bad entry, duplicate detection, etc.) are covered
+    // by `parse_eip712_canonical_types` unit tests in the cheatcodes crate.
+    const artifacts = [
+      loadContract("./data/artifacts/default/SetupConsistencyCheck.json"),
+    ];
+    const testSuites = artifacts.map((artifact) => artifact.id);
+    const config = {
+      projectRoot: __dirname,
+      hardfork: l1HardforkToString(l1HardforkLatest()),
+      eip712CanonicalTypes: ["gibberish"],
+    };
+
+    let error: any;
+    try {
+      await runAllSolidityTests(
+        context,
+        L1_CHAIN_TYPE,
+        artifacts,
+        testSuites,
+        config
+      );
+    } catch (e) {
+      error = e;
+    }
+
+    assert.isDefined(error);
+    assert.equal(error.code, "InvalidArg");
+  });
+
   it("filters tests according to pattern", async function () {
     const artifacts = [
       loadContract("./data/artifacts/default/SetupConsistencyCheck.json"),

--- a/crates/edr_solidity_tests/tests/testdata/default/cheats/Eip712.t.sol
+++ b/crates/edr_solidity_tests/tests/testdata/default/cheats/Eip712.t.sol
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity 0.8.18;
+
+import "ds-test/test.sol";
+import "cheats/Vm.sol";
+
+// EIP-712 worked example from https://eips.ethereum.org/EIPS/eip-712
+contract Eip712Test is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+
+    string constant MAIL_TYPE =
+        "Mail(Person from,Person to,string contents)Person(string name,address wallet)";
+    string constant PERSON_TYPE = "Person(string name,address wallet)";
+
+    struct Person {
+        string name;
+        address wallet;
+    }
+
+    struct Mail {
+        Person from;
+        Person to;
+        string contents;
+    }
+
+    address constant COW = 0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826;
+    address constant BOB = 0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB;
+
+    function _mail() internal pure returns (Mail memory) {
+        return
+            Mail({
+                from: Person({name: "Cow", wallet: COW}),
+                to: Person({name: "Bob", wallet: BOB}),
+                contents: "Hello, Bob!"
+            });
+    }
+
+    function _hashPerson(Person memory p) internal pure returns (bytes32) {
+        return
+            keccak256(
+                abi.encode(
+                    keccak256(bytes(PERSON_TYPE)),
+                    keccak256(bytes(p.name)),
+                    p.wallet
+                )
+            );
+    }
+
+    function _hashMail(Mail memory m) internal pure returns (bytes32) {
+        return
+            keccak256(
+                abi.encode(
+                    keccak256(bytes(MAIL_TYPE)),
+                    _hashPerson(m.from),
+                    _hashPerson(m.to),
+                    keccak256(bytes(m.contents))
+                )
+            );
+    }
+
+    function testEip712HashType() public {
+        assertEq(vm.eip712HashType(MAIL_TYPE), keccak256(bytes(MAIL_TYPE)));
+    }
+
+    function testEip712HashTypeNormalizesWhitespace() public {
+        // Non-canonical whitespace after commas should be normalized before hashing.
+        assertEq(
+            vm.eip712HashType(
+                "Mail(address from, address to, string contents)"
+            ),
+            keccak256(bytes("Mail(address from,address to,string contents)"))
+        );
+    }
+
+    function testEip712HashStruct() public {
+        Mail memory m = _mail();
+        assertEq(vm.eip712HashStruct(MAIL_TYPE, abi.encode(m)), _hashMail(m));
+    }
+
+    function testEip712HashTypedData() public {
+        string memory json = '{"types":{'
+        '"EIP712Domain":['
+        '{"name":"name","type":"string"},'
+        '{"name":"version","type":"string"},'
+        '{"name":"chainId","type":"uint256"},'
+        '{"name":"verifyingContract","type":"address"}'
+        "],"
+        '"Person":['
+        '{"name":"name","type":"string"},'
+        '{"name":"wallet","type":"address"}'
+        "],"
+        '"Mail":['
+        '{"name":"from","type":"Person"},'
+        '{"name":"to","type":"Person"},'
+        '{"name":"contents","type":"string"}'
+        "]"
+        "},"
+        '"primaryType":"Mail",'
+        '"domain":{'
+        '"name":"Ether Mail",'
+        '"version":"1",'
+        '"chainId":1,'
+        '"verifyingContract":"0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"'
+        "},"
+        '"message":{'
+        '"from":{"name":"Cow","wallet":"0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"},'
+        '"to":{"name":"Bob","wallet":"0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"},'
+        '"contents":"Hello, Bob!"'
+        "}"
+        "}";
+
+        bytes32 domainTypeHash = keccak256(
+            "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+        );
+        bytes32 domainSeparator = keccak256(
+            abi.encode(
+                domainTypeHash,
+                keccak256(bytes("Ether Mail")),
+                keccak256(bytes("1")),
+                uint256(1),
+                address(0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC)
+            )
+        );
+        bytes32 expected = keccak256(
+            abi.encodePacked(
+                bytes2(0x1901),
+                domainSeparator,
+                _hashMail(_mail())
+            )
+        );
+
+        assertEq(vm.eip712HashTypedData(json), expected);
+    }
+
+    // Bindings-path overloads are unsupported: they would require filesystem
+    // access, which EDR intentionally does not provide for EIP-712 cheatcodes.
+    // See https://github.com/NomicFoundation/edr/issues/1365 for context.
+
+    function testEip712HashTypeBindingsPathReverts() public {
+        vm._expectCheatcodeRevert();
+        vm.eip712HashType("bindings.json", "Mail");
+    }
+
+    function testEip712HashStructBindingsPathReverts() public {
+        vm._expectCheatcodeRevert();
+        vm.eip712HashStruct("bindings.json", "Mail", hex"");
+    }
+}

--- a/crates/foundry/cheatcodes/Cargo.toml
+++ b/crates/foundry/cheatcodes/Cargo.toml
@@ -51,7 +51,7 @@ revm.workspace = true
 revm-inspectors.workspace = true
 semver.workspace = true
 serde_json.workspace = true
-strum.workspace = true
+strum = { workspace = true, features = ["derive"] }
 thiserror.workspace = true
 toml = { workspace = true, features = ["preserve_order"] }
 tracing.workspace = true

--- a/crates/foundry/cheatcodes/assets/cheatcodes.json
+++ b/crates/foundry/cheatcodes/assets/cheatcodes.json
@@ -4336,7 +4336,7 @@
     {
       "func": {
         "id": "eip712HashStruct_0",
-        "description": "Generates the struct hash of the canonical EIP-712 type representation and its abi-encoded data.\nSupports 2 different inputs:\n 1. Name of a primary type previously declared via the\n    `eip712CanonicalTypes` runner configuration\n 2. String representation of the type (i.e. \"Foo(Bar bar) Bar(uint256 baz)\").\n    * Note: the cheatcode will use the canonical type even if the input is malformed\n            with the wrong order of elements or with extra whitespaces.",
+        "description": "Generates the struct hash of the canonical EIP-712 type representation and its abi-encoded data.\nSupports 2 different inputs:\n 1. Name of a primary type previously declared via the\n    `eip712CanonicalTypes` runner configuration\n 2. String representation of the type (i.e. \"Foo(Bar bar) Bar(uint256 baz)\").\n    Note: the cheatcode will use the canonical type even if the input is malformed\n          with the wrong order of elements or with extra whitespaces.",
         "declaration": "function eip712HashStruct(string calldata typeNameOrDefinition, bytes calldata abiEncodedData) external pure returns (bytes32 typeHash);",
         "visibility": "external",
         "mutability": "pure",
@@ -4376,7 +4376,7 @@
     {
       "func": {
         "id": "eip712HashType_0",
-        "description": "Generates the hash of the canonical EIP-712 type representation.\nSupports 2 different inputs:\n 1. Name of a primary type previously declared via the\n    `eip712CanonicalTypes` runner configuration\n 2. String representation of the type (i.e. \"Foo(Bar bar) Bar(uint256 baz)\").\n    * Note: the cheatcode will output the canonical type even if the input is malformed\n            with the wrong order of elements or with extra whitespaces.",
+        "description": "Generates the hash of the canonical EIP-712 type representation.\nSupports 2 different inputs:\n 1. Name of a primary type previously declared via the\n    `eip712CanonicalTypes` runner configuration.\n 2. String representation of the type (i.e. \"Foo(Bar bar) Bar(uint256 baz)\").\n    Note: the cheatcode will output the canonical type even if the input is malformed\n          with the wrong order of elements or with extra whitespaces.",
         "declaration": "function eip712HashType(string calldata typeNameOrDefinition) external pure returns (bytes32 typeHash);",
         "visibility": "external",
         "mutability": "pure",

--- a/crates/foundry/cheatcodes/assets/cheatcodes.json
+++ b/crates/foundry/cheatcodes/assets/cheatcodes.json
@@ -4336,7 +4336,7 @@
     {
       "func": {
         "id": "eip712HashStruct_0",
-        "description": "Generates the struct hash of the canonical EIP-712 type representation and its abi-encoded data.\nSupports 2 different inputs:\n 1. Name of the type (i.e. \"PermitSingle\")\n    * Requires previous `eip712CanonicalTypes` configuration\n 2. String representation of the type (i.e. \"Foo(Bar bar) Bar(uint256 baz)\").\n    * Note: the cheatcode will use the canonical type even if the input is malformated\n            with the wrong order of elements or with extra whitespaces.",
+        "description": "Generates the struct hash of the canonical EIP-712 type representation and its abi-encoded data.\nSupports 2 different inputs:\n 1. Name of a primary type previously declared via the\n    `eip712CanonicalTypes` runner configuration\n 2. String representation of the type (i.e. \"Foo(Bar bar) Bar(uint256 baz)\").\n    * Note: the cheatcode will use the canonical type even if the input is malformed\n            with the wrong order of elements or with extra whitespaces.",
         "declaration": "function eip712HashStruct(string calldata typeNameOrDefinition, bytes calldata abiEncodedData) external pure returns (bytes32 typeHash);",
         "visibility": "external",
         "mutability": "pure",
@@ -4376,7 +4376,7 @@
     {
       "func": {
         "id": "eip712HashType_0",
-        "description": "Generates the hash of the canonical EIP-712 type representation.\nSupports 2 different inputs:\n 1. Name of the type (i.e. \"Transaction\").\n    * Requires previous `eip712CanonicalTypes` configuration\n 2. String representation of the type (i.e. \"Foo(Bar bar) Bar(uint256 baz)\").\n    * Note: the cheatcode will output the canonical type even if the input is malformated\n            with the wrong order of elements or with extra whitespaces.",
+        "description": "Generates the hash of the canonical EIP-712 type representation.\nSupports 2 different inputs:\n 1. Name of a primary type previously declared via the\n    `eip712CanonicalTypes` runner configuration\n 2. String representation of the type (i.e. \"Foo(Bar bar) Bar(uint256 baz)\").\n    * Note: the cheatcode will output the canonical type even if the input is malformed\n            with the wrong order of elements or with extra whitespaces.",
         "declaration": "function eip712HashType(string calldata typeNameOrDefinition) external pure returns (bytes32 typeHash);",
         "visibility": "external",
         "mutability": "pure",

--- a/crates/foundry/cheatcodes/assets/cheatcodes.json
+++ b/crates/foundry/cheatcodes/assets/cheatcodes.json
@@ -4376,7 +4376,7 @@
     {
       "func": {
         "id": "eip712HashType_0",
-        "description": "Generates the hash of the canonical EIP-712 type representation.\nSupports 2 different inputs:\n 1. Name of a primary type previously declared via the\n    `eip712CanonicalTypes` runner configuration.\n 2. String representation of the type (i.e. \"Foo(Bar bar) Bar(uint256 baz)\").\n    Note: the cheatcode will output the canonical type even if the input is malformed\n          with the wrong order of elements or with extra whitespaces.",
+        "description": "Generates the hash of the canonical EIP-712 type representation.\nSupports 2 different inputs:\n 1. Name of a primary type previously declared via the\n    `eip712CanonicalTypes` runner configuration.\n 2. String representation of the type (i.e. \"Foo(Bar bar) Bar(uint256 baz)\").\n    Note: the cheatcode will use the canonical type even if the input is malformed\n          with the wrong order of elements or with extra whitespaces.",
         "declaration": "function eip712HashType(string calldata typeNameOrDefinition) external pure returns (bytes32 typeHash);",
         "visibility": "external",
         "mutability": "pure",

--- a/crates/foundry/cheatcodes/assets/cheatcodes.json
+++ b/crates/foundry/cheatcodes/assets/cheatcodes.json
@@ -4336,7 +4336,7 @@
     {
       "func": {
         "id": "eip712HashStruct_0",
-        "description": "EIP-712 cheatcodes are not supported.",
+        "description": "Generates the struct hash of the canonical EIP-712 type representation and its abi-encoded data.\nSupports 2 different inputs:\n 1. Name of the type (i.e. \"PermitSingle\")\n    * Requires previous `eip712CanonicalTypes` configuration\n 2. String representation of the type (i.e. \"Foo(Bar bar) Bar(uint256 baz)\").\n    * Note: the cheatcode will use the canonical type even if the input is malformated\n            with the wrong order of elements or with extra whitespaces.",
         "declaration": "function eip712HashStruct(string calldata typeNameOrDefinition, bytes calldata abiEncodedData) external pure returns (bytes32 typeHash);",
         "visibility": "external",
         "mutability": "pure",
@@ -4350,7 +4350,7 @@
         ]
       },
       "group": "utilities",
-      "status": "unsupported",
+      "status": "stable",
       "safety": "safe"
     },
     {
@@ -4376,7 +4376,7 @@
     {
       "func": {
         "id": "eip712HashType_0",
-        "description": "EIP-712 cheatcodes are not supported.",
+        "description": "Generates the hash of the canonical EIP-712 type representation.\nSupports 2 different inputs:\n 1. Name of the type (i.e. \"Transaction\").\n    * Requires previous `eip712CanonicalTypes` configuration\n 2. String representation of the type (i.e. \"Foo(Bar bar) Bar(uint256 baz)\").\n    * Note: the cheatcode will output the canonical type even if the input is malformated\n            with the wrong order of elements or with extra whitespaces.",
         "declaration": "function eip712HashType(string calldata typeNameOrDefinition) external pure returns (bytes32 typeHash);",
         "visibility": "external",
         "mutability": "pure",
@@ -4390,7 +4390,7 @@
         ]
       },
       "group": "utilities",
-      "status": "unsupported",
+      "status": "stable",
       "safety": "safe"
     },
     {
@@ -4416,7 +4416,7 @@
     {
       "func": {
         "id": "eip712HashTypedData",
-        "description": "EIP-712 cheatcodes are not supported.",
+        "description": "Generates a ready-to-sign digest of human-readable typed data following the EIP-712 standard.",
         "declaration": "function eip712HashTypedData(string calldata jsonData) external pure returns (bytes32 digest);",
         "visibility": "external",
         "mutability": "pure",
@@ -4430,7 +4430,7 @@
         ]
       },
       "group": "utilities",
-      "status": "unsupported",
+      "status": "stable",
       "safety": "safe"
     },
     {

--- a/crates/foundry/cheatcodes/spec/src/vm.rs
+++ b/crates/foundry/cheatcodes/spec/src/vm.rs
@@ -2525,6 +2525,34 @@ interface Vm {
     #[cheatcode(group = Utilities, safety = Unsafe)]
     function interceptInitcode() external;
 
+    /// Generates the hash of the canonical EIP-712 type representation.
+    ///
+    /// Supports 2 different inputs:
+    ///  1. Name of the type (i.e. "Transaction").
+    ///     * Requires previous `eip712CanonicalTypes` configuration
+    ///
+    ///  2. String representation of the type (i.e. "Foo(Bar bar) Bar(uint256 baz)").
+    ///     * Note: the cheatcode will output the canonical type even if the input is malformated
+    ///             with the wrong order of elements or with extra whitespaces.
+    #[cheatcode(group = Utilities)]
+    function eip712HashType(string calldata typeNameOrDefinition) external pure returns (bytes32 typeHash);
+
+    /// Generates the struct hash of the canonical EIP-712 type representation and its abi-encoded data.
+    ///
+    /// Supports 2 different inputs:
+    ///  1. Name of the type (i.e. "PermitSingle")
+    ///     * Requires previous `eip712CanonicalTypes` configuration
+    ///
+    ///  2. String representation of the type (i.e. "Foo(Bar bar) Bar(uint256 baz)").
+    ///     * Note: the cheatcode will use the canonical type even if the input is malformated
+    ///             with the wrong order of elements or with extra whitespaces.
+    #[cheatcode(group = Utilities)]
+    function eip712HashStruct(string calldata typeNameOrDefinition, bytes calldata abiEncodedData) external pure returns (bytes32 typeHash);
+
+    /// Generates a ready-to-sign digest of human-readable typed data following the EIP-712 standard.
+    #[cheatcode(group = Utilities)]
+    function eip712HashTypedData(string calldata jsonData) external pure returns (bytes32 digest);
+
     // ======== Unsupported Cheatcodes ========
 
     // -------- Data Structures --------
@@ -2777,23 +2805,13 @@ interface Vm {
 
     /// EIP-712 cheatcodes are not supported.
     #[cheatcode(group = Utilities, status = Unsupported)]
-    function eip712HashType(string calldata typeNameOrDefinition) external pure returns (bytes32 typeHash);
-
-    /// EIP-712 cheatcodes are not supported.
-    #[cheatcode(group = Utilities, status = Unsupported)]
     function eip712HashType(string calldata bindingsPath, string calldata typeName) external pure returns (bytes32 typeHash);
 
-    /// EIP-712 cheatcodes are not supported.
-    #[cheatcode(group = Utilities, status = Unsupported)]
-    function eip712HashStruct(string calldata typeNameOrDefinition, bytes calldata abiEncodedData) external pure returns (bytes32 typeHash);
 
     /// EIP-712 cheatcodes are not supported.
     #[cheatcode(group = Utilities, status = Unsupported)]
     function eip712HashStruct(string calldata bindingsPath, string calldata typeName, bytes calldata abiEncodedData) external pure returns (bytes32 typeHash);
 
-    /// EIP-712 cheatcodes are not supported.
-    #[cheatcode(group = Utilities, status = Unsupported)]
-    function eip712HashTypedData(string calldata jsonData) external pure returns (bytes32 digest);
 
     // -------- Testing --------
 

--- a/crates/foundry/cheatcodes/spec/src/vm.rs
+++ b/crates/foundry/cheatcodes/spec/src/vm.rs
@@ -2529,11 +2529,11 @@ interface Vm {
     ///
     /// Supports 2 different inputs:
     ///  1. Name of a primary type previously declared via the
-    ///     `eip712CanonicalTypes` runner configuration
+    ///     `eip712CanonicalTypes` runner configuration.
     ///
     ///  2. String representation of the type (i.e. "Foo(Bar bar) Bar(uint256 baz)").
-    ///     * Note: the cheatcode will output the canonical type even if the input is malformed
-    ///             with the wrong order of elements or with extra whitespaces.
+    ///     Note: the cheatcode will output the canonical type even if the input is malformed
+    ///           with the wrong order of elements or with extra whitespaces.
     #[cheatcode(group = Utilities)]
     function eip712HashType(string calldata typeNameOrDefinition) external pure returns (bytes32 typeHash);
 
@@ -2544,8 +2544,8 @@ interface Vm {
     ///     `eip712CanonicalTypes` runner configuration
     ///
     ///  2. String representation of the type (i.e. "Foo(Bar bar) Bar(uint256 baz)").
-    ///     * Note: the cheatcode will use the canonical type even if the input is malformed
-    ///             with the wrong order of elements or with extra whitespaces.
+    ///     Note: the cheatcode will use the canonical type even if the input is malformed
+    ///           with the wrong order of elements or with extra whitespaces.
     #[cheatcode(group = Utilities)]
     function eip712HashStruct(string calldata typeNameOrDefinition, bytes calldata abiEncodedData) external pure returns (bytes32 typeHash);
 

--- a/crates/foundry/cheatcodes/spec/src/vm.rs
+++ b/crates/foundry/cheatcodes/spec/src/vm.rs
@@ -2532,7 +2532,7 @@ interface Vm {
     ///     `eip712CanonicalTypes` runner configuration.
     ///
     ///  2. String representation of the type (i.e. "Foo(Bar bar) Bar(uint256 baz)").
-    ///     Note: the cheatcode will output the canonical type even if the input is malformed
+    ///     Note: the cheatcode will use the canonical type even if the input is malformed
     ///           with the wrong order of elements or with extra whitespaces.
     #[cheatcode(group = Utilities)]
     function eip712HashType(string calldata typeNameOrDefinition) external pure returns (bytes32 typeHash);

--- a/crates/foundry/cheatcodes/spec/src/vm.rs
+++ b/crates/foundry/cheatcodes/spec/src/vm.rs
@@ -2528,7 +2528,7 @@ interface Vm {
     /// Generates the hash of the canonical EIP-712 type representation.
     ///
     /// Supports 2 different inputs:
-    ///   1. Name of a primary type previously declared via the
+    ///  1. Name of a primary type previously declared via the
     ///     `eip712CanonicalTypes` runner configuration
     ///
     ///  2. String representation of the type (i.e. "Foo(Bar bar) Bar(uint256 baz)").

--- a/crates/foundry/cheatcodes/spec/src/vm.rs
+++ b/crates/foundry/cheatcodes/spec/src/vm.rs
@@ -2528,11 +2528,11 @@ interface Vm {
     /// Generates the hash of the canonical EIP-712 type representation.
     ///
     /// Supports 2 different inputs:
-    ///  1. Name of the type (i.e. "Transaction").
-    ///     * Requires previous `eip712CanonicalTypes` configuration
+    ///   1. Name of a primary type previously declared via the
+    ///     `eip712CanonicalTypes` runner configuration
     ///
     ///  2. String representation of the type (i.e. "Foo(Bar bar) Bar(uint256 baz)").
-    ///     * Note: the cheatcode will output the canonical type even if the input is malformated
+    ///     * Note: the cheatcode will output the canonical type even if the input is malformed
     ///             with the wrong order of elements or with extra whitespaces.
     #[cheatcode(group = Utilities)]
     function eip712HashType(string calldata typeNameOrDefinition) external pure returns (bytes32 typeHash);
@@ -2540,11 +2540,11 @@ interface Vm {
     /// Generates the struct hash of the canonical EIP-712 type representation and its abi-encoded data.
     ///
     /// Supports 2 different inputs:
-    ///  1. Name of the type (i.e. "PermitSingle")
-    ///     * Requires previous `eip712CanonicalTypes` configuration
+    ///  1. Name of a primary type previously declared via the
+    ///     `eip712CanonicalTypes` runner configuration
     ///
     ///  2. String representation of the type (i.e. "Foo(Bar bar) Bar(uint256 baz)").
-    ///     * Note: the cheatcode will use the canonical type even if the input is malformated
+    ///     * Note: the cheatcode will use the canonical type even if the input is malformed
     ///             with the wrong order of elements or with extra whitespaces.
     #[cheatcode(group = Utilities)]
     function eip712HashStruct(string calldata typeNameOrDefinition, bytes calldata abiEncodedData) external pure returns (bytes32 typeHash);

--- a/crates/foundry/cheatcodes/src/config.rs
+++ b/crates/foundry/cheatcodes/src/config.rs
@@ -11,7 +11,6 @@ use edr_artifact::ArtifactId;
 use edr_common::fs::normalize_path;
 use foundry_compilers::utils::canonicalize;
 use foundry_evm_core::{contracts::ContractsByArtifact, evm_context::HardforkTr, opts::EvmOpts};
-use itertools::Itertools;
 
 use super::{FsAccessKind, FsPermissions, Result, RpcEndpoint, RpcEndpointUrl, RpcEndpoints};
 use crate::{cache::StorageCachingConfig, Vm::Rpc};
@@ -143,8 +142,8 @@ pub enum Eip712ConfigError {
     #[error("failed to canonicalize EIP-712 type {input}: {reason}")]
     Canonicalize { input: String, reason: String },
 
-    #[error("duplicate EIP-712 type name {name}")] // TODO: not being used, should we?
-    DuplicateName { name: String },
+    #[error("duplicate EIP-712 type definition {name}")]
+    DuplicateTypeDef { name: String },
 }
 
 impl PartialEq for TestFunctionIdentifier {
@@ -386,18 +385,21 @@ impl<HardforkT: HardforkTr> CheatsConfig<HardforkT> {
     }
 }
 
-/// Parses and canonicalizes a list of EIP-712 type definitions, keyed by their
+/// Parses and canonicalizes a list of EIP-712 type definitions, keyed by
 /// primary type name.
 ///
-/// Only the **primary** (leftmost) type of each entry is registered by name.
+/// Each entry must be a self-contained canonical definition — nested struct
+/// types referenced by the primary type must be inlined in the same string.
 ///
-/// Returns every error encountered
+/// Only the primary (leftmost) type is registered by name; nested types
+/// are not.
+///
+/// Collects every error encountered rather than stopping at the first.
 pub fn parse_eip712_canonical_types(
     eip712_type_definitions: Vec<String>,
 ) -> Result<HashMap<String, String>, Vec<Eip712ConfigError>> {
-    let (entries, errors): (Vec<_>, Vec<_>) = eip712_type_definitions
-        .into_iter()
-        .map::<Result<(String, String), Eip712ConfigError>, _>(|eip712_definition| {
+    let parse_definition =
+        |eip712_definition: String| -> Result<(String, String), Eip712ConfigError> {
             // Normalize type definitions defensively; downstream relies on canonical form.
             let encode_type = EncodeType::parse(&eip712_definition).map_err(|error| {
                 Eip712ConfigError::Parse {
@@ -408,7 +410,7 @@ pub fn parse_eip712_canonical_types(
             let name = encode_type
                 .types
                 .first()
-                .ok_or(Eip712ConfigError::Parse {
+                .ok_or_else(|| Eip712ConfigError::Parse {
                     input: eip712_definition.clone(),
                     reason: "no parseable type definition found".into(),
                 })?
@@ -423,13 +425,36 @@ pub fn parse_eip712_canonical_types(
                     })?;
 
             Ok((name, canonical))
-        })
-        .partition_result();
+        };
 
-    if !errors.is_empty() {
-        Err(errors)
+    let (eip712_types_by_name, errors) = eip712_type_definitions
+        .into_iter()
+        .map(parse_definition)
+        .fold(
+            (
+                HashMap::<String, String>::new(),
+                Vec::<Eip712ConfigError>::new(),
+            ),
+            |(mut map, mut errors), parsed| {
+                match parsed {
+                    Ok((name, canonical)) => {
+                        // Reject duplicates rather than silently overwriting: conflicting EIP-712
+                        // definitions would yield a wrong hash that's visually indistinguishable
+                        // from a correct one.
+                        if map.insert(name.clone(), canonical).is_some() {
+                            errors.push(Eip712ConfigError::DuplicateTypeDef { name });
+                        }
+                    }
+                    Err(err) => errors.push(err),
+                }
+                (map, errors)
+            },
+        );
+
+    if errors.is_empty() {
+        Ok(eip712_types_by_name)
     } else {
-        Ok(entries.into_iter().collect())
+        Err(errors)
     }
 }
 

--- a/crates/foundry/cheatcodes/src/config.rs
+++ b/crates/foundry/cheatcodes/src/config.rs
@@ -1090,4 +1090,170 @@ mod tests {
             .ensure_path_allowed("./out/OtherFile.sol", FsAccessKind::Write)
             .is_ok());
     }
+
+    mod parse_eip712_canonical_types {
+        //! Fixtures are drawn from the EIP-712 specification's worked example:
+        //! <https://eips.ethereum.org/EIPS/eip-712>.
+        //!
+        //! Canonical encoding rule: primary type first, referenced struct
+        //! types appended in alphabetical order. Members are
+        //! `type ‖ " " ‖ name`, comma-separated, with no other whitespace.
+
+        use super::*;
+
+        const MAIL_WITH_PERSON_CANONICAL: &str =
+            "Mail(Person from,Person to,string contents)Person(address wallet,string name)";
+        const PERSON_CANONICAL: &str = "Person(address wallet,string name)";
+        const SIMPLE_MAIL_CANONICAL: &str = "Mail(address from,address to,string contents)";
+
+        #[test]
+        fn accepts_canonical_input() {
+            let map = super::parse_eip712_canonical_types(vec![SIMPLE_MAIL_CANONICAL.to_string()])
+                .unwrap();
+            assert_eq!(map.len(), 1);
+            assert_eq!(map.get("Mail").unwrap(), SIMPLE_MAIL_CANONICAL);
+        }
+
+        #[test]
+        fn accepts_empty_input() {
+            let map = super::parse_eip712_canonical_types(vec![]).unwrap();
+            assert!(map.is_empty());
+        }
+
+        #[test]
+        fn normalizes_whitespace() {
+            // Extra whitespace after commas — not canonical per EIP-712.
+            let noisy = "Mail(address from, address to, string contents)";
+            let map = super::parse_eip712_canonical_types(vec![noisy.to_string()]).unwrap();
+            assert_eq!(map.get("Mail").unwrap(), SIMPLE_MAIL_CANONICAL);
+        }
+
+        #[test]
+        fn sorts_referenced_types_alphabetically() {
+            // EIP-712: "the set of referenced struct types is collected,
+            // sorted by name and appended to the encoding". Input here has
+            // Person before Asset; canonical output must swap them.
+            let non_canonical = "Transaction(Person from,Person to,Asset tx)\
+                                 Person(address wallet,string name)\
+                                 Asset(address token,uint256 amount)";
+            let expected = "Transaction(Person from,Person to,Asset tx)\
+                            Asset(address token,uint256 amount)\
+                            Person(address wallet,string name)";
+
+            let map = super::parse_eip712_canonical_types(vec![non_canonical.to_string()]).unwrap();
+            assert_eq!(map.get("Transaction").unwrap(), expected);
+        }
+
+        #[test]
+        fn registers_only_primary_type() {
+            // Mail inlines Person; only "Mail" should be registered.
+            let map =
+                super::parse_eip712_canonical_types(vec![MAIL_WITH_PERSON_CANONICAL.to_string()])
+                    .unwrap();
+            assert_eq!(map.len(), 1);
+            assert!(map.contains_key("Mail"));
+            assert!(!map.contains_key("Person"));
+        }
+
+        #[test]
+        fn registers_each_entry_under_its_primary() {
+            // Supply Mail and Person as separate entries to expose both by name.
+            let map = super::parse_eip712_canonical_types(vec![
+                MAIL_WITH_PERSON_CANONICAL.to_string(),
+                PERSON_CANONICAL.to_string(),
+            ])
+            .unwrap();
+            assert_eq!(map.len(), 2);
+            assert_eq!(map.get("Mail").unwrap(), MAIL_WITH_PERSON_CANONICAL);
+            assert_eq!(map.get("Person").unwrap(), PERSON_CANONICAL);
+        }
+
+        #[test]
+        fn rejects_empty_string() {
+            let errors = super::parse_eip712_canonical_types(vec![String::new()]).unwrap_err();
+            assert_eq!(errors.len(), 1);
+            assert!(matches!(
+                &errors[0],
+                Eip712ConfigError::Parse { reason, .. }
+                    if reason == "no parseable type definition found"
+            ));
+        }
+
+        #[test]
+        fn rejects_unparseable_input() {
+            let errors =
+                super::parse_eip712_canonical_types(vec!["not a type definition".to_string()])
+                    .unwrap_err();
+            assert_eq!(errors.len(), 1);
+            assert!(matches!(&errors[0], Eip712ConfigError::Parse { .. }));
+        }
+
+        #[test]
+        fn rejects_unresolved_nested_types() {
+            // Mail references Person but does not inline its definition.
+            // Canonicalization must resolve every referenced type.
+            let input = "Mail(Person from,Person to,string contents)";
+            let errors = super::parse_eip712_canonical_types(vec![input.to_string()]).unwrap_err();
+            assert_eq!(errors.len(), 1);
+            assert!(matches!(&errors[0], Eip712ConfigError::Canonicalize { .. }));
+        }
+
+        #[test]
+        fn rejects_duplicate_primary_names() {
+            // Two entries sharing the same primary type name — even with
+            // different bodies — are ambiguous and rejected.
+            let errors = super::parse_eip712_canonical_types(vec![
+                SIMPLE_MAIL_CANONICAL.to_string(),
+                "Mail(uint256 x)".to_string(),
+            ])
+            .unwrap_err();
+            assert_eq!(errors.len(), 1);
+            assert!(matches!(
+                &errors[0],
+                Eip712ConfigError::DuplicateTypeDef { name } if name == "Mail"
+            ));
+        }
+
+        #[test]
+        fn rejects_identical_duplicates() {
+            // Identical entries are still rejected: silent overwrite would
+            // be worse than an explicit error.
+            let errors = super::parse_eip712_canonical_types(vec![
+                SIMPLE_MAIL_CANONICAL.to_string(),
+                SIMPLE_MAIL_CANONICAL.to_string(),
+            ])
+            .unwrap_err();
+            assert_eq!(errors.len(), 1);
+            assert!(matches!(
+                &errors[0],
+                Eip712ConfigError::DuplicateTypeDef { .. }
+            ));
+        }
+
+        #[test]
+        fn collects_every_error() {
+            // Confirm the function does not short-circuit: two parse errors
+            // and one duplicate should all surface in a single call.
+            let errors = super::parse_eip712_canonical_types(vec![
+                String::new(),                     // parse error (empty)
+                "gibberish".to_string(),           // parse error (unparseable)
+                SIMPLE_MAIL_CANONICAL.to_string(), // ok
+                SIMPLE_MAIL_CANONICAL.to_string(), // duplicate
+            ])
+            .unwrap_err();
+
+            assert_eq!(errors.len(), 3);
+
+            let parse_errors = errors
+                .iter()
+                .filter(|e| matches!(e, Eip712ConfigError::Parse { .. }))
+                .count();
+            let dup_errors = errors
+                .iter()
+                .filter(|e| matches!(e, Eip712ConfigError::DuplicateTypeDef { .. }))
+                .count();
+            assert_eq!(parse_errors, 2);
+            assert_eq!(dup_errors, 1);
+        }
+    }
 }

--- a/crates/foundry/cheatcodes/src/config.rs
+++ b/crates/foundry/cheatcodes/src/config.rs
@@ -63,7 +63,7 @@ pub struct CheatsConfig<HardforkT> {
     /// Mapping of chain IDs to their aliases
     pub chain_id_to_alias: HashMap<u64, String>,
     /// Mapping of known EIP-712 canonical type definitions by type name.
-    pub eip712_types_by_name: HashMap<String, String>,
+    pub eip712_types_by_name: HashMap<String, Eip712TypeDef>,
 }
 
 /// Chain data for getChain cheatcodes
@@ -120,7 +120,7 @@ pub struct CheatsConfigOptions {
     /// as the test. Overrides the global setting for specific test functions.
     pub functions_internal_expect_revert: HashSet<TestFunctionIdentifier>,
     /// Mapping of known EIP-712 canonical type definitions by type name.
-    pub eip712_types_by_name: HashMap<String, String>,
+    pub eip712_types_by_name: HashMap<String, Eip712TypeDef>,
 }
 
 // TODO: https://github.com/NomicFoundation/edr/issues/1184
@@ -135,7 +135,7 @@ pub struct TestFunctionIdentifier {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum Eip712ConfigError {
+pub enum Eip712Error {
     #[error("failed to parse EIP-712 canonical type {input}: {reason}")]
     Parse { input: String, reason: String },
 
@@ -144,6 +144,62 @@ pub enum Eip712ConfigError {
 
     #[error("duplicate EIP-712 type definition {name}")]
     DuplicateTypeDef { name: String },
+}
+
+/// An EIP-712 type definition in canonical form, paired with its
+/// primary-type name.
+///
+/// Only [`Eip712TypeDef::parse`] can construct one, which guarantees the
+/// canonical-form invariant.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Eip712TypeDef {
+    name: String,
+    canonical_definition: String,
+}
+
+impl Eip712TypeDef {
+    /// Parses and canonicalizes an EIP-712 type definition, extracting its
+    /// primary-type name.
+    pub fn parse(input: &str) -> std::result::Result<Self, Eip712Error> {
+        let encode_type = EncodeType::parse(input).map_err(|error| Eip712Error::Parse {
+            input: input.to_string(),
+            reason: error.to_string(),
+        })?;
+
+        let name = encode_type
+            .types
+            .first()
+            .ok_or_else(|| Eip712Error::Parse {
+                input: input.to_string(),
+                reason: "no parseable type definition found".into(),
+            })?
+            .type_name
+            .to_string();
+
+        let canonical_definition =
+            encode_type
+                .canonicalize()
+                .map_err(|error| Eip712Error::Canonicalize {
+                    input: input.to_string(),
+                    reason: error.to_string(),
+                })?;
+
+        Ok(Self {
+            name,
+            canonical_definition,
+        })
+    }
+
+    /// Primary type name (the leftmost type in the canonical definition).
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Canonical EIP-712 type definition, as produced by
+    /// [`EncodeType::canonicalize`].
+    pub fn canonical_definition(&self) -> &str {
+        &self.canonical_definition
+    }
 }
 
 impl PartialEq for TestFunctionIdentifier {
@@ -397,52 +453,24 @@ impl<HardforkT: HardforkTr> CheatsConfig<HardforkT> {
 /// Collects every error encountered rather than stopping at the first.
 pub fn parse_eip712_canonical_types(
     eip712_type_definitions: Vec<String>,
-) -> Result<HashMap<String, String>, Vec<Eip712ConfigError>> {
-    let parse_definition =
-        |eip712_definition: String| -> Result<(String, String), Eip712ConfigError> {
-            // Normalize type definitions defensively; downstream relies on canonical form.
-            let encode_type = EncodeType::parse(&eip712_definition).map_err(|error| {
-                Eip712ConfigError::Parse {
-                    input: eip712_definition.clone(),
-                    reason: error.to_string(),
-                }
-            })?;
-            let name = encode_type
-                .types
-                .first()
-                .ok_or_else(|| Eip712ConfigError::Parse {
-                    input: eip712_definition.clone(),
-                    reason: "no parseable type definition found".into(),
-                })?
-                .type_name
-                .into();
-            let canonical =
-                encode_type
-                    .canonicalize()
-                    .map_err(|error| Eip712ConfigError::Canonicalize {
-                        input: eip712_definition,
-                        reason: error.to_string(),
-                    })?;
-
-            Ok((name, canonical))
-        };
-
+) -> Result<HashMap<String, Eip712TypeDef>, Vec<Eip712Error>> {
     let (eip712_types_by_name, errors) = eip712_type_definitions
         .into_iter()
-        .map(parse_definition)
+        .map(|def| Eip712TypeDef::parse(&def))
         .fold(
             (
-                HashMap::<String, String>::new(),
-                Vec::<Eip712ConfigError>::new(),
+                HashMap::<String, Eip712TypeDef>::new(),
+                Vec::<Eip712Error>::new(),
             ),
             |(mut map, mut errors), parsed| {
                 match parsed {
-                    Ok((name, canonical)) => {
+                    Ok(type_def) => {
                         // Reject duplicates rather than silently overwriting: conflicting EIP-712
                         // definitions would yield a wrong hash that's visually indistinguishable
                         // from a correct one.
-                        if map.insert(name.clone(), canonical).is_some() {
-                            errors.push(Eip712ConfigError::DuplicateTypeDef { name });
+                        let name = type_def.name().to_string();
+                        if map.insert(name.clone(), type_def).is_some() {
+                            errors.push(Eip712Error::DuplicateTypeDef { name });
                         }
                     }
                     Err(err) => errors.push(err),
@@ -1091,41 +1119,27 @@ mod tests {
             .is_ok());
     }
 
-    mod parse_eip712_canonical_types {
-        //! Fixtures are drawn from the EIP-712 specification's worked example:
-        //! <https://eips.ethereum.org/EIPS/eip-712>.
-        //!
-        //! Canonical encoding rule: primary type first, referenced struct
-        //! types appended in alphabetical order. Members are
-        //! `type ‖ " " ‖ name`, comma-separated, with no other whitespace.
+    const MAIL_WITH_PERSON_CANONICAL: &str =
+        "Mail(Person from,Person to,string contents)Person(address wallet,string name)";
+    const PERSON_CANONICAL: &str = "Person(address wallet,string name)";
+    const SIMPLE_MAIL_CANONICAL: &str = "Mail(address from,address to,string contents)";
 
+    mod eip712_type_def {
         use super::*;
 
-        const MAIL_WITH_PERSON_CANONICAL: &str =
-            "Mail(Person from,Person to,string contents)Person(address wallet,string name)";
-        const PERSON_CANONICAL: &str = "Person(address wallet,string name)";
-        const SIMPLE_MAIL_CANONICAL: &str = "Mail(address from,address to,string contents)";
-
         #[test]
-        fn accepts_canonical_input() {
-            let map = super::parse_eip712_canonical_types(vec![SIMPLE_MAIL_CANONICAL.to_string()])
-                .unwrap();
-            assert_eq!(map.len(), 1);
-            assert_eq!(map.get("Mail").unwrap(), SIMPLE_MAIL_CANONICAL);
-        }
-
-        #[test]
-        fn accepts_empty_input() {
-            let map = super::parse_eip712_canonical_types(vec![]).unwrap();
-            assert!(map.is_empty());
+        fn parses_canonical_definition() {
+            let def = Eip712TypeDef::parse(SIMPLE_MAIL_CANONICAL).unwrap();
+            assert_eq!(def.name(), "Mail");
+            assert_eq!(def.canonical_definition(), SIMPLE_MAIL_CANONICAL);
         }
 
         #[test]
         fn normalizes_whitespace() {
             // Extra whitespace after commas — not canonical per EIP-712.
             let noisy = "Mail(address from, address to, string contents)";
-            let map = super::parse_eip712_canonical_types(vec![noisy.to_string()]).unwrap();
-            assert_eq!(map.get("Mail").unwrap(), SIMPLE_MAIL_CANONICAL);
+            let def = Eip712TypeDef::parse(noisy).unwrap();
+            assert_eq!(def.canonical_definition(), SIMPLE_MAIL_CANONICAL);
         }
 
         #[test]
@@ -1140,16 +1154,51 @@ mod tests {
                             Asset(address token,uint256 amount)\
                             Person(address wallet,string name)";
 
-            let map = super::parse_eip712_canonical_types(vec![non_canonical.to_string()]).unwrap();
-            assert_eq!(map.get("Transaction").unwrap(), expected);
+            let def = Eip712TypeDef::parse(non_canonical).unwrap();
+            assert_eq!(def.name(), "Transaction");
+            assert_eq!(def.canonical_definition(), expected);
+        }
+
+        #[test]
+        fn rejects_empty_input() {
+            let err = Eip712TypeDef::parse("").unwrap_err();
+            assert!(matches!(
+                &err,
+                Eip712Error::Parse { reason, .. }
+                    if reason == "no parseable type definition found"
+            ));
+        }
+
+        #[test]
+        fn rejects_unparseable_input() {
+            let err = Eip712TypeDef::parse("not a type definition").unwrap_err();
+            assert!(matches!(&err, Eip712Error::Parse { .. }));
+        }
+
+        #[test]
+        fn rejects_unresolved_nested_types() {
+            // Mail references Person but does not inline its definition.
+            // Canonicalization must resolve every referenced type.
+            let err =
+                Eip712TypeDef::parse("Mail(Person from,Person to,string contents)").unwrap_err();
+            assert!(matches!(&err, Eip712Error::Canonicalize { .. }));
+        }
+    }
+
+    mod parse_eip712_canonical_types {
+        use super::*;
+
+        #[test]
+        fn accepts_empty_input() {
+            let map = parse_eip712_canonical_types(vec![]).unwrap();
+            assert!(map.is_empty());
         }
 
         #[test]
         fn registers_only_primary_type() {
             // Mail inlines Person; only "Mail" should be registered.
             let map =
-                super::parse_eip712_canonical_types(vec![MAIL_WITH_PERSON_CANONICAL.to_string()])
-                    .unwrap();
+                parse_eip712_canonical_types(vec![MAIL_WITH_PERSON_CANONICAL.to_string()]).unwrap();
             assert_eq!(map.len(), 1);
             assert!(map.contains_key("Mail"));
             assert!(!map.contains_key("Person"));
@@ -1158,51 +1207,27 @@ mod tests {
         #[test]
         fn registers_each_entry_under_its_primary() {
             // Supply Mail and Person as separate entries to expose both by name.
-            let map = super::parse_eip712_canonical_types(vec![
+            let map = parse_eip712_canonical_types(vec![
                 MAIL_WITH_PERSON_CANONICAL.to_string(),
                 PERSON_CANONICAL.to_string(),
             ])
             .unwrap();
             assert_eq!(map.len(), 2);
-            assert_eq!(map.get("Mail").unwrap(), MAIL_WITH_PERSON_CANONICAL);
-            assert_eq!(map.get("Person").unwrap(), PERSON_CANONICAL);
-        }
-
-        #[test]
-        fn rejects_empty_string() {
-            let errors = super::parse_eip712_canonical_types(vec![String::new()]).unwrap_err();
-            assert_eq!(errors.len(), 1);
-            assert!(matches!(
-                &errors[0],
-                Eip712ConfigError::Parse { reason, .. }
-                    if reason == "no parseable type definition found"
-            ));
-        }
-
-        #[test]
-        fn rejects_unparseable_input() {
-            let errors =
-                super::parse_eip712_canonical_types(vec!["not a type definition".to_string()])
-                    .unwrap_err();
-            assert_eq!(errors.len(), 1);
-            assert!(matches!(&errors[0], Eip712ConfigError::Parse { .. }));
-        }
-
-        #[test]
-        fn rejects_unresolved_nested_types() {
-            // Mail references Person but does not inline its definition.
-            // Canonicalization must resolve every referenced type.
-            let input = "Mail(Person from,Person to,string contents)";
-            let errors = super::parse_eip712_canonical_types(vec![input.to_string()]).unwrap_err();
-            assert_eq!(errors.len(), 1);
-            assert!(matches!(&errors[0], Eip712ConfigError::Canonicalize { .. }));
+            assert_eq!(
+                map.get("Mail").unwrap().canonical_definition(),
+                MAIL_WITH_PERSON_CANONICAL
+            );
+            assert_eq!(
+                map.get("Person").unwrap().canonical_definition(),
+                PERSON_CANONICAL
+            );
         }
 
         #[test]
         fn rejects_duplicate_primary_names() {
             // Two entries sharing the same primary type name — even with
             // different bodies — are ambiguous and rejected.
-            let errors = super::parse_eip712_canonical_types(vec![
+            let errors = parse_eip712_canonical_types(vec![
                 SIMPLE_MAIL_CANONICAL.to_string(),
                 "Mail(uint256 x)".to_string(),
             ])
@@ -1210,7 +1235,7 @@ mod tests {
             assert_eq!(errors.len(), 1);
             assert!(matches!(
                 &errors[0],
-                Eip712ConfigError::DuplicateTypeDef { name } if name == "Mail"
+                Eip712Error::DuplicateTypeDef { name } if name == "Mail"
             ));
         }
 
@@ -1218,23 +1243,20 @@ mod tests {
         fn rejects_identical_duplicates() {
             // Identical entries are still rejected: silent overwrite would
             // be worse than an explicit error.
-            let errors = super::parse_eip712_canonical_types(vec![
+            let errors = parse_eip712_canonical_types(vec![
                 SIMPLE_MAIL_CANONICAL.to_string(),
                 SIMPLE_MAIL_CANONICAL.to_string(),
             ])
             .unwrap_err();
             assert_eq!(errors.len(), 1);
-            assert!(matches!(
-                &errors[0],
-                Eip712ConfigError::DuplicateTypeDef { .. }
-            ));
+            assert!(matches!(&errors[0], Eip712Error::DuplicateTypeDef { .. }));
         }
 
         #[test]
         fn collects_every_error() {
-            // Confirm the function does not short-circuit: two parse errors
-            // and one duplicate should all surface in a single call.
-            let errors = super::parse_eip712_canonical_types(vec![
+            // Two parse errors (forwarded from Eip712TypeDef::parse) plus one
+            // duplicate must all surface in a single call.
+            let errors = parse_eip712_canonical_types(vec![
                 String::new(),                     // parse error (empty)
                 "gibberish".to_string(),           // parse error (unparseable)
                 SIMPLE_MAIL_CANONICAL.to_string(), // ok
@@ -1246,11 +1268,11 @@ mod tests {
 
             let parse_errors = errors
                 .iter()
-                .filter(|e| matches!(e, Eip712ConfigError::Parse { .. }))
+                .filter(|e| matches!(e, Eip712Error::Parse { .. }))
                 .count();
             let dup_errors = errors
                 .iter()
-                .filter(|e| matches!(e, Eip712ConfigError::DuplicateTypeDef { .. }))
+                .filter(|e| matches!(e, Eip712Error::DuplicateTypeDef { .. }))
                 .count();
             assert_eq!(parse_errors, 2);
             assert_eq!(dup_errors, 1);

--- a/crates/foundry/cheatcodes/src/config.rs
+++ b/crates/foundry/cheatcodes/src/config.rs
@@ -5,11 +5,13 @@ use std::{
     time::Duration,
 };
 
+use alloy_dyn_abi::eip712_parser::EncodeType;
 use alloy_primitives::{map::AddressHashMap, U256};
 use edr_artifact::ArtifactId;
 use edr_common::fs::normalize_path;
 use foundry_compilers::utils::canonicalize;
 use foundry_evm_core::{contracts::ContractsByArtifact, evm_context::HardforkTr, opts::EvmOpts};
+use itertools::Itertools;
 
 use super::{FsAccessKind, FsPermissions, Result, RpcEndpoint, RpcEndpointUrl, RpcEndpoints};
 use crate::{cache::StorageCachingConfig, Vm::Rpc};
@@ -61,6 +63,8 @@ pub struct CheatsConfig<HardforkT> {
     pub chains: HashMap<String, ChainData>,
     /// Mapping of chain IDs to their aliases
     pub chain_id_to_alias: HashMap<u64, String>,
+    // Mapping of knwon EIP-712 canonical type definition by type name.
+    pub eip712_types_by_name: HashMap<String, String>,
 }
 
 /// Chain data for getChain cheatcodes
@@ -116,6 +120,8 @@ pub struct CheatsConfigOptions {
     /// Allow expecting reverts with `expectRevert` at the same callstack depth
     /// as the test. Overrides the global setting for specific test functions.
     pub functions_internal_expect_revert: HashSet<TestFunctionIdentifier>,
+    /// Mapping of knwon EIP-712 canonical type definition by type name.
+    pub eip712_types_by_name: HashMap<String, String>,
 }
 
 // TODO: https://github.com/NomicFoundation/edr/issues/1184
@@ -127,6 +133,18 @@ pub struct TestFunctionIdentifier {
     pub contract_artifact: ArtifactId,
     /// The function selector as hex string
     pub function_selector: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Eip712ConfigError {
+    #[error("failed to parse EIP-712 canonical type {input}: {reason}")]
+    Parse { input: String, reason: String },
+
+    #[error("failed to canonicalize EIP-712 type {input}: {reason}")]
+    Canonicalize { input: String, reason: String },
+
+    #[error("duplicate EIP-712 type name {name}")] // TODO: not being used, should we?
+    DuplicateName { name: String },
 }
 
 impl PartialEq for TestFunctionIdentifier {
@@ -167,6 +185,7 @@ impl<HardforkT: HardforkTr> CheatsConfig<HardforkT> {
             seed,
             allow_internal_expect_revert,
             functions_internal_expect_revert,
+            eip712_types_by_name,
         } = config;
 
         // TODO
@@ -193,6 +212,7 @@ impl<HardforkT: HardforkTr> CheatsConfig<HardforkT> {
             functions_internal_expect_revert,
             chains: HashMap::new(),
             chain_id_to_alias: HashMap::new(),
+            eip712_types_by_name,
         }
     }
 
@@ -366,6 +386,53 @@ impl<HardforkT: HardforkTr> CheatsConfig<HardforkT> {
     }
 }
 
+/// Parses and canonicalizes a list of EIP-712 type definitions, keyed by their
+/// primary type name.
+///
+/// Only the **primary** (leftmost) type of each entry is registered by name.
+///
+/// Returns every error encountered
+pub fn parse_eip712_canonical_types(
+    eip712_type_definitions: Vec<String>,
+) -> Result<HashMap<String, String>, Vec<Eip712ConfigError>> {
+    let (entries, errors): (Vec<_>, Vec<_>) = eip712_type_definitions
+        .into_iter()
+        .map::<Result<(String, String), Eip712ConfigError>, _>(|eip712_definition| {
+            // Normalize type definitions defensively; downstream relies on canonical form.
+            let encode_type = EncodeType::parse(&eip712_definition).map_err(|error| {
+                Eip712ConfigError::Parse {
+                    input: eip712_definition.clone(),
+                    reason: error.to_string(),
+                }
+            })?;
+            let name = encode_type
+                .types
+                .first()
+                .ok_or(Eip712ConfigError::Parse {
+                    input: eip712_definition.clone(),
+                    reason: "no parseable type definition found".into(),
+                })?
+                .type_name
+                .into();
+            let canonical =
+                encode_type
+                    .canonicalize()
+                    .map_err(|error| Eip712ConfigError::Canonicalize {
+                        input: eip712_definition,
+                        reason: error.to_string(),
+                    })?;
+
+            Ok((name, canonical))
+        })
+        .partition_result();
+
+    if !errors.is_empty() {
+        Err(errors)
+    } else {
+        Ok(entries.into_iter().collect())
+    }
+}
+
 impl<HardforkT: HardforkTr> Default for CheatsConfig<HardforkT> {
     fn default() -> Self {
         Self {
@@ -386,6 +453,7 @@ impl<HardforkT: HardforkTr> Default for CheatsConfig<HardforkT> {
             functions_internal_expect_revert: HashSet::new(),
             chains: HashMap::new(),
             chain_id_to_alias: HashMap::new(),
+            eip712_types_by_name: HashMap::new(),
         }
     }
 }
@@ -796,6 +864,7 @@ mod tests {
             seed: None,
             allow_internal_expect_revert: false,
             functions_internal_expect_revert: HashSet::new(),
+            eip712_types_by_name: HashMap::new(),
         };
 
         CheatsConfig::new(

--- a/crates/foundry/cheatcodes/src/config.rs
+++ b/crates/foundry/cheatcodes/src/config.rs
@@ -62,7 +62,7 @@ pub struct CheatsConfig<HardforkT> {
     pub chains: HashMap<String, ChainData>,
     /// Mapping of chain IDs to their aliases
     pub chain_id_to_alias: HashMap<u64, String>,
-    // Mapping of knwon EIP-712 canonical type definition by type name.
+    /// Mapping of known EIP-712 canonical type definitions by type name.
     pub eip712_types_by_name: HashMap<String, String>,
 }
 
@@ -119,7 +119,7 @@ pub struct CheatsConfigOptions {
     /// Allow expecting reverts with `expectRevert` at the same callstack depth
     /// as the test. Overrides the global setting for specific test functions.
     pub functions_internal_expect_revert: HashSet<TestFunctionIdentifier>,
-    /// Mapping of knwon EIP-712 canonical type definition by type name.
+    /// Mapping of known EIP-712 canonical type definitions by type name.
     pub eip712_types_by_name: HashMap<String, String>,
 }
 

--- a/crates/foundry/cheatcodes/src/lib.rs
+++ b/crates/foundry/cheatcodes/src/lib.rs
@@ -14,7 +14,8 @@ extern crate tracing;
 
 use alloy_primitives::Address;
 pub use config::{
-    CheatsConfig, CheatsConfigOptions, ExecutionContextConfig, TestFunctionIdentifier,
+    parse_eip712_canonical_types, CheatsConfig, CheatsConfigOptions, ExecutionContextConfig,
+    TestFunctionIdentifier,
 };
 pub use endpoints::{RpcEndpoint, RpcEndpointUrl, RpcEndpoints};
 pub use error::{Error, ErrorKind, Result};

--- a/crates/foundry/cheatcodes/src/unsupported.rs
+++ b/crates/foundry/cheatcodes/src/unsupported.rs
@@ -22,8 +22,7 @@ use crate::{
         broadcast_2Call, createWallet_0Call, createWallet_1Call, createWallet_2Call,
         deployCode_0Call, deployCode_1Call, deployCode_2Call, deployCode_3Call, deployCode_4Call,
         deployCode_5Call, deployCode_6Call, deployCode_7Call, deriveKey_0Call, deriveKey_1Call,
-        deriveKey_2Call, deriveKey_3Call, eip712HashStruct_0Call, eip712HashStruct_1Call,
-        eip712HashType_0Call, eip712HashType_1Call, eip712HashTypedDataCall,
+        deriveKey_2Call, deriveKey_3Call, eip712HashStruct_1Call, eip712HashType_1Call,
         foundryVersionAtLeastCall, foundryVersionCmpCall, getArtifactPathByCodeCall,
         getArtifactPathByDeployedCodeCall, getBroadcastCall, getBroadcasts_0Call,
         getBroadcasts_1Call, getDeployment_0Call, getDeployment_1Call, getDeploymentsCall,
@@ -141,11 +140,8 @@ impl_unsupported_cheatcode! {
     deriveKey_3Call => "deriveKey(string,string,uint32,string)",
 
     // EIP-712 cheatcodes
-    eip712HashType_0Call => "eip712HashType(string)",
     eip712HashType_1Call => "eip712HashType(string,string)",
-    eip712HashStruct_0Call => "eip712HashStruct(string,bytes)",
     eip712HashStruct_1Call => "eip712HashStruct(string,string,bytes)",
-    eip712HashTypedDataCall => "eip712HashTypedData(string)",
 
     // Debugger cheatcodes
     breakpoint_0Call => "breakpoint(string)",

--- a/crates/foundry/cheatcodes/src/utils.rs
+++ b/crates/foundry/cheatcodes/src/utils.rs
@@ -1062,6 +1062,110 @@ impl Cheatcode for setSeedCall {
     }
 }
 
+impl_is_pure_true!(eip712HashType_0Call);
+impl Cheatcode for eip712HashType_0Call {
+    fn apply<
+        BlockT: BlockEnvTr,
+        TxT: TransactionEnvTr,
+        EvmBuilderT: EvmBuilderTrait<BlockT, ChainContextT, HaltReasonT, HardforkT, TransactionErrorT, TxT>,
+        HaltReasonT: HaltReasonTr,
+        HardforkT: HardforkTr,
+        TransactionErrorT: TransactionErrorTrait,
+        ChainContextT: ChainContextTr,
+        DatabaseT: CheatcodeBackend<
+            BlockT,
+            TxT,
+            EvmBuilderT,
+            HaltReasonT,
+            HardforkT,
+            TransactionErrorT,
+            ChainContextT,
+        >,
+    >(
+        &self,
+        _state: &mut Cheatcodes<
+            BlockT,
+            TxT,
+            ChainContextT,
+            EvmBuilderT,
+            HaltReasonT,
+            HardforkT,
+            TransactionErrorT,
+        >,
+    ) -> Result {
+        todo!()
+    }
+}
+
+impl_is_pure_true!(eip712HashStruct_0Call);
+impl Cheatcode for eip712HashStruct_0Call {
+    fn apply<
+        BlockT: BlockEnvTr,
+        TxT: TransactionEnvTr,
+        EvmBuilderT: EvmBuilderTrait<BlockT, ChainContextT, HaltReasonT, HardforkT, TransactionErrorT, TxT>,
+        HaltReasonT: HaltReasonTr,
+        HardforkT: HardforkTr,
+        TransactionErrorT: TransactionErrorTrait,
+        ChainContextT: ChainContextTr,
+        DatabaseT: CheatcodeBackend<
+            BlockT,
+            TxT,
+            EvmBuilderT,
+            HaltReasonT,
+            HardforkT,
+            TransactionErrorT,
+            ChainContextT,
+        >,
+    >(
+        &self,
+        _state: &mut Cheatcodes<
+            BlockT,
+            TxT,
+            ChainContextT,
+            EvmBuilderT,
+            HaltReasonT,
+            HardforkT,
+            TransactionErrorT,
+        >,
+    ) -> Result {
+        todo!()
+    }
+}
+
+impl_is_pure_true!(eip712HashTypedDataCall);
+impl Cheatcode for eip712HashTypedDataCall {
+    fn apply<
+        BlockT: BlockEnvTr,
+        TxT: TransactionEnvTr,
+        EvmBuilderT: EvmBuilderTrait<BlockT, ChainContextT, HaltReasonT, HardforkT, TransactionErrorT, TxT>,
+        HaltReasonT: HaltReasonTr,
+        HardforkT: HardforkTr,
+        TransactionErrorT: TransactionErrorTrait,
+        ChainContextT: ChainContextTr,
+        DatabaseT: CheatcodeBackend<
+            BlockT,
+            TxT,
+            EvmBuilderT,
+            HaltReasonT,
+            HardforkT,
+            TransactionErrorT,
+            ChainContextT,
+        >,
+    >(
+        &self,
+        _state: &mut Cheatcodes<
+            BlockT,
+            TxT,
+            ChainContextT,
+            EvmBuilderT,
+            HaltReasonT,
+            HardforkT,
+            TransactionErrorT,
+        >,
+    ) -> Result {
+        todo!()
+    }
+}
 /// Helper to generate a random `uint` value (with given bits or bounded if
 /// specified) from type strategy.
 fn random_uint<

--- a/crates/foundry/cheatcodes/src/utils.rs
+++ b/crates/foundry/cheatcodes/src/utils.rs
@@ -1185,6 +1185,7 @@ impl Cheatcode for eip712HashTypedDataCall {
         Ok(digest.to_vec())
     }
 }
+
 /// Helper to generate a random `uint` value (with given bits or bounded if
 /// specified) from type strategy.
 fn random_uint<

--- a/crates/foundry/cheatcodes/src/utils.rs
+++ b/crates/foundry/cheatcodes/src/utils.rs
@@ -1,8 +1,8 @@
 //! Implementations of [`Utilities`](spec::Group::Utilities) cheatcodes.
 
-use alloy_dyn_abi::{DynSolType, DynSolValue};
+use alloy_dyn_abi::{eip712_parser::EncodeType, DynSolType, DynSolValue, Resolver, TypedData};
 use alloy_ens::namehash;
-use alloy_primitives::{aliases::B32, map::HashMap, B64, U256};
+use alloy_primitives::{aliases::B32, keccak256, map::HashMap, Bytes, B64, U256};
 use alloy_sol_types::SolValue;
 use foundry_evm_core::{
     backend::CheatcodeBackend,
@@ -1093,7 +1093,11 @@ impl Cheatcode for eip712HashType_0Call {
             TransactionErrorT,
         >,
     ) -> Result {
-        todo!()
+        let Self {
+            typeNameOrDefinition,
+        } = self;
+        let type_def = get_canonical_type_def(typeNameOrDefinition)?;
+        Ok(keccak256(type_def.as_bytes()).to_vec())
     }
 }
 
@@ -1128,7 +1132,15 @@ impl Cheatcode for eip712HashStruct_0Call {
             TransactionErrorT,
         >,
     ) -> Result {
-        todo!()
+        let Self {
+            typeNameOrDefinition,
+            abiEncodedData,
+        } = self;
+
+        let type_def = get_canonical_type_def(typeNameOrDefinition)?;
+        let primary = &type_def[..type_def.find('(').unwrap_or(type_def.len())];
+
+        get_struct_hash(primary, &type_def, abiEncodedData)
     }
 }
 
@@ -1163,7 +1175,11 @@ impl Cheatcode for eip712HashTypedDataCall {
             TransactionErrorT,
         >,
     ) -> Result {
-        todo!()
+        let Self { jsonData } = self;
+        let typed_data: TypedData = serde_json::from_str(jsonData)?;
+        let digest = typed_data.eip712_signing_hash()?;
+
+        Ok(digest.to_vec())
     }
 }
 /// Helper to generate a random `uint` value (with given bits or bounded if
@@ -1256,4 +1272,60 @@ fn random_int<
             .current()
             .abi_encode(),
     )
+}
+
+/// Returns EIP-712 canonical type definition from the provided string type
+/// representation or type name. If type name provided, then it looks up
+/// bindings from `eip712CanonicalTypes` configuration.
+fn get_canonical_type_def(name_or_def: &str) -> Result<String> {
+    let type_def = if name_or_def.contains('(') {
+        // If the input contains '(', it must be the type definition.
+        EncodeType::parse(name_or_def).and_then(|parsed| parsed.canonicalize())?
+    } else {
+        // Otherwise, it must be the type name.
+        todo!("Get type def from configured canonical types")
+    };
+
+    Ok(type_def)
+}
+
+/// Returns the EIP-712 struct hash for provided name, definition and ABI
+/// encoded data.
+fn get_struct_hash(primary: &str, type_def: &String, abi_encoded_data: &Bytes) -> Result {
+    let mut resolver = Resolver::default();
+
+    // Populate the resolver by ingesting the canonical type definition, and then
+    // get the corresponding `DynSolType` of the primary type.
+    resolver
+        .ingest_string(type_def)
+        .map_err(|e| fmt_err!("Resolver failed to ingest type definition: {e}"))?;
+
+    let resolved_sol_type = resolver
+        .resolve(primary)
+        .map_err(|e| fmt_err!("Failed to resolve EIP-712 primary type '{primary}': {e}"))?;
+
+    // ABI-decode the bytes into `DynSolValue::CustomStruct`.
+    let sol_value = resolved_sol_type
+        .abi_decode(abi_encoded_data.as_ref())
+        .map_err(|e| {
+            fmt_err!("Failed to ABI decode using resolved_sol_type directly for '{primary}': {e}.")
+        })?;
+
+    // Use the resolver to properly encode the data.
+    let encoded_data: Vec<u8> = resolver
+        .encode_data(&sol_value)
+        .map_err(|e| fmt_err!("Failed to EIP-712 encode data for struct '{primary}': {e}"))?
+        .ok_or_else(|| fmt_err!("EIP-712 data encoding returned 'None' for struct '{primary}'"))?;
+
+    // Compute the type hash of the primary type.
+    let type_hash = resolver
+        .type_hash(primary)
+        .map_err(|e| fmt_err!("Failed to compute typeHash for EIP712 type '{primary}': {e}"))?;
+
+    // Compute the struct hash of the concatenated type hash and encoded data.
+    let mut bytes_to_hash = Vec::with_capacity(32 + encoded_data.len());
+    bytes_to_hash.extend_from_slice(type_hash.as_slice());
+    bytes_to_hash.extend_from_slice(&encoded_data);
+
+    Ok(keccak256(&bytes_to_hash).to_vec())
 }

--- a/crates/foundry/cheatcodes/src/utils.rs
+++ b/crates/foundry/cheatcodes/src/utils.rs
@@ -1083,7 +1083,7 @@ impl Cheatcode for eip712HashType_0Call {
         >,
     >(
         &self,
-        _state: &mut Cheatcodes<
+        state: &mut Cheatcodes<
             BlockT,
             TxT,
             ChainContextT,
@@ -1096,7 +1096,9 @@ impl Cheatcode for eip712HashType_0Call {
         let Self {
             typeNameOrDefinition,
         } = self;
-        let type_def = get_canonical_type_def(typeNameOrDefinition)?;
+
+        let type_def =
+            get_canonical_type_def(typeNameOrDefinition, &state.config.eip712_types_by_name)?;
         Ok(keccak256(type_def.as_bytes()).to_vec())
     }
 }
@@ -1122,7 +1124,7 @@ impl Cheatcode for eip712HashStruct_0Call {
         >,
     >(
         &self,
-        _state: &mut Cheatcodes<
+        state: &mut Cheatcodes<
             BlockT,
             TxT,
             ChainContextT,
@@ -1137,7 +1139,8 @@ impl Cheatcode for eip712HashStruct_0Call {
             abiEncodedData,
         } = self;
 
-        let type_def = get_canonical_type_def(typeNameOrDefinition)?;
+        let type_def =
+            get_canonical_type_def(typeNameOrDefinition, &state.config.eip712_types_by_name)?;
         let primary = &type_def[..type_def.find('(').unwrap_or(type_def.len())];
 
         get_struct_hash(primary, &type_def, abiEncodedData)
@@ -1277,21 +1280,25 @@ fn random_int<
 /// Returns EIP-712 canonical type definition from the provided string type
 /// representation or type name. If type name provided, then it looks up
 /// bindings from `eip712CanonicalTypes` configuration.
-fn get_canonical_type_def(name_or_def: &str) -> Result<String> {
-    let type_def = if name_or_def.contains('(') {
+fn get_canonical_type_def(
+    name_or_def: &str,
+    eip712_types_by_name: &std::collections::HashMap<String, String>,
+) -> Result<String> {
+    if name_or_def.contains('(') {
         // If the input contains '(', it must be the type definition.
-        EncodeType::parse(name_or_def).and_then(|parsed| parsed.canonicalize())?
+        Ok(EncodeType::parse(name_or_def).and_then(|parsed| parsed.canonicalize())?)
     } else {
         // Otherwise, it must be the type name.
-        todo!("Get type def from configured canonical types")
-    };
-
-    Ok(type_def)
+        match eip712_types_by_name.get(name_or_def) {
+            Some(value) => Ok(value.clone()),
+            None => bail!("'{name_or_def}' not defined in `eip712CanonicalTypes`",),
+        }
+    }
 }
 
 /// Returns the EIP-712 struct hash for provided name, definition and ABI
 /// encoded data.
-fn get_struct_hash(primary: &str, type_def: &String, abi_encoded_data: &Bytes) -> Result {
+fn get_struct_hash(primary: &str, type_def: &str, abi_encoded_data: &Bytes) -> Result {
     let mut resolver = Resolver::default();
 
     // Populate the resolver by ingesting the canonical type definition, and then

--- a/crates/foundry/cheatcodes/src/utils.rs
+++ b/crates/foundry/cheatcodes/src/utils.rs
@@ -1,6 +1,6 @@
 //! Implementations of [`Utilities`](spec::Group::Utilities) cheatcodes.
 
-use alloy_dyn_abi::{eip712_parser::EncodeType, DynSolType, DynSolValue, Resolver, TypedData};
+use alloy_dyn_abi::{DynSolType, DynSolValue, Resolver, TypedData};
 use alloy_ens::namehash;
 use alloy_primitives::{aliases::B32, keccak256, map::HashMap, Bytes, B64, U256};
 use alloy_sol_types::SolValue;
@@ -18,8 +18,8 @@ use revm::{context::result::HaltReasonTr, context_interface::JournalTr as _};
 
 #[allow(clippy::wildcard_imports)]
 use crate::{
-    impl_is_pure_false, impl_is_pure_true, Cheatcode, Cheatcodes, CheatcodesExecutor, CheatsCtxt,
-    Result, Vm::*,
+    config::Eip712TypeDef, impl_is_pure_false, impl_is_pure_true, Cheatcode, Cheatcodes,
+    CheatcodesExecutor, CheatsCtxt, Result, Vm::*,
 };
 
 /// Contains locations of traces ignored via cheatcodes.
@@ -1099,7 +1099,7 @@ impl Cheatcode for eip712HashType_0Call {
 
         let type_def =
             get_canonical_type_def(typeNameOrDefinition, &state.config.eip712_types_by_name)?;
-        Ok(keccak256(type_def.as_bytes()).to_vec())
+        Ok(keccak256(type_def.canonical_definition().as_bytes()).to_vec())
     }
 }
 
@@ -1141,9 +1141,12 @@ impl Cheatcode for eip712HashStruct_0Call {
 
         let type_def =
             get_canonical_type_def(typeNameOrDefinition, &state.config.eip712_types_by_name)?;
-        let primary = &type_def[..type_def.find('(').unwrap_or(type_def.len())];
 
-        get_struct_hash(primary, &type_def, abiEncodedData)
+        get_struct_hash(
+            type_def.name(),
+            type_def.canonical_definition(),
+            abiEncodedData,
+        )
     }
 }
 
@@ -1278,22 +1281,22 @@ fn random_int<
     )
 }
 
-/// Returns EIP-712 canonical type definition from the provided string type
-/// representation or type name. If type name provided, then it looks up
-/// bindings from `eip712CanonicalTypes` configuration.
+/// Resolves an EIP-712 type definition from either:
+///
+/// - an inline type definition string (detected by the presence of `(`), which
+///   is parsed and canonicalized on demand, or
+/// - a type name, looked up in the `eip712CanonicalTypes` runner config.
 fn get_canonical_type_def(
     name_or_def: &str,
-    eip712_types_by_name: &std::collections::HashMap<String, String>,
-) -> Result<String> {
+    eip712_types_by_name: &std::collections::HashMap<String, Eip712TypeDef>,
+) -> Result<Eip712TypeDef> {
     if name_or_def.contains('(') {
-        // If the input contains '(', it must be the type definition.
-        Ok(EncodeType::parse(name_or_def).and_then(|parsed| parsed.canonicalize())?)
+        Eip712TypeDef::parse(name_or_def).map_err(|error| fmt_err!("{error}"))
     } else {
-        // Otherwise, it must be the type name.
-        match eip712_types_by_name.get(name_or_def) {
-            Some(value) => Ok(value.clone()),
-            None => bail!("'{name_or_def}' not defined in `eip712CanonicalTypes`",),
-        }
+        eip712_types_by_name
+            .get(name_or_def)
+            .cloned()
+            .ok_or_else(|| fmt_err!("'{name_or_def}' not defined in `eip712CanonicalTypes`"))
     }
 }
 

--- a/crates/foundry/cheatcodes/src/utils.rs
+++ b/crates/foundry/cheatcodes/src/utils.rs
@@ -1142,11 +1142,7 @@ impl Cheatcode for eip712HashStruct_0Call {
         let type_def =
             get_canonical_type_def(typeNameOrDefinition, &state.config.eip712_types_by_name)?;
 
-        get_struct_hash(
-            type_def.name(),
-            type_def.canonical_definition(),
-            abiEncodedData,
-        )
+        get_struct_hash(&type_def, abiEncodedData)
     }
 }
 
@@ -1302,36 +1298,55 @@ fn get_canonical_type_def(
 
 /// Returns the EIP-712 struct hash for provided name, definition and ABI
 /// encoded data.
-fn get_struct_hash(primary: &str, type_def: &str, abi_encoded_data: &Bytes) -> Result {
+fn get_struct_hash(type_def: &Eip712TypeDef, abi_encoded_data: &Bytes) -> Result {
     let mut resolver = Resolver::default();
 
     // Populate the resolver by ingesting the canonical type definition, and then
     // get the corresponding `DynSolType` of the primary type.
     resolver
-        .ingest_string(type_def)
+        .ingest_string(type_def.canonical_definition())
         .map_err(|e| fmt_err!("Resolver failed to ingest type definition: {e}"))?;
 
-    let resolved_sol_type = resolver
-        .resolve(primary)
-        .map_err(|e| fmt_err!("Failed to resolve EIP-712 primary type '{primary}': {e}"))?;
+    let resolved_sol_type = resolver.resolve(type_def.name()).map_err(|e| {
+        fmt_err!(
+            "Failed to resolve EIP-712 primary type '{}': {e}",
+            type_def.name()
+        )
+    })?;
 
     // ABI-decode the bytes into `DynSolValue::CustomStruct`.
     let sol_value = resolved_sol_type
         .abi_decode(abi_encoded_data.as_ref())
         .map_err(|e| {
-            fmt_err!("Failed to ABI decode using resolved_sol_type directly for '{primary}': {e}.")
+            fmt_err!(
+                "Failed to ABI decode using resolved_sol_type directly for '{}': {e}.",
+                type_def.name()
+            )
         })?;
 
     // Use the resolver to properly encode the data.
     let encoded_data: Vec<u8> = resolver
         .encode_data(&sol_value)
-        .map_err(|e| fmt_err!("Failed to EIP-712 encode data for struct '{primary}': {e}"))?
-        .ok_or_else(|| fmt_err!("EIP-712 data encoding returned 'None' for struct '{primary}'"))?;
+        .map_err(|e| {
+            fmt_err!(
+                "Failed to EIP-712 encode data for struct '{}': {e}",
+                type_def.name()
+            )
+        })?
+        .ok_or_else(|| {
+            fmt_err!(
+                "EIP-712 data encoding returned 'None' for struct '{}'",
+                type_def.name()
+            )
+        })?;
 
     // Compute the type hash of the primary type.
-    let type_hash = resolver
-        .type_hash(primary)
-        .map_err(|e| fmt_err!("Failed to compute typeHash for EIP712 type '{primary}': {e}"))?;
+    let type_hash = resolver.type_hash(type_def.name()).map_err(|e| {
+        fmt_err!(
+            "Failed to compute typeHash for EIP712 type '{}': {e}",
+            type_def.name()
+        )
+    })?;
 
     // Compute the struct hash of the concatenated type hash and encoded data.
     let mut bytes_to_hash = Vec::with_capacity(32 + encoded_data.len());


### PR DESCRIPTION
related [design doc](https://www.notion.so/nomicfoundation/EIP-712-cheatcodes-31a578cdeaf58091ae82c295a39d88d7) 
closes NomicFoundation/edr#1365 

## Summary

Implements three [EIP-712](https://eips.ethereum.org/EIPS/eip-712) Forge cheatcodes, ported from upstream foundry:

  - `vm.eip712HashType(string)` - canonical typeHash of an EIP-712 type definition.
  - `vm.eip712HashStruct(string, bytes)` - EIP-712 hashStruct for a type + ABI-encoded payload.
  - `vm.eip712HashTypedData(string)` - full `keccak256("\x19\x01" ‖ domainSeparator ‖ hashStruct(message))` digest from a JSON typed-data payload.

The cheatcode bodies are an almost-exact copy-paste of the foundry implementation. One deliberate divergence is described below (see [Why reify `Eip712TypeDef`](#why-reify-eip712typedef)).

The filesystem-reading overloads (`eip712HashType(string, string)` / `eip712HashStruct(string, string, bytes)`) remain unsupported: EDR intentionally avoids disk access for these, per the scope discussed in the issue. Callers hitting those overloads will keep getting a targeted `UnsupportedCheatcode` error with the signature in the message.

## API specs

`eip712HashType` / `eip712HashStruct` accept either an inline type definition or a registered type name. Name resolution goes through a new runner config field:

```ts
solidityTestRunnerConfig.eip712CanonicalTypes: string[]
```

Each entry is an independent, self-contained EIP-712 type definition. Nested struct types referenced by the primary type must be inlined in the same string. Only the primary (leftmost) type is registered by name; nested sub-types are *not* auto-exposed. To reach a sub-type by name, the user should supply it as its own top-level entry:

```ts
eip712CanonicalTypes: [
  "Mail(Person from,Person to,string contents)Person(address wallet,string name)",
  "Person(address wallet,string name)",
]
```

Entries are validated at runner startup, not on first cheatcode call. Callers can expect:

- **Non-canonical input is accepted and normalized.** Entries don't need to already be in canonical form — whitespace and referenced-type ordering are fixed up on ingest, and the stored form is always the canonical one.
- **Every bad entry is reported in a single error.** If the list contains multiple unparseable or unresolvable entries, startup fails with all of them enumerated.
- **Duplicate primary-type names are rejected.** If the list contains two entries for the same primary type — even with identical bodies — startup fails. Silently letting the last one win would be dangerous: EIP-712 hashes are cryptographic, so a wrong typeHash produces a wrong signature with no visible trace back to the config.


## Tech design decisions

### Not auto-exploding EIP-712 types
Callers setting the `eip712CanonicalTypes` config are already doing the full type-discovery walk on their side — that's how they know which types to register in the first place. 
Having EDR re-expand nested types would duplicate that work. It would also risk clashing with types the caller deliberately registered at the top level: EDR doesn't know where any of these types originate, so it's not in a position to make registration decisions about nested ones.

### Why reify `Eip712TypeDef`

Foundry resolves type names by reading a bindings file (generated by `forge bind-json`) on disk at cheatcode-call time. `get_canonical_type_def` returns a plain `String` each call, and the primary-type name is recovered where needed via a defensive string slice: `type_def[..type_def.find('(').unwrap_or(type_def.len())]`.

EDR can't do that — disk access is intentionally off the table — so name resolution has to go through the in-memory `eip712CanonicalTypes` runner config. Validation therefore happens up front at config load, not lazily per call, and the validated results get stored for reuse.

Once we're storing validated values, the question is *what* to store. A plain `HashMap<String, String>` works, but:

- anyone receiving a `&str` from the map has to trust the canonical-form property on faith;
- call sites still have to string-slice the value to recover the primary-type name.

Reifying `Eip712TypeDef` removes both at the type level:

```rust
pub struct Eip712TypeDef {
    name: String,                  // private
    canonical_definition: String,  // private
}

impl Eip712TypeDef {
    pub fn parse(input: &str) -> Result<Self, Eip712Error> { ... }
    pub fn name(&self) -> &str { ... }
    pub fn canonical_definition(&self) -> &str { ... }
}
```

Private fields plus a single public constructor means any `Eip712TypeDef` anywhere in the program is guaranteed to have gone through `parse`, which canonicalizes the input. What this buys us:

- **Compile-time guarantee that the canonical-form invariant holds.** Not a convention upheld by inspection. Anyone holding one can rely on it.
- **No string slicing at call sites** to recover the primary-type name. It's a field extracted from the parser's AST, not a substring re-carved defensively each time.
- **Single source of truth for parse + canonicalize + name-extract.** `Eip712TypeDef::parse` is the only path; both config-time ingestion and cheatcode-time inline parsing funnel through it, so the three-step logic lives in exactly one place.
- **No reconstruction at call sites.** The config stores `HashMap<String, Eip712TypeDef>` directly, so cheatcode impls clone from the map instead of rebuilding the type.

