### PR TITLE
ci: remove redundant manual Rust cache from benchmark jobs

### DIFF
--- a/.github/workflows/edr-benchmark.yml
+++ b/.github/workflows/edr-benchmark.yml
@@ -59,19 +59,6 @@ jobs:
       - uses: ./.github/actions/setup-node
       - uses: ./.github/actions/setup-rust
 
-      - name: Rust cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            .cargo-cache
-            target/
-          save-always: true
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
-
       - name: Install packages
         run: sfw pnpm install --frozen-lockfile --prefer-offline
 
@@ -123,19 +110,6 @@ jobs:
           path: |
             **/edr-cache
           key: edr-rs-rpc-cache-v1
-
-      - name: Rust cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            .cargo-cache
-            target/
-          save-always: true
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
 
       - name: Install packages
         run: sfw pnpm install --frozen-lockfile --prefer-offline


### PR DESCRIPTION
We use Swatinem/rust-cache across our CI as part of the setup-rust action. 

The js-scenario-benchmark and js-soltests-benchmark jobs each had manual actions/cache@v4 block caching `~/.cargo/registry`, `~/.cargo/git`, and `target/` already covered by Swatinem/rust-cache. 

Random flake: 
https://github.com/NomicFoundation/edr/actions/runs/25296236163/job/74155560495?pr=1381

Does seem related to fix in https://github.com/NomicFoundation/edr/pull/1378, I hope this will be fixed as well.