### PR TITLE
ci: add explicit restore-keys for EDR RPC cache

### DIFF
--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -116,6 +116,10 @@ jobs:
           path: |
             **/edr-cache
           key: edr-rs-rpc-cache-v1-${{ matrix.os }}
+          # Save key includes a hashFiles suffix; restore via the
+          # OS-scoped prefix to pick up the most recent matching entry.
+          restore-keys: |
+            edr-rs-rpc-cache-v1-${{ matrix.os }}-
 
       - name: Run cargo tests (with coverage)
         env:
@@ -192,6 +196,10 @@ jobs:
           path: |
             **/edr-cache
           key: edr-ts-rpc-cache-v1-${{ matrix.os }}
+          # Save key includes a hashFiles suffix; restore via the
+          # OS-scoped prefix to pick up the most recent matching entry.
+          restore-keys: |
+            edr-ts-rpc-cache-v1-${{ matrix.os }}-
 
       - name: Install package
         run: pnpm install --frozen-lockfile --prefer-offline


### PR DESCRIPTION
Add an explicit `restore-keys: edr-(rs|ts)-rpc-cache-v1-<os>-` fallback to EDR RPC cache. 

The save step writes keys with a hashFiles suffix (`edr-rs-rpc-cache-v1-<os>-<hash>`) but the restore step's `key:` was prefix only (`edr-rs-rpc-cache-v1-<os>`). Without an explicit `restore-keys`, the prefix-match was relying on actions/cache@v4 undocumented behaviour.