### PR TITLE
test: relax UnixTimeAgainstDate to fix clock-boundary flake

### DIFF
--- a/crates/edr_solidity_tests/tests/testdata/default/cheats/UnixTime.t.sol
+++ b/crates/edr_solidity_tests/tests/testdata/default/cheats/UnixTime.t.sol
@@ -8,7 +8,7 @@ contract UnixTimeTest is DSTest {
     Vm constant vm = Vm(HEVM_ADDRESS);
 
     // This is really wide because CI sucks.
-    uint256 constant errMargin = 500;
+    uint256 constant errMargin = 1000;
 
     function testUnixTimeAgainstDate() public {
         string[] memory inputs = new string[](2);
@@ -22,7 +22,7 @@ contract UnixTimeTest is DSTest {
         // Limit precision to 1000 ms
         uint256 time = vm.unixTime() / 1000 * 1000;
 
-        assertEq(date, time, ".unixTime() is inaccurate");
+        vm.assertApproxEqAbs(date, time, errMargin, ".unixTime() is inaccurate vs date");
     }
 
     function testUnixTime() public {


### PR DESCRIPTION
Noticed the flake while trying to work on renovate.

  Recent flakes (same `cheats::test_cheats_local_default` on `Test EDR`):
  - 2026-04-29, Windows — [run 25113637796](https://github.com/NomicFoundation/edr/actions/runs/25113637796) (PR #1372)
  - 2026-04-27, Windows — [run 25007026699](https://github.com/NomicFoundation/edr/actions/runs/25007026699) (push to
  `main`, #1369)
  - 2026-04-24, macOS — [run 24904528235](https://github.com/NomicFoundation/edr/actions/runs/24904528235) (merge-group,
   #1367)

Mirror upstream Foundry's fix from foundry-rs/foundry#8362 ("test: relax unix time test once again").