### PR TITLE
fix(CI): write to correct path in forge-std patch

### DIFF
--- a/js/benchmark/patches/forge-std.patch
+++ b/js/benchmark/patches/forge-std.patch
@@ -4178,7 +4178,7 @@ index 6bedfcc..cf2b18b 100644
          NestedJson memory decodedData = abi.decode(data, (NestedJson));
  
 diff --git a/test/StdToml.t.sol b/test/StdToml.t.sol
-index 5a45f4f..57bb5d9 100644
+index 5a45f4f..bd4e64b 100644
 --- a/test/StdToml.t.sol
 +++ b/test/StdToml.t.sol
 @@ -7,11 +7,13 @@ contract StdTomlTest is Test {
@@ -4211,10 +4211,10 @@ index 5a45f4f..57bb5d9 100644
          string memory semiFinal = json.serialize("b", string("test"));
          string memory finalJson = json.serialize("c", semiFinal);
 -        finalJson.write(path);
-+        finalJson.write(readPath);
++        finalJson.write(writePath);
  
 -        string memory toml = vm.readFile(path);
-+        string memory toml = vm.readFile(readPath);
++        string memory toml = vm.readFile(writePath);
          bytes memory data = toml.parseRaw("$");
          NestedToml memory decodedData = abi.decode(data, (NestedToml));
  


### PR DESCRIPTION
This PR fixes [a sporadic CI failure](https://github.com/NomicFoundation/edr/actions/runs/25680744357/job/75392667537?pr=1397).

This is very likely caused by `test_writeToml` writing to the wrong `readPath` instead of `writePath`, which resulted in a read-write race during parallel execution of the read/write tests: even though the written format is consistent with the `test_readToml` expectation, there is a small windows where the file is truncated during `fs::write` which can cause the `test_readToml` to fail as it is trying to read it. This has a small probability to happen, hence the sporadic failures.