### PR TITLE
build: update to Rust v1.94.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -360,7 +360,11 @@ num-format = "0.4.4"
 yansi = { version = "1.0", features = ["detect-tty", "detect-env"] }
 tempfile = "3.25"
 tokio = "1"
-uuid = { version = "1.19", default-features = false, features = ["serde", "std", "v4"] }
+uuid = { version = "1.19", default-features = false, features = [
+    "serde",
+    "std",
+    "v4",
+] }
 walkdir = "2"
 
 hyper = "1.0"
@@ -385,7 +389,7 @@ dbg_macro = "warn"
 debug_assert_with_mut_call = "warn"
 default_trait_access = "warn"
 doc_markdown = "warn"
-empty_enum = "warn"
+empty_enums = "warn"
 enum_glob_use = "warn"
 exit = "warn"
 expl_impl_clone_on_copy = "warn"

--- a/crates/foundry/cheatcodes/src/evm.rs
+++ b/crates/foundry/cheatcodes/src/evm.rs
@@ -3410,14 +3410,7 @@ fn inner_start_gas_snapshot<
 ) -> Result {
     // Revert if there is an active gas snapshot as we can only have one active
     // snapshot at a time.
-    if ccx.state.gas_metering.active_gas_snapshot.is_some() {
-        let (group, name) = ccx
-            .state
-            .gas_metering
-            .active_gas_snapshot
-            .as_ref()
-            .unwrap()
-            .clone();
+    if let Some((group, name)) = ccx.state.gas_metering.active_gas_snapshot.as_ref() {
         bail!("gas snapshot was already started with group: {group} and name: {name}");
     }
 

--- a/crates/foundry/cheatcodes/src/test/revert_handlers.rs
+++ b/crates/foundry/cheatcodes/src/test/revert_handlers.rs
@@ -236,26 +236,24 @@ pub(crate) fn handle_expect_revert(
                     let decoded_revert = decode_revert(retdata.to_vec());
 
                     // Provide more specific error messages based on what was expected
-                    if expected_revert.reverter.is_some() && expected_revert.reason.is_some() {
-                        Err(fmt_err!(
+                    match (expected_revert.reverter, expected_revert.reason.is_some()) {
+                        (Some(reverter), true) => Err(fmt_err!(
                             "call reverted with '{}' from {}, but expected 0 reverts with reason '{}' from {}",
                             &stringify(&decoded_revert),
                             expected_revert.reverted_by.unwrap_or_default(),
                             &stringify(expected_reason.unwrap_or_default()),
-                            expected_revert.reverter.unwrap()
-                        ))
-                    } else if expected_revert.reverter.is_some() {
-                        Err(fmt_err!(
+                            reverter
+                        )),
+                        (Some(reverter), false) => Err(fmt_err!(
                             "call reverted with '{}' from {}, but expected 0 reverts from {}",
                             &stringify(&decoded_revert),
                             expected_revert.reverted_by.unwrap_or_default(),
-                            expected_revert.reverter.unwrap()
-                        ))
-                    } else {
-                        Err(fmt_err!(
+                            reverter
+                        )),
+                        (None, _) => Err(fmt_err!(
                             "call reverted with '{}' when it was expected not to revert",
                             &stringify(&decoded_revert)
-                        ))
+                        )),
                     }
                 }
             }

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.91.0"
+channel = "1.94.0"


### PR DESCRIPTION
This PR updates to Rust v1.94.0.

This is a prerequisite for updating `slang` to the [latest version v1.3.5](https://github.com/NomicFoundation/slang/releases/tag/v1.3.5).