### PR TITLE
chore: remove rust files from npm package

### DIFF
--- a/crates/edr_napi/package.json
+++ b/crates/edr_napi/package.json
@@ -37,7 +37,6 @@
   "files": [
     "index.js",
     "index.d.ts",
-    "src/",
     "dist/src/",
     "coverage.sol"
   ],


### PR DESCRIPTION
Remove `src/` dir from `package.json` `files` field.
`crates/edr_napi/src/` dir contains rust files.
It make no sense to include this files in the npm package. See npm [package structure](https://www.npmjs.com/package/@nomicfoundation/edr/v/0.12.0-next.32?activeTab=code)