### PR TITLE
test: stop interval mining in afterEach to prevent leaked tokio tasks

### DIFF
--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -159,6 +159,9 @@ jobs:
     name: Test EDR TS bindings (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     needs: check-edr
+    # Cap well below GHA's 6h ceiling so a hung mocha test fails fast
+    # rather than burning a full job slot.
+    timeout-minutes: 30
     # See comment on test-edr-rs above re crt-static handling.
     env:
       RUSTFLAGS: -Dwarnings

--- a/.github/workflows/hardhat-tests.yml
+++ b/.github/workflows/hardhat-tests.yml
@@ -13,6 +13,9 @@ jobs:
   run-hardhat-tests:
     name: Run Hardhat tests (${{ matrix.os }}, Node ${{ matrix.node }})
     runs-on: ${{ matrix.os }}
+    # Cap well below GHA's 6h ceiling so a hung mocha test fails fast
+    # rather than burning a full job slot.
+    timeout-minutes: 30
     # See comment on test-edr-rs in edr-ci.yml re crt-static handling.
     env:
       RUSTFLAGS: -Dwarnings

--- a/crates/edr_napi/test/logs.ts
+++ b/crates/edr_napi/test/logs.ts
@@ -260,13 +260,13 @@ const providerConfig = {
 };
 
 describe("Provider logs", function () {
-  const mockTimer = MockTime.now();
-
   describe("Interval mining", function () {
     let gasPrice: bigint;
     let logger: FakeModulesLogger;
+    let mockTimer: MockTime;
     let provider: Provider;
     beforeEach(async function () {
+      mockTimer = MockTime.now();
       logger = new FakeModulesLogger();
 
       const printLineFn = logger.printLineFn();
@@ -309,6 +309,21 @@ describe("Provider logs", function () {
 
       // Remove the `eth_gasPrice` call from the logger
       logger.reset();
+    });
+
+    afterEach(async function () {
+      // Stop interval mining explicitly so the background task is torn
+      // down here instead of whenever JS GC reclaims the provider.
+      if (provider !== undefined) {
+        await provider.handleRequest(
+          JSON.stringify({
+            id: 1,
+            jsonrpc: "2.0",
+            method: "evm_setIntervalMining",
+            params: [0],
+          })
+        );
+      }
     });
 
     it("should only print the mined block when there are no pending txs", async function () {

--- a/hardhat-tests/test/internal/hardhat-network/helpers/useProvider.ts
+++ b/hardhat-tests/test/internal/hardhat-network/helpers/useProvider.ts
@@ -132,6 +132,13 @@ export function useProvider({
   });
 
   afterEach("Remove provider", async function () {
+    // Stop interval mining before dropping the provider so its tokio
+    // task is torn down here instead of whenever JS GC reclaims the
+    // wrapper.
+    if (this.provider !== undefined) {
+      await this.provider.send("evm_setIntervalMining", [0]);
+    }
+
     // These two deletes are unsafe, but we use this properties
     // in very locally and are ok with the risk.
     // To make this safe the properties should be optional, which


### PR DESCRIPTION
Had a good go at fixing the occasional 6 hour hang in CI. Did initial research in #1377 (will close it in favour of this PR) and used that to derive a fix. 

I performed a whole bunch of test re-runs. pro-tip, you can use a `gh run watch` + `rerun` to queue loads of re-runs. E.g.: 
```bash
RUN=25294639955
REPO=NomicFoundation/edr
for i in $(seq 1 10); do
  echo "=== rerun $i at $(date) ==="
  gh run rerun "$RUN" --repo "$REPO"
  gh run watch  "$RUN" --repo "$REPO" --exit-status \
    || echo "attempt $i did not pass (rc=$?) — continuing"
done
```
I still saw one hanging test in the Hardhat tests workflow (run [25294639956](https://github.com/NomicFoundation/edr/actions/runs/25294639956), `Run Hardhat tests (macos-15)`, 365 m, killed at the 6 h cap before the timeout-minutes change took effect). I only saw this one time in all my testing, but will keep an eye out if this happens again.

# Claude summary:


## What's broken

Tests that construct an EDR `Provider` with interval mining enabled — without an explicit teardown — leak a long-running tokio task (spawned by `IntervalMiner::new`) until JS GC eventually reclaims the napi wrapper and runs `IntervalMiner::Drop`. Across many tests the leaked tasks accumulate on the shared tokio runtime and contend on the mining notifier; on Windows and macOS this has been observed to deadlock the JS event loop deeply enough that mocha's per-test 25 s timer can't fire — producing 6 h CI hangs.

The hang lands in `Provider logs > Interval mining` in `crates/edr_napi/test/logs.ts`. Exact `it()` that wedges varies (sometimes test 3 `should stop collapsing when a different method is called`, sometimes test 4 `should print a block with one transaction`), consistent with a timing-sensitive deadlock rather than a deterministic bug location.

## What's in this PR

1. **`crates/edr_napi/test/logs.ts`** — `Provider logs > Interval mining` gets an `afterEach` that issues `evm_setIntervalMining(0)` against the current provider. That request hits `handle_set_interval_mining` in `crates/edr_provider/src/requests/eth/mine.rs`, which assigns `*interval_miner = None`, dropping the previous `IntervalMiner` and running its existing `Drop` impl (`crates/edr_provider/src/interval.rs:90`) — sends the cancellation oneshot, then `block_on`s the spawned task. Also scopes `mockTimer` per-test rather than at the outer describe scope, matching JS testing convention for mocked time fixtures.

2. **`hardhat-tests/.../useProvider.ts`** — same `evm_setIntervalMining(0)` call in `useProvider`'s afterEach. Most hardhat-tests that explicitly use interval mining already pair it with an afterEach reset; this hits the gap for tests that go through `useProvider` and never explicitly reset.

3. **`.github/workflows/edr-ci.yml`** + **`.github/workflows/hardhat-tests.yml`** — `timeout-minutes: 30` on the two mocha-driven jobs. If the bug ever regresses, hangs surface in ~2× normal runtime (5–15 min typical) instead of burning a full 6 h job slot. **This piece is lifted from #1377 — that PR is being superseded by this one.**

## Empirical evidence

Failing CI run that confirmed the diagnosis (on PR #1377's diagnostic branch, before any fix):
<https://github.com/NomicFoundation/edr/actions/runs/25279523193/job/74132774239> — 30 m 18 s, killed at the 30 m cap. Last observed test:

```
[mocha-start] should stop collapsing when a different method is called   ← test 3 starts
##[error] cancelled                                                       ← 22 m 22 s of silence
```

After applying the fix here (commit `aa9063a70`), the same workflow was re-run **9 times** on Linux/macOS/Windows. Pass rate per OS for the previously-hang-prone job:

| Job | Before (historical) | After (this PR, 9 attempts) |
|---|---|---|
| `Test EDR TS bindings (windows-2025)` | ~1-in-4 hung at 6 h cap | **9/9 green** |
| `Test EDR TS bindings (macos-15)` | occasional hangs | **9/9 green** |
| `Test EDR TS bindings (ubuntu-24.04)` | rare hangs | **9/9 green** |

So **18/18 successful runs on the platforms that historically deadlocked** — strong signal the fix holds for this suite.



## Relationship to PR #1377

#1377 was the diagnostic branch that produced the empirical evidence above (multi-attempt diagnostic probes, failing run linked, root cause identified). This PR carries forward the only piece of #1377 that's a real fix as opposed to a debug aid — the `timeout-minutes: 30` cap — and adds the actual `afterEach` cleanup that fixes the underlying bug. **#1377 will be closed in favor of this one.**
