### PR TITLE
ci(edr-npm-release): pin pnpm to 10.17.1 in Dockerized test legs

### DIFF
--- a/.github/workflows/edr-npm-release.yml
+++ b/.github/workflows/edr-npm-release.yml
@@ -265,7 +265,7 @@ jobs:
       - name: Test bindings
         # Setting CI=1 is important to make PNPM install non-interactive
         # https://github.com/pnpm/pnpm/issues/6615#issuecomment-1656945689
-        run: docker run --rm  -e CI=1 -v $(pwd):/build -w /build/crates/edr_napi node:${{ matrix.node }} bash -c "wget -qO- 'https://unpkg.com/@pnpm/self-installer' | node; pnpm testNoBuild"
+        run: docker run --rm  -e CI=1 -v $(pwd):/build -w /build/crates/edr_napi node:${{ matrix.node }} bash -c "npm install -g pnpm@10.17.1; pnpm testNoBuild"
   test-linux-x64-musl-binding:
     name: Test bindings on x86_64-unknown-linux-musl - node@${{ matrix.node }}
     needs:
@@ -298,7 +298,7 @@ jobs:
         run: ls -R .
         shell: bash
       - name: Test bindings
-        run: docker run --rm  -e CI=1 -v $(pwd):/build -w /build/crates/edr_napi node:${{ matrix.node }}-alpine sh -c "wget -qO- 'https://unpkg.com/@pnpm/self-installer' | node; pnpm testNoBuild"
+        run: docker run --rm  -e CI=1 -v $(pwd):/build -w /build/crates/edr_napi node:${{ matrix.node }}-alpine sh -c "npm install -g pnpm@10.17.1; pnpm testNoBuild"
   test-linux-aarch64-gnu-binding:
     name: Test bindings on aarch64-unknown-linux-gnu - node@${{ matrix.node }}
     needs:
@@ -337,7 +337,7 @@ jobs:
           image: node:${{ matrix.node }}
           options: "--platform linux/arm64 -v ${{ github.workspace }}:/build -w /build/crates/edr_napi -e CI=1"
           run: |
-            wget -qO- 'https://unpkg.com/@pnpm/self-installer' | node
+            npm install -g pnpm@10.17.1
             set -e
             pnpm testNoBuild
             ls -la
@@ -378,7 +378,7 @@ jobs:
           image: node:${{ matrix.node }}-alpine
           options: "--platform linux/arm64 -v ${{ github.workspace }}:/build -w /build/crates/edr_napi -e CI=1"
           run: |
-            wget -qO- 'https://unpkg.com/@pnpm/self-installer' | node
+            npm install -g pnpm@10.17.1
             set -e
             pnpm testNoBuild
 


### PR DESCRIPTION
Quick fix to pin pnpm in the docker containers that are currently broken in main. Will revisit (as in generalise) this when we need to make the jump to Node 24/26 away from Node 20.


# Claude summary
The four `Test bindings on <triple> - node@20` matrix jobs install pnpm inside a `node:${matrix.node}` (or alpine) container with:

  wget -qO- 'https://unpkg.com/@pnpm/self-installer' | node

`@pnpm/self-installer` unconditionally fetches the latest pnpm. pnpm 11.0.8 (released recently) dropped Node 20 support — its store layer calls `require('node:sqlite')`, which only exists in Node 22.5+. Every Node 20 leg of the matrix has been failing as a result, with:
```
  warn: This version of pnpm requires at least Node.js v22.13
  warn: The current version of Node.js is v20.20.2
  Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite
      at Module._load (node:internal/modules/cjs/loader:1031:13)
      at __init (file:///usr/local/lib/node_modules/pnpm/dist/pnpm.mjs:15:56)
```
(Observed on PR #1385 / run 25490186616, 5 failing matrix legs all sharing this exit path. Node 22 legs in the same matrix passed cleanly.)

Replace the latest-pnpm fetch with a version-pinned install:

  `npm install -g pnpm@10.17.1`

Matches the `packageManager: pnpm@10.17.1` pin already in the repo's top-level `package.json`, so the in-container pnpm matches the host-side pnpm exactly. `node:20` and `node:20-alpine` both ship with `npm`, so no extra setup is needed in either base image.

Four call sites, all identical (`replace_all`):
  - test-linux-x64-gnu-binding (line 268)
  - test-linux-x64-musl-binding (line 301)
  - test-linux-aarch64-gnu-binding (line 340, inside docker-run-action)
  - test-linux-aarch64-musl-binding (line 381, inside docker-run-action)