### PR TITLE
ci/improve caching

### DIFF
--- a/.github/actions/cache-rust-deps/restore/action.yml
+++ b/.github/actions/cache-rust-deps/restore/action.yml
@@ -1,0 +1,21 @@
+name: cache-rust-deps/restore
+description: |
+  Restore the cargo dependencies cache (`~/.cargo/registry/`,
+  `~/.cargo/git/`). Pair with `cache-rust-deps/save` at the end of
+  the job. Key is per-OS, hashed against the rust-toolchain pin and
+  Cargo.lock; restore-keys fall back through partial matches if the
+  exact combination isn't available.
+
+runs:
+  using: composite
+  steps:
+    - name: Restore Rust dependencies cache
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: |
+          ~/.cargo/registry/
+          ~/.cargo/git/
+        key: rust-deps-${{ runner.os }}-v1-${{ hashFiles('rust-toolchain.toml', 'rust-toolchain') }}-${{ hashFiles('Cargo.lock') }}
+        restore-keys: |
+          rust-deps-${{ runner.os }}-v1-${{ hashFiles('rust-toolchain.toml', 'rust-toolchain') }}-
+          rust-deps-${{ runner.os }}-v1-

--- a/.github/actions/cache-rust-deps/save/action.yml
+++ b/.github/actions/cache-rust-deps/save/action.yml
@@ -4,10 +4,23 @@ description: |
   `~/.cargo/git/`). Pair with `cache-rust-deps/restore` at the start
   of the job. Same key as the restore.
 
+inputs:
+  save-if:
+    description: |
+      Whether to save the cache. Default "true" saves on every run,
+      including PRs. PR-scoped saves help iteration but accumulate
+      against the repo cache budget when many PRs are open
+      (e.g. Renovate). Pass `${{ github.ref == 'refs/heads/main' }}`
+      from the callsite to restrict to main pushes once iteration
+      stabilizes.
+    required: false
+    default: "true"
+
 runs:
   using: composite
   steps:
     - name: Save Rust dependencies cache
+      if: ${{ inputs.save-if == 'true' }}
       uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |

--- a/.github/actions/cache-rust-deps/save/action.yml
+++ b/.github/actions/cache-rust-deps/save/action.yml
@@ -1,0 +1,16 @@
+name: cache-rust-deps/save
+description: |
+  Save the cargo dependencies cache (`~/.cargo/registry/`,
+  `~/.cargo/git/`). Pair with `cache-rust-deps/restore` at the start
+  of the job. Same key as the restore.
+
+runs:
+  using: composite
+  steps:
+    - name: Save Rust dependencies cache
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: |
+          ~/.cargo/registry/
+          ~/.cargo/git/
+        key: rust-deps-${{ runner.os }}-v1-${{ hashFiles('rust-toolchain.toml', 'rust-toolchain') }}-${{ hashFiles('Cargo.lock') }}

--- a/.github/actions/cache-rust-deps/save/action.yml
+++ b/.github/actions/cache-rust-deps/save/action.yml
@@ -10,9 +10,9 @@ inputs:
       Whether to save the cache. Default "true" saves on every run,
       including PRs. PR-scoped saves help iteration but accumulate
       against the repo cache budget when many PRs are open
-      (e.g. Renovate). Pass `${{ github.ref == 'refs/heads/main' }}`
-      from the callsite to restrict to main pushes once iteration
-      stabilizes.
+      (e.g. Renovate). Callsite can pass any GHA-style expression
+      string (typically a main-only check) to gate saves to specific
+      refs once iteration stabilizes.
     required: false
     default: "true"
 

--- a/.github/actions/cache-rust-deps/save/action.yml
+++ b/.github/actions/cache-rust-deps/save/action.yml
@@ -4,6 +4,15 @@ description: |
   `~/.cargo/git/`). Pair with `cache-rust-deps/restore` at the start
   of the job. Same key as the restore.
 
+  First does a `lookup-only` check: if the key already exists (from
+  a prior run, or another concurrent job that won the race in the
+  current run), the save step is skipped entirely. This avoids
+  wasted tar+compress work — actions/cache/save tars the cache
+  contents BEFORE attempting the cache reservation, so a failed
+  reservation still costs the full tar time (5+ min on Windows).
+  lookup-only is a cheap HEAD request that short-circuits the no-op
+  case.
+
 inputs:
   save-if:
     description: |
@@ -19,8 +28,19 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Save Rust dependencies cache
+    - name: Look up existing rust-deps cache (skip save if key exists)
+      id: lookup
       if: ${{ inputs.save-if == 'true' }}
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: |
+          ~/.cargo/registry/
+          ~/.cargo/git/
+        key: rust-deps-${{ runner.os }}-v1-${{ hashFiles('rust-toolchain.toml', 'rust-toolchain') }}-${{ hashFiles('Cargo.lock') }}
+        lookup-only: true
+
+    - name: Save Rust dependencies cache
+      if: ${{ inputs.save-if == 'true' && steps.lookup.outputs.cache-hit != 'true' }}
       uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |

--- a/.github/actions/cache-rust-target/restore/action.yml
+++ b/.github/actions/cache-rust-target/restore/action.yml
@@ -6,7 +6,13 @@ description: |
   (profile, features, RUSTFLAGS) don't thrash each other.
 
   Current buckets:
-    workspace-strict   — check-edr, cargo-hack-edr (RUSTFLAGS=-Dwarnings, dev profile)
+    workspace-strict   — check-edr (RUSTFLAGS=-Dwarnings, dev profile)
+    workspace-hack     — cargo-hack-edr (feature-powerset; isolated from
+                         workspace-strict because the powerset writes ~2-3×
+                         more compile artifacts than check-edr produces, so
+                         sharing a bucket causes cargo-hack to lose its
+                         artifacts whenever check-edr saves last and forces
+                         a partial recompile).
     workspace-dev      — edr-style (clippy), edr-docs (cargo doc)
     workspace-coverage — test-edr-rs (cargo llvm-cov, dev profile, all-features)
     napi-coverage      — test-edr-ts, edr-integration-tests, run-hardhat-tests

--- a/.github/actions/cache-rust-target/restore/action.yml
+++ b/.github/actions/cache-rust-target/restore/action.yml
@@ -1,0 +1,32 @@
+name: cache-rust-target/restore
+description: |
+  Restore the workspace `target/` directory for a named bucket.
+  Pair with `cache-rust-target/save` at the end of the job. Buckets
+  scope the cache so jobs with different build configurations
+  (profile, features, RUSTFLAGS) don't thrash each other.
+
+  Current buckets:
+    workspace-strict   — check-edr, cargo-hack-edr (RUSTFLAGS=-Dwarnings, dev profile)
+    workspace-dev      — edr-style (clippy), edr-docs (cargo doc)
+    workspace-coverage — test-edr-rs (cargo llvm-cov, dev profile, all-features)
+    napi-coverage      — test-edr-ts, edr-integration-tests, run-hardhat-tests
+                         (release profile via napi build, op,test-mock features)
+
+inputs:
+  bucket:
+    description: Cache bucket name. See description above.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Restore target cache
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: |
+          target/
+          crates/edr_napi/target/
+        key: rust-target-${{ runner.os }}-${{ inputs.bucket }}-v1-${{ hashFiles('rust-toolchain.toml', 'rust-toolchain') }}-${{ hashFiles('Cargo.lock') }}
+        restore-keys: |
+          rust-target-${{ runner.os }}-${{ inputs.bucket }}-v1-${{ hashFiles('rust-toolchain.toml', 'rust-toolchain') }}-
+          rust-target-${{ runner.os }}-${{ inputs.bucket }}-v1-

--- a/.github/actions/cache-rust-target/restore/action.yml
+++ b/.github/actions/cache-rust-target/restore/action.yml
@@ -12,6 +12,18 @@ description: |
     napi-coverage      — test-edr-ts, edr-integration-tests, run-hardhat-tests
                          (release profile via napi build, op,test-mock features)
 
+  Cache key inputs (auto-invalidate when these change):
+    - rust-toolchain pin
+    - workspace `.cargo/config.toml` (build.rustflags, target.<triple>.rustflags)
+    - per-crate `.cargo/config.toml` (target-dir, target-feature)
+    - Cargo.lock
+
+  Things NOT in the key — bump the `v1` suffix manually if any of these
+  changes invalidates compile output:
+    - RUSTFLAGS / RUSTDOCFLAGS env set in workflow YAML
+    - cargo-llvm-cov / other tool versions pinned in workflow YAML
+    - the setup-rust composite's behavior (Augment-RUSTFLAGS step, etc.)
+
 inputs:
   bucket:
     description: Cache bucket name. See description above.
@@ -26,7 +38,7 @@ runs:
         path: |
           target/
           crates/edr_napi/target/
-        key: rust-target-${{ runner.os }}-${{ inputs.bucket }}-v1-${{ hashFiles('rust-toolchain.toml', 'rust-toolchain') }}-${{ hashFiles('Cargo.lock') }}
+        key: rust-target-${{ runner.os }}-${{ inputs.bucket }}-v1-${{ hashFiles('rust-toolchain.toml', 'rust-toolchain', '.cargo/config.toml', 'crates/**/.cargo/config.toml') }}-${{ hashFiles('Cargo.lock') }}
         restore-keys: |
-          rust-target-${{ runner.os }}-${{ inputs.bucket }}-v1-${{ hashFiles('rust-toolchain.toml', 'rust-toolchain') }}-
+          rust-target-${{ runner.os }}-${{ inputs.bucket }}-v1-${{ hashFiles('rust-toolchain.toml', 'rust-toolchain', '.cargo/config.toml', 'crates/**/.cargo/config.toml') }}-
           rust-target-${{ runner.os }}-${{ inputs.bucket }}-v1-

--- a/.github/actions/cache-rust-target/save/action.yml
+++ b/.github/actions/cache-rust-target/save/action.yml
@@ -1,0 +1,21 @@
+name: cache-rust-target/save
+description: |
+  Save the workspace `target/` directory for a named bucket. Pair
+  with `cache-rust-target/restore` at the start of the job. Same key
+  as the restore.
+
+inputs:
+  bucket:
+    description: Cache bucket name. Must match the restore step's bucket.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Save target cache
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: |
+          target/
+          crates/edr_napi/target/
+        key: rust-target-${{ runner.os }}-${{ inputs.bucket }}-v1-${{ hashFiles('rust-toolchain.toml', 'rust-toolchain') }}-${{ hashFiles('Cargo.lock') }}

--- a/.github/actions/cache-rust-target/save/action.yml
+++ b/.github/actions/cache-rust-target/save/action.yml
@@ -8,11 +8,22 @@ inputs:
   bucket:
     description: Cache bucket name. Must match the restore step's bucket.
     required: true
+  save-if:
+    description: |
+      Whether to save the cache. Default "true" saves on every run,
+      including PRs. PR-scoped saves help iteration but accumulate
+      against the repo cache budget when many PRs are open
+      (e.g. Renovate). Pass `${{ github.ref == 'refs/heads/main' }}`
+      from the callsite to restrict to main pushes once iteration
+      stabilizes.
+    required: false
+    default: "true"
 
 runs:
   using: composite
   steps:
     - name: Save target cache
+      if: ${{ inputs.save-if == 'true' }}
       uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |

--- a/.github/actions/cache-rust-target/save/action.yml
+++ b/.github/actions/cache-rust-target/save/action.yml
@@ -4,6 +4,15 @@ description: |
   with `cache-rust-target/restore` at the start of the job. Same key
   as the restore.
 
+  First does a `lookup-only` check: if the key already exists (from
+  a prior run, or another concurrent job that won the race in the
+  current run), the save step is skipped entirely. This avoids
+  wasted tar+compress work — actions/cache/save tars the cache
+  contents BEFORE attempting the cache reservation, so a failed
+  reservation still costs the full tar time (5+ min on Windows for
+  the larger ~2 GB target buckets). lookup-only is a cheap HEAD
+  request that short-circuits the no-op case.
+
 inputs:
   bucket:
     description: Cache bucket name. Must match the restore step's bucket.
@@ -22,8 +31,19 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Save target cache
+    - name: Look up existing target cache (skip save if key exists)
+      id: lookup
       if: ${{ inputs.save-if == 'true' }}
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: |
+          target/
+          crates/edr_napi/target/
+        key: rust-target-${{ runner.os }}-${{ inputs.bucket }}-v1-${{ hashFiles('rust-toolchain.toml', 'rust-toolchain') }}-${{ hashFiles('Cargo.lock') }}
+        lookup-only: true
+
+    - name: Save target cache
+      if: ${{ inputs.save-if == 'true' && steps.lookup.outputs.cache-hit != 'true' }}
       uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |

--- a/.github/actions/cache-rust-target/save/action.yml
+++ b/.github/actions/cache-rust-target/save/action.yml
@@ -13,9 +13,9 @@ inputs:
       Whether to save the cache. Default "true" saves on every run,
       including PRs. PR-scoped saves help iteration but accumulate
       against the repo cache budget when many PRs are open
-      (e.g. Renovate). Pass `${{ github.ref == 'refs/heads/main' }}`
-      from the callsite to restrict to main pushes once iteration
-      stabilizes.
+      (e.g. Renovate). Callsite can pass any GHA-style expression
+      string (typically a main-only check) to gate saves to specific
+      refs once iteration stabilizes.
     required: false
     default: "true"
 

--- a/.github/actions/cache-rust-target/save/action.yml
+++ b/.github/actions/cache-rust-target/save/action.yml
@@ -39,7 +39,7 @@ runs:
         path: |
           target/
           crates/edr_napi/target/
-        key: rust-target-${{ runner.os }}-${{ inputs.bucket }}-v1-${{ hashFiles('rust-toolchain.toml', 'rust-toolchain') }}-${{ hashFiles('Cargo.lock') }}
+        key: rust-target-${{ runner.os }}-${{ inputs.bucket }}-v1-${{ hashFiles('rust-toolchain.toml', 'rust-toolchain', '.cargo/config.toml', 'crates/**/.cargo/config.toml') }}-${{ hashFiles('Cargo.lock') }}
         lookup-only: true
 
     - name: Save target cache
@@ -49,4 +49,4 @@ runs:
         path: |
           target/
           crates/edr_napi/target/
-        key: rust-target-${{ runner.os }}-${{ inputs.bucket }}-v1-${{ hashFiles('rust-toolchain.toml', 'rust-toolchain') }}-${{ hashFiles('Cargo.lock') }}
+        key: rust-target-${{ runner.os }}-${{ inputs.bucket }}-v1-${{ hashFiles('rust-toolchain.toml', 'rust-toolchain', '.cargo/config.toml', 'crates/**/.cargo/config.toml') }}-${{ hashFiles('Cargo.lock') }}

--- a/.github/actions/restore-mtime/action.yml
+++ b/.github/actions/restore-mtime/action.yml
@@ -1,0 +1,21 @@
+name: restore-mtime
+description: |
+  Restore file mtimes to each file's last commit time. Without this,
+  fresh GHA checkouts set every file's mtime to "now", making Cargo
+  see them as newer than cached `target/` artifacts and force
+  unnecessary rebuilds of workspace crates on warm-cache runs.
+
+  Requires `fetch-depth: 0` on the preceding `actions/checkout` so
+  the action can find each file's last commit time.
+
+  Mirrors slang's `git/restore-mtime` composite. Uses
+  `--commit-time` (not author time) since caches are shared across
+  branches and committer time is more stable.
+
+runs:
+  using: composite
+  steps:
+    - name: Restore file mtimes from git
+      uses: chetan/git-restore-mtime-action@d186aca54f8760da4dec55313195e51ed3ebb0b3 # v2.3
+      with:
+        args: "--commit-time"

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -10,17 +10,34 @@ inputs:
   cache:
     description: Automatically configure Rust cache
     default: true
+  cache-shared-key:
+    description: |
+      Stable cache key shared across multiple jobs. Use to consolidate
+      similar jobs (same OS, same build profile, same RUSTFLAGS) into a
+      single Swatinem cache scope, avoiding per-job cache duplication.
+    required: false
+  cache-save-if:
+    description: |
+      When the cache should be saved. Default is to save on every run
+      (including PRs) so we can iterate on cache configuration. Once
+      stable, tighten to `${{ github.ref == 'refs/heads/main' }}` to
+      stop PR-scoped saves from polluting the cache budget and from
+      being used as a poisoning surface by external contributors.
+    required: false
+    default: "true"
 
 runs:
   using: composite
   steps:
     - name: Install Rust
-      uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
+      uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
       with:
         # Empty string means rust-toolchain if it exists, otherwise stable
         toolchain: ${{ inputs.toolchain }}
         components: ${{ inputs.components }}
         cache: ${{ inputs.cache }}
+        cache-shared-key: ${{ inputs.cache-shared-key }}
+        cache-save-if: ${{ inputs.cache-save-if }}
         # Do not override the RUSTFLAGS by default and instead do that per job,
         # if needed. Setting RUSTFLAGS via env var, config, etc. is mutually
         # exclusive and often a source of bugs.

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -19,10 +19,14 @@ inputs:
   cache-save-if:
     description: |
       Expression controlling when the cache is saved. Default "true"
-      saves on every run (including PRs) so we can iterate on cache
-      config. Tighten to a main-only expression once stable, to stop
-      PR-scoped saves from polluting the cache budget and from being
-      used as a poisoning surface by external contributors.
+      saves on every run, including PRs. PR caches are scoped to
+      refs/pull/N/merge and cannot be restored by main runs, so this
+      is not a poisoning vector — the per-ref scoping is the security
+      barrier. The reason to ever flip this to a main-only expression
+      is budget: large PR-scoped Swatinem caches (~1 GB each) and
+      sccache entries from churny Renovate PRs can accumulate against
+      the repo cache limit. RPC caches (~30 MB) are too small to
+      worry about.
     required: false
     default: "true"
 

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -18,11 +18,11 @@ inputs:
     required: false
   cache-save-if:
     description: |
-      When the cache should be saved. Default is to save on every run
-      (including PRs) so we can iterate on cache configuration. Once
-      stable, tighten to `${{ github.ref == 'refs/heads/main' }}` to
-      stop PR-scoped saves from polluting the cache budget and from
-      being used as a poisoning surface by external contributors.
+      Expression controlling when the cache is saved. Default "true"
+      saves on every run (including PRs) so we can iterate on cache
+      config. Tighten to a main-only expression once stable, to stop
+      PR-scoped saves from polluting the cache budget and from being
+      used as a poisoning surface by external contributors.
     required: false
     default: "true"
 

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,5 +1,10 @@
 name: Setup Rust
-description: Sets up Rust
+description: |
+  Install the Rust toolchain. Caching is handled separately via the
+  `cache-rust-deps` and `cache-rust-target` composite actions —
+  this composite always passes `cache: false` to the underlying
+  setup-rust-toolchain action so its bundled Swatinem doesn't run.
+
 inputs:
   toolchain:
     description: The Rust toolchain to use
@@ -7,28 +12,6 @@ inputs:
   components:
     description: Comma-separated list of components to install
     required: false
-  cache:
-    description: Automatically configure Rust cache
-    default: true
-  cache-shared-key:
-    description: |
-      Stable cache key shared across multiple jobs. Use to consolidate
-      similar jobs (same OS, same build profile, same RUSTFLAGS) into a
-      single Swatinem cache scope, avoiding per-job cache duplication.
-    required: false
-  cache-save-if:
-    description: |
-      Expression controlling when the cache is saved. Default "true"
-      saves on every run, including PRs. PR caches are scoped to
-      refs/pull/N/merge and cannot be restored by main runs, so this
-      is not a poisoning vector — the per-ref scoping is the security
-      barrier. The reason to ever flip this to a main-only expression
-      is budget: large PR-scoped Swatinem caches (~1 GB each) and
-      sccache entries from churny Renovate PRs can accumulate against
-      the repo cache limit. RPC caches (~30 MB) are too small to
-      worry about.
-    required: false
-    default: "true"
 
 runs:
   using: composite
@@ -39,9 +22,8 @@ runs:
         # Empty string means rust-toolchain if it exists, otherwise stable
         toolchain: ${{ inputs.toolchain }}
         components: ${{ inputs.components }}
-        cache: ${{ inputs.cache }}
-        cache-shared-key: ${{ inputs.cache-shared-key }}
-        cache-save-if: ${{ inputs.cache-save-if }}
+        # Caching handled by ./.github/actions/cache-rust-{deps,target}.
+        cache: false
         # Do not override the RUSTFLAGS by default and instead do that per job,
         # if needed. Setting RUSTFLAGS via env var, config, etc. is mutually
         # exclusive and often a source of bugs.

--- a/.github/scripts/cargo-hack-edr.sh
+++ b/.github/scripts/cargo-hack-edr.sh
@@ -2,10 +2,15 @@
 
 set -e
 
-# Execute cargo hack only for EDR crates
+# Powerset over all feature combinations is `O(2^n_features)` per crate; running
+# it on the full workspace (foundry-* and other forks include large feature
+# graphs) makes CI prohibitively slow. Restrict to crates we own and want fully
+# covered. Non-edr_* crates are still checked under their default + all-features
+# combinations elsewhere (check-edr uses --no-default-features, edr-style
+# clippy uses --all-features).
 for dir in crates/edr_*/ ; do
     if [ -d "$dir" ]; then
-      pushd "$dir" > /dev/null 
+      pushd "$dir" > /dev/null
       cargo hack check --feature-powerset --exclude-no-default-features --no-dev-deps
       popd > /dev/null
     fi

--- a/.github/workflows/edr-benchmark.yml
+++ b/.github/workflows/edr-benchmark.yml
@@ -59,19 +59,6 @@ jobs:
       - uses: ./.github/actions/setup-node
       - uses: ./.github/actions/setup-rust
 
-      - name: Rust cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            .cargo-cache
-            target/
-          save-always: true
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
-
       - name: Install packages
         run: sfw pnpm install --frozen-lockfile --prefer-offline
 
@@ -123,19 +110,6 @@ jobs:
           path: |
             **/edr-cache
           key: edr-rs-rpc-cache-v1
-
-      - name: Rust cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            .cargo-cache
-            target/
-          save-always: true
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
 
       - name: Install packages
         run: sfw pnpm install --frozen-lockfile --prefer-offline

--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -173,6 +173,7 @@ jobs:
         # edr_napi sets `doctest = false` in its Cargo.toml so it's silently
         # skipped here without needing `--exclude`, which would shrink the
         # feature unification universe and invalidate sibling-crate caches.
+        # The "cdylib doc tests not supported" warning still fires anyway: rust-lang/cargo#15964.
         run: cargo test --doc --workspace --all-features --locked --no-fail-fast
 
       - name: Save EDR RPC cache

--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -87,7 +87,7 @@ jobs:
       - uses: ./.github/actions/cache-rust-deps/restore
       - uses: ./.github/actions/cache-rust-target/restore
         with:
-          bucket: workspace-strict
+          bucket: workspace-hack
 
       # Install pre-built binaries for cargo hack
       - uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53
@@ -105,7 +105,7 @@ jobs:
       - uses: ./.github/actions/cache-rust-target/save
         if: always()
         with:
-          bucket: workspace-strict
+          bucket: workspace-hack
 
   test-edr-rs:
     name: Test EDR (${{ matrix.os }})

--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -134,6 +134,10 @@ jobs:
           path: |
             **/edr-cache
           key: edr-rs-rpc-cache-v1-${{ matrix.os }}
+          # Save key includes a hashFiles suffix; restore via the
+          # OS-scoped prefix to pick up the most recent matching entry.
+          restore-keys: |
+            edr-rs-rpc-cache-v1-${{ matrix.os }}-
 
       - name: Run cargo tests (with coverage)
         env:
@@ -219,6 +223,10 @@ jobs:
           path: |
             **/edr-cache
           key: edr-ts-rpc-cache-v1-${{ matrix.os }}
+          # Save key includes a hashFiles suffix; restore via the
+          # OS-scoped prefix to pick up the most recent matching entry.
+          restore-keys: |
+            edr-ts-rpc-cache-v1-${{ matrix.os }}-
 
       - name: Install package
         run: pnpm install --frozen-lockfile --prefer-offline

--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -35,9 +35,6 @@ jobs:
         with:
           mode: firewall
       - uses: ./.github/actions/setup-rust
-        with:
-          # No compile happens in this job; skip the Rust cache.
-          cache: false
       - uses: ./.github/actions/setup-node
 
       - name: Pnpm safety
@@ -54,12 +51,20 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-rust
+      - uses: ./.github/actions/cache-rust-deps/restore
+      - uses: ./.github/actions/cache-rust-target/restore
         with:
-          # Shared with cargo-hack-edr (also RUSTFLAGS=-Dwarnings).
-          cache-shared-key: linux-dev-strict
+          bucket: workspace-strict
 
       - name: Cargo check no default features for all crates
         run: cargo check --workspace --all-targets --no-default-features --locked
+
+      - uses: ./.github/actions/cache-rust-deps/save
+        if: always()
+      - uses: ./.github/actions/cache-rust-target/save
+        if: always()
+        with:
+          bucket: workspace-strict
 
   cargo-hack-edr:
     name: cargo-hack check EDR
@@ -75,9 +80,10 @@ jobs:
           persist-credentials: false
 
       - uses: ./.github/actions/setup-rust
+      - uses: ./.github/actions/cache-rust-deps/restore
+      - uses: ./.github/actions/cache-rust-target/restore
         with:
-          # Shared with check-edr (also RUSTFLAGS=-Dwarnings).
-          cache-shared-key: linux-dev-strict
+          bucket: workspace-strict
 
       # Install pre-built binaries for cargo hack
       - uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53
@@ -89,6 +95,13 @@ jobs:
           chmod +x ./.github/scripts/cargo-hack-edr.sh
           ./.github/scripts/cargo-hack-edr.sh
         shell: bash
+
+      - uses: ./.github/actions/cache-rust-deps/save
+        if: always()
+      - uses: ./.github/actions/cache-rust-target/save
+        if: always()
+        with:
+          bucket: workspace-strict
 
   test-edr-rs:
     name: Test EDR (${{ matrix.os }})
@@ -105,13 +118,6 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-24.04", "macos-15", "windows-2025"]
-        include:
-          - os: ubuntu-24.04
-            cache-family: linux
-          - os: macos-15
-            cache-family: macos
-          - os: windows-2025
-            cache-family: windows
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
@@ -120,8 +126,10 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           components: llvm-tools-preview
-          # Shared with test-edr-ts on the same OS (both use cargo llvm-cov).
-          cache-shared-key: ${{ matrix.cache-family }}-coverage
+      - uses: ./.github/actions/cache-rust-deps/restore
+      - uses: ./.github/actions/cache-rust-target/restore
+        with:
+          bucket: workspace-coverage
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53
@@ -162,6 +170,13 @@ jobs:
             **/edr-cache
           key: edr-rs-rpc-cache-v1-${{ matrix.os }}-${{ hashFiles('**/edr-cache/**/*') }}
 
+      - uses: ./.github/actions/cache-rust-deps/save
+        if: always()
+      - uses: ./.github/actions/cache-rust-target/save
+        if: always()
+        with:
+          bucket: workspace-coverage
+
       # disable until:
       # 1) https://github.com/napi-rs/napi-rs/issues/1405 is resolved (Windows-only)
       # 2) https://github.com/nextest-rs/nextest/issues/871 (all platforms)
@@ -190,13 +205,6 @@ jobs:
       matrix:
         node: [20]
         os: [ubuntu-24.04, macos-15, windows-2025]
-        include:
-          - os: ubuntu-24.04
-            cache-family: linux
-          - os: macos-15
-            cache-family: macos
-          - os: windows-2025
-            cache-family: windows
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
@@ -209,8 +217,10 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           components: llvm-tools-preview
-          # Shared with test-edr-rs on the same OS (both use cargo llvm-cov).
-          cache-shared-key: ${{ matrix.cache-family }}-coverage
+      - uses: ./.github/actions/cache-rust-deps/restore
+      - uses: ./.github/actions/cache-rust-target/restore
+        with:
+          bucket: napi-coverage
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53
@@ -258,6 +268,13 @@ jobs:
             **/edr-cache
           key: edr-ts-rpc-cache-v1-${{ matrix.os }}-${{ hashFiles('**/edr-cache/**/*') }}
 
+      - uses: ./.github/actions/cache-rust-deps/save
+        if: always()
+      - uses: ./.github/actions/cache-rust-target/save
+        if: always()
+        with:
+          bucket: napi-coverage
+
   edr-style:
     name: Check EDR Style
     runs-on: ubuntu-24.04
@@ -270,20 +287,30 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           components: clippy
-          cache-shared-key: linux-dev
 
       - name: Install nightly rustfmt
         uses: ./.github/actions/setup-rust
         with:
           toolchain: nightly
           components: rustfmt
-          cache: false # already set up in previous step
+
+      - uses: ./.github/actions/cache-rust-deps/restore
+      - uses: ./.github/actions/cache-rust-target/restore
+        with:
+          bucket: workspace-dev
 
       - name: Run cargo fmt
         run: cargo +nightly fmt --all --check
 
       - name: Run cargo clippy
         run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+
+      - uses: ./.github/actions/cache-rust-deps/save
+        if: always()
+      - uses: ./.github/actions/cache-rust-target/save
+        if: always()
+        with:
+          bucket: workspace-dev
 
   edr-docs:
     name: Build EDR Docs
@@ -295,14 +322,23 @@ jobs:
           persist-credentials: false
 
       - uses: ./.github/actions/setup-rust
+      - uses: ./.github/actions/cache-rust-deps/restore
+      - uses: ./.github/actions/cache-rust-target/restore
         with:
-          cache-shared-key: linux-dev
+          bucket: workspace-dev
 
       - name: Cargo doc
         run: |
           chmod +x ./.github/scripts/cargo-doc.sh
           ./.github/scripts/cargo-doc.sh
         shell: bash
+
+      - uses: ./.github/actions/cache-rust-deps/save
+        if: always()
+      - uses: ./.github/actions/cache-rust-target/save
+        if: always()
+        with:
+          bucket: workspace-dev
 
   build-and-lint:
     name: Build and lint
@@ -358,8 +394,10 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           components: llvm-tools-preview
-          # Shared with test-edr-rs and test-edr-ts on Linux (also cargo llvm-cov).
-          cache-shared-key: linux-coverage
+      - uses: ./.github/actions/cache-rust-deps/restore
+      - uses: ./.github/actions/cache-rust-target/restore
+        with:
+          bucket: napi-coverage
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53
@@ -384,6 +422,13 @@ jobs:
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
+      - uses: ./.github/actions/cache-rust-deps/save
+        if: always()
+      - uses: ./.github/actions/cache-rust-target/save
+        if: always()
+        with:
+          bucket: napi-coverage
+
   cooldown-check:
     name: cooldown check
     runs-on: ubuntu-24.04
@@ -393,8 +438,6 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-rust
-        with:
-          cache-shared-key: linux-dev
 
       - name: Cache cooldown data
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -170,7 +170,9 @@ jobs:
         # Was previously `--features tracing` only; broaden to --all-features
         # to match the main test compile and reuse fingerprints. Revert if
         # this surfaces real doctest breakage.
-        run: cargo test --doc --workspace --all-features --locked --no-fail-fast
+        # Exclude edr_napi: it's the only cdylib in the workspace and Cargo
+        # warns "doc tests are not supported for crate type(s) `cdylib`".
+        run: cargo test --doc --workspace --exclude edr_napi --all-features --locked --no-fail-fast
 
       - name: Save EDR RPC cache
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -262,6 +262,15 @@ jobs:
         shell: bash
         run: |
           source <(cargo llvm-cov show-env --sh)
+          # napi-rs's `napi build` only re-emits index.js / index.d.ts when
+          # cargo actually compiles (proc-macros write the intermediate
+          # type-def file as a side effect). On a warm cache, cargo can say
+          # "fresh" in <1s and skip emitting, leaving the committed
+          # production-feature bindings in place — which lack symbols gated
+          # behind `test-mock` (e.g. MockTime). Force a real rebuild so the
+          # bindings match the feature set we test against.
+          # Tracked upstream: napi-rs/napi-rs#1276, fix in #3124.
+          cargo clean -p edr_napi
           pnpm -C crates/edr_napi test
           # `--release` included to match `build:dev` compilation flags
           cargo llvm-cov report --release --locked --codecov --output-path codecov.json
@@ -430,6 +439,9 @@ jobs:
         shell: bash
         run: |
           source <(cargo llvm-cov show-env --sh)
+          # See note in test-edr-ts above: force napi rebuild so index.js /
+          # index.d.ts regenerate with the build:dev feature set.
+          cargo clean -p edr_napi
           pnpm run --recursive --filter './js/integration-tests/*' test
           # `--release` included to match `build:dev` compilation flags
           cargo llvm-cov report --release --locked --codecov --output-path codecov.json

--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -35,6 +35,9 @@ jobs:
         with:
           mode: firewall
       - uses: ./.github/actions/setup-rust
+        with:
+          # No compile happens in this job; skip the Rust cache.
+          cache: false
       - uses: ./.github/actions/setup-node
 
       - name: Pnpm safety
@@ -51,6 +54,9 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-rust
+        with:
+          # Shared with cargo-hack-edr (also RUSTFLAGS=-Dwarnings).
+          cache-shared-key: ubuntu-24.04-dev-strict
 
       - name: Cargo check no default features for all crates
         run: cargo check --workspace --all-targets --no-default-features --locked
@@ -69,6 +75,9 @@ jobs:
           persist-credentials: false
 
       - uses: ./.github/actions/setup-rust
+        with:
+          # Shared with check-edr (also RUSTFLAGS=-Dwarnings).
+          cache-shared-key: ubuntu-24.04-dev-strict
 
       # Install pre-built binaries for cargo hack
       - uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53
@@ -104,6 +113,8 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           components: llvm-tools-preview
+          # Shared with test-edr-ts on the same OS (both use cargo llvm-cov).
+          cache-shared-key: ${{ matrix.os }}-coverage
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53
@@ -180,6 +191,8 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           components: llvm-tools-preview
+          # Shared with test-edr-rs on the same OS (both use cargo llvm-cov).
+          cache-shared-key: ${{ matrix.os }}-coverage
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53
@@ -235,6 +248,7 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           components: clippy
+          cache-shared-key: ubuntu-24.04-dev
 
       - name: Install nightly rustfmt
         uses: ./.github/actions/setup-rust
@@ -259,6 +273,8 @@ jobs:
           persist-credentials: false
 
       - uses: ./.github/actions/setup-rust
+        with:
+          cache-shared-key: ubuntu-24.04-dev
 
       - name: Cargo doc
         run: |
@@ -320,6 +336,8 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           components: llvm-tools-preview
+          # Shared with test-edr-rs and test-edr-ts on Linux (also cargo llvm-cov).
+          cache-shared-key: ubuntu-24.04-coverage
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53
@@ -353,6 +371,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-rust
+        with:
+          cache-shared-key: ubuntu-24.04-dev
 
       - name: Cache cooldown data
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -271,8 +271,14 @@ jobs:
           # production-feature bindings in place — which lack symbols gated
           # behind `test-mock` (e.g. MockTime). Force a real rebuild so the
           # bindings match the feature set we test against.
+          #
+          # Run the clean from inside crates/edr_napi/ so its
+          # .cargo/config.toml (target-dir = "./target") resolves the same
+          # way `napi build` does in the subsequent pnpm test step. From
+          # the workspace root the per-package target-dir doesn't apply
+          # and `cargo clean -p edr_napi` removes 0 files.
           # Tracked upstream: napi-rs/napi-rs#1276, fix in #3124.
-          cargo clean -p edr_napi
+          (cd crates/edr_napi && cargo clean -p edr_napi)
           pnpm -C crates/edr_napi test
           # `--release` included to match `build:dev` compilation flags
           cargo llvm-cov report --release --locked --codecov --output-path codecov.json
@@ -442,8 +448,9 @@ jobs:
         run: |
           source <(cargo llvm-cov show-env --sh)
           # See note in test-edr-ts above: force napi rebuild so index.js /
-          # index.d.ts regenerate with the build:dev feature set.
-          cargo clean -p edr_napi
+          # index.d.ts regenerate with the build:dev feature set. Run from
+          # inside crates/edr_napi/ so the per-package target-dir matches.
+          (cd crates/edr_napi && cargo clean -p edr_napi)
           pnpm run --recursive --filter './js/integration-tests/*' test
           # `--release` included to match `build:dev` compilation flags
           cargo llvm-cov report --release --locked --codecov --output-path codecov.json

--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -170,9 +170,10 @@ jobs:
         # Was previously `--features tracing` only; broaden to --all-features
         # to match the main test compile and reuse fingerprints. Revert if
         # this surfaces real doctest breakage.
-        # Exclude edr_napi: it's the only cdylib in the workspace and Cargo
-        # warns "doc tests are not supported for crate type(s) `cdylib`".
-        run: cargo test --doc --workspace --exclude edr_napi --all-features --locked --no-fail-fast
+        # edr_napi sets `doctest = false` in its Cargo.toml so it's silently
+        # skipped here without needing `--exclude`, which would shrink the
+        # feature unification universe and invalidate sibling-crate caches.
+        run: cargo test --doc --workspace --all-features --locked --no-fail-fast
 
       - name: Save EDR RPC cache
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           # Shared with cargo-hack-edr (also RUSTFLAGS=-Dwarnings).
-          cache-shared-key: ubuntu-24.04-dev-strict
+          cache-shared-key: linux-dev-strict
 
       - name: Cargo check no default features for all crates
         run: cargo check --workspace --all-targets --no-default-features --locked
@@ -77,7 +77,7 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           # Shared with check-edr (also RUSTFLAGS=-Dwarnings).
-          cache-shared-key: ubuntu-24.04-dev-strict
+          cache-shared-key: linux-dev-strict
 
       # Install pre-built binaries for cargo hack
       - uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53
@@ -105,6 +105,13 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-24.04", "macos-15", "windows-2025"]
+        include:
+          - os: ubuntu-24.04
+            cache-family: linux
+          - os: macos-15
+            cache-family: macos
+          - os: windows-2025
+            cache-family: windows
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
@@ -114,7 +121,7 @@ jobs:
         with:
           components: llvm-tools-preview
           # Shared with test-edr-ts on the same OS (both use cargo llvm-cov).
-          cache-shared-key: ${{ matrix.os }}-coverage
+          cache-shared-key: ${{ matrix.cache-family }}-coverage
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53
@@ -179,6 +186,13 @@ jobs:
       matrix:
         node: [20]
         os: [ubuntu-24.04, macos-15, windows-2025]
+        include:
+          - os: ubuntu-24.04
+            cache-family: linux
+          - os: macos-15
+            cache-family: macos
+          - os: windows-2025
+            cache-family: windows
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
@@ -192,7 +206,7 @@ jobs:
         with:
           components: llvm-tools-preview
           # Shared with test-edr-rs on the same OS (both use cargo llvm-cov).
-          cache-shared-key: ${{ matrix.os }}-coverage
+          cache-shared-key: ${{ matrix.cache-family }}-coverage
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53
@@ -248,7 +262,7 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           components: clippy
-          cache-shared-key: ubuntu-24.04-dev
+          cache-shared-key: linux-dev
 
       - name: Install nightly rustfmt
         uses: ./.github/actions/setup-rust
@@ -274,7 +288,7 @@ jobs:
 
       - uses: ./.github/actions/setup-rust
         with:
-          cache-shared-key: ubuntu-24.04-dev
+          cache-shared-key: linux-dev
 
       - name: Cargo doc
         run: |
@@ -337,7 +351,7 @@ jobs:
         with:
           components: llvm-tools-preview
           # Shared with test-edr-rs and test-edr-ts on Linux (also cargo llvm-cov).
-          cache-shared-key: ubuntu-24.04-coverage
+          cache-shared-key: linux-coverage
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53
@@ -372,7 +386,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup-rust
         with:
-          cache-shared-key: ubuntu-24.04-dev
+          cache-shared-key: linux-dev
 
       - name: Cache cooldown data
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -50,6 +50,8 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           persist-credentials: false
+          fetch-depth: 0 # full history needed by ./.github/actions/restore-mtime
+      - uses: ./.github/actions/restore-mtime
       - uses: ./.github/actions/setup-rust
       - uses: ./.github/actions/cache-rust-deps/restore
       - uses: ./.github/actions/cache-rust-target/restore
@@ -78,6 +80,8 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           persist-credentials: false
+          fetch-depth: 0 # full history needed by ./.github/actions/restore-mtime
+      - uses: ./.github/actions/restore-mtime
 
       - uses: ./.github/actions/setup-rust
       - uses: ./.github/actions/cache-rust-deps/restore
@@ -122,6 +126,8 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           persist-credentials: false
+          fetch-depth: 0 # full history needed by ./.github/actions/restore-mtime
+      - uses: ./.github/actions/restore-mtime
 
       - uses: ./.github/actions/setup-rust
         with:
@@ -212,6 +218,8 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           persist-credentials: false
+          fetch-depth: 0 # full history needed by ./.github/actions/restore-mtime
+      - uses: ./.github/actions/restore-mtime
 
       - uses: ./.github/actions/setup-node
         with:
@@ -286,6 +294,8 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           persist-credentials: false
+          fetch-depth: 0 # full history needed by ./.github/actions/restore-mtime
+      - uses: ./.github/actions/restore-mtime
 
       - uses: ./.github/actions/setup-rust
         with:
@@ -323,6 +333,8 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           persist-credentials: false
+          fetch-depth: 0 # full history needed by ./.github/actions/restore-mtime
+      - uses: ./.github/actions/restore-mtime
 
       - uses: ./.github/actions/setup-rust
       - uses: ./.github/actions/cache-rust-deps/restore
@@ -391,6 +403,8 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           persist-credentials: false
+          fetch-depth: 0 # full history needed by ./.github/actions/restore-mtime
+      - uses: ./.github/actions/restore-mtime
 
       - uses: ./.github/actions/setup-node
 

--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -272,13 +272,15 @@ jobs:
           # behind `test-mock` (e.g. MockTime). Force a real rebuild so the
           # bindings match the feature set we test against.
           #
-          # Run the clean from inside crates/edr_napi/ so its
-          # .cargo/config.toml (target-dir = "./target") resolves the same
-          # way `napi build` does in the subsequent pnpm test step. From
-          # the workspace root the per-package target-dir doesn't apply
-          # and `cargo clean -p edr_napi` removes 0 files.
+          # `cargo clean -p edr_napi` is unreliable here: the cached target
+          # layout doesn't match what `cargo clean -p` looks for and it
+          # reports "Removed 0 files" even from inside the crate. Touching
+          # a source file inverts the mtime comparison cargo uses for its
+          # fingerprint check (restore-mtime sets sources to old git times
+          # and the cache restore preserves newer artifact mtimes), so
+          # cargo recompiles edr_napi and napi-derive re-emits the typedef.
           # Tracked upstream: napi-rs/napi-rs#1276, fix in #3124.
-          (cd crates/edr_napi && cargo clean -p edr_napi)
+          touch crates/edr_napi/src/lib.rs
           pnpm -C crates/edr_napi test
           # `--release` included to match `build:dev` compilation flags
           cargo llvm-cov report --release --locked --codecov --output-path codecov.json
@@ -447,10 +449,11 @@ jobs:
         shell: bash
         run: |
           source <(cargo llvm-cov show-env --sh)
-          # See note in test-edr-ts above: force napi rebuild so index.js /
-          # index.d.ts regenerate with the build:dev feature set. Run from
-          # inside crates/edr_napi/ so the per-package target-dir matches.
-          (cd crates/edr_napi && cargo clean -p edr_napi)
+          # See note in test-edr-ts above: touch a source file to invert
+          # the mtime comparison cargo uses for its fingerprint, forcing
+          # napi-derive to re-emit index.js / index.d.ts with the
+          # build:dev feature set.
+          touch crates/edr_napi/src/lib.rs
           pnpm run --recursive --filter './js/integration-tests/*' test
           # `--release` included to match `build:dev` compilation flags
           cargo llvm-cov report --release --locked --codecov --output-path codecov.json

--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -161,7 +161,10 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Doctests
-        run: cargo test --doc --workspace --features tracing --locked --no-fail-fast
+        # Was previously `--features tracing` only; broaden to --all-features
+        # to match the main test compile and reuse fingerprints. Revert if
+        # this surfaces real doctest breakage.
+        run: cargo test --doc --workspace --all-features --locked --no-fail-fast
 
       - name: Save EDR RPC cache
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/.github/workflows/hardhat-tests.yml
+++ b/.github/workflows/hardhat-tests.yml
@@ -22,13 +22,6 @@ jobs:
       matrix:
         node: [20]
         os: ["macos-15", "ubuntu-24.04", "windows-2025"]
-        include:
-          - os: ubuntu-24.04
-            cache-family: linux
-          - os: macos-15
-            cache-family: macos
-          - os: windows-2025
-            cache-family: windows
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
@@ -41,9 +34,10 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           components: llvm-tools-preview
-          # Shared with test-edr-rs / test-edr-ts / edr-integration-tests
-          # in edr-ci.yml (all cargo llvm-cov, same OS).
-          cache-shared-key: ${{ matrix.cache-family }}-coverage
+      - uses: ./.github/actions/cache-rust-deps/restore
+      - uses: ./.github/actions/cache-rust-target/restore
+        with:
+          bucket: napi-coverage
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53
@@ -81,6 +75,13 @@ jobs:
           pnpm -C hardhat-tests test
           # `--release` included to match `build:dev` compilation flags
           cargo llvm-cov report --release --locked --codecov --output-path codecov.json
+
+      - uses: ./.github/actions/cache-rust-deps/save
+        if: always()
+      - uses: ./.github/actions/cache-rust-target/save
+        if: always()
+        with:
+          bucket: napi-coverage
 
   lint-hardhat-tests:
     name: Lint Hardhat tests

--- a/.github/workflows/hardhat-tests.yml
+++ b/.github/workflows/hardhat-tests.yml
@@ -26,6 +26,8 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           persist-credentials: false
+          fetch-depth: 0 # full history needed by ./.github/actions/restore-mtime
+      - uses: ./.github/actions/restore-mtime
 
       - uses: ./.github/actions/setup-node
         with:

--- a/.github/workflows/hardhat-tests.yml
+++ b/.github/workflows/hardhat-tests.yml
@@ -22,6 +22,13 @@ jobs:
       matrix:
         node: [20]
         os: ["macos-15", "ubuntu-24.04", "windows-2025"]
+        include:
+          - os: ubuntu-24.04
+            cache-family: linux
+          - os: macos-15
+            cache-family: macos
+          - os: windows-2025
+            cache-family: windows
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
@@ -34,6 +41,9 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           components: llvm-tools-preview
+          # Shared with test-edr-rs / test-edr-ts / edr-integration-tests
+          # in edr-ci.yml (all cargo llvm-cov, same OS).
+          cache-shared-key: ${{ matrix.cache-family }}-coverage
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53

--- a/crates/edr_napi/Cargo.toml
+++ b/crates/edr_napi/Cargo.toml
@@ -5,6 +5,12 @@ edition.workspace = true
 
 [lib]
 crate-type = ["cdylib"]
+# Cdylibs don't support doctests; opt out at the crate level so
+# `cargo test --doc --workspace` silently skips us instead of needing
+# `--exclude edr_napi` at every callsite (which changes feature
+# unification across the workspace and invalidates the test-step
+# build cache for sibling crates).
+doctest = false
 
 [dependencies]
 alloy-dyn-abi.workspace = true


### PR DESCRIPTION
## Summary

Master caching/CI-hygiene branch. Will be split into smaller landable PRs once the experiment settles. Two main shifts:

- Replace Swatinem (via `actions-rust-lang/setup-rust-toolchain` bundled cache) with **slang-style `actions/cache` composites** for Rust deps + workspace target. Reason: newer Swatinem versions prune `target/` more aggressively (warm-cache compile time on Linux jumped 1m 40s → 5m 32s and the cache shrank 1171 MB → 714 MB, not coincidentally). slang's pattern saves the full `target/` archive verbatim — no surprise pruning.
- **Probe (Option C)**: enable `RUSTFLAGS=-Dwarnings` + `RUSTDOCFLAGS=-Dwarnings` on test/integration/hardhat jobs. Surfaces any latent warnings in test/cfg(test) code paths. Easily revertable if it goes red.

Plus several smaller cleanups (RPC cache restore-keys, redundant manual benchmark cache, Hardhat-tests joining the `napi-coverage` bucket, comments documenting cargo-hack scope, doctest features broadened).

Full research, methodology and follow-up backlog in `edr-caching-research.md` (workspace-local, not in this PR).

## Status quo before this branch

### Cache budget

- 10 GB → 50 GB → **100 GB** (bumped twice during this work).
- Pre-bump observed state: 11.7 GB used, 17 active entries — frequent LRU churn.
- Today: ample headroom, ~93 entries.

### Per-job Rust cache fragmentation (single ref)

Linux x86_64 entries on `refs/pull/1373/merge` (one PR, 13 distinct Rust caches, ~8 GB):

```
1171 MB  v0-rust-test-edr-rs-Linux-x64                 (edr-ci.yml)
 875 MB  v0-rust-js-scenario-benchmark-Linux-x64       (edr-benchmark.yml)
 862 MB  v0-rust-benchmarks-test-Linux-x64             (edr-benchmark.yml)
 802 MB  v0-rust-js-soltests-benchmark-Linux-x64       (edr-benchmark.yml)
 715 MB  v0-rust-test-edr-ts-Linux-x64                 (edr-ci.yml)
 715 MB  v0-rust-edr-integration-tests-Linux-x64       (edr-ci.yml)
 714 MB  v0-rust-run-hardhat-tests-Linux-x64           (hardhat-tests.yml)
 709 MB  v0-rust-cargo-hack-edr-Linux-x64              (edr-ci.yml)
 505 MB  v0-rust-edr-docs-Linux-x64                    (edr-ci.yml)
 465 MB  v0-rust-edr-style-Linux-x64                   (edr-ci.yml)
 463 MB  v0-rust-check-edr-Linux-x64                   (edr-ci.yml)
 208 MB  v0-rust-cooldown-check-Linux-x64              (edr-ci.yml)
 206 MB  v0-rust-check-edr-safety-Linux-x64            (edr-ci.yml)
```

Same shape on macOS/Windows. With matrix-multi-OS jobs, a single PR effectively maintains 30+ Rust caches across all refs.

### Critical-path job timings

Recent main push (2026-04-27, run 25007026699), warm Rust + RPC caches:

| Job                              | Duration | Compile (warm) | Test exec  |
| -------------------------------- | -------- | -------------- | ---------- |
| Test EDR (ubuntu-24.04)          | 37 min   | 1m 40s         | ~30 min    |
| Test EDR (macos-15)              | 36 min   | 1m 43s         | ~30 min    |
| Test EDR (windows-2025)          | 22 min*  | 6m 48s         | ~14 min    |

\* Failed mid-suite; full run typically 25-30 min. `setup-rust` (toolchain install + cache restore) takes 24s ubuntu / 42s macOS / 52s windows. Cache restore was already fast — wall-clock dominated by **test execution**, not compile or restore.

### Cold-RPC-cache run impact

When the EDR RPC cache misses, durations explode (PR #1373 run 25155164696):

| Job                              | Cold RPC | Warm RPC | Δ        |
| -------------------------------- | -------- | -------- | -------- |
| Test EDR (macos-15)              | 81 min   | 36 min   | **+45 min** |
| Test EDR (windows-2025)          | 54 min   | 22 min   | +32 min  |
| Test EDR (ubuntu-24.04)          | 49 min   | 37 min   | +12 min  |

Root cause: asymmetric save/restore keys on the RPC cache (save had a `hashFiles` suffix, restore didn't, no `restore-keys` configured) + previous 10 GB LRU evicting smaller main-scoped entries when multi-GB per-PR Rust caches grew.

## What this branch changes

### Cache pattern: Swatinem → slang-style composites

Four new composite actions:

```
.github/actions/cache-rust-deps/{restore,save}/action.yml
.github/actions/cache-rust-target/{restore,save}/action.yml
```

Cache keys:

- `rust-deps-${runner.os}-v1-${rust-toolchain-hash}-${Cargo.lock-hash}`
- `rust-target-${runner.os}-${bucket}-v1-${rust-toolchain-hash}-${Cargo.lock-hash}`

`runner.os` returns family names (Linux/macOS/Windows) — cache survives runner image bumps. Toolchain hash via `hashFiles('rust-toolchain.toml', 'rust-toolchain')` — slang's gap that we wanted to close, addresses safety against rustc bumps invalidating cache cleanly. `restore-keys` progressively drop the lockfile and toolchain hashes for partial-match fallback.

Both target paths (`target/` and `crates/edr_napi/target/`) cached for all buckets — `crates/edr_napi/.cargo/config.toml` overrides target-dir inside napi.

### Bucket assignment

| Bucket             | Jobs                                                              |
| ------------------ | ----------------------------------------------------------------- |
| `workspace-strict` | check-edr, cargo-hack-edr (RUSTFLAGS=-Dwarnings)                  |
| `workspace-dev`    | edr-style (clippy + nightly fmt), edr-docs                        |
| `workspace-coverage` | test-edr-rs (matrix; cargo llvm-cov, dev profile, all-features) |
| `napi-coverage`    | test-edr-ts (matrix), edr-integration-tests, run-hardhat-tests (matrix; release profile via napi build, op,test-mock features) |

Cross-workflow sharing: `run-hardhat-tests` joins `napi-coverage` since it builds the same napi-rs profile transitively.

Skipped from cache wiring:
- `check-edr-safety` (no compile)
- `cooldown-check` (external action)
- `edr-napi-typings-file` (small + separate)
- `build-and-lint` (no cargo invocation)
- `edr-benchmark.yml` jobs (self-hosted runner; left alone)

### Probe (Option C): strict warning gate on test/release jobs

`test-edr-rs`, `test-edr-ts`, `edr-integration-tests`, `run-hardhat-tests` set `RUSTFLAGS=-Dwarnings` + `RUSTDOCFLAGS=-Dwarnings` at job level. Caveat: env RUSTFLAGS clobbers `target.<triple>.rustflags` in `crates/edr_napi/.cargo/config.toml`, so the Windows native build loses `+crt-static`. Tests still run on the GHA Windows runner (VC++ Redist preinstalled); the released artifact is built by `edr-npm-release.yml` separately and is unaffected. Revertable if real warnings surface that aren't worth fixing inline.

### Smaller cleanups

- **RPC cache `restore-keys`** added on the existing `actions/cache/restore` calls in `edr-ci.yml`. Save has a `hashFiles` suffix; restore now explicitly falls back through the prefix. Kills the "main has no rs caches" bug we observed.
- **Removed redundant manual `actions/cache@v4` blocks** from `js-scenario-benchmark` and `js-soltests-benchmark`. Caching paths overlapped with what Swatinem (now removed) was already doing; copy-paste leftover from the npm-release workflow's Docker bind-mount setup.
- **Doctests broadened**: `cargo test --doc --workspace --features tracing` → `--all-features`. Aligns with the main test step's compile fingerprint so they share `target/` artifacts. Revert if it surfaces real doctest breakage.
- **`cargo-hack-edr.sh` comment** explaining the `crates/edr_*/`-only loop. Powerset over feature combinations is `O(2^n)` per crate; running it on the full workspace (foundry-* has large feature graphs) would make CI prohibitively slow.
- **`actions-rust-lang/setup-rust-toolchain`** bumped v1.15.2 → v1.16.0 (Node 20 → 24 forward-compat, exposes `cache: false` cleanly).

### setup-rust composite

Always passes `cache: false` to `setup-rust-toolchain` so Swatinem never runs. Cache, cache-shared-key, cache-save-if inputs all removed (no longer plumbed). Matrix `cache-family` includes removed from edr-ci.yml (test-edr-rs, test-edr-ts) and hardhat-tests.yml — `runner.os` in the cache action handles the OS dimension.

### Save-on-PR knob

The new `save-if` input on `cache-rust-{deps,target}/save` defaults to `'true'` (save on every run, including PRs — matches current iteration behavior). When iteration stabilizes and Renovate starts producing churny PRs that accumulate cache budget, callsites can pass `${{ github.ref == 'refs/heads/main' }}` to gate save to main pushes only. Per-ref scoping prevents PR caches from poisoning main, so save-on-PR is not a security concern — it's purely a budget question.

## What this branch does not do

- **sccache** (attempted earlier in this branch, fully removed). sccache 0.15.0's native GHA backend has 100% cache write failures with GitHub's Actions Cache v2 (full diagnosis in research doc). Two paths forward: wait for sccache 0.16+ with v2 support, or mirror solx's pattern (`SCCACHE_DIR` + `actions/cache` wrapper). Either is a separate PR.
- **Test execution time** (the 30-minute critical path). Not a caching problem. nextest sharding is the lever — TODO at `edr-ci.yml:142` pending two upstream issues.
- **Node 20 → 24 upgrade** (two axes: tested Node.js versions in matrices, and GHA action JS runtimes). Deadline 2026-06-02 (forced default) / 2026-09-16 (removal). Separate.
- **`[workspace.lints]` deny-warnings refactor**. Three-commit refactor (77 Cargo.toml + audit + flip). Sequenced after the Option C probe tells us how clean the codebase is.
- **Hung-job timeouts** (paused on `ci/job-timeouts` branch with handoff doc).
- **Cleanup of stale `v0-rust-*` Swatinem caches**. Will let LRU eviction handle naturally; manual `gh api -X DELETE` is reserved for if budget pressure becomes acute.

## Test plan

- [ ] First push after the slang-pattern switch: confirm new buckets appear in `gh api .../actions/caches` with names `rust-target-{Linux,macOS,Windows}-{workspace-strict,workspace-dev,workspace-coverage,napi-coverage}-v1-…` and `rust-deps-{Linux,macOS,Windows}-v1-…`.
- [ ] Second push: confirm cache hits on those buckets (setup-rust step similar duration to baseline).
- [ ] Confirm Linux/macOS Test EDR (rs) compile time drops back from 5m 32s toward 1m-something (the regression we attributed to Swatinem pruning should reverse with the slang pattern).
- [ ] Option C probe: do test/integration/hardhat jobs surface any new `-Dwarnings` failures? Fix or revert.
- [ ] Doctests: does `cargo test --doc --workspace --all-features` still build cleanly? If not, revert that line.
- [ ] Benchmark workflow still passes on self-hosted runner.
- [ ] Closer to merge: flip `save-if` to main-only, confirm PR runs no longer save.