### PR TITLE
ci: gate test/integration jobs on -Dwarnings

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,3 +5,21 @@ scenario-with-tracing   = "run --locked --release --features tracing --bin edr_t
 replay-block            = "run --locked --release --bin edr_tool_cli -- replay-block"
 generate-cheats-interface = "test -p foundry-cheatcodes-spec --features schema --locked tests::"
 op-chain-config         = "run --locked --release --bin edr_tool_op_chain_config_generator"
+
+# Per-target rustflags must live in the workspace root so they apply to
+# cargo invocations from anywhere in the tree. A copy under
+# crates/edr_napi/.cargo/ would only be loaded when cargo is invoked from
+# inside that crate (Cargo searches cwd upward, never into subdirectories).
+#
+# These are clobbered wholesale by env RUSTFLAGS — Cargo's resolution is
+# "first source wins, no merging." Jobs that set RUSTFLAGS (warning gate,
+# cargo-llvm-cov instrumentation) must include `-C target-feature=...` in
+# the env value or accept a CRT-linkage divergence from the released NAPI.
+# `.github/actions/setup-rust` augments RUSTFLAGS on Windows runners to
+# preserve `+crt-static`.
+[target.aarch64-unknown-linux-musl]
+linker = "aarch64-linux-musl-gcc"
+rustflags = ["-C", "target-feature=-crt-static"]
+
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -29,3 +29,20 @@ runs:
         # By default, we do not override the toolchain from rust-toolchain.
         # The user needs to explicitly use `<cmd> +<toolchain>` for clarity.
         override: false
+
+    # Append platform target features to RUSTFLAGS so they survive any env
+    # RUSTFLAGS the job (or cargo-llvm-cov, etc.) sets. Cargo's resolution
+    # rule is "first source wins, no merging" — env RUSTFLAGS clobbers the
+    # `target.<triple>.rustflags` from .cargo/config.toml wholesale, so the
+    # only reliable way to preserve `+crt-static` on Windows test builds
+    # (matching the released NAPI ABI) is to bake it into the env value
+    # itself before any later step appends instrumentation flags.
+    - name: Augment RUSTFLAGS with platform target features
+      shell: bash
+      run: |
+        case "$RUNNER_OS" in
+          Windows)
+            echo "RUSTFLAGS=${RUSTFLAGS:-} -C target-feature=+crt-static" >> "$GITHUB_ENV"
+            ;;
+          *) ;;
+        esac

--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -85,6 +85,16 @@ jobs:
     name: Test EDR (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     needs: check-edr
+    # Set strict warning gate on test compiles to surface any latent
+    # warnings in test/cfg(test) code paths. Caveat: env RUSTFLAGS
+    # clobbers `target.<triple>.rustflags` from
+    # crates/edr_napi/.cargo/config.toml, so the Windows native build
+    # loses `+crt-static`. Tests still run on the GHA Windows runner
+    # (VC++ Redistributable is installed); the released artifact is
+    # built separately by edr-npm-release.yml and is unaffected.
+    env:
+      RUSTFLAGS: -Dwarnings
+      RUSTDOCFLAGS: -Dwarnings
     strategy:
       fail-fast: false
       matrix:
@@ -152,6 +162,10 @@ jobs:
     name: Test EDR TS bindings (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     needs: check-edr
+    # See comment on test-edr-rs above. Same crt-static caveat applies.
+    env:
+      RUSTFLAGS: -Dwarnings
+      RUSTDOCFLAGS: -Dwarnings
     strategy:
       fail-fast: false
       matrix:
@@ -296,6 +310,10 @@ jobs:
     name: Run integration tests
     runs-on: ubuntu-24.04
     needs: check-edr-safety
+    # See comment on test-edr-rs above.
+    env:
+      RUSTFLAGS: -Dwarnings
+      RUSTDOCFLAGS: -Dwarnings
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:

--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -192,7 +192,7 @@ jobs:
           FORCE_COLOR: 3
         shell: bash
         run: |
-          source <(cargo llvm-cov show-env --export-prefix)
+          source <(cargo llvm-cov show-env --sh)
           pnpm -C crates/edr_napi test
           # `--release` included to match `build:dev` compilation flags
           cargo llvm-cov report --release --locked --codecov --output-path codecov.json
@@ -318,7 +318,7 @@ jobs:
       - name: Run integration tests
         shell: bash
         run: |
-          source <(cargo llvm-cov show-env --export-prefix)
+          source <(cargo llvm-cov show-env --sh)
           pnpm run --recursive --filter './js/integration-tests/*' test
           # `--release` included to match `build:dev` compilation flags
           cargo llvm-cov report --release --locked --codecov --output-path codecov.json

--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -85,13 +85,10 @@ jobs:
     name: Test EDR (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     needs: check-edr
-    # Set strict warning gate on test compiles to surface any latent
-    # warnings in test/cfg(test) code paths. Caveat: env RUSTFLAGS
-    # clobbers `target.<triple>.rustflags` from
-    # crates/edr_napi/.cargo/config.toml, so the Windows native build
-    # loses `+crt-static`. Tests still run on the GHA Windows runner
-    # (VC++ Redistributable is installed); the released artifact is
-    # built separately by edr-npm-release.yml and is unaffected.
+    # Strict warning gate on test/cfg(test) compiles. The setup-rust
+    # composite action appends `-C target-feature=+crt-static` on
+    # Windows so this env value doesn't clobber the CRT-static linkage
+    # that matches the released NAPI artifact.
     env:
       RUSTFLAGS: -Dwarnings
       RUSTDOCFLAGS: -Dwarnings
@@ -162,7 +159,7 @@ jobs:
     name: Test EDR TS bindings (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     needs: check-edr
-    # See comment on test-edr-rs above. Same crt-static caveat applies.
+    # See comment on test-edr-rs above re crt-static handling.
     env:
       RUSTFLAGS: -Dwarnings
       RUSTDOCFLAGS: -Dwarnings
@@ -310,7 +307,6 @@ jobs:
     name: Run integration tests
     runs-on: ubuntu-24.04
     needs: check-edr-safety
-    # See comment on test-edr-rs above.
     env:
       RUSTFLAGS: -Dwarnings
       RUSTDOCFLAGS: -Dwarnings

--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53
         with:
-          tool: cargo-llvm-cov@0.6.21
+          tool: cargo-llvm-cov@0.8.5
 
       - name: Restore EDR RPC cache
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
@@ -173,7 +173,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53
         with:
-          tool: cargo-llvm-cov@0.6.21
+          tool: cargo-llvm-cov@0.8.5
 
       - name: Restore EDR RPC cache
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
@@ -310,7 +310,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53
         with:
-          tool: cargo-llvm-cov@0.6.21
+          tool: cargo-llvm-cov@0.8.5
 
       - name: Install package
         run: pnpm install --frozen-lockfile --prefer-offline

--- a/.github/workflows/hardhat-tests.yml
+++ b/.github/workflows/hardhat-tests.yml
@@ -13,6 +13,12 @@ jobs:
   run-hardhat-tests:
     name: Run Hardhat tests (${{ matrix.os }}, Node ${{ matrix.node }})
     runs-on: ${{ matrix.os }}
+    # See comment on test-edr-rs in edr-ci.yml. Same crt-static caveat
+    # applies on Windows native — release artifact is built by
+    # edr-npm-release.yml separately and is unaffected.
+    env:
+      RUSTFLAGS: -Dwarnings
+      RUSTDOCFLAGS: -Dwarnings
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/hardhat-tests.yml
+++ b/.github/workflows/hardhat-tests.yml
@@ -13,9 +13,7 @@ jobs:
   run-hardhat-tests:
     name: Run Hardhat tests (${{ matrix.os }}, Node ${{ matrix.node }})
     runs-on: ${{ matrix.os }}
-    # See comment on test-edr-rs in edr-ci.yml. Same crt-static caveat
-    # applies on Windows native — release artifact is built by
-    # edr-npm-release.yml separately and is unaffected.
+    # See comment on test-edr-rs in edr-ci.yml re crt-static handling.
     env:
       RUSTFLAGS: -Dwarnings
       RUSTDOCFLAGS: -Dwarnings

--- a/.github/workflows/hardhat-tests.yml
+++ b/.github/workflows/hardhat-tests.yml
@@ -63,7 +63,7 @@ jobs:
           DEBUG: "hardhat:core:hardhat-network:*"
         shell: bash
         run: |
-          source <(cargo llvm-cov show-env --export-prefix)
+          source <(cargo llvm-cov show-env --sh)
           pnpm -C hardhat-tests test
           # `--release` included to match `build:dev` compilation flags
           cargo llvm-cov report --release --locked --codecov --output-path codecov.json

--- a/.github/workflows/hardhat-tests.yml
+++ b/.github/workflows/hardhat-tests.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53
         with:
-          tool: cargo-llvm-cov@0.6.21
+          tool: cargo-llvm-cov@0.8.5
 
       - name: Install package
         run: pnpm install --frozen-lockfile --prefer-offline

--- a/crates/edr_napi/.cargo/config.toml
+++ b/crates/edr_napi/.cargo/config.toml
@@ -3,9 +3,8 @@
 # Let's use a separate target-dir "$THIS_CRATE/target" to avoid invalidating the workspace-level cache.
 target-dir = "./target"
 
-[target.aarch64-unknown-linux-musl]
-linker = "aarch64-linux-musl-gcc"
-rustflags = ["-C", "target-feature=-crt-static"]
-
-[target.x86_64-pc-windows-msvc]
-rustflags = ["-C", "target-feature=+crt-static"]
+# Per-target rustflags moved to the workspace-root .cargo/config.toml so
+# they apply to cargo invocations from anywhere in the tree (notably
+# test-edr-rs, which runs from the repo root and previously never picked
+# them up). Workspace-root config is loaded here too via Cargo's
+# cwd-upward search.


### PR DESCRIPTION
Note: still stacked on #1376.

## Summary

Adds `RUSTFLAGS=-Dwarnings` to test/integration jobs and reworks where per-target rustflags live so the gate doesn't drop `+crt-static` from Windows test builds. Unifying `RUSTFLAGS` is also a precondition for #1374's caching work — Cargo's fingerprint hashes the value, so consistent env across jobs is needed before bucket consolidation can land.

Stacked on #1376, which fixed cargo-llvm-cov's contribution to the same `+crt-static`-clobbering bug; this PR closes the remaining sources.

## Changes

1. **Warning gate.** `RUSTFLAGS=-Dwarnings` + `RUSTDOCFLAGS=-Dwarnings` on `test-edr-rs`, `test-edr-ts`, `edr-integration-tests`, `run-hardhat-tests`. Previously only `check-edr` / `cargo-hack-edr` enforced this; warnings in `cfg(test)` code slipped through across all 3 OSes.
2. **Workspace-root rustflags.** Move `target.<triple>.rustflags` from `crates/edr_napi/.cargo/config.toml` to the workspace-root `.cargo/config.toml`.
3. **setup-rust augmentation.** On Windows runners, append `-C target-feature=+crt-static` to `RUSTFLAGS` so it survives any env value set later.

## Why (2) and (3)

Cargo's rustflags resolution is "first source wins, no merging." A job env `RUSTFLAGS` clobbers `target.<triple>.rustflags` from `.cargo/config.toml` wholesale. Two compounding problems made test builds diverge from the release ABI on Windows:

- **Pre-existing**: `test-edr-rs` runs cargo from the repo root, where the package-local config is never read — its Windows builds have always linked the CRT dynamically while the released NAPI links statically. Change (1) didn't introduce this; it surfaced it.
- **Would be introduced by (1) on this branch alone**: `test-edr-ts` and `run-hardhat-tests` invoke cargo from inside `crates/edr_napi/` (via napi build), where the package-local config *is* loaded — but the warning gate's env `RUSTFLAGS` would clobber it.

Change (2) fixes the first: workspace-root config is found by repo-root invocations. Change (3) fixes the second: the target feature is baked into `RUSTFLAGS` *before* the gate is set, so the env value already includes it. Stacked on #1376 because cargo-llvm-cov 0.7+ no longer mutates `RUSTFLAGS` itself, leaving the warning gate as the only remaining clobber source.

The released artifact is unaffected: `edr-npm-release.yml` sets no `RUSTFLAGS` and runs from `crates/edr_napi/`, so config loads cleanly. Same logic generalizes to `aarch64-unknown-linux-musl` (`-crt-static`) for completeness, though no test job runs on a musl host.