### PR TITLE
improvement: print full eyre::Report chain

### DIFF
--- a/.changeset/dry-melons-care.md
+++ b/.changeset/dry-melons-care.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Print more detailed error descriptions for EVM, invariant fuzz, and cheatcode errors

--- a/crates/foundry/cheatcodes/src/error.rs
+++ b/crates/foundry/cheatcodes/src/error.rs
@@ -353,6 +353,13 @@ impl From<CheatcodeErrorDetails> for Error {
     }
 }
 
+impl From<eyre::Report> for Error {
+    fn from(value: eyre::Report) -> Self {
+        // Print the entire error chain for better debugging
+        Self::from(format!("{value:#}"))
+    }
+}
+
 // So we can use `?` on `Result<_, Error>`.
 macro_rules! impl_from {
     ($($t:ty),* $(,)?) => {$(
@@ -368,7 +375,6 @@ impl_from!(
     alloy_sol_types::Error,
     alloy_dyn_abi::Error,
     alloy_primitives::SignatureError,
-    eyre::Report,
     FsPathError,
     hex::FromHexError,
     BackendError,

--- a/crates/foundry/evm/evm/src/executors/invariant/error.rs
+++ b/crates/foundry/evm/evm/src/executors/invariant/error.rs
@@ -54,7 +54,8 @@ impl InvariantFuzzError {}
 
 impl From<eyre::Report> for InvariantFuzzError {
     fn from(value: Report) -> Self {
-        Self::Other(value.to_string())
+        // Print the entire error chain for better debugging
+        Self::Other(format!("{value:#}"))
     }
 }
 

--- a/crates/foundry/evm/evm/src/executors/mod.rs
+++ b/crates/foundry/evm/evm/src/executors/mod.rs
@@ -1086,7 +1086,7 @@ pub enum EvmError<
     #[error("{0}")]
     Skip(SkipReason),
     /// Any other error.
-    #[error("{0}")]
+    #[error("{0:#}")]
     Eyre(
         #[from]
         #[source]


### PR DESCRIPTION
When converting `eyre::Report`s to strings, we were only displaying the outermost error message for `eyre::Report` resulting in non-descriptive error messages.

Per the `eyre::Report` documentation:

```rs
/// To print causes as well using eyre's default formatting of causes, use the
/// alternate selector "{:#}".
```

This should allow end-users to better understand the reason for failures and debug issues with e.g. their `SolidityTestRunnerConfig`.

**Before**

```bash
  1) TransactionGasCapTest#setUp()
    Error: EVM error
```

**After**

```bash
  1) TransactionGasCapTest#setUp()
    Error: EVM error: transaction validation error: transaction gas limit (9223372036854775807) is greater than the cap (30000000): transaction gas limit (9223372036854775807) is greater than the cap (30000000)
```