### PR TITLE
ci: share Rust cache for same-profile dev/check jobs

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -10,17 +10,34 @@ inputs:
   cache:
     description: Automatically configure Rust cache
     default: true
+  cache-shared-key:
+    description: |
+      Stable cache key shared across multiple jobs. Use to consolidate
+      similar jobs (same OS, same build profile, same RUSTFLAGS) into a
+      single Swatinem cache scope, avoiding per-job cache duplication.
+    required: false
+  cache-save-if:
+    description: |
+      When the cache should be saved. Default is to save on every run
+      (including PRs) so we can iterate on cache configuration. Once
+      stable, tighten to `${{ github.ref == 'refs/heads/main' }}` to
+      stop PR-scoped saves from polluting the cache budget and from
+      being used as a poisoning surface by external contributors.
+    required: false
+    default: "true"
 
 runs:
   using: composite
   steps:
     - name: Install Rust
-      uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
+      uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
       with:
         # Empty string means rust-toolchain if it exists, otherwise stable
         toolchain: ${{ inputs.toolchain }}
         components: ${{ inputs.components }}
         cache: ${{ inputs.cache }}
+        cache-shared-key: ${{ inputs.cache-shared-key }}
+        cache-save-if: ${{ inputs.cache-save-if }}
         # Do not override the RUSTFLAGS by default and instead do that per job,
         # if needed. Setting RUSTFLAGS via env var, config, etc. is mutually
         # exclusive and often a source of bugs.

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -19,10 +19,14 @@ inputs:
   cache-save-if:
     description: |
       Expression controlling when the cache is saved. Default "true"
-      saves on every run (including PRs) so we can iterate on cache
-      config. Tighten to a main-only expression once stable, to stop
-      PR-scoped saves from polluting the cache budget and from being
-      used as a poisoning surface by external contributors.
+      saves on every run, including PRs. PR caches are scoped to
+      refs/pull/N/merge and cannot be restored by main runs, so this
+      is not a poisoning vector — the per-ref scoping is the security
+      barrier. The reason to ever flip this to a main-only expression
+      is budget: large PR-scoped Swatinem caches (~1 GB each) and
+      sccache entries from churny Renovate PRs can accumulate against
+      the repo cache limit. RPC caches (~30 MB) are too small to
+      worry about.
     required: false
     default: "true"
 

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -16,32 +16,18 @@ inputs:
       similar jobs (same OS, same build profile, same RUSTFLAGS) into a
       single Swatinem cache scope, avoiding per-job cache duplication.
     required: false
-  cache-save-if:
-    description: |
-      Expression controlling when the cache is saved. Default "true"
-      saves on every run, including PRs. PR caches are scoped to
-      refs/pull/N/merge and cannot be restored by main runs, so this
-      is not a poisoning vector — the per-ref scoping is the security
-      barrier. The reason to ever flip this to a main-only expression
-      is budget: large PR-scoped Swatinem caches (~1 GB each) and
-      sccache entries from churny Renovate PRs can accumulate against
-      the repo cache limit. RPC caches (~30 MB) are too small to
-      worry about.
-    required: false
-    default: "true"
 
 runs:
   using: composite
   steps:
     - name: Install Rust
-      uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
+      uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
       with:
         # Empty string means rust-toolchain if it exists, otherwise stable
         toolchain: ${{ inputs.toolchain }}
         components: ${{ inputs.components }}
         cache: ${{ inputs.cache }}
         cache-shared-key: ${{ inputs.cache-shared-key }}
-        cache-save-if: ${{ inputs.cache-save-if }}
         # Do not override the RUSTFLAGS by default and instead do that per job,
         # if needed. Setting RUSTFLAGS via env var, config, etc. is mutually
         # exclusive and often a source of bugs.

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -18,11 +18,11 @@ inputs:
     required: false
   cache-save-if:
     description: |
-      When the cache should be saved. Default is to save on every run
-      (including PRs) so we can iterate on cache configuration. Once
-      stable, tighten to `${{ github.ref == 'refs/heads/main' }}` to
-      stop PR-scoped saves from polluting the cache budget and from
-      being used as a poisoning surface by external contributors.
+      Expression controlling when the cache is saved. Default "true"
+      saves on every run (including PRs) so we can iterate on cache
+      config. Tighten to a main-only expression once stable, to stop
+      PR-scoped saves from polluting the cache budget and from being
+      used as a poisoning surface by external contributors.
     required: false
     default: "true"
 

--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -105,13 +105,6 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-24.04", "macos-15", "windows-2025"]
-        include:
-          - os: ubuntu-24.04
-            cache-family: linux
-          - os: macos-15
-            cache-family: macos
-          - os: windows-2025
-            cache-family: windows
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
@@ -120,8 +113,6 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           components: llvm-tools-preview
-          # Shared with test-edr-ts on the same OS (both use cargo llvm-cov).
-          cache-shared-key: ${{ matrix.cache-family }}-coverage
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53
@@ -193,13 +184,6 @@ jobs:
       matrix:
         node: [20]
         os: [ubuntu-24.04, macos-15, windows-2025]
-        include:
-          - os: ubuntu-24.04
-            cache-family: linux
-          - os: macos-15
-            cache-family: macos
-          - os: windows-2025
-            cache-family: windows
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
@@ -212,8 +196,6 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           components: llvm-tools-preview
-          # Shared with test-edr-rs on the same OS (both use cargo llvm-cov).
-          cache-shared-key: ${{ matrix.cache-family }}-coverage
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53
@@ -361,8 +343,6 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           components: llvm-tools-preview
-          # Shared with test-edr-rs and test-edr-ts on Linux (also cargo llvm-cov).
-          cache-shared-key: linux-coverage
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53

--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           # Shared with cargo-hack-edr (also RUSTFLAGS=-Dwarnings).
-          cache-shared-key: ubuntu-24.04-dev-strict
+          cache-shared-key: linux-dev-strict
 
       - name: Cargo check no default features for all crates
         run: cargo check --workspace --all-targets --no-default-features --locked
@@ -77,7 +77,7 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           # Shared with check-edr (also RUSTFLAGS=-Dwarnings).
-          cache-shared-key: ubuntu-24.04-dev-strict
+          cache-shared-key: linux-dev-strict
 
       # Install pre-built binaries for cargo hack
       - uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53
@@ -105,6 +105,13 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-24.04", "macos-15", "windows-2025"]
+        include:
+          - os: ubuntu-24.04
+            cache-family: linux
+          - os: macos-15
+            cache-family: macos
+          - os: windows-2025
+            cache-family: windows
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
@@ -114,7 +121,7 @@ jobs:
         with:
           components: llvm-tools-preview
           # Shared with test-edr-ts on the same OS (both use cargo llvm-cov).
-          cache-shared-key: ${{ matrix.os }}-coverage
+          cache-shared-key: ${{ matrix.cache-family }}-coverage
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53
@@ -186,6 +193,13 @@ jobs:
       matrix:
         node: [20]
         os: [ubuntu-24.04, macos-15, windows-2025]
+        include:
+          - os: ubuntu-24.04
+            cache-family: linux
+          - os: macos-15
+            cache-family: macos
+          - os: windows-2025
+            cache-family: windows
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
@@ -199,7 +213,7 @@ jobs:
         with:
           components: llvm-tools-preview
           # Shared with test-edr-rs on the same OS (both use cargo llvm-cov).
-          cache-shared-key: ${{ matrix.os }}-coverage
+          cache-shared-key: ${{ matrix.cache-family }}-coverage
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53
@@ -259,7 +273,7 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           components: clippy
-          cache-shared-key: ubuntu-24.04-dev
+          cache-shared-key: linux-dev
 
       - name: Install nightly rustfmt
         uses: ./.github/actions/setup-rust
@@ -285,7 +299,7 @@ jobs:
 
       - uses: ./.github/actions/setup-rust
         with:
-          cache-shared-key: ubuntu-24.04-dev
+          cache-shared-key: linux-dev
 
       - name: Cargo doc
         run: |
@@ -348,7 +362,7 @@ jobs:
         with:
           components: llvm-tools-preview
           # Shared with test-edr-rs and test-edr-ts on Linux (also cargo llvm-cov).
-          cache-shared-key: ubuntu-24.04-coverage
+          cache-shared-key: linux-coverage
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53
@@ -383,7 +397,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup-rust
         with:
-          cache-shared-key: ubuntu-24.04-dev
+          cache-shared-key: linux-dev
 
       - name: Cache cooldown data
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -35,6 +35,9 @@ jobs:
         with:
           mode: firewall
       - uses: ./.github/actions/setup-rust
+        with:
+          # No compile happens in this job; skip the Rust cache.
+          cache: false
       - uses: ./.github/actions/setup-node
 
       - name: Pnpm safety
@@ -51,6 +54,9 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-rust
+        with:
+          # Shared with cargo-hack-edr (also RUSTFLAGS=-Dwarnings).
+          cache-shared-key: ubuntu-24.04-dev-strict
 
       - name: Cargo check no default features for all crates
         run: cargo check --workspace --all-targets --no-default-features --locked
@@ -69,6 +75,9 @@ jobs:
           persist-credentials: false
 
       - uses: ./.github/actions/setup-rust
+        with:
+          # Shared with check-edr (also RUSTFLAGS=-Dwarnings).
+          cache-shared-key: ubuntu-24.04-dev-strict
 
       # Install pre-built binaries for cargo hack
       - uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53
@@ -104,6 +113,8 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           components: llvm-tools-preview
+          # Shared with test-edr-ts on the same OS (both use cargo llvm-cov).
+          cache-shared-key: ${{ matrix.os }}-coverage
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53
@@ -187,6 +198,8 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           components: llvm-tools-preview
+          # Shared with test-edr-rs on the same OS (both use cargo llvm-cov).
+          cache-shared-key: ${{ matrix.os }}-coverage
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53
@@ -246,6 +259,7 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           components: clippy
+          cache-shared-key: ubuntu-24.04-dev
 
       - name: Install nightly rustfmt
         uses: ./.github/actions/setup-rust
@@ -270,6 +284,8 @@ jobs:
           persist-credentials: false
 
       - uses: ./.github/actions/setup-rust
+        with:
+          cache-shared-key: ubuntu-24.04-dev
 
       - name: Cargo doc
         run: |
@@ -331,6 +347,8 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           components: llvm-tools-preview
+          # Shared with test-edr-rs and test-edr-ts on Linux (also cargo llvm-cov).
+          cache-shared-key: ubuntu-24.04-coverage
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53
@@ -364,6 +382,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-rust
+        with:
+          cache-shared-key: ubuntu-24.04-dev
 
       - name: Cache cooldown data
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/.github/workflows/hardhat-tests.yml
+++ b/.github/workflows/hardhat-tests.yml
@@ -25,6 +25,13 @@ jobs:
       matrix:
         node: [20]
         os: ["macos-15", "ubuntu-24.04", "windows-2025"]
+        include:
+          - os: ubuntu-24.04
+            cache-family: linux
+          - os: macos-15
+            cache-family: macos
+          - os: windows-2025
+            cache-family: windows
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
@@ -37,6 +44,9 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           components: llvm-tools-preview
+          # Shared with test-edr-rs / test-edr-ts / edr-integration-tests
+          # in edr-ci.yml (all cargo llvm-cov, same OS).
+          cache-shared-key: ${{ matrix.cache-family }}-coverage
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53

--- a/.github/workflows/hardhat-tests.yml
+++ b/.github/workflows/hardhat-tests.yml
@@ -25,13 +25,6 @@ jobs:
       matrix:
         node: [20]
         os: ["macos-15", "ubuntu-24.04", "windows-2025"]
-        include:
-          - os: ubuntu-24.04
-            cache-family: linux
-          - os: macos-15
-            cache-family: macos
-          - os: windows-2025
-            cache-family: windows
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
@@ -44,9 +37,6 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           components: llvm-tools-preview
-          # Shared with test-edr-rs / test-edr-ts / edr-integration-tests
-          # in edr-ci.yml (all cargo llvm-cov, same OS).
-          cache-shared-key: ${{ matrix.cache-family }}-coverage
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53


### PR DESCRIPTION
## Summary

Carve-out from #1374. Adds Swatinem `cache-shared-key` plumbing to the local `setup-rust` composite, then uses it to merge the two clusters of jobs whose Rust compile profiles are actually identical. Earlier rev of this PR also merged `*-coverage` jobs by OS, but attempt-2 timings showed a fingerprint-mismatch regression there (see notes); that merger has been dropped.

## Buckets

| Key | Jobs |
|---|---|
| `linux-dev-strict` | `check-edr`, `cargo-hack-edr` (workspace `cargo check --locked` under `RUSTFLAGS=-Dwarnings`) |
| `linux-dev` | `edr-style`, `edr-docs`, `cooldown-check` (plain dev workspace, no coverage instrumentation) |

The strict bucket is separate from `linux-dev` because `RUSTFLAGS=-Dwarnings` hashes into Cargo's fingerprint; collapsing them would invalidate either side on every run. A `[workspace.lints]` deny-warnings refactor would let them merge.

`test-edr-rs`, `test-edr-ts`, `edr-integration-tests`, and `run-hardhat-tests` keep their per-job buckets. They share the same OS and key inputs but diverge on crate-type and feature resolution (`cargo llvm-cov --workspace` for `test-edr-rs` vs. `edr_napi` cdylib for the napi/hardhat path), which collides on the Swatinem key but mismatches cargo's per-unit fingerprint — the warm-cache penalty was +2 min/job on macOS in PR-internal A/B.

## Other changes

- `pnpm-safety` job: `cache: false` on `setup-rust` — no Rust compile happens there, so the cache step is dead weight.

## Test plan

- [ ] `linux-dev-strict` and `linux-dev` keys appear in `gh api repos/NomicFoundation/edr/actions/caches` after first run on the branch.
- [ ] Second run hits the consolidated buckets — confirm via Swatinem's "Cache hit" log line on the affected jobs and watch for absence of full `proc-macro2` recompile right after.
- [ ] `check-edr` / `cargo-hack-edr` / `edr-style` / `edr-docs` / `cooldown-check` wall-clocks match or beat current baseline.