### PR TITLE
ci: upgrade cargo-llvm-cov 0.6.21 → 0.8.5

### DIFF
--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -192,7 +192,7 @@ jobs:
           FORCE_COLOR: 3
         shell: bash
         run: |
-          source <(cargo llvm-cov show-env --export-prefix)
+          source <(cargo llvm-cov show-env --sh)
           pnpm -C crates/edr_napi test
           # `--release` included to match `build:dev` compilation flags
           cargo llvm-cov report --release --locked --codecov --output-path codecov.json
@@ -318,7 +318,7 @@ jobs:
       - name: Run integration tests
         shell: bash
         run: |
-          source <(cargo llvm-cov show-env --export-prefix)
+          source <(cargo llvm-cov show-env --sh)
           pnpm run --recursive --filter './js/integration-tests/*' test
           # `--release` included to match `build:dev` compilation flags
           cargo llvm-cov report --release --locked --codecov --output-path codecov.json

--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53
         with:
-          tool: cargo-llvm-cov@0.6.21
+          tool: cargo-llvm-cov@0.8.5
 
       - name: Restore EDR RPC cache
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
@@ -173,7 +173,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53
         with:
-          tool: cargo-llvm-cov@0.6.21
+          tool: cargo-llvm-cov@0.8.5
 
       - name: Restore EDR RPC cache
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
@@ -310,7 +310,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53
         with:
-          tool: cargo-llvm-cov@0.6.21
+          tool: cargo-llvm-cov@0.8.5
 
       - name: Install package
         run: pnpm install --frozen-lockfile --prefer-offline

--- a/.github/workflows/hardhat-tests.yml
+++ b/.github/workflows/hardhat-tests.yml
@@ -63,7 +63,7 @@ jobs:
           DEBUG: "hardhat:core:hardhat-network:*"
         shell: bash
         run: |
-          source <(cargo llvm-cov show-env --export-prefix)
+          source <(cargo llvm-cov show-env --sh)
           pnpm -C hardhat-tests test
           # `--release` included to match `build:dev` compilation flags
           cargo llvm-cov report --release --locked --codecov --output-path codecov.json

--- a/.github/workflows/hardhat-tests.yml
+++ b/.github/workflows/hardhat-tests.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53
         with:
-          tool: cargo-llvm-cov@0.6.21
+          tool: cargo-llvm-cov@0.8.5
 
       - name: Install package
         run: pnpm install --frozen-lockfile --prefer-offline


### PR DESCRIPTION
Bumps `cargo-llvm-cov` from 0.6.21 to 0.8.5.

0.6.x runs `cargo clean -p <each-workspace-member>` before every invocation, which deletes the per-crate `.fingerprint/<crate>-<hash>/` directories. Result: our coverage-instrumented jobs (`test-edr-rs`, `test-edr-ts`, `edr-integration-tests`, `run-hardhat-tests`) recompile the whole workspace on every CI run regardless of cache state. Confirmed on probe runs against `ci/improve-caching` — fingerprints were sha256-confirmed in the restored cache, deleted before `prepare_target`, then rewritten with identical content during the rebuild.

0.7+ ([taiki-e/cargo-llvm-cov#471](https://github.com/taiki-e/cargo-llvm-cov/pull/471)) replaced the strategy with `RUSTC_WRAPPER`. `-C instrument-coverage` now gets appended to rustc's argv after cargo has resolved everything, so global `RUSTFLAGS` is untouched and the pre-build `cargo clean -p` is gone. Workspace fingerprints survive across runs.

Drop-in upgrade for the 4 invocations across `edr-ci.yml` and `hardhat-tests.yml`. The three `cargo llvm-cov show-env --export-prefix` callsites are renamed to `--sh` (the modern flag introduced in 0.7.0; same output). MSRV is rustc 1.87+ (we're on 1.91.0).

Refs upstream: [#198](https://github.com/taiki-e/cargo-llvm-cov/issues/198), [#293](https://github.com/taiki-e/cargo-llvm-cov/issues/293).

This also addressed llvm-cov removing the `+crt-static` from a few of our runs. Will address a few more in https://github.com/NomicFoundation/edr/pull/1375.