### PR TITLE
ci: upload Hardhat-tests coverage to Codecov

### DIFF
--- a/.github/workflows/hardhat-tests.yml
+++ b/.github/workflows/hardhat-tests.yml
@@ -75,6 +75,14 @@ jobs:
           # `--release` included to match `build:dev` compilation flags
           cargo llvm-cov report --release --locked --codecov --output-path codecov.json
 
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
+        with:
+          files: codecov.json
+          name: ${{ matrix.os }}
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
   lint-hardhat-tests:
     name: Lint Hardhat tests
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Why

The `hardhat-tests` workflow already runs `cargo llvm-cov report` after the JS test run and produces a `codecov.json`, but it never had an upload step — the file was generated and discarded. That suite exercises the napi binding code paths end-to-end (subscriptions, provider lifecycles, Solidity test runs, stack-trace decoding), so without its upload those files look under-covered on every PR even though they are tested.

Most visible on #1385 (napi v3 migration): patch coverage 52% with `call_override.rs`, `provider.rs`, and `trace/debug.rs` showing 0% — exactly the files Hardhat-tests would cover.

## Change

Add a `codecov-action` upload step to `hardhat-tests.yml` after `cargo llvm-cov report`, matching the pattern already used by the three uploads in `edr-ci.yml` (matrix-named, SHA-pinned, `fail_ci_if_error: false`, `CODECOV_TOKEN`).