### PR TITLE
fix(edr_provider): prevent `IntervalMiner::Drop` from deadlocking

### DIFF
--- a/.changeset/clever-experts-say.md
+++ b/.changeset/clever-experts-say.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Fixed interval mining from causing the process to hang indefinitely on provider drop

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5750,9 +5750,9 @@ dependencies = [
 
 [[package]]
 name = "napi-build"
-version = "2.1.6"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28acfa557c083f6e254a786e01ba253fc56f18ee000afcd4f79af735f73a6da"
+checksum = "c9c366d2c8c60b86fa632df75f745509b52f9128f91a6bad4c796e44abb505e1"
 
 [[package]]
 name = "napi-derive"

--- a/crates/edr_provider/src/interval.rs
+++ b/crates/edr_provider/src/interval.rs
@@ -116,11 +116,11 @@ impl<ChainSpecT: ProviderSpec<TimerT>, TimerT: Clone + TimeSinceEpoch> Drop
                     Err(RecvTimeoutError::Timeout) => {
                         log::warn!(
                             target: "edr_provider::interval_miner",
-                            "IntervalMiner::Drop timed out (TSFN deadlock suspected, see EDR #1394)"
+                            "IntervalMiner::Drop timed out (TSFN deadlock suspected)"
                         );
                         eprintln!(
                             "[edr_provider] WARNING: IntervalMiner::Drop timed out after 5s \
-                             (TSFN deadlock suspected, see EDR #1394)"
+                             (TSFN deadlock suspected)"
                         );
                         // task is dropped here — detaches without aborting
                     }

--- a/crates/edr_provider/src/interval.rs
+++ b/crates/edr_provider/src/interval.rs
@@ -118,10 +118,6 @@ impl<ChainSpecT: ProviderSpec<TimerT>, TimerT: Clone + TimeSinceEpoch> Drop
                             target: "edr_provider::interval_miner",
                             "IntervalMiner::Drop timed out (TSFN deadlock suspected)"
                         );
-                        eprintln!(
-                            "[edr_provider] WARNING: IntervalMiner::Drop timed out after 5s \
-                             (TSFN deadlock suspected)"
-                        );
                         // task is dropped here — detaches without aborting
                     }
                     _ => {

--- a/crates/edr_provider/src/interval.rs
+++ b/crates/edr_provider/src/interval.rs
@@ -23,6 +23,9 @@ pub struct IntervalMiner<ChainSpecT: ProviderSpec<TimerT>, TimerT: Clone + TimeS
 struct Inner<ChainSpecT: ProviderSpec<TimerT>, TimerT: Clone + TimeSinceEpoch> {
     cancellation_sender: oneshot::Sender<()>,
     background_task: JoinHandle<Result<(), ProviderErrorForChainSpec<ChainSpecT>>>,
+    // Receives a signal when the background task exits (sender is dropped by
+    // the task on return). Used in Drop to wait without polling.
+    task_exited_rx: std::sync::mpsc::Receiver<()>,
     _phantom: PhantomData<fn() -> TimerT>,
 }
 
@@ -37,13 +40,16 @@ impl<
         data: Arc<Mutex<ProviderData<ChainSpecT, TimerT>>>,
     ) -> Self {
         let (cancellation_sender, cancellation_receiver) = oneshot::channel();
-        let background_task = runtime
-            .spawn(async move { interval_mining_loop(config, data, cancellation_receiver).await });
+        let (task_exited_tx, task_exited_rx) = std::sync::mpsc::channel::<()>();
+        let background_task = runtime.spawn(async move {
+            interval_mining_loop(config, data, cancellation_receiver, task_exited_tx).await
+        });
 
         Self {
             inner: Some(Inner {
                 cancellation_sender,
                 background_task,
+                task_exited_rx,
                 _phantom: PhantomData,
             }),
             runtime,
@@ -59,6 +65,8 @@ async fn interval_mining_loop<
     config: IntervalConfig,
     data: Arc<Mutex<ProviderData<ChainSpecT, TimerT>>>,
     mut cancellation_receiver: oneshot::Receiver<()>,
+    // Dropped when the loop exits, waking the Drop-side recv_timeout.
+    _task_exited_tx: std::sync::mpsc::Sender<()>,
 ) -> Result<(), ProviderErrorForChainSpec<ChainSpecT>> {
     let mut now = Instant::now();
     loop {
@@ -95,12 +103,34 @@ impl<ChainSpecT: ProviderSpec<TimerT>, TimerT: Clone + TimeSinceEpoch> Drop
         if let Some(Inner {
             cancellation_sender,
             background_task: task,
+            task_exited_rx,
             _phantom,
         }) = self.inner.take()
         {
-            if let Ok(()) = cancellation_sender.send(()) {
-                let _result = tokio::task::block_in_place(move || self.runtime.block_on(task))
-                    .expect("Failed to join interval mininig task");
+            if cancellation_sender.send(()).is_ok() {
+                // task_exited_tx is dropped when interval_mining_loop returns,
+                // waking recv_timeout immediately in the normal case.
+                // In the deadlock case recv_timeout returns Err(Timeout) after 5s.
+                use std::sync::mpsc::RecvTimeoutError;
+                match task_exited_rx.recv_timeout(std::time::Duration::from_secs(5)) {
+                    Err(RecvTimeoutError::Timeout) => {
+                        log::warn!(
+                            target: "edr_provider::interval_miner",
+                            "IntervalMiner::Drop timed out (TSFN deadlock suspected, see EDR #1394)"
+                        );
+                        eprintln!(
+                            "[edr_provider] WARNING: IntervalMiner::Drop timed out after 5s \
+                             (TSFN deadlock suspected, see EDR #1394)"
+                        );
+                        // task is dropped here — detaches without aborting
+                    }
+                    _ => {
+                        // Task exited normally; block_on polls once and returns
+                        // immediately since the task is already done.
+                        let _ = tokio::task::block_in_place(|| self.runtime.block_on(task))
+                            .expect("interval mining task panicked");
+                    }
+                }
             } else {
                 log::debug!(
                     "Failed to send cancellation signal to interval mining task. The runtime must have already terminated."

--- a/js/deadlock-repro/leaked-interval-miner.mjs
+++ b/js/deadlock-repro/leaked-interval-miner.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env -S node --expose-gc --max-old-space-size=8192
+
+// Force-reproduce the leaked-IntervalMiner-Drop deadlock at a controlled
+// moment by calling V8's `global.gc()` after creating N providers with
+// interval mining enabled.
+//
+// Prerequisites:
+//   1. Build the EDR napi crate:
+//        pnpm -C crates/edr_napi build:dev
+//      This produces crates/edr_napi/edr.<platform>.node + index.js
+//
+//   2. Run on any OS (Linux/macOS/Windows) — the deadlock is OS-independent:
+//        node --expose-gc js/deadlock-repro/leaked-interval-miner.mjs [N]
+//      Default N=20.
+//
+// Outcomes:
+//   - Prints "Survived Nms after gc()" within a few seconds → no deadlock
+//   - Script HANGS at "Waiting Nms for deferred finalizers" → deadlock
+//     reproduced. Wrap with `timeout 30s` (or use js/deadlock-repro/run.sh):
+//        timeout 30s node --expose-gc js/deadlock-repro/leaked-interval-miner.mjs 20
+//        echo "exit code: $?   (124 = hang, 0 = clean)"
+
+import {
+  EdrContext,
+  GENERIC_CHAIN_TYPE,
+  L1_CHAIN_TYPE,
+  ContractDecoder,
+  MineOrdering,
+  genericChainProviderFactory,
+  l1GenesisState,
+  l1HardforkFromString,
+  l1HardforkLatest,
+  l1HardforkToString,
+  l1ProviderFactory,
+} from "../../crates/edr_napi/index.js";
+
+const N = parseInt(process.argv[2] ?? "20", 10);
+const INTERVAL_MINING = !process.argv.includes("--no-interval");
+
+// Validate --expose-gc
+const gc = globalThis.gc;
+if (typeof gc !== "function") {
+  console.error("ERROR: run with `node --expose-gc`");
+  console.error("Example: node --expose-gc js/deadlock-repro/leaked-interval-miner.mjs 20");
+  process.exit(2);
+}
+
+// ─── Provider config ──────────────────────────────────────────────────────
+// Mirrors the canonical config from crates/edr_napi/test/provider.ts.
+// With --no-interval: autoMine ON, no background task (control case).
+// Default: autoMine OFF, mining.interval=50ms — each provider gets its own
+// IntervalMiner background task.
+
+const hardfork = l1HardforkToString(l1HardforkLatest());
+const genesisState = l1GenesisState(l1HardforkFromString(hardfork));
+
+const providerConfig = {
+  allowBlocksWithSameTimestamp: false,
+  allowUnlimitedContractSize: true,
+  bailOnCallFailure: false,
+  bailOnTransactionFailure: false,
+  chainId: 123n,
+  chainOverrides: [],
+  coinbase: new Uint8Array(
+    Buffer.from("0000000000000000000000000000000000000000", "hex"),
+  ),
+  defaultTransactionGasLimit: 300_000_000n,
+  genesisState,
+  hardfork,
+  initialBlobGas: {
+    gasUsed: 0n,
+    excessGas: 0n,
+  },
+  initialParentBeaconBlockRoot: new Uint8Array(
+    Buffer.from(
+      "0000000000000000000000000000000000000000000000000000000000000000",
+      "hex",
+    ),
+  ),
+  minGasPrice: 0n,
+  mining: {
+    // interval mining ON (default): autoMine OFF, 50ms interval.
+    // Each provider gets its own IntervalMiner background task, which is
+    // the load-bearing piece of the deadlock. Short interval maximises
+    // time spent in blocking TSFN calls and the probability of GC firing
+    // mid-mine.
+    //
+    // interval mining OFF (--no-interval): autoMine ON, no background task.
+    // Control case — expected to GC cleanly with no deadlock.
+    autoMine: !INTERVAL_MINING,
+    blockGasLimit: 300_000_000n,
+    ...(INTERVAL_MINING ? { interval: 50n } : {}),
+    memPool: { order: MineOrdering.Priority },
+  },
+  network: {
+    genesisBlobGas: {
+      gasUsed: 0n,
+      excessGas: 0n,
+    },
+    genesisBlockGasLimit: 300_000_000n,
+  },
+  networkId: 123n,
+  observability: {},
+  ownedAccounts: [
+    "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+  ],
+  precompileOverrides: [],
+};
+
+const loggerConfig = {
+  // Must be true — when false, logger.rs short-circuits before calling print_line_fn,
+  // so the IntervalMiner task never makes any blocking-on-JS TSFN calls and the
+  // deadlock cycle cannot form.
+  enable: true,
+  decodeConsoleLogInputsCallback: (_inputs) => [],
+  printLineCallback: (_message, _replace) => {},
+};
+
+const subscriptionConfig = {
+  subscriptionCallback: (_event) => {},
+};
+
+// ─── Test body ────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log(`leaked-interval-miner repro: N=${N}`);
+  console.log(`Node: ${process.version}, platform: ${process.platform}-${process.arch}`);
+  console.log(`Hardfork: ${hardfork}`);
+  console.log("");
+
+  console.log("Initializing EdrContext...");
+  const ctx = new EdrContext();
+  await ctx.registerProviderFactory(GENERIC_CHAIN_TYPE, genericChainProviderFactory());
+  await ctx.registerProviderFactory(L1_CHAIN_TYPE, l1ProviderFactory());
+  const contractDecoder = new ContractDecoder();
+
+  const modeLabel = INTERVAL_MINING
+    ? `interval mining ON (interval=${providerConfig.mining.interval}ms)`
+    : "interval mining OFF (autoMine, no background task — control case)";
+  console.log(`Creating ${N} providers with ${modeLabel}...`);
+  for (let i = 0; i < N; i++) {
+    let p = await ctx.createProvider(
+      GENERIC_CHAIN_TYPE,
+      providerConfig,
+      loggerConfig,
+      subscriptionConfig,
+      contractDecoder,
+    );
+
+    // Touch the provider once so the IntervalMiner has actually started.
+    await p.handleRequest(
+      JSON.stringify({ jsonrpc: "2.0", id: i, method: "eth_blockNumber" }),
+    );
+
+    // Drop the JS reference without calling any napi-level cleanup.
+    // HH2 does `delete this.provider`; HH3's close() does
+    // `this.#provider = undefined`. Both drop the JS reference and rely on
+    // V8 GC to run the Rust finalizer — neither signals the tokio runtime
+    // or IntervalMiner directly.
+    p = null;
+
+    if ((i + 1) % 5 === 0 || i + 1 === N) {
+      console.log(`  ${i + 1}/${N} created and abandoned`);
+    }
+  }
+
+  console.log("");
+  console.log("All providers dropped.");
+  console.log("IntervalMiner tasks are still alive in their respective tokio runtimes.");
+  console.log("");
+
+  console.log(`Requesting GC at ${new Date().toISOString()}...`);
+  console.log("NOTE: global.gc() marks objects as unreachable but V8 schedules");
+  console.log("napi_finalize callbacks as DEFERRED work — they run on the JS");
+  console.log("thread when the callstack unwinds and the event loop gets its");
+  console.log("next turn. The deadlock therefore fires in the await below, not");
+  console.log("inside the gc() call itself.");
+  console.log("");
+
+  const before = Date.now();
+  gc(); // marks unreachable objects; napi_finalize runs after callstack unwinds
+  const gcCallMs = Date.now() - before;
+  console.log(`gc() call returned in ${gcCallMs}ms (finalizers not yet run).`);
+  console.log("");
+
+  // Allow the event loop to pump so that deferred napi_finalize callbacks
+  // execute. If any IntervalMiner::Drop deadlocks, the process will hang
+  // here and the outer `timeout` wrapper will catch it (exit 124).
+  const WAIT_MS = 5_000;
+  console.log(`Waiting ${WAIT_MS}ms for deferred finalizers to run...`);
+  console.log("  → If the script hangs here, the deadlock has fired.");
+  console.log("  → Wrap with 'timeout 30s' (run.sh) to detect.");
+  console.log("");
+  await new Promise((resolve) => setTimeout(resolve, WAIT_MS));
+
+  const elapsed = Date.now() - before;
+  console.log(`Survived ${elapsed}ms after gc(). Process did not hang.`);
+  console.log("Check stderr for '[edr_provider] WARNING' lines:");
+  console.log("  WARNING present → deadlock fired but was bounded by the Drop timeout.");
+  console.log("  No WARNING      → no deadlock. Either:");
+  console.log("    - This Node version has the upstream fix (≥ 24.13.1 LTS, or ≥ 25)");
+  console.log("    - The architectural conditions for the deadlock weren't met");
+  console.log("    - N=" + N + " wasn't enough to trigger; try bumping it");
+}
+
+main().catch((err) => {
+  console.error("repro failed:", err);
+  process.exit(1);
+});

--- a/js/deadlock-repro/run.sh
+++ b/js/deadlock-repro/run.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Wrapper that runs the leaked-interval-miner reproducer with a hard timeout,
+# so a deadlock surfaces as a definite exit code rather than an indefinite hang.
+#
+# Platform-agnostic: the leak/deadlock mechanism is V8 GC + finalizer + tokio
+# block_on, which is identical on Linux, macOS, and Windows (WSL/bash).
+# Only the napi build artifact suffix differs by platform.
+#
+# Usage:
+#   js/deadlock-repro/run.sh [N] [--no-interval]
+#
+# Exit codes:
+#   0   clean — no deadlock detected
+#   2   deadlock detected via IntervalMiner::Drop timeout warning
+#   124 deadlock detected via process hang (process killed by timeout)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+log() { printf '[%s] %s\n' "$(date '+%H:%M:%S')" "$*" >&2; }
+die() { log "ERROR: $*"; exit 1; }
+
+TIMEOUT="${REPRO_TIMEOUT:-30s}"
+NO_INTERVAL=""
+POSITIONAL=()
+for arg in "$@"; do
+  case "$arg" in
+    --no-interval) NO_INTERVAL="--no-interval" ;;
+    *) POSITIONAL+=("$arg") ;;
+  esac
+done
+N="${POSITIONAL[0]:-20}"
+
+# Locate the napi build artifact for any platform.
+# napi-rs emits one of: edr.darwin-*.node, edr.linux-*.node, edr.win32-*.node
+shopt -s nullglob
+artifacts=("$REPO_ROOT"/crates/edr_napi/edr.*.node)
+if (( ${#artifacts[@]} == 0 )); then
+  die "no edr.*.node artifact found — run 'pnpm -C crates/edr_napi build:dev' first"
+fi
+
+# Verify `timeout` is available (GNU coreutils; on macOS install via 'brew install coreutils' → gtimeout)
+if ! command -v timeout >/dev/null 2>&1; then
+  if command -v gtimeout >/dev/null 2>&1; then
+    TIMEOUT_CMD=gtimeout
+  else
+    die "neither 'timeout' nor 'gtimeout' found; on macOS: brew install coreutils"
+  fi
+else
+  TIMEOUT_CMD=timeout
+fi
+
+log "Platform: $(uname -s) $(uname -m)"
+log "Build artifact: ${artifacts[0]}"
+log "Reproducer N=$N, timeout=$TIMEOUT${NO_INTERVAL:+, interval mining OFF (control case)}"
+log ""
+
+# Tee combined output to a temp file so we can detect Drop timeout
+# warnings even when the process exits 0.
+tmpout=$(mktemp)
+trap 'rm -f "$tmpout"' EXIT
+
+set +e
+"$TIMEOUT_CMD" "$TIMEOUT" \
+  node --expose-gc --max-old-space-size=8192 \
+  "$SCRIPT_DIR/leaked-interval-miner.mjs" \
+  "$N" ${NO_INTERVAL:+--no-interval} 2>&1 | tee "$tmpout"
+# PIPESTATUS[0] = exit code of node/timeout; PIPESTATUS[1] = tee (always 0)
+code="${PIPESTATUS[0]}"
+set -e
+
+# If the Rust Drop timeout warning fired, the deadlock was detected even
+# though the process exited 0 (the 5s cap let it continue).
+# Report this as exit 2 so callers can distinguish three outcomes:
+#   0   → clean, no deadlock
+#   2   → deadlock detected via IntervalMiner::Drop timeout
+#   124 → deadlock detected via process hang
+if [[ "$code" -eq 0 ]] && grep -q "IntervalMiner::Drop timed out" "$tmpout"; then
+  code=2
+fi
+
+log ""
+case "$code" in
+  0)
+    if [[ -n "$NO_INTERVAL" ]]; then
+      log "EXIT 0 — clean exit (control case: interval mining disabled, no deadlock expected)"
+    else
+      log "EXIT 0 — no deadlock detected. Either:"
+      log "  - This Node version has the fix (Node 24.13.1+ Krypton LTS, or Node 25+)"
+      log "  - N=$N wasn't enough to trigger; try bumping: $0 50"
+      log "  - The deadlock requires more pressure / specific timing"
+    fi
+    ;;
+  2)
+    log "EXIT 2 — DEADLOCK detected via IntervalMiner::Drop timeout warning."
+    log "         The 5s Drop timeout prevented an indefinite hang."
+    log "         Search the output above for '[edr_provider] WARNING' for details."
+    ;;
+  124)
+    log "EXIT 124 — TIMEOUT after $TIMEOUT. Deadlock reproduced (process hung)."
+    log "           The node process was hung in V8 finalize."
+    ;;
+  *)
+    log "EXIT $code — unexpected (see output above)."
+    ;;
+esac
+
+exit "$code"

--- a/js/deadlock-repro/run.sh
+++ b/js/deadlock-repro/run.sh
@@ -98,7 +98,7 @@ case "$code" in
   2)
     log "EXIT 2 — DEADLOCK detected via IntervalMiner::Drop timeout warning."
     log "         The 5s Drop timeout prevented an indefinite hang."
-    log "         Search the output above for '[edr_provider] WARNING' for details."
+    log "         Search the output above for 'IntervalMiner::Drop timed out' for details."
     ;;
   124)
     log "EXIT 124 — TIMEOUT after $TIMEOUT. Deadlock reproduced (process hung)."

--- a/js/deadlock-repro/run.sh
+++ b/js/deadlock-repro/run.sh
@@ -23,6 +23,8 @@ log() { printf '[%s] %s\n' "$(date '+%H:%M:%S')" "$*" >&2; }
 die() { log "ERROR: $*"; exit 1; }
 
 TIMEOUT="${REPRO_TIMEOUT:-30s}"
+RUST_LOG="${RUST_LOG:-error,edr=warn}"
+export RUST_LOG
 NO_INTERVAL=""
 POSITIONAL=()
 for arg in "$@"; do


### PR DESCRIPTION
## Context
Current interval mining implementation can deadlock on drop. As a result, the running process hangs and never ends - unless terminated.

Evidences:  37 hardhat-test CI hangs in 40 days

## Changes
This PR is twofold: includes a workaround for preventing deadlock together with a Claude-generated script for reproducing the deadlock.

### The deadlock

#### Root cause 

explained by Claude:

> When a provider is garbage-collected, V8 runs its Rust finalizer on the JS thread ([`napi_add_finalizer`](https://nodejs.org/docs/latest/api/n-api.html#napi_add_finalizer)). The finalizer drops `IntervalMiner`, whose `Drop` called `block_on(task)` — parking the JS thread until the background mining task finished.
The mining task, meanwhile, needed to call back into JS via a blocking TSFN (e.g. `subscriptionCallback` on every mined block, or `print_line_fn` if logging is enabled). Blocking TSFNs dispatch on the JS thread ([docs](https://nodejs.org/docs/latest/api/n-api.html#napi_threadsafe_function_call_js)).
Circle: JS thread waits for mining task → mining task waits for JS thread.

 #### The workaround

 Instead of blocking the JS thread waiting for the task, `IntervalMiner` now:

  1. Uses a new mpsc channel to coordinate the interval mining loop and the drop function
     Interval mining loop holds the channel tx, while the inner state of the interval miner holds the rx.
      The interval task, once it exits normally, drops its end of the channel, waking `recv_timeout` immediately. 
  2. The `drop` function waits on a std::sync::mpsc::recv_timeout(5s) — an OS-level wait that does not hold or need the JS thread.
  3. Only after recv_timeout returns (task is already done) does `Drop` call `block_on` — at that point it polls once and returns instantly, just to propagate any panic.
  4. If the task is stuck in the deadlock, `recv_timeout` times out after 5 seconds, logs a warning, and detaches the task, bounding what was previously an infinite hang (5s value is an arbitrary value that's intended to be generous enough to survive slow machines and short enough to avoid unnecessary hangs).

**👀 Note**: This is a workaround, not a definitive fix. The intent is to prevent the process from hanging indefinitely and to surface the deadlock as a bounded warning, so it can be tracked in CI and user usage. A proper fix, rearchitecting `IntervalMiner` to avoid blocking TSFN calls from the mining task, should be done in a follow-up PR.


### The repro script
What it does: using Node API, creates & drops several providers, dropping means leaving the object unreferenced so that the GC can pick it up. This mirrors how both HH2 and HH3 release providers: neither signals the runtime directly; both drop the JS reference and rely on V8 GC, `delete this.provider` in HH2, `this.#provider = undefined` in HH3's `close()`.
After creating and dropping all the providers, calls `gc()` to force the GC execution.
This is enough for reproducing the deadlock. 

#### Script usage
The js script comes with a `.sh` wrapper, that wraps the JS process with a timeout to make sure that the script doesn't hang infinitely. Even if this isn't necessary if run against a build from this branch, it makes the script useful for running on `main` 

```sh
./js/deadlock-repro/run.sh [N] [--no-interval]
```
`N`: number of providers to create through `EdrContext.createProvider`
`--no-interval`: to create providers without interval mining enabled - as control case to compare with

**Note:** The deadlock was reproduced on both Node v22.22.1 and Node v24.15.0, confirming this is independent of the memory-corruption fix introduced in Node 24.13.1. It is a pure logic deadlock, not a use-after-free issue.


