### PR TITLE
fix(edr_napi): bridge log:: records into the NAPI tracing subscriber

### DIFF
--- a/.changeset/loud-baboons-tap.md
+++ b/.changeset/loud-baboons-tap.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Fixed `log::` records from EDR crates being silently dropped when running as a Node module

--- a/crates/edr_napi/Cargo.toml
+++ b/crates/edr_napi/Cargo.toml
@@ -76,6 +76,7 @@ tracing-subscriber = { version = "0.3.18", default-features = false, features = 
     "env-filter",
     "fmt",
     "parking_lot",
+    "tracing-log",
     "smallvec",
     "std",
 ] }

--- a/crates/edr_napi/src/context.rs
+++ b/crates/edr_napi/src/context.rs
@@ -382,7 +382,7 @@ impl Context {
         #[cfg(feature = "tracing")]
         let subscriber = subscriber.with(flame_layer);
 
-        if let Err(error) = tracing::subscriber::set_global_default(subscriber) {
+        if let Err(error) = subscriber.try_init() {
             println!(
                 "Failed to set global tracing subscriber with error: {error}\n\
                 Please only initialize EdrContext once per process to avoid this error."


### PR DESCRIPTION
## Context 
Log records emitted via `log::warn!` / `log::error!` / etc. were being silently dropped when running EDR as a Node module since the NAPI tracing subscriber had no log backend wired up.

## Changes
  - Enable the `tracing-log` feature on the existing `tracing-subscriber` dependency in `edr_napi` crate
  - Replace `tracing::subscriber::set_global_default()` with `subscriber.try_init()`, which, when tracing-log is enabled, automatically initializes a `LogTracer` that forwards log records into the tracing pipeline as events
 
from `tracing-subscriber` crate rust docs (`tracing-subscriber-0.3.23/src/util.rs`)
```rust
    /// Attempts to set `self` as the [global default subscriber] in the current
    /// scope, returning an error if one is already set.
    ///
    /// If the "tracing-log" feature flag is enabled, this will also attempt to
    /// initialize a [`log`] compatibility layer. This allows the subscriber to
    /// consume `log::Record`s as though they were `tracing` `Event`s.
    ///
    /// ...
    fn try_init(self) -> Result<(), TryInitError> {
```
### Consequences: 
 - log output is now subject to the same `RUST_LOG` filter as tracing spans. 
- `LogTracer` is initialized with the subscriber's level filter.

## Pending question
Current setup means that EDR will only log Error+ records, since `EnvFilter::from_default_env()` defaults to `LevelFilter::ERROR` if `RUST_LOG` env variable isn't properly configured. Should we change this to default to 👇 
```rust
 EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("error,edr=warn"));
```
that way, by default all warn records emitted by `edr*` crates will get included.

I originally added that change to this branch, but then decided to roll it back until discussed with the team since this might impact EDR NAPI users (HH) 
