### PR TITLE
fix: coverage instrumentation interfering with single-call `vm.prank`

### DIFF
--- a/.changeset/quick-queens-appear.md
+++ b/.changeset/quick-queens-appear.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Fixed coverage instrumentation interfering with the single-call `vm.prank` cheatcode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4104,6 +4104,7 @@ dependencies = [
  "ecdsa",
  "edr_artifact",
  "edr_common",
+ "edr_coverage",
  "edr_decoder_revert",
  "eyre",
  "foundry-cheatcodes-spec 0.3.8",

--- a/crates/edr_solidity_tests/tests/it/coverage.rs
+++ b/crates/edr_solidity_tests/tests/it/coverage.rs
@@ -26,3 +26,33 @@ async fn test_coverage_returndata() {
         )]),
     );
 }
+
+/// Regression test for <https://github.com/NomicFoundation/edr/issues/1391> —
+/// coverage instrumentation probes must not consume `vm.prank` state.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_coverage_prank() {
+    let filter = SolidityTestFilter::new(".*", ".*", "default/coverage/CoveragePrank.t.sol");
+    let mut config = TEST_DATA_DEFAULT.config_with_mock_rpc();
+    config.coverage = true;
+    config.on_collected_coverage_fn = Some(Box::new(|_hits| Ok(())));
+    let runner = TEST_DATA_DEFAULT.runner_with_fuzz_persistence(config).await;
+    let results = runner.test_collect(filter).await.suite_results;
+
+    assert_multiple(
+        &results,
+        BTreeMap::from([(
+            "default/coverage/CoveragePrank.t.sol:CoveragePrankTest",
+            vec![
+                ("testPrankSurvivesCoverageProbe()", true, None, None, None),
+                (
+                    "testPrankWithOriginSurvivesCoverageProbe()",
+                    true,
+                    None,
+                    None,
+                    None,
+                ),
+                ("testStartPrankStillWorks()", true, None, None, None),
+            ],
+        )]),
+    );
+}

--- a/crates/edr_solidity_tests/tests/testdata/default/coverage/CoveragePrank.t.sol
+++ b/crates/edr_solidity_tests/tests/testdata/default/coverage/CoveragePrank.t.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.26;
+
+import "ds-test/test.sol";
+import "./InstrumentedCoveragePrankTest.sol";
+
+/// Regression test for https://github.com/NomicFoundation/edr/issues/1391 —
+/// coverage instrumentation must not interfere with `vm.prank`. Each scenario
+/// runs through `CoveragePrankHelper`, which is instrumented with coverage
+/// probes between the cheatcode and the call it should affect.
+contract CoveragePrankTest is DSTest {
+    CoveragePrankHelper helper;
+    SenderRecorder target;
+
+    function setUp() public {
+        helper = new CoveragePrankHelper();
+        target = new SenderRecorder();
+    }
+
+    /// `vm.prank(addr)` must apply to the next call even when a coverage
+    /// probe is injected between the cheatcode and that call.
+    function testPrankSurvivesCoverageProbe() public {
+        address pranked = address(0xCAFE);
+        address recorded = helper.prankAndRecordSender(target, pranked);
+        assertEq(
+            recorded,
+            pranked,
+            "vm.prank should make pranked the msg.sender of the next call"
+        );
+    }
+
+    /// `vm.prank(addr, origin)` must apply both `msg.sender` and
+    /// `tx.origin` to the next call, despite intervening coverage probes.
+    function testPrankWithOriginSurvivesCoverageProbe() public {
+        address pranked = address(0xCAFE);
+        address newOrigin = address(0xBEEF);
+        (address sender, address origin) = helper.prankAndRecordSenderAndOrigin(
+            target,
+            pranked,
+            newOrigin
+        );
+        assertEq(
+            sender,
+            pranked,
+            "vm.prank(addr, origin) should set msg.sender"
+        );
+        assertEq(
+            origin,
+            newOrigin,
+            "vm.prank(addr, origin) should set tx.origin"
+        );
+    }
+
+    /// `vm.startPrank` was already unaffected by the bug. This
+    /// guards against changes that break the recurrent prank.
+    function testStartPrankStillWorks() public {
+        address pranked = address(0xCAFE);
+        (address first, address second) = helper.startPrankAndRecordTwice(
+            target,
+            pranked
+        );
+        assertEq(
+            first,
+            pranked,
+            "vm.startPrank should set msg.sender on the first call"
+        );
+        assertEq(
+            second,
+            pranked,
+            "vm.startPrank should keep msg.sender on subsequent calls"
+        );
+    }
+}

--- a/crates/edr_solidity_tests/tests/testdata/default/coverage/InstrumentedCoveragePrankTest.sol
+++ b/crates/edr_solidity_tests/tests/testdata/default/coverage/InstrumentedCoveragePrankTest.sol
@@ -1,0 +1,60 @@
+// Auto-generated from data/contracts/test/CoveragePrank.sol — do not edit manually.
+// Regenerate with:
+//   cargo run -p edr_tool_solidity -- --instrument-only data/contracts/test/CoveragePrank.sol
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.26;
+
+import "cheats/Vm.sol";
+
+/// @dev Verifies that coverage instrumentation does not interfere with the
+/// single-call `vm.prank` cheatcode. The instrumenter injects a `STATICCALL`
+/// to the coverage address before each statement which should not consume
+/// the single-call `prank`.
+contract CoveragePrankHelper {
+    Vm constant vm =
+        Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    /// Sets a single-call prank for `pranked`, then immediately calls
+    /// `target.recordSender()`. The the recorded sender should be `pranked`.
+    function prankAndRecordSender(
+        SenderRecorder target,
+        address pranked
+    ) external returns (address) {
+__NomicFoundationCoverage.sendHit(0x5b1bae0df22ecaf575aecbdf8cbb50dee5231ee532ff064624e1929c956b344b);         vm.prank(pranked);
+__NomicFoundationCoverage.sendHit(0xc7d6f1bb9c09169a7eb25121686028c9dfabe35ee6446f8185a70e6095eb379d);         return target.recordSender();
+    }
+
+    /// Same as above but with `vm.prank(addr, origin)` so we also catch
+    /// premature restoration of `tx.origin` by the cheatcodes inspector.
+    function prankAndRecordSenderAndOrigin(
+        SenderRecorder target,
+        address pranked,
+        address newOrigin
+    ) external returns (address sender, address origin) {
+__NomicFoundationCoverage.sendHit(0x3326dd1b26b6c6c307e314f36057f8931367d71faf7852f4a06c48a34a189b5f);         vm.prank(pranked, newOrigin);
+__NomicFoundationCoverage.sendHit(0x1898f99f1097997a59caa86e6252288467890e24cccf8546fd26dcb3d7f770d6);         return target.recordSenderAndOrigin();
+    }
+
+    /// `vm.startPrank` is not single-call. Included to guard against regressions.
+    function startPrankAndRecordTwice(
+        SenderRecorder target,
+        address pranked
+    ) external returns (address first, address second) {
+__NomicFoundationCoverage.sendHit(0xb067465d36072d7321324caee093760308d3c41ce8798fa84c9768753cbaf4aa);         vm.startPrank(pranked);
+__NomicFoundationCoverage.sendHit(0x2285ec72bd18c12ef5f684a28f29b1eda10ef36be3d5dc0c9dce7927eaa1b17f);         first = target.recordSender();
+__NomicFoundationCoverage.sendHit(0x00bd8bf3087aa84dde1a4c57333c755c000a75fea4810f29b2483557be82fe8f);         second = target.recordSender();
+__NomicFoundationCoverage.sendHit(0x7f58c135e11378c2014a7e57a49a267757f785f1db070980427b39bdea5513ce);         vm.stopPrank();
+    }
+}
+
+contract SenderRecorder {
+    function recordSender() external view returns (address) {
+__NomicFoundationCoverage.sendHit(0xa6effab53389158e07b84454221a66a7a9a5ea65890d20813c29d562d1cea9ca);         return msg.sender;
+    }
+
+    function recordSenderAndOrigin() external view returns (address, address) {
+__NomicFoundationCoverage.sendHit(0x50020f1a925abb966e10d34cb078ddc6659c8289b29f53efc10771c12dbd4ae3);         return (msg.sender, tx.origin);
+    }
+}
+
+import "__NomicFoundationCoverage-1fe87c59-dedc-4831-8918-604bc223bbfa.sol";

--- a/crates/foundry/cheatcodes/Cargo.toml
+++ b/crates/foundry/cheatcodes/Cargo.toml
@@ -13,6 +13,7 @@ foundry-cheatcodes-spec.workspace = true
 upstream-foundry-cheatcodes-spec = { git = "https://github.com/foundry-rs/foundry", tag = "v1.5.0", package = "foundry-cheatcodes-spec" }
 edr_artifact.workspace = true
 edr_common.workspace = true
+edr_coverage.workspace = true
 edr_decoder_revert.workspace = true
 foundry-compilers.workspace = true
 foundry-evm-core.workspace = true

--- a/crates/foundry/cheatcodes/src/inspector.rs
+++ b/crates/foundry/cheatcodes/src/inspector.rs
@@ -22,6 +22,7 @@ use alloy_primitives::{
 use alloy_rpc_types::AccessList;
 use alloy_sol_types::{SolCall, SolInterface};
 use derive_where::derive_where;
+use edr_coverage::COVERAGE_ADDRESS;
 use foundry_evm_core::{
     abi::Vm::stopExpectSafeMemoryCall,
     backend::{CheatcodeBackend, RevertDiagnostic},
@@ -937,6 +938,18 @@ impl<
             return None;
         }
 
+        // Coverage instrumentation probes are inlined STATICCALLs to
+        // `COVERAGE_ADDRESS`. They are part of the test runner's bookkeeping —
+        // not the user's contract logic — and must be invisible to cheatcode
+        // state. In particular, applying or consuming a single-call `vm.prank`
+        // here would defeat the prank for the user's intended next call.
+        // `CoverageHitCollector` short-circuits these calls earlier in the
+        // inspector stack so this guard is normally unreachable; we keep it
+        // for correctness under any future inspector reordering.
+        if call.target_address == COVERAGE_ADDRESS {
+            return None;
+        }
+
         // Handle expected calls
 
         // Grab the different calldatas expected.
@@ -1432,8 +1445,14 @@ impl<
         call: &CallInputs,
         outcome: &mut CallOutcome,
     ) {
+        // System addresses that are transparent to cheatcode state.
+        // Treating `COVERAGE_ADDRESS` as a system address prevents the prank cleanup
+        // below from running for coverage instrumentation probes — which would
+        // otherwise wipe a single-call `vm.prank` before the user's intended next call
+        // could consume it.
         let cheatcode_call = call.target_address == CHEATCODE_ADDRESS
-            || call.target_address == HARDHAT_CONSOLE_ADDRESS;
+            || call.target_address == HARDHAT_CONSOLE_ADDRESS
+            || call.target_address == COVERAGE_ADDRESS;
 
         // Clean up pranks/broadcasts if it's not a cheatcode call end. We shouldn't do
         // it for cheatcode calls because they are not applied for cheatcodes in the

--- a/data/contracts/test/CoveragePrank.sol
+++ b/data/contracts/test/CoveragePrank.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.26;
+
+import "cheats/Vm.sol";
+
+/// @dev Verifies that coverage instrumentation does not interfere with the
+/// single-call `vm.prank` cheatcode. The instrumenter injects a `STATICCALL`
+/// to the coverage address before each statement which should not consume
+/// the single-call `prank`.
+contract CoveragePrankHelper {
+    Vm constant vm =
+        Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    /// Sets a single-call prank for `pranked`, then immediately calls
+    /// `target.recordSender()`. The the recorded sender should be `pranked`.
+    function prankAndRecordSender(
+        SenderRecorder target,
+        address pranked
+    ) external returns (address) {
+        vm.prank(pranked);
+        return target.recordSender();
+    }
+
+    /// Same as above but with `vm.prank(addr, origin)` so we also catch
+    /// premature restoration of `tx.origin` by the cheatcodes inspector.
+    function prankAndRecordSenderAndOrigin(
+        SenderRecorder target,
+        address pranked,
+        address newOrigin
+    ) external returns (address sender, address origin) {
+        vm.prank(pranked, newOrigin);
+        return target.recordSenderAndOrigin();
+    }
+
+    /// `vm.startPrank` is not single-call. Included to guard against regressions.
+    function startPrankAndRecordTwice(
+        SenderRecorder target,
+        address pranked
+    ) external returns (address first, address second) {
+        vm.startPrank(pranked);
+        first = target.recordSender();
+        second = target.recordSender();
+        vm.stopPrank();
+    }
+}
+
+contract SenderRecorder {
+    function recordSender() external view returns (address) {
+        return msg.sender;
+    }
+
+    function recordSenderAndOrigin() external view returns (address, address) {
+        return (msg.sender, tx.origin);
+    }
+}


### PR DESCRIPTION
This PR fixes coverage instrumentation interfering with single-call `vm.prank`. Previously, the `STATICCALL` injected by the coverage instrumentation before each statement consumed the `prank`.

closes #1391  