### PR TITLE
Bas/fix ci test flakes

### DIFF
--- a/crates/edr_rpc_eth/tests/integration/client.rs
+++ b/crates/edr_rpc_eth/tests/integration/client.rs
@@ -469,14 +469,16 @@ mod alchemy {
             .await
             .expect_err("should have failed");
 
-        let RpcClientError::HttpStatus(error) = error else {
-            panic!("Expected HttpStatus error, got: {error:?}");
-        };
-
-        assert_eq!(
-            reqwest::Error::from(error).status(),
-            Some(reqwest::StatusCode::BAD_REQUEST)
-        );
+        // Providers report "block does not exist yet" inconsistently: some
+        // return HTTP 400, others a JSON-RPC error. Accept either.
+        match error {
+            RpcClientError::HttpStatus(error) => assert_eq!(
+                reqwest::Error::from(error).status(),
+                Some(reqwest::StatusCode::BAD_REQUEST)
+            ),
+            RpcClientError::JsonRpcError { .. } => {}
+            other => panic!("Expected HttpStatus or JsonRpcError, got: {other:?}"),
+        }
     }
 
     #[tokio::test]
@@ -593,14 +595,16 @@ mod alchemy {
             .await
             .expect_err("should have failed");
 
-        let RpcClientError::HttpStatus(error) = error else {
-            panic!("Expected HttpStatus error, got: {error:?}");
-        };
-
-        assert_eq!(
-            reqwest::Error::from(error).status(),
-            Some(reqwest::StatusCode::BAD_REQUEST)
-        );
+        // Providers report "block does not exist yet" inconsistently: some
+        // return HTTP 400, others a JSON-RPC error. Accept either.
+        match error {
+            RpcClientError::HttpStatus(error) => assert_eq!(
+                reqwest::Error::from(error).status(),
+                Some(reqwest::StatusCode::BAD_REQUEST)
+            ),
+            RpcClientError::JsonRpcError { .. } => {}
+            other => panic!("Expected HttpStatus or JsonRpcError, got: {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/edr_solidity_tests/tests/testdata/default/cheats/UnixTime.t.sol
+++ b/crates/edr_solidity_tests/tests/testdata/default/cheats/UnixTime.t.sol
@@ -8,7 +8,7 @@ contract UnixTimeTest is DSTest {
     Vm constant vm = Vm(HEVM_ADDRESS);
 
     // This is really wide because CI sucks.
-    uint256 constant errMargin = 1000;
+    uint256 constant errMargin = 5000;
 
     function testUnixTimeAgainstDate() public {
         string[] memory inputs = new string[](2);


### PR DESCRIPTION
Two flakes:
* More fun with `UnixTimeTest` time drift. I don't think we particularly care about precision, so I've increased the allowed drift. 
* Alchemy started returning a JsonRpcError for future block requests. I've adapted the test to allow both. 

See https://github.com/NomicFoundation/edr/actions/runs/26032135043/job/76521143259?pr=1420 for an example of the two flakes.