### PR TITLE
ci: only save rust-cache on pushes to main

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -15,12 +15,13 @@ runs:
   using: composite
   steps:
     - name: Install Rust
-      uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
+      uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
       with:
         # Empty string means rust-toolchain if it exists, otherwise stable
         toolchain: ${{ inputs.toolchain }}
         components: ${{ inputs.components }}
         cache: ${{ inputs.cache }}
+        cache-save-if: ${{ github.ref == 'refs/heads/main' }}
         # Do not override the RUSTFLAGS by default and instead do that per job,
         # if needed. Setting RUSTFLAGS via env var, config, etc. is mutually
         # exclusive and often a source of bugs.


### PR DESCRIPTION
The setup-rust composite calls Swatinem/rust-cache via actions-rust-lang/setup-rust-toolchain. With hash-suffixed save keys, every PR push was creating ~6 jobs × 3 OS new entries (~1–1.5 GB each), pushing the repo over the 100 GB Actions cache quota and LRU-evicting main-scoped entries. New PRs and main pushes were then starting cold because main no longer had a baseline to inherit from.

Bump actions-rust-lang/setup-rust-toolchain to v1.16.1 (the first version that exposes cache-save-if as a pass-through to Swatinem's save-if) and gate saves on github.ref == 'refs/heads/main'. PRs still restore from main, but no longer write back — keeping main's baseline stable in LRU and freeing ~50 GB of headroom.