### PR TITLE
ci: cap mocha test jobs at 30m and dump active handles on exit

### DIFF
--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -159,6 +159,9 @@ jobs:
     name: Test EDR TS bindings (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     needs: check-edr
+    # Cap below GHA's 6h ceiling so the recurring mocha-process-hang surfaces
+    # within ~2× normal runtime instead of burning a full job slot.
+    timeout-minutes: 30
     # See comment on test-edr-rs above re crt-static handling.
     env:
       RUSTFLAGS: -Dwarnings

--- a/.github/workflows/hardhat-tests.yml
+++ b/.github/workflows/hardhat-tests.yml
@@ -13,6 +13,9 @@ jobs:
   run-hardhat-tests:
     name: Run Hardhat tests (${{ matrix.os }}, Node ${{ matrix.node }})
     runs-on: ${{ matrix.os }}
+    # Cap below GHA's 6h ceiling so the recurring mocha-process-hang surfaces
+    # within ~2× normal runtime instead of burning a full job slot.
+    timeout-minutes: 30
     # See comment on test-edr-rs in edr-ci.yml re crt-static handling.
     env:
       RUSTFLAGS: -Dwarnings

--- a/crates/edr_napi/.mocharc.json
+++ b/crates/edr_napi/.mocharc.json
@@ -1,4 +1,5 @@
 {
   "require": "ts-node/register/transpile-only",
+  "file": "./test/setup.ts",
   "timeout": 25000
 }

--- a/crates/edr_napi/package.json
+++ b/crates/edr_napi/package.json
@@ -74,7 +74,7 @@
     "lint:fix": "pnpm run prettier --write",
     "pretest": "pnpm build:dev",
     "prettier": "prettier --check \"test/**.ts\"",
-    "test": "node --max-old-space-size=8192 --expose-gc node_modules/mocha/bin/_mocha --recursive \"test/**/*.ts\"",
+    "test": "node --max-old-space-size=8192 node_modules/mocha/bin/_mocha --recursive \"test/**/*.ts\"",
     "testNoBuild": "node --max-old-space-size=8192 node_modules/mocha/bin/_mocha --recursive \"test/**/{,!(logs|mock)}.ts\"",
     "universal": "napi universal",
     "version": "napi version"

--- a/crates/edr_napi/package.json
+++ b/crates/edr_napi/package.json
@@ -74,7 +74,7 @@
     "lint:fix": "pnpm run prettier --write",
     "pretest": "pnpm build:dev",
     "prettier": "prettier --check \"test/**.ts\"",
-    "test": "node --max-old-space-size=8192 node_modules/mocha/bin/_mocha --recursive \"test/**/*.ts\"",
+    "test": "node --max-old-space-size=8192 --expose-gc node_modules/mocha/bin/_mocha --recursive \"test/**/*.ts\"",
     "testNoBuild": "node --max-old-space-size=8192 node_modules/mocha/bin/_mocha --recursive \"test/**/{,!(logs|mock)}.ts\"",
     "universal": "napi universal",
     "version": "napi version"

--- a/crates/edr_napi/test/logs.ts
+++ b/crates/edr_napi/test/logs.ts
@@ -429,27 +429,30 @@ describe("Provider logs", function () {
       }
     });
 
-    it("should print a block with one transaction", async function () {
-      await sendTransaction(provider, { gasPrice });
-
-      logger.reset();
-
-      await intervalMine(logger, mockTimer);
-
-      assert.lengthOf(logger.lines, 9);
-      // prettier-ignore
-      {
-            assert.match(logger.lines[0], /^Mined block #\d+$/);
-            assert.match(logger.lines[1], /^  Block: 0x[0-9a-f]{64}/);
-            assert.match(logger.lines[2], /^    Base fee: \d+$/);
-            assert.match(logger.lines[3], /^    Transaction: 0x[0-9a-f]{64}/);
-            assert.match(logger.lines[4], /^      From:      0x[0-9a-f]{40}/);
-            assert.match(logger.lines[5], /^      To:        0x[0-9a-f]{40}/);
-            assert.match(logger.lines[6], /^      Value:     0 ETH$/);
-            assert.match(logger.lines[7], /^      Gas used:  21000 of 21000$/);
-            assert.equal(logger.lines[8], "");
-          }
-    });
+    // EXPERIMENT: amplify the failing trigger by registering it 20 times.
+    // Each rep is its own `it()`, so mocha's per-test 25s timeout fires
+    // cheaply on a hang rather than wedging the whole job. Revert before
+    // merge.
+    for (let rep = 0; rep < 20; rep++) {
+      it(`should print a block with one transaction (rep ${rep})`, async function () {
+        await sendTransaction(provider, { gasPrice });
+        logger.reset();
+        await intervalMine(logger, mockTimer);
+        assert.lengthOf(logger.lines, 9);
+        // prettier-ignore
+        {
+          assert.match(logger.lines[0], /^Mined block #\d+$/);
+          assert.match(logger.lines[1], /^  Block: 0x[0-9a-f]{64}/);
+          assert.match(logger.lines[2], /^    Base fee: \d+$/);
+          assert.match(logger.lines[3], /^    Transaction: 0x[0-9a-f]{64}/);
+          assert.match(logger.lines[4], /^      From:      0x[0-9a-f]{40}/);
+          assert.match(logger.lines[5], /^      To:        0x[0-9a-f]{40}/);
+          assert.match(logger.lines[6], /^      Value:     0 ETH$/);
+          assert.match(logger.lines[7], /^      Gas used:  21000 of 21000$/);
+          assert.equal(logger.lines[8], "");
+        }
+      });
+    }
 
     it("should print a block with two transactions", async function () {
       await sendTransaction(provider, { gasPrice });

--- a/crates/edr_napi/test/logs.ts
+++ b/crates/edr_napi/test/logs.ts
@@ -262,6 +262,73 @@ const providerConfig = {
 describe("Provider logs", function () {
   const mockTimer = MockTime.now();
 
+  // EXPERIMENT: copy of `should print a block with one transaction` —
+  // the test that the recurring CI hang dies before — placed in its own
+  // describe with its own MockTime, logger and Provider, and registered
+  // BEFORE `Interval mining` so it runs without any leaked sibling
+  // providers subscribed to the shared mockTimer. If this passes while
+  // the original (below) still hangs, the cause is shared state across
+  // siblings; if both hang, the bug is intrinsic to sendTransaction +
+  // intervalMine in this configuration.
+  describe("Interval mining (isolated repro of test 4)", function () {
+    it("should print a block with one transaction (isolated)", async function () {
+      const isolatedTimer = MockTime.now();
+      const isolatedLogger = new FakeModulesLogger();
+      const isolatedLoggerConfig = {
+        enable: true,
+        decodeConsoleLogInputsCallback: (inputs: ArrayBuffer[]): string[] => {
+          return ConsoleLogger.getDecodedLogs(
+            inputs.map((input) => Buffer.from(input))
+          );
+        },
+        printLineCallback: (message: string, replace: boolean): void => {
+          if (replace) {
+            isolatedLogger.replaceLastLineFn()(message);
+          } else {
+            isolatedLogger.printLineFn()(message);
+          }
+        },
+      };
+
+      const isolatedProvider = await createProviderWithMockTimer(
+        {
+          ...providerConfig,
+          genesisState: providerConfig.genesisState.concat(
+            l1GenesisState(l1HardforkFromString(providerConfig.hardfork))
+          ),
+        },
+        isolatedLoggerConfig,
+        {
+          subscriptionCallback: (_event: SubscriptionEvent) => {},
+        },
+        new ContractDecoder(),
+        isolatedTimer
+      );
+
+      const isolatedGasPrice = await getGasPrice(isolatedProvider);
+      isolatedLogger.reset();
+
+      await sendTransaction(isolatedProvider, { gasPrice: isolatedGasPrice });
+      isolatedLogger.reset();
+
+      await intervalMine(isolatedLogger, isolatedTimer);
+
+      assert.lengthOf(isolatedLogger.lines, 9);
+      // prettier-ignore
+      {
+        assert.match(isolatedLogger.lines[0], /^Mined block #\d+$/);
+        assert.match(isolatedLogger.lines[1], /^  Block: 0x[0-9a-f]{64}/);
+        assert.match(isolatedLogger.lines[2], /^    Base fee: \d+$/);
+        assert.match(isolatedLogger.lines[3], /^    Transaction: 0x[0-9a-f]{64}/);
+        assert.match(isolatedLogger.lines[4], /^      From:      0x[0-9a-f]{40}/);
+        assert.match(isolatedLogger.lines[5], /^      To:        0x[0-9a-f]{40}/);
+        assert.match(isolatedLogger.lines[6], /^      Value:     0 ETH$/);
+        assert.match(isolatedLogger.lines[7], /^      Gas used:  21000 of 21000$/);
+        assert.equal(isolatedLogger.lines[8], "");
+      }
+    });
+  });
+
   describe("Interval mining", function () {
     let gasPrice: bigint;
     let logger: FakeModulesLogger;

--- a/crates/edr_napi/test/logs.ts
+++ b/crates/edr_napi/test/logs.ts
@@ -378,23 +378,6 @@ describe("Provider logs", function () {
       logger.reset();
     });
 
-    // EXPERIMENT: drop the provider reference and force GC after each
-    // test so the previous Provider's tokio runtime tasks (still
-    // subscribed to the shared `mockTimer`) are torn down before the
-    // next beforeEach spawns a fresh one. If the recurring hang at
-    // `should print a block with one transaction` goes away with this
-    // hook, the cause is leaked siblings — and the proper fix is to
-    // expose a `Provider.close()` API from edr_napi so cleanup doesn't
-    // depend on JS GC.
-    afterEach(async function () {
-      provider = undefined as unknown as Provider;
-      const maybeGc = (globalThis as { gc?: () => void }).gc;
-      if (typeof maybeGc === "function") {
-        maybeGc();
-      }
-      await new Promise((resolve) => setTimeout(resolve, 100));
-    });
-
     it("should only print the mined block when there are no pending txs", async function () {
       await intervalMine(logger, mockTimer);
 

--- a/crates/edr_napi/test/logs.ts
+++ b/crates/edr_napi/test/logs.ts
@@ -311,6 +311,23 @@ describe("Provider logs", function () {
       logger.reset();
     });
 
+    // EXPERIMENT: drop the provider reference and force GC after each
+    // test so the previous Provider's tokio runtime tasks (still
+    // subscribed to the shared `mockTimer`) are torn down before the
+    // next beforeEach spawns a fresh one. If the recurring hang at
+    // `should print a block with one transaction` goes away with this
+    // hook, the cause is leaked siblings — and the proper fix is to
+    // expose a `Provider.close()` API from edr_napi so cleanup doesn't
+    // depend on JS GC.
+    afterEach(async function () {
+      provider = undefined as unknown as Provider;
+      const maybeGc = (globalThis as { gc?: () => void }).gc;
+      if (typeof maybeGc === "function") {
+        maybeGc();
+      }
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    });
+
     it("should only print the mined block when there are no pending txs", async function () {
       await intervalMine(logger, mockTimer);
 

--- a/crates/edr_napi/test/setup.ts
+++ b/crates/edr_napi/test/setup.ts
@@ -1,7 +1,47 @@
-// Diagnostic for the recurring 6h CI hang: if the process is still alive a
-// few seconds after the last test, dump active async resources and force-exit
-// so CI surfaces *what* is keeping the event loop open (likely a leaked
-// edr_napi handle / tokio runtime / HTTP socket).
+import { Worker } from "worker_threads";
+
+// Probe 1: log every test the moment it starts. The default mocha spec
+// reporter only prints a name on completion, so when the loop wedges mid-test
+// the log gives no clue *which* test was running. The last `[mocha-start]`
+// line in CI output now answers that definitively.
+beforeEach(function () {
+  // eslint-disable-next-line no-console
+  console.error(
+    `[mocha-start] ${this.currentTest?.fullTitle() ?? "(no test)"}`
+  );
+});
+
+// Probe 2: heartbeat watchdog running on a Worker thread. The recurring hang
+// looks like a hard JS-event-loop jam (mocha's per-test setTimeout never
+// fires), so any diagnostic that runs on the main loop is silenced. A worker
+// has its own loop and keeps printing even when the main thread is wedged.
+const WATCHDOG_HEARTBEAT_MS = 5_000;
+const WATCHDOG_STALL_MS = 30_000;
+const watchdogSource = `
+  const { parentPort } = require("worker_threads");
+  let lastBeat = Date.now();
+  let lastWarning = 0;
+  parentPort.on("message", (msg) => {
+    if (msg && msg.type === "beat") lastBeat = Date.now();
+  });
+  setInterval(() => {
+    const silentMs = Date.now() - lastBeat;
+    if (silentMs >= ${WATCHDOG_STALL_MS} && Date.now() - lastWarning >= ${WATCHDOG_STALL_MS}) {
+      console.error("[mocha-watchdog] main-thread silent for " + Math.round(silentMs / 1000) + "s");
+      lastWarning = Date.now();
+    }
+  }, ${WATCHDOG_HEARTBEAT_MS}).unref();
+`;
+const watchdog = new Worker(watchdogSource, { eval: true });
+watchdog.unref();
+const heartbeat = setInterval(() => {
+  watchdog.postMessage({ type: "beat" });
+}, WATCHDOG_HEARTBEAT_MS);
+heartbeat.unref();
+
+// Probe 3 (existing): if the loop *is* still functional but a handle is
+// keeping the process alive after the suite ends, dump the active resources
+// 5s after the last `after` and force-exit so CI doesn't burn the timeout.
 after(function () {
   setTimeout(() => {
     const active =

--- a/crates/edr_napi/test/setup.ts
+++ b/crates/edr_napi/test/setup.ts
@@ -15,29 +15,72 @@ beforeEach(function () {
 // looks like a hard JS-event-loop jam (mocha's per-test setTimeout never
 // fires), so any diagnostic that runs on the main loop is silenced. A worker
 // has its own loop and keeps printing even when the main thread is wedged.
+//
+// First instrumented run produced no watchdog output during a 21-min hang,
+// so this iteration is self-instrumenting: lifecycle handlers prove whether
+// the worker even started, the worker logs on startup, and the main thread
+// emits a periodic alive line independent of the worker so we can tell
+// whether the JS loop itself is moving.
 const WATCHDOG_HEARTBEAT_MS = 5_000;
 const WATCHDOG_STALL_MS = 30_000;
+const MAIN_ALIVE_MS = 10_000;
 const watchdogSource = `
   const { parentPort } = require("worker_threads");
+  console.error("[mocha-watchdog] worker started, pid=" + process.pid);
   let lastBeat = Date.now();
   let lastWarning = 0;
+  let beatCount = 0;
   parentPort.on("message", (msg) => {
-    if (msg && msg.type === "beat") lastBeat = Date.now();
+    if (msg && msg.type === "beat") {
+      lastBeat = Date.now();
+      beatCount++;
+    }
   });
   setInterval(() => {
     const silentMs = Date.now() - lastBeat;
     if (silentMs >= ${WATCHDOG_STALL_MS} && Date.now() - lastWarning >= ${WATCHDOG_STALL_MS}) {
-      console.error("[mocha-watchdog] main-thread silent for " + Math.round(silentMs / 1000) + "s");
+      console.error("[mocha-watchdog] main-thread silent for " + Math.round(silentMs / 1000) + "s (beats=" + beatCount + ")");
       lastWarning = Date.now();
     }
   }, ${WATCHDOG_HEARTBEAT_MS}).unref();
 `;
-const watchdog = new Worker(watchdogSource, { eval: true });
-watchdog.unref();
+let watchdog: Worker | null = null;
+try {
+  watchdog = new Worker(watchdogSource, { eval: true });
+  watchdog.on("error", (err) => {
+    // eslint-disable-next-line no-console
+    console.error(`[mocha-watchdog] worker error: ${err.message}`);
+  });
+  watchdog.on("exit", (code) => {
+    // eslint-disable-next-line no-console
+    console.error(`[mocha-watchdog] worker exited code=${code}`);
+  });
+  watchdog.on("online", () => {
+    // eslint-disable-next-line no-console
+    console.error("[mocha-watchdog] worker online");
+  });
+  watchdog.unref();
+} catch (err) {
+  // eslint-disable-next-line no-console
+  console.error(
+    `[mocha-watchdog] failed to spawn worker: ${(err as Error).message}`
+  );
+}
+
 const heartbeat = setInterval(() => {
-  watchdog.postMessage({ type: "beat" });
+  watchdog?.postMessage({ type: "beat" });
 }, WATCHDOG_HEARTBEAT_MS);
 heartbeat.unref();
+
+// Probe 2b: main-thread liveness ping. Independent of the worker — if these
+// lines stop appearing, the JS event loop itself is wedged. If they keep
+// appearing through a hang, the loop is alive but mocha's per-test timer is
+// somehow disabled or a NAPI promise isn't resolving.
+const mainAlive = setInterval(() => {
+  // eslint-disable-next-line no-console
+  console.error(`[mocha-main-alive] uptime=${Math.round(process.uptime())}s`);
+}, MAIN_ALIVE_MS);
+mainAlive.unref();
 
 // Probe 3 (existing): if the loop *is* still functional but a handle is
 // keeping the process alive after the suite ends, dump the active resources

--- a/crates/edr_napi/test/setup.ts
+++ b/crates/edr_napi/test/setup.ts
@@ -1,0 +1,17 @@
+// Diagnostic for the recurring 6h CI hang: if the process is still alive a
+// few seconds after the last test, dump active async resources and force-exit
+// so CI surfaces *what* is keeping the event loop open (likely a leaked
+// edr_napi handle / tokio runtime / HTTP socket).
+after(function () {
+  setTimeout(() => {
+    const active =
+      typeof (process as any).getActiveResourcesInfo === "function"
+        ? (process as any).getActiveResourcesInfo()
+        : [];
+    // eslint-disable-next-line no-console
+    console.error(
+      `[mocha-exit-diagnostic] process still alive after suite; active resources (${active.length}): ${JSON.stringify(active)}`
+    );
+    process.exit(0);
+  }, 5000).unref();
+});

--- a/hardhat-tests/test/setup.ts
+++ b/hardhat-tests/test/setup.ts
@@ -33,3 +33,21 @@ if (INFURA_URL === undefined) {
 if (ALCHEMY_URL === undefined) {
   printForkingLogicNotBeingTestedWarning("ALCHEMY_URL");
 }
+
+// Diagnostic for the recurring 6h CI hang: if the process is still alive a
+// few seconds after the last test, dump active async resources and force-exit
+// so CI surfaces *what* is keeping the event loop open (likely a leaked
+// edr_napi handle / tokio runtime / HTTP socket).
+after(function () {
+  setTimeout(() => {
+    const active =
+      typeof (process as any).getActiveResourcesInfo === "function"
+        ? (process as any).getActiveResourcesInfo()
+        : [];
+    // eslint-disable-next-line no-console
+    console.error(
+      `[mocha-exit-diagnostic] process still alive after suite; active resources (${active.length}): ${JSON.stringify(active)}`
+    );
+    process.exit(0);
+  }, 5000).unref();
+});

--- a/hardhat-tests/test/setup.ts
+++ b/hardhat-tests/test/setup.ts
@@ -1,6 +1,7 @@
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
 import chalk from "chalk";
+import { Worker } from "worker_threads";
 
 chai.use(chaiAsPromised);
 
@@ -34,10 +35,48 @@ if (ALCHEMY_URL === undefined) {
   printForkingLogicNotBeingTestedWarning("ALCHEMY_URL");
 }
 
-// Diagnostic for the recurring 6h CI hang: if the process is still alive a
-// few seconds after the last test, dump active async resources and force-exit
-// so CI surfaces *what* is keeping the event loop open (likely a leaked
-// edr_napi handle / tokio runtime / HTTP socket).
+// Probe 1: log every test the moment it starts. The default mocha spec
+// reporter only prints a name on completion, so when the loop wedges mid-test
+// the log gives no clue *which* test was running. The last `[mocha-start]`
+// line in CI output now answers that definitively.
+beforeEach(function () {
+  // eslint-disable-next-line no-console
+  console.error(
+    `[mocha-start] ${this.currentTest?.fullTitle() ?? "(no test)"}`
+  );
+});
+
+// Probe 2: heartbeat watchdog running on a Worker thread. The recurring hang
+// looks like a hard JS-event-loop jam (mocha's per-test setTimeout never
+// fires), so any diagnostic that runs on the main loop is silenced. A worker
+// has its own loop and keeps printing even when the main thread is wedged.
+const WATCHDOG_HEARTBEAT_MS = 5_000;
+const WATCHDOG_STALL_MS = 30_000;
+const watchdogSource = `
+  const { parentPort } = require("worker_threads");
+  let lastBeat = Date.now();
+  let lastWarning = 0;
+  parentPort.on("message", (msg) => {
+    if (msg && msg.type === "beat") lastBeat = Date.now();
+  });
+  setInterval(() => {
+    const silentMs = Date.now() - lastBeat;
+    if (silentMs >= ${WATCHDOG_STALL_MS} && Date.now() - lastWarning >= ${WATCHDOG_STALL_MS}) {
+      console.error("[mocha-watchdog] main-thread silent for " + Math.round(silentMs / 1000) + "s");
+      lastWarning = Date.now();
+    }
+  }, ${WATCHDOG_HEARTBEAT_MS}).unref();
+`;
+const watchdog = new Worker(watchdogSource, { eval: true });
+watchdog.unref();
+const heartbeat = setInterval(() => {
+  watchdog.postMessage({ type: "beat" });
+}, WATCHDOG_HEARTBEAT_MS);
+heartbeat.unref();
+
+// Probe 3 (existing): if the loop *is* still functional but a handle is
+// keeping the process alive after the suite ends, dump the active resources
+// 5s after the last `after` and force-exit so CI doesn't burn the timeout.
 after(function () {
   setTimeout(() => {
     const active =

--- a/hardhat-tests/test/setup.ts
+++ b/hardhat-tests/test/setup.ts
@@ -50,29 +50,72 @@ beforeEach(function () {
 // looks like a hard JS-event-loop jam (mocha's per-test setTimeout never
 // fires), so any diagnostic that runs on the main loop is silenced. A worker
 // has its own loop and keeps printing even when the main thread is wedged.
+//
+// First instrumented run produced no watchdog output during a 21-min hang,
+// so this iteration is self-instrumenting: lifecycle handlers prove whether
+// the worker even started, the worker logs on startup, and the main thread
+// emits a periodic alive line independent of the worker so we can tell
+// whether the JS loop itself is moving.
 const WATCHDOG_HEARTBEAT_MS = 5_000;
 const WATCHDOG_STALL_MS = 30_000;
+const MAIN_ALIVE_MS = 10_000;
 const watchdogSource = `
   const { parentPort } = require("worker_threads");
+  console.error("[mocha-watchdog] worker started, pid=" + process.pid);
   let lastBeat = Date.now();
   let lastWarning = 0;
+  let beatCount = 0;
   parentPort.on("message", (msg) => {
-    if (msg && msg.type === "beat") lastBeat = Date.now();
+    if (msg && msg.type === "beat") {
+      lastBeat = Date.now();
+      beatCount++;
+    }
   });
   setInterval(() => {
     const silentMs = Date.now() - lastBeat;
     if (silentMs >= ${WATCHDOG_STALL_MS} && Date.now() - lastWarning >= ${WATCHDOG_STALL_MS}) {
-      console.error("[mocha-watchdog] main-thread silent for " + Math.round(silentMs / 1000) + "s");
+      console.error("[mocha-watchdog] main-thread silent for " + Math.round(silentMs / 1000) + "s (beats=" + beatCount + ")");
       lastWarning = Date.now();
     }
   }, ${WATCHDOG_HEARTBEAT_MS}).unref();
 `;
-const watchdog = new Worker(watchdogSource, { eval: true });
-watchdog.unref();
+let watchdog: Worker | null = null;
+try {
+  watchdog = new Worker(watchdogSource, { eval: true });
+  watchdog.on("error", (err) => {
+    // eslint-disable-next-line no-console
+    console.error(`[mocha-watchdog] worker error: ${err.message}`);
+  });
+  watchdog.on("exit", (code) => {
+    // eslint-disable-next-line no-console
+    console.error(`[mocha-watchdog] worker exited code=${code}`);
+  });
+  watchdog.on("online", () => {
+    // eslint-disable-next-line no-console
+    console.error("[mocha-watchdog] worker online");
+  });
+  watchdog.unref();
+} catch (err) {
+  // eslint-disable-next-line no-console
+  console.error(
+    `[mocha-watchdog] failed to spawn worker: ${(err as Error).message}`
+  );
+}
+
 const heartbeat = setInterval(() => {
-  watchdog.postMessage({ type: "beat" });
+  watchdog?.postMessage({ type: "beat" });
 }, WATCHDOG_HEARTBEAT_MS);
 heartbeat.unref();
+
+// Probe 2b: main-thread liveness ping. Independent of the worker — if these
+// lines stop appearing, the JS event loop itself is wedged. If they keep
+// appearing through a hang, the loop is alive but mocha's per-test timer is
+// somehow disabled or a NAPI promise isn't resolving.
+const mainAlive = setInterval(() => {
+  // eslint-disable-next-line no-console
+  console.error(`[mocha-main-alive] uptime=${Math.round(process.uptime())}s`);
+}, MAIN_ALIVE_MS);
+mainAlive.unref();
 
 // Probe 3 (existing): if the loop *is* still functional but a handle is
 // keeping the process alive after the suite ends, dump the active resources


### PR DESCRIPTION
## Status

**Draft / debug branch.** Diagnostic experiments live alongside the actual CI fix. The experiment commits will be stripped before merge — once we have a real fix in `edr_napi`, this PR keeps only the `timeout-minutes:30` change and (TBD) the always-on diagnostics.

## What was happening

`Test EDR TS bindings` and `Run Hardhat tests` jobs intermittently hang for the full 6h GHA ceiling — observed across Windows, macOS, and at least once on Ubuntu. Per-test mocha timeout is 25s, but the failure mode is *total log silence* until the runner kills the job, so even mocha's own timer doesn't fire.

The hang lands in `Provider logs > Interval mining` in `crates/edr_napi/test/logs.ts`. Exact `it()` that wedges varies — sometimes test 3 (`should stop collapsing when a different method is called`), sometimes test 4 (`should print a block with one transaction`). Consistent with a timing-sensitive deadlock, not a deterministic bug location.

## Root cause

The `Interval mining` describe block declares **one shared `mockTimer`** at the outer scope and creates a fresh `Provider` in every `beforeEach` without disposing the previous one. `crates/edr_napi/src/provider.rs` defines no `Drop` impl and exposes no `close()` to JS, so the previous `Provider`'s tokio tasks (still subscribed to the shared mockTimer) keep running. With several providers all reacting to `mockTimer.addSeconds(...)` and contending on the mining notifier, one tick deadlocks deeply enough that the JS event loop itself wedges — neither mocha's per-test setTimeout nor any other timer can fire.

## Empirical confirmation

Commit `99d12d153` (afterEach that drops the provider reference, calls `globalThis.gc()`, and yields 100ms) suppressed the hang across multiple CI runs. Reverting just that commit — keeping the multiplied-trigger amplification and the diagnostic probes — produced a hang on the very next Windows TS-bindings run:

> <https://github.com/NomicFoundation/edr/actions/runs/25279523193/job/74132774239?pr=1377> — 30 m 18 s, killed at the new 30 m cap.

That swing is what proves the leaked-providers theory: with the afterEach the bug doesn't fire; without it, it does.

What the new probes captured on the failing run:

```
[mocha-watchdog] worker online
[mocha-watchdog] worker started, pid=8456
[mocha-start] should only print the mined block when there are no pending txs
✔ (1137ms)
[mocha-start] should collapse the mined block info
✔ (2168ms)
[mocha-start] should stop collapsing when a different method is called   ← test 3 starts
##[error] cancelled                                                       ← 22m 22s of silence
```

The watchdog *worker* started successfully and printed twice — but no further output from any thread arrives during the hang. No `[mocha-main-alive]` (expected every 10 s ≈ 130 lines) and no `[mocha-watchdog] main-thread silent` (expected every 30 s ≈ 44 lines). Speculation: on Windows the parent and worker share an stderr pipe and writes serialize; if the main thread deadlocks while holding the console handle, the worker blocks too. Out of scope for this PR — it's a *separate* observability problem with the diagnostic infra, not part of the bug. To peer into the hang itself we'd need an external watchdog (sidecar process polling `/proc`-equivalent on Windows).

## What's actually shipping

Two pieces, both already in the branch as commit `c615d6159`:

1. **`timeout-minutes: 30`** on `test-edr-ts` and `run-hardhat-tests`. Caps a hang at ~30 min instead of 6 h — already validated end-to-end by the failing run linked above (job died at exactly 30 m).
2. **Post-suite handle dump + force-exit** in each suite's `setup.ts`. After the last test, dumps `process.getActiveResourcesInfo()` and `process.exit(0)` 5s later. Defensive: doesn't help with the deadlock-style hang we just diagnosed (the loop is wedged before the suite ends), but covers the other failure shape where tests pass and the process won't exit.

The probes from `fc897f0f0` (`[mocha-start]` logging, worker watchdog) and `a6c8b785f` (worker lifecycle handlers + main-thread alive pings) are useful and could stay as permanent diagnostics — TBD whether to keep them or strip before merge.

## The actual fix lives elsewhere

The leaked-providers theory points at a missing API in `edr_napi`. To do this properly:

- **`crates/edr_napi/src/provider.rs`** — implement `Drop` on `Provider` that aborts in-flight tokio tasks (currently the default `Drop` just drops the `Arc`s without canceling anything spawned).
- **Expose `#[napi] pub async fn close(&self)`** — explicit JS-callable disposal, awaited so callers get deterministic cleanup. Doesn't rely on JS GC.
- Replace the `globalThis.gc()`-based `afterEach` in `logs.ts` with `await provider.close()`.

That fix will be a separate PR. This PR's only role is to (a) stop the bleeding for CI minutes via the 30 m cap and (b) document the diagnosis so the followup can land cleanly.

## Commit chronology (will be cleaned up before merge)

| SHA | What | Status |
|---|---|---|
| `c615d6159` | `timeout-minutes:30` + post-suite handle dump | **keep** |
| `fc897f0f0` | `[mocha-start]` logging + worker-thread watchdog | keep or strip |
| `99d12d153` | afterEach: drop provider + force GC + `--expose-gc` | drop — replaced by Rust fix |
| `0e51c3672` | isolated copy of failing test in own describe | drop (debug-only) |
| `a6c8b785f` | self-instrument the probes (lifecycle handlers, main-alive ping) | keep or strip |
| `1015d21e3` | multiply test 4 by 20× to amplify CI repro | drop (debug-only) |
| `4e1707892` | revert `99d12d153` to confirm the experiment was the fix | drop |
