### PR TITLE
ci: disable rust-cache cache-bin to survive macOS image bumps

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -22,6 +22,11 @@ runs:
         components: ${{ inputs.components }}
         cache: ${{ inputs.cache }}
         cache-save-if: ${{ github.ref == 'refs/heads/main' }}
+        # Disabled: caching ~/.cargo/bin/ wholesale clobbers rustup's proxy
+        # binaries on restore after a runner image bump, leaving `cargo` to
+        # behave as `rustup-init` and rejecting every subcommand.
+        # See https://github.com/Swatinem/rust-cache/issues/341
+        cache-bin: "false"
         # Do not override the RUSTFLAGS by default and instead do that per job,
         # if needed. Setting RUSTFLAGS via env var, config, etc. is mutually
         # exclusive and often a source of bugs.

--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -71,7 +71,7 @@ jobs:
       - uses: ./.github/actions/setup-rust
 
       # Install pre-built binaries for cargo hack
-      - uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53
+      - uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2.78.1
         with:
           tool: cargo-hack@0.6.39
 
@@ -106,7 +106,7 @@ jobs:
           components: llvm-tools-preview
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53
+        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2.78.1
         with:
           tool: cargo-llvm-cov@0.8.5
 
@@ -189,7 +189,7 @@ jobs:
           components: llvm-tools-preview
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53
+        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2.78.1
         with:
           tool: cargo-llvm-cov@0.8.5
 
@@ -333,7 +333,7 @@ jobs:
           components: llvm-tools-preview
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53
+        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2.78.1
         with:
           tool: cargo-llvm-cov@0.8.5
 

--- a/.github/workflows/hardhat-tests.yml
+++ b/.github/workflows/hardhat-tests.yml
@@ -39,7 +39,7 @@ jobs:
           components: llvm-tools-preview
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@8cd2ac21dc357ca7dd807fe294d11e9ef84f60ec # v2.62.53
+        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2.78.1
         with:
           tool: cargo-llvm-cov@0.8.5
 


### PR DESCRIPTION
Still recurring issues with the MacOS, `cache-bin` and `llvm-cov`. I've put `cache-bin: false` for the swatinem Rust cache, as it seems to be a recurring issue, and not worth it for caching `llvm-cov` anyway.

I will clean up the cache entries after merging this. 


## Claude Summary

Two CI hygiene changes around the macOS-15 runner image bump (`20260427.0018` → `20260511.0048` / macOS 15.7.4 → 15.7.5) that broke three different jobs this week.

- **Disable `cache-bin` in the rust-cache leg of our composite `setup-rust` action.** When a runner image refresh ships, the cached `~/.cargo/bin/` clobbers rustup's freshly-installed proxy binaries on restore, leaving `cargo` to behave as `rustup-init` (`Usage: rustup-init[EXE] [OPTIONS]`) and rejecting every subcommand. Observed on `Test EDR TS bindings (macos-15)` ([failing run](https://github.com/NomicFoundation/edr/actions/runs/25912201387/job/76160597984)), `Run Hardhat tests (macos-15)` ([failing run](https://github.com/NomicFoundation/edr/actions/runs/25917983442/job/76179323976)), and queued to bite the remaining macOS legs. Cost of disabling: one ~3s `cargo-binstall` of `cargo-llvm-cov` per macOS run. Upstream tracking: [Swatinem/rust-cache#341](https://github.com/Swatinem/rust-cache/issues/341).

- **Bump `taiki-e/install-action` v2.62.53 → v2.78.1.** The pinned version predates the manifest entry for `cargo-llvm-cov@0.8.5` on `aarch64_macos`; every macOS run fell back to `cargo-binstall` with a warning. v2.78.1's manifest includes the native entry, so install-action takes the fast path directly.

Adjacent followup (not in this PR): the three remaining macOS rust-cache entries saved on the old image still need to be deleted via \`gh api -X DELETE\` to force a cold restore (already done for the test-edr-ts entries; \`check-edr-safety\`, \`test-edr-rs\`, \`run-hardhat-tests\` remain).

## Test plan

- [x] CI green on this PR, including all macOS legs that recently failed
- [x] Confirm the \`cargo-llvm-cov@0.8.5 ... fallback to cargo-binstall\` warning is gone in the install step logs