### PR TITLE
build: upgrade Slang to v1.3.5

### DIFF
--- a/.changeset/stale-seas-hide.md
+++ b/.changeset/stale-seas-hide.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Added support for instrumentation of Solidity 0.8.35

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2340,7 +2340,7 @@ dependencies = [
  "alloy-json-abi",
  "edr_primitives",
  "foundry-compilers",
- "semver 1.0.26",
+ "semver 1.0.28",
  "serde",
 ]
 
@@ -2947,7 +2947,7 @@ name = "edr_instrument"
 version = "0.3.8"
 dependencies = [
  "edr_primitives",
- "semver 1.0.26",
+ "semver 1.0.28",
  "serde",
  "sha3",
  "slang_solidity",
@@ -3031,7 +3031,7 @@ dependencies = [
  "openssl-sys",
  "parking_lot 0.12.3",
  "rand 0.8.5",
- "semver 1.0.26",
+ "semver 1.0.28",
  "serde",
  "serde_json",
  "static_assertions",
@@ -3436,7 +3436,7 @@ dependencies = [
  "revm-inspectors",
  "revm-interpreter",
  "revm-precompile",
- "semver 1.0.26",
+ "semver 1.0.28",
  "serde",
  "serde_json",
  "strum 0.26.3",
@@ -3480,7 +3480,7 @@ dependencies = [
  "proptest",
  "rayon",
  "regex",
- "semver 1.0.26",
+ "semver 1.0.28",
  "serde",
  "serde_json",
  "serial_test",
@@ -3741,7 +3741,7 @@ dependencies = [
  "edr_instrument",
  "foundry-compilers",
  "hex",
- "semver 1.0.26",
+ "semver 1.0.28",
  "tempfile",
 ]
 
@@ -4121,7 +4121,7 @@ dependencies = [
  "regex",
  "revm",
  "revm-inspectors",
- "semver 1.0.26",
+ "semver 1.0.28",
  "serde",
  "serde_json",
  "similar-asserts",
@@ -4173,7 +4173,7 @@ dependencies = [
  "path-slash",
  "rand 0.8.5",
  "rayon",
- "semver 1.0.26",
+ "semver 1.0.28",
  "serde",
  "serde_json",
  "sha2",
@@ -4210,7 +4210,7 @@ dependencies = [
  "path-slash",
  "rayon",
  "regex",
- "semver 1.0.26",
+ "semver 1.0.28",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -4230,7 +4230,7 @@ dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-core",
  "path-slash",
- "semver 1.0.26",
+ "semver 1.0.28",
  "serde",
 ]
 
@@ -4246,7 +4246,7 @@ dependencies = [
  "fs_extra",
  "path-slash",
  "regex",
- "semver 1.0.26",
+ "semver 1.0.28",
  "serde",
  "serde_json",
  "svm-rs",
@@ -4350,7 +4350,7 @@ dependencies = [
  "foundry-evm-core",
  "rayon",
  "revm",
- "semver 1.0.26",
+ "semver 1.0.28",
  "tracing",
 ]
 
@@ -5623,20 +5623,20 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "metaslang_bindings"
-version = "1.3.3"
-source = "git+https://github.com/NomicFoundation/slang?tag=v1.3.3#3ad185704aa8d7f638f3d574317ece89ab66d818"
+version = "1.3.5"
+source = "git+https://github.com/NomicFoundation/slang?tag=v1.3.5#9c5a234eb2da64243f0c46202c1780236321a2bc"
 dependencies = [
  "metaslang_cst",
  "metaslang_graph_builder",
  "metaslang_stack_graphs",
- "semver 1.0.26",
+ "semver 1.0.28",
  "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "metaslang_cst"
-version = "1.3.3"
-source = "git+https://github.com/NomicFoundation/slang?tag=v1.3.3#3ad185704aa8d7f638f3d574317ece89ab66d818"
+version = "1.3.5"
+source = "git+https://github.com/NomicFoundation/slang?tag=v1.3.5#9c5a234eb2da64243f0c46202c1780236321a2bc"
 dependencies = [
  "nom",
  "serde",
@@ -5645,8 +5645,8 @@ dependencies = [
 
 [[package]]
 name = "metaslang_graph_builder"
-version = "1.3.3"
-source = "git+https://github.com/NomicFoundation/slang?tag=v1.3.3#3ad185704aa8d7f638f3d574317ece89ab66d818"
+version = "1.3.5"
+source = "git+https://github.com/NomicFoundation/slang?tag=v1.3.5#9c5a234eb2da64243f0c46202c1780236321a2bc"
 dependencies = [
  "log",
  "metaslang_cst",
@@ -5659,15 +5659,15 @@ dependencies = [
 
 [[package]]
 name = "metaslang_stack_graphs"
-version = "1.3.3"
-source = "git+https://github.com/NomicFoundation/slang?tag=v1.3.3#3ad185704aa8d7f638f3d574317ece89ab66d818"
+version = "1.3.5"
+source = "git+https://github.com/NomicFoundation/slang?tag=v1.3.5#9c5a234eb2da64243f0c46202c1780236321a2bc"
 dependencies = [
  "bitvec",
  "controlled-option",
  "either",
  "enumset",
  "fxhash",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "libc",
  "lsp-positions",
  "smallvec",
@@ -5698,12 +5698,6 @@ dependencies = [
  "mime",
  "unicase",
 ]
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -5796,7 +5790,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "semver 1.0.26",
+ "semver 1.0.28",
  "syn 2.0.115",
 ]
 
@@ -5828,12 +5822,11 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.3"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -7277,7 +7270,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.26",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -7559,11 +7552,12 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.26"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -7869,15 +7863,14 @@ dependencies = [
 
 [[package]]
 name = "slang_solidity"
-version = "1.3.3"
-source = "git+https://github.com/NomicFoundation/slang?tag=v1.3.3#3ad185704aa8d7f638f3d574317ece89ab66d818"
+version = "1.3.5"
+source = "git+https://github.com/NomicFoundation/slang?tag=v1.3.5#9c5a234eb2da64243f0c46202c1780236321a2bc"
 dependencies = [
  "metaslang_bindings",
  "metaslang_cst",
- "semver 1.0.26",
+ "semver 1.0.28",
  "serde",
- "strum 0.26.3",
- "strum_macros 0.26.4",
+ "strum 0.28.0",
  "thiserror 2.0.12",
 ]
 
@@ -7921,7 +7914,7 @@ dependencies = [
  "either",
  "num-bigint",
  "num-rational",
- "semver 1.0.26",
+ "semver 1.0.28",
  "solar-data-structures",
  "solar-interface",
  "solar-macros",
@@ -8093,6 +8086,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8119,6 +8121,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8133,7 +8147,7 @@ dependencies = [
  "const-hex",
  "dirs",
  "reqwest 0.12.15",
- "semver 1.0.26",
+ "semver 1.0.28",
  "serde",
  "serde_json",
  "sha2",
@@ -8150,7 +8164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1ebe77b200f965e8dbec3ef1d8337e974179ca1ecaa9fc28f67288d6b438159"
 dependencies = [
  "const-hex",
- "semver 1.0.26",
+ "semver 1.0.28",
  "serde_json",
  "svm-rs",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -333,7 +333,7 @@ parking_lot = { version = "0.12.1", default-features = false }
 paste = { version = "1.0.14", default-features = false }
 proptest = "1.7.0"
 regex = { version = "1", default-features = false }
-semver = { version = "1.0.26", default-features = false }
+semver = { version = "1.0.28", default-features = false }
 sha2 = { version = "0.10.8", default-features = false }
 sha3 = { version = "0.10.8", default-features = false }
 similar-asserts = "1.7"

--- a/crates/edr_instrument/Cargo.toml
+++ b/crates/edr_instrument/Cargo.toml
@@ -8,7 +8,7 @@ edr_primitives.workspace = true
 semver.workspace = true
 serde = { workspace = true, features = ["derive"] }
 sha3.workspace = true
-slang_solidity = { git = "https://github.com/NomicFoundation/slang", tag = "v1.3.3" }
+slang_solidity = { git = "https://github.com/NomicFoundation/slang", tag = "v1.3.5" }
 thiserror.workspace = true
 
 [lints]

--- a/hardhat-tests/test/internal/hardhat-network/stack-traces/compilers-list.ts
+++ b/hardhat-tests/test/internal/hardhat-network/stack-traces/compilers-list.ts
@@ -378,11 +378,23 @@ export const solidityCompilers: SolidityCompiler[] = [
   {
     solidityVersion: "0.8.34",
     compilerPath: "soljson-v0.8.34+commit.80d5c536.js",
-    latestSolcVersion: true,
   },
   {
     solidityVersion: "0.8.34",
     compilerPath: "soljson-v0.8.34+commit.80d5c536.js",
+    optimizer: {
+      runs: 200,
+      viaIR: true,
+    },
+  },
+  {
+    solidityVersion: "0.8.35",
+    compilerPath: "soljson-v0.8.35+commit.47b9dedd.js",
+    latestSolcVersion: true,
+  },
+  {
+    solidityVersion: "0.8.35",
+    compilerPath: "soljson-v0.8.35+commit.47b9dedd.js",
     optimizer: {
       runs: 200,
       viaIR: true,


### PR DESCRIPTION
Upgrades Slang to [v1.3.5](https://github.com/NomicFoundation/slang/releases/tag/v1.3.5), with support for Solidity 0.8.35.

This also required updating `semver` to v1.0.28.