### PR TITLE
fix: remove gas snapshot name validation

### DIFF
--- a/.changeset/green-bats-sort.md
+++ b/.changeset/green-bats-sort.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Removed validation checks for names provided in gas snapshot cheatcodes

--- a/crates/foundry/cheatcodes/src/evm.rs
+++ b/crates/foundry/cheatcodes/src/evm.rs
@@ -3323,7 +3323,7 @@ fn inner_value_snapshot<
     name: Option<String>,
     value: String,
 ) -> Result {
-    let (group, name) = derive_snapshot_name(ccx, group, name)?;
+    let (group, name) = derive_snapshot_name(ccx, group, name);
 
     ccx.state
         .gas_snapshots
@@ -3366,7 +3366,7 @@ fn inner_last_gas_snapshot<
     name: Option<String>,
     value: u64,
 ) -> Result {
-    let (group, name) = derive_snapshot_name(ccx, group, name)?;
+    let (group, name) = derive_snapshot_name(ccx, group, name);
 
     ccx.state
         .gas_snapshots
@@ -3414,7 +3414,7 @@ fn inner_start_gas_snapshot<
         bail!("gas snapshot was already started with group: {group} and name: {name}");
     }
 
-    let (group, name) = derive_snapshot_name(ccx, group, name)?;
+    let (group, name) = derive_snapshot_name(ccx, group, name);
 
     ccx.state.gas_metering.gas_records.push(GasRecord {
         group: group.clone(),
@@ -3522,28 +3522,6 @@ fn inner_stop_gas_snapshot<
     }
 }
 
-/// Validates that a snapshot group name or entry name is safe for use as a
-/// filename component. Allows only ASCII alphanumeric characters, hyphens,
-/// underscores, spaces, commas, and non-consecutive dots, which prevents
-/// names containing path separators or traversal sequences (such as `..`)
-/// from being used.
-fn validate_snapshot_name(value: &str, is_group_name: bool) -> Result<()> {
-    let is_valid = !value.is_empty()
-        && value != "."
-        && !value.contains("..")
-        && value
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | ' ' | ',' | '.'));
-    let kind = if is_group_name { "group name" } else { "name" };
-
-    ensure!(
-        is_valid,
-        "invalid snapshot {kind}: \"{value}\". Only alphanumeric characters, hyphens, underscores, spaces, commas, and non-consecutive dots are allowed."
-    );
-
-    Ok(())
-}
-
 // Derives the snapshot group and name from the provided group and name or the
 // running contract.
 fn derive_snapshot_name<
@@ -3576,7 +3554,7 @@ fn derive_snapshot_name<
     >,
     group: Option<String>,
     name: Option<String>,
-) -> Result<(String, String)> {
+) -> (String, String) {
     let group = group.unwrap_or_else(|| {
         ccx.state
             .config
@@ -3586,10 +3564,8 @@ fn derive_snapshot_name<
             .name
     });
     let name = name.unwrap_or_else(|| "default".to_string());
-    validate_snapshot_name(&group, true)?;
-    validate_snapshot_name(&name, false)?;
 
-    Ok((group, name))
+    (group, name)
 }
 
 /// Reads the current caller information and returns the current [`CallerMode`],

--- a/js/integration-tests/solidity-tests/test-contracts/ScopedSnapshot.sol
+++ b/js/integration-tests/solidity-tests/test-contracts/ScopedSnapshot.sol
@@ -170,42 +170,6 @@ contract GasSnapshotTest is Test {
         slot0 = 1;
         vm.stopSnapshotGas("testGroup", "testMissingStartSnapshot");
     }
-
-    // snapshotValue with a group name containing path separators should revert.
-    function testInvalidGroupNameSlash() public {
-        vm.snapshotValue("../../evil", "a", 1);
-    }
-
-    // snapshotValue with a group name containing backslash should revert.
-    function testInvalidGroupNameBackslash() public {
-        vm.snapshotValue("foo\\bar", "a", 1);
-    }
-
-    // snapshotValue with an empty group name should revert.
-    function testInvalidGroupNameEmpty() public {
-        vm.snapshotValue("", "a", 1);
-    }
-
-    // snapshotGasLastCall with a group name containing a dot-dot should revert.
-    function testInvalidGroupNameDotDot() public {
-        flare.run(1);
-        vm.snapshotGasLastCall("group..name", "a");
-    }
-
-    // startSnapshotGas with a name containing special characters should revert.
-    function testInvalidSnapshotName() public {
-        vm.startSnapshotGas("validGroup", "name/with/slashes");
-    }
-
-    // snapshotValue with a snapshot name containing a comma should succeed.
-    function testValidSnapshotNameWithComma() public {
-        vm.snapshotValue("GasSnapshotTest", "name,with,comma", 789);
-    }
-
-    // snapshotValue with a snapshot name containing non-consecutive dots should succeed.
-    function testValidSnapshotNameWithDot() public {
-        vm.snapshotValue("GasSnapshotTest", "name.with.dot", 101);
-    }
 }
 
 contract Flare {

--- a/js/integration-tests/solidity-tests/test/unit.ts
+++ b/js/integration-tests/solidity-tests/test/unit.ts
@@ -342,8 +342,8 @@ describe("Unit tests", () => {
     const { totalTests, failedTests, suiteResults } =
       await testContext.runTestsWithStats("GasSnapshotTest", {}, L1_CHAIN_TYPE);
 
-    assert.equal(totalTests, 22);
-    assert.equal(failedTests, 8);
+    assert.equal(totalTests, 15);
+    assert.equal(failedTests, 3);
 
     let snapshots = new Map<string, Map<string, string>>();
 
@@ -372,48 +372,6 @@ describe("Unit tests", () => {
           assert.equal(
             testResult.reason,
             "vm.stopSnapshotGas: no gas snapshot was started with the name: testMissingStartSnapshot in group: testGroup"
-          );
-          continue;
-        }
-
-        if (testResult.name === "testInvalidGroupNameSlash()") {
-          assert.equal(testResult.status, "Failure");
-          assert.match(
-            testResult.reason!,
-            /invalid snapshot group name: "\.\.\/\.\.\/evil"/
-          );
-          continue;
-        }
-
-        if (testResult.name === "testInvalidGroupNameBackslash()") {
-          assert.equal(testResult.status, "Failure");
-          assert.match(
-            testResult.reason!,
-            /invalid snapshot group name: "foo\\bar"/
-          );
-          continue;
-        }
-
-        if (testResult.name === "testInvalidGroupNameEmpty()") {
-          assert.equal(testResult.status, "Failure");
-          assert.match(testResult.reason!, /invalid snapshot group name: ""/);
-          continue;
-        }
-
-        if (testResult.name === "testInvalidGroupNameDotDot()") {
-          assert.equal(testResult.status, "Failure");
-          assert.match(
-            testResult.reason!,
-            /invalid snapshot group name: "group\.\.name"/
-          );
-          continue;
-        }
-
-        if (testResult.name === "testInvalidSnapshotName()") {
-          assert.equal(testResult.status, "Failure");
-          assert.match(
-            testResult.reason!,
-            /invalid snapshot name: "name\/with\/slashes"/
           );
           continue;
         }
@@ -468,8 +426,6 @@ describe("Unit tests", () => {
             ["d", "123"],
             ["e", "456"],
             ["f", "789"],
-            ["name,with,comma", "789"],
-            ["name.with.dot", "101"],
             ["testAssertGasExternal", "50260"],
             ["testAssertGasInternalA", "22047"],
             ["testAssertGasInternalB", "1011"],


### PR DESCRIPTION
This PR reverts the changes made in #1337 and #1360. EDR doesn't do any file creation and operation, so these checks shouldn't be included here and should be implemented by the users of EDR APIs.