### PR TITLE
fix(edr_napi): detach provider drop from JS thread to prevent deadlock

### DIFF
--- a/.changeset/rotten-badgers-refuse.md
+++ b/.changeset/rotten-badgers-refuse.md
@@ -2,4 +2,4 @@
 "@nomicfoundation/edr": patch
 ---
 
-Fixed interval mining from causing the process to hang indefinitely on provider drop
+Fixed process deadlock/hang when dropping a provider with interval mining enabled.

--- a/.changeset/rotten-badgers-refuse.md
+++ b/.changeset/rotten-badgers-refuse.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Fixed interval mining from causing the process to hang indefinitely on provider drop

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1938,6 +1938,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2268,7 +2277,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2978,6 +2987,7 @@ dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
  "alloy-sol-types",
+ "crossbeam-channel",
  "derive-where",
  "derive_more 2.0.1",
  "edr_artifact",
@@ -5454,7 +5464,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5830,7 +5840,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7260,7 +7270,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7936,7 +7946,7 @@ dependencies = [
  "solar-config",
  "solar-data-structures",
  "solar-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
  "unicode-width",
 ]
@@ -8120,7 +8130,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "url",
  "zip",
 ]
@@ -8243,7 +8253,7 @@ dependencies = [
  "getrandom 0.3.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9067,7 +9077,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/edr_napi/Cargo.toml
+++ b/crates/edr_napi/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib"]
 alloy-dyn-abi.workspace = true
 alloy-json-abi.workspace = true
 alloy-sol-types.workspace = true
+crossbeam-channel = "0.5"
 derive_more.workspace = true
 derive-where.workspace = true
 edr_artifact.workspace = true

--- a/crates/edr_napi/src/async_deallocator.rs
+++ b/crates/edr_napi/src/async_deallocator.rs
@@ -1,0 +1,135 @@
+use std::{convert::Infallible, thread::JoinHandle};
+
+use crossbeam_channel::{bounded, select_biased, unbounded, SendError, Sender};
+use napi::tokio::runtime;
+
+/// Owns a dedicated OS thread that drops values of type `T` outside of the
+/// calling thread. Producers obtain cloneable senders via [`Self::sender`] and
+/// call [`AsyncDeallocatorSender::deallocate`].
+///
+/// If the dedicated thread is no longer accepting work (e.g. because the
+/// owning [`AsyncDeallocator`] has been dropped, or the thread has panicked),
+/// `deallocate` falls back to dropping the value on the tokio blocking pool.
+///
+/// # Shutdown via channel disconnection
+///
+/// On `Drop`, the dedicated thread is signalled to exit by **disconnecting**
+/// a dedicated cancellation channel — that is, by dropping its `Sender`,
+/// rather than by sending a sentinel message. The channel's item type is
+/// [`std::convert::Infallible`], so the compiler statically guarantees that no
+/// message can ever be sent on it; thus guaranteeing that disconnection is the
+/// only event that can ever occur on it.
+///
+/// This idiom is described in the async-std book's
+/// [Handling Disconnection](https://book.async.rs/tutorial/handling_disconnection.html)
+/// chapter: "Closing a channel is a synchronization event, so we don't need
+/// to send a shutdown message, we can just drop the sender. This way, we
+/// statically guarantee that we issue shutdown exactly once, even if we
+/// early return via `?` or panic."
+pub struct AsyncDeallocator<T: Send + 'static> {
+    sender: Sender<T>,
+    runtime: runtime::Handle,
+    cancellation_sender: Option<Sender<Infallible>>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl<T: Send + 'static> AsyncDeallocator<T> {
+    /// Constructs a new instance.
+    pub fn new(runtime: runtime::Handle) -> Self {
+        let (sender, receiver) = unbounded::<T>();
+        // See the "Shutdown via channel disconnection" section of
+        // [`AsyncDeallocator`]'s docs for why this channel is parameterized
+        // with `Infallible` and signalled by sender-drop.
+        let (cancellation_sender, cancellation_receiver) = bounded::<Infallible>(1);
+
+        let thread = std::thread::spawn(move || loop {
+            // `select_biased!` picks the first listed branch when multiple
+            // arms are ready, so cancellation always wins over pending work.
+            select_biased! {
+                // Cancellation channel was disconnected by AsyncDeallocator::drop.
+                recv(cancellation_receiver) -> _ => break,
+                recv(receiver) -> msg => match msg {
+                    Ok(value) => drop(value),
+                    // All senders dropped; no more work can arrive.
+                    Err(_) => break,
+                },
+            }
+        });
+
+        Self {
+            sender,
+            runtime,
+            cancellation_sender: Some(cancellation_sender),
+            thread: Some(thread),
+        }
+    }
+
+    /// Returns a cloneable handle for enqueueing values to be dropped on the
+    /// dedicated thread.
+    pub fn sender(&self) -> AsyncDeallocatorSender<T> {
+        AsyncDeallocatorSender {
+            sender: self.sender.clone(),
+            runtime: self.runtime.clone(),
+        }
+    }
+}
+
+impl<T: Send + 'static> Drop for AsyncDeallocator<T> {
+    fn drop(&mut self) {
+        // Drop the cancellation sender, disconnecting the cancellation
+        // channel and waking the dropper thread.
+        self.cancellation_sender.take();
+
+        if let Some(handle) = self.thread.take()
+            && let Err(error) = handle.join()
+        {
+            tracing::error!("AsyncDeallocator thread panicked: {error:?}");
+        }
+    }
+}
+
+/// A cheap, cloneable handle for sending values to an [`AsyncDeallocator`].
+///
+/// [`Self::deallocate`] is infallible from the caller's perspective: if the
+/// dedicated thread is unavailable, it falls back to the tokio blocking pool.
+pub struct AsyncDeallocatorSender<T: Send + 'static> {
+    sender: Sender<T>,
+    runtime: runtime::Handle,
+}
+
+impl<T: Send + 'static> Clone for AsyncDeallocatorSender<T> {
+    fn clone(&self) -> Self {
+        Self {
+            sender: self.sender.clone(),
+            runtime: self.runtime.clone(),
+        }
+    }
+}
+
+impl<T: Send + 'static> AsyncDeallocatorSender<T> {
+    /// Enqueues `value` for asynchronous deallocation on the dedicated
+    /// dropper thread, falling back to the tokio blocking pool if that
+    /// thread is unavailable.
+    #[inline]
+    pub fn deallocate(&self, value: T) {
+        if let Err(SendError(value)) = self.sender.send(value) {
+            fallback(&self.runtime, value);
+        }
+    }
+}
+
+/// The dedicated thread is unavailable — fall back to dropping `value` on
+/// the tokio blocking pool. Marked `#[cold]` and `#[inline(never)]` so the
+/// common `Ok` path in [`AsyncDeallocatorSender::deallocate`] stays
+/// branch-free after inlining.
+///
+/// The tokio blocking pool can shrink idle threads, so a fallback drop can
+/// pay the cost of spawning a fresh OS thread; that's why this is a
+/// fallback rather than the primary path.
+#[cold]
+#[inline(never)]
+fn fallback<T: Send + 'static>(runtime: &runtime::Handle, value: T) {
+    runtime.spawn_blocking(move || {
+        drop(value);
+    });
+}

--- a/crates/edr_napi/src/context.rs
+++ b/crates/edr_napi/src/context.rs
@@ -21,6 +21,7 @@ use napi_derive::napi;
 use tracing_subscriber::{prelude::*, EnvFilter, Registry};
 
 use crate::{
+    async_deallocator::AsyncDeallocator,
     config::{resolve_configs, ConfigResolution, ProviderConfig, TracingConfigWithBuffers},
     contract_decoder::ContractDecoder,
     logger::LoggerConfig,
@@ -45,7 +46,7 @@ impl EdrContext {
     /// Creates a new [`EdrContext`] instance. Should only be called once!
     #[napi(catch_unwind, constructor)]
     pub fn new() -> napi::Result<Self> {
-        let context = Context::new()?;
+        let context = Context::new(runtime::Handle::current())?;
 
         Ok(Self {
             inner: Arc::new(AsyncMutex::new(context)),
@@ -105,7 +106,7 @@ impl EdrContext {
             let context = runtime.block_on(async { self.inner.lock().await });
 
             let factory = try_or_reject_promise!(context.get_provider_factory(&chain_type));
-            let dropped_provider_sender = context.dropped_provider_sender.clone();
+            let dropped_provider_sender = context.provider_deallocator.sender();
 
             (factory, dropped_provider_sender)
         };
@@ -368,7 +369,7 @@ impl EdrContext {
 
         let dropped_provider_sender = {
             let context = runtime.block_on(async { self.inner.lock().await });
-            context.dropped_provider_sender.clone()
+            context.provider_deallocator.sender()
         };
 
         let provider = Provider::new(
@@ -435,7 +436,7 @@ impl EdrContext {
 
         let dropped_provider_sender = {
             let context = runtime.block_on(async { self.inner.lock().await });
-            context.dropped_provider_sender.clone()
+            context.provider_deallocator.sender()
         };
 
         runtime.clone().spawn_blocking(move || {
@@ -495,15 +496,14 @@ impl EdrContext {
 pub struct Context {
     provider_factories: HashMap<String, Arc<dyn SyncProviderFactory>>,
     solidity_test_runner_factories: HashMap<String, Arc<dyn solidity::SyncTestRunnerFactory>>,
-    dropped_provider_sender: std::sync::mpsc::Sender<Arc<dyn SyncProvider>>,
-    provider_dropper_thread: std::thread::JoinHandle<()>,
+    provider_deallocator: AsyncDeallocator<Arc<dyn SyncProvider>>,
     #[cfg(feature = "tracing")]
     _tracing_write_guard: tracing_flame::FlushGuard<std::io::BufWriter<std::fs::File>>,
 }
 
 impl Context {
     /// Creates a new [`Context`] instance. Should only be called once!
-    pub fn new() -> napi::Result<Self> {
+    pub fn new(runtime: runtime::Handle) -> napi::Result<Self> {
         let fmt_layer = tracing_subscriber::fmt::layer()
             .with_file(true)
             .with_line_number(true)
@@ -538,19 +538,10 @@ impl Context {
             );
         }
 
-        let (dropped_provider_sender, dropped_provider_receiver) = std::sync::mpsc::channel();
-
-        let provider_deallocation_thread = std::thread::spawn(move || {
-            while let Ok(provider) = dropped_provider_receiver.recv() {
-                drop(provider);
-            }
-        });
-
         Ok(Self {
             provider_factories: HashMap::default(),
             solidity_test_runner_factories: HashMap::default(),
-            dropped_provider_sender,
-            provider_dropper_thread: provider_deallocation_thread,
+            provider_deallocator: AsyncDeallocator::new(runtime),
             #[cfg(feature = "tracing")]
             _tracing_write_guard: guard,
         })

--- a/crates/edr_napi/src/context.rs
+++ b/crates/edr_napi/src/context.rs
@@ -1,7 +1,10 @@
 use std::sync::Arc;
 
 use edr_decoder_revert::RevertDecoder;
-use edr_napi_core::{provider::SyncProviderFactory, solidity};
+use edr_napi_core::{
+    provider::{SyncProvider, SyncProviderFactory},
+    solidity,
+};
 use edr_primitives::HashMap;
 use edr_solidity_tests::{
     multi_runner::{SuiteResultAndArtifactId, TestContract, TestContracts},
@@ -96,12 +99,15 @@ impl EdrContext {
                 logger_config.enable,
             )));
 
-        let factory = {
+        let (factory, dropped_provider_sender) = {
             // TODO: https://github.com/NomicFoundation/edr/issues/760
             // TODO: Don't block the JS event loop
             let context = runtime.block_on(async { self.inner.lock().await });
 
-            try_or_reject_promise!(context.get_provider_factory(&chain_type))
+            let factory = try_or_reject_promise!(context.get_provider_factory(&chain_type));
+            let dropped_provider_sender = context.dropped_provider_sender.clone();
+
+            (factory, dropped_provider_sender)
         };
 
         let contract_decoder = Arc::clone(contract_decoder.as_inner());
@@ -119,6 +125,7 @@ impl EdrContext {
                         provider,
                         runtime,
                         contract_decoder,
+                        dropped_provider_sender,
                         #[cfg(feature = "scenarios")]
                         scenario_file,
                     )
@@ -345,9 +352,151 @@ impl EdrContext {
     }
 }
 
+#[cfg(feature = "test-mock")]
+#[napi]
+impl EdrContext {
+    /// Creates a mock provider, which always returns the given response.
+    /// For testing purposes.
+    #[napi]
+    pub fn create_mock_provider(
+        &self,
+        mocked_response: serde_json::Value,
+    ) -> napi::Result<Provider> {
+        use crate::mock::MockProvider;
+
+        let runtime = runtime::Handle::current();
+
+        let dropped_provider_sender = {
+            let context = runtime.block_on(async { self.inner.lock().await });
+            context.dropped_provider_sender.clone()
+        };
+
+        let provider = Provider::new(
+            Arc::new(MockProvider::new(mocked_response)),
+            runtime,
+            Arc::default(),
+            dropped_provider_sender,
+            #[cfg(feature = "scenarios")]
+            None,
+        );
+
+        Ok(provider)
+    }
+
+    /// Creates a provider with a mock timer.
+    /// For testing purposes.
+    #[napi(catch_unwind, ts_return_type = "Promise<Provider>")]
+    pub fn create_provider_with_mock_timer(
+        &self,
+        env: Env,
+        provider_config: ProviderConfig,
+        logger_config: LoggerConfig,
+        subscription_config: SubscriptionConfig,
+        contract_decoder: &ContractDecoder,
+        time: &crate::mock::time::MockTime,
+    ) -> napi::Result<JsObject> {
+        use edr_chain_spec::ChainSpec;
+        use edr_chain_spec_block::BlockChainSpec;
+        use edr_chain_spec_rpc::RpcBlockChainSpec;
+        use edr_generic::GenericChainSpec;
+        use edr_napi_core::logger::Logger;
+        use edr_primitives::B256;
+
+        let (deferred, promise) = env.create_deferred()?;
+
+        macro_rules! try_or_reject_promise {
+            ($expr:expr) => {
+                match $expr {
+                    Ok(value) => value,
+                    Err(error) => {
+                        deferred.reject(error);
+                        return Ok(promise);
+                    }
+                }
+            };
+        }
+
+        let runtime = runtime::Handle::current();
+
+        let ConfigResolution {
+            logger_config,
+            provider_config,
+            subscription_callback,
+        } = try_or_reject_promise!(resolve_configs(
+            &env,
+            runtime.clone(),
+            provider_config,
+            logger_config,
+            subscription_config,
+        ));
+
+        let contract_decoder = Arc::clone(contract_decoder.as_inner());
+        let timer = Arc::clone(time.as_inner());
+
+        let dropped_provider_sender = {
+            let context = runtime.block_on(async { self.inner.lock().await });
+            context.dropped_provider_sender.clone()
+        };
+
+        runtime.clone().spawn_blocking(move || {
+            // Using a closure to limit the scope, allowing us to use `?` for error
+            // handling. This is necessary because the result of the closure is used
+            // to resolve the deferred promise.
+            let create_provider = move || -> napi::Result<Provider> {
+                let logger = Logger::<GenericChainSpec, Arc<edr_provider::time::MockTime>>::new(
+                    logger_config,
+                    Arc::clone(&contract_decoder),
+                )?;
+
+                let provider_config =
+                    edr_provider::config::Provider::<edr_chain_l1::Hardfork>::try_from(
+                        provider_config,
+                    )?;
+
+                let provider = edr_provider::Provider::<
+                    GenericChainSpec,
+                    Arc<edr_provider::time::MockTime>,
+                >::new(
+                    runtime.clone(),
+                    Box::new(logger),
+                    Box::new(move |event| {
+                        let event = edr_napi_core::subscription::SubscriptionEvent::new::<
+                            <GenericChainSpec as BlockChainSpec>::Block,
+                            <GenericChainSpec as RpcBlockChainSpec>::RpcBlock<B256>,
+                            <GenericChainSpec as ChainSpec>::SignedTransaction,
+                        >(event);
+
+                        subscription_callback.call(event);
+                    }),
+                    provider_config,
+                    Arc::clone(&contract_decoder),
+                    timer,
+                )
+                .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+
+                Ok(Provider::new(
+                    Arc::new(provider),
+                    runtime,
+                    contract_decoder,
+                    dropped_provider_sender,
+                    #[cfg(feature = "scenarios")]
+                    None,
+                ))
+            };
+
+            let result = create_provider();
+            deferred.resolve(|_env| result);
+        });
+
+        Ok(promise)
+    }
+}
+
 pub struct Context {
     provider_factories: HashMap<String, Arc<dyn SyncProviderFactory>>,
     solidity_test_runner_factories: HashMap<String, Arc<dyn solidity::SyncTestRunnerFactory>>,
+    dropped_provider_sender: std::sync::mpsc::Sender<Arc<dyn SyncProvider>>,
+    provider_dropper_thread: std::thread::JoinHandle<()>,
     #[cfg(feature = "tracing")]
     _tracing_write_guard: tracing_flame::FlushGuard<std::io::BufWriter<std::fs::File>>,
 }
@@ -389,9 +538,19 @@ impl Context {
             );
         }
 
+        let (dropped_provider_sender, dropped_provider_receiver) = std::sync::mpsc::channel();
+
+        let provider_deallocation_thread = std::thread::spawn(move || {
+            while let Ok(provider) = dropped_provider_receiver.recv() {
+                drop(provider);
+            }
+        });
+
         Ok(Self {
             provider_factories: HashMap::default(),
             solidity_test_runner_factories: HashMap::default(),
+            dropped_provider_sender,
+            provider_dropper_thread: provider_deallocation_thread,
             #[cfg(feature = "tracing")]
             _tracing_write_guard: guard,
         })

--- a/crates/edr_napi/src/lib.rs
+++ b/crates/edr_napi/src/lib.rs
@@ -6,6 +6,7 @@
 static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 mod account;
+mod async_deallocator;
 mod block;
 /// Types for overriding a call.
 pub mod call_override;

--- a/crates/edr_napi/src/mock.rs
+++ b/crates/edr_napi/src/mock.rs
@@ -4,10 +4,6 @@ use std::sync::Arc;
 
 use edr_napi_core::provider::SyncProvider;
 use edr_rpc_client::jsonrpc;
-use napi::tokio::runtime;
-use napi_derive::napi;
-
-use crate::{context::EdrContext, provider::Provider};
 
 /// A mock provider that always returns the given mocked response.
 pub struct MockProvider {
@@ -41,25 +37,4 @@ impl SyncProvider for MockProvider {
     }
 
     fn set_verbose_tracing(&self, _enabled: bool) {}
-}
-
-#[napi]
-impl EdrContext {
-    #[doc = "Creates a mock provider, which always returns the given response."]
-    #[doc = "For testing purposes."]
-    #[napi]
-    pub fn create_mock_provider(
-        &self,
-        mocked_response: serde_json::Value,
-    ) -> napi::Result<Provider> {
-        let provider = Provider::new(
-            Arc::new(MockProvider::new(mocked_response)),
-            runtime::Handle::current(),
-            Arc::default(),
-            #[cfg(feature = "scenarios")]
-            None,
-        );
-
-        Ok(provider)
-    }
 }

--- a/crates/edr_napi/src/mock/time.rs
+++ b/crates/edr_napi/src/mock/time.rs
@@ -1,26 +1,19 @@
 use std::sync::Arc;
 
-use edr_chain_spec::ChainSpec;
-use edr_chain_spec_block::BlockChainSpec;
-use edr_chain_spec_rpc::RpcBlockChainSpec;
-use edr_generic::GenericChainSpec;
-use edr_napi_core::logger::Logger;
-use edr_primitives::B256;
-use napi::{bindgen_prelude::BigInt, tokio::runtime, Env, JsObject};
+use napi::bindgen_prelude::BigInt;
 use napi_derive::napi;
 
-use crate::{
-    cast::TryCast as _,
-    config::{resolve_configs, ConfigResolution, ProviderConfig},
-    contract_decoder::ContractDecoder,
-    logger::LoggerConfig,
-    provider::Provider,
-    subscription::SubscriptionConfig,
-};
+use crate::cast::TryCast as _;
 
 #[napi]
 pub struct MockTime {
     inner: Arc<edr_provider::time::MockTime>,
+}
+
+impl MockTime {
+    pub fn as_inner(&self) -> &Arc<edr_provider::time::MockTime> {
+        &self.inner
+    }
 }
 
 #[napi]
@@ -41,96 +34,4 @@ impl MockTime {
         self.inner.add_seconds(seconds);
         Ok(())
     }
-}
-
-#[doc = "Creates a provider with a mock timer."]
-#[doc = "For testing purposes."]
-#[napi(catch_unwind, ts_return_type = "Promise<Provider>")]
-pub fn create_provider_with_mock_timer(
-    env: Env,
-    provider_config: ProviderConfig,
-    logger_config: LoggerConfig,
-    subscription_config: SubscriptionConfig,
-    contract_decoder: &ContractDecoder,
-    time: &MockTime,
-) -> napi::Result<JsObject> {
-    let (deferred, promise) = env.create_deferred()?;
-
-    macro_rules! try_or_reject_promise {
-        ($expr:expr) => {
-            match $expr {
-                Ok(value) => value,
-                Err(error) => {
-                    deferred.reject(error);
-                    return Ok(promise);
-                }
-            }
-        };
-    }
-
-    let runtime = runtime::Handle::current();
-
-    let ConfigResolution {
-        logger_config,
-        provider_config,
-        subscription_callback,
-    } = try_or_reject_promise!(resolve_configs(
-        &env,
-        runtime.clone(),
-        provider_config,
-        logger_config,
-        subscription_config,
-    ));
-
-    let contract_decoder = Arc::clone(contract_decoder.as_inner());
-    let timer = Arc::clone(&time.inner);
-
-    runtime.clone().spawn_blocking(move || {
-        // Using a closure to limit the scope, allowing us to use `?` for error
-        // handling. This is necessary because the result of the closure is used
-        // to resolve the deferred promise.
-        let create_provider = move || -> napi::Result<Provider> {
-            let logger = Logger::<GenericChainSpec, Arc<edr_provider::time::MockTime>>::new(
-                logger_config,
-                Arc::clone(&contract_decoder),
-            )?;
-
-            let provider_config =
-                edr_provider::config::Provider::<edr_chain_l1::Hardfork>::try_from(
-                    provider_config,
-                )?;
-
-            let provider =
-                edr_provider::Provider::<GenericChainSpec, Arc<edr_provider::time::MockTime>>::new(
-                    runtime.clone(),
-                    Box::new(logger),
-                    Box::new(move |event| {
-                        let event = edr_napi_core::subscription::SubscriptionEvent::new::<
-                            <GenericChainSpec as BlockChainSpec>::Block,
-                            <GenericChainSpec as RpcBlockChainSpec>::RpcBlock<B256>,
-                            <GenericChainSpec as ChainSpec>::SignedTransaction,
-                        >(event);
-
-                        subscription_callback.call(event);
-                    }),
-                    provider_config,
-                    Arc::clone(&contract_decoder),
-                    timer,
-                )
-                .map_err(|error| napi::Error::from_reason(error.to_string()))?;
-
-            Ok(Provider::new(
-                Arc::new(provider),
-                runtime,
-                contract_decoder,
-                #[cfg(feature = "scenarios")]
-                None,
-            ))
-        };
-
-        let result = create_provider();
-        deferred.resolve(|_env| result);
-    });
-
-    Ok(promise)
 }

--- a/crates/edr_napi/src/provider.rs
+++ b/crates/edr_napi/src/provider.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use edr_napi_core::provider::SyncProvider;
 use edr_solidity::compiler::create_models_and_decode_bytecodes;
-use napi::{tokio::runtime, Env, JsFunction, JsObject, Status};
+use napi::{bindgen_prelude::ObjectFinalize, tokio::runtime, Env, JsFunction, JsObject, Status};
 use napi_derive::napi;
 use parking_lot::RwLock;
 
@@ -15,7 +15,7 @@ use self::response::Response;
 use crate::{call_override::CallOverrideCallback, contract_decoder::ContractDecoder};
 
 /// A JSON-RPC provider for Ethereum.
-#[napi]
+#[napi(custom_finalize)]
 pub struct Provider {
     contract_decoder: Arc<RwLock<edr_solidity::contract_decoder::ContractDecoder>>,
     provider: Arc<dyn SyncProvider>,
@@ -158,5 +158,27 @@ impl Provider {
             })
             .await
             .map_err(|error| napi::Error::new(Status::GenericFailure, error.to_string()))
+    }
+}
+
+impl ObjectFinalize for Provider {
+    fn finalize(self, _env: Env) -> napi::Result<()> {
+        let Self {
+            provider, runtime, ..
+        } = self;
+
+        // Move deallocation of the provider to a separate thread to avoid blocking the
+        // JS thread. This is necessary because the provider may be running thread-safe
+        // functions on a background thread. If so, this would cause a deadlock.
+        //
+        // This creates a detached task, which will be automatically executed and
+        // cleaned up by Tokio when it finishes. `await`ing the `JoinHandle` would just
+        // inform us of the task's completion, but we explicitly do not want to do that
+        // to avoid blocking the JS thread.
+        runtime.spawn_blocking(move || {
+            drop(provider);
+        });
+
+        Ok(())
     }
 }

--- a/crates/edr_napi/src/provider.rs
+++ b/crates/edr_napi/src/provider.rs
@@ -6,7 +6,11 @@ use std::sync::Arc;
 
 use edr_napi_core::provider::SyncProvider;
 use edr_solidity::compiler::create_models_and_decode_bytecodes;
-use napi::{bindgen_prelude::ObjectFinalize, tokio::runtime, Env, JsFunction, JsObject, Status};
+use napi::{
+    bindgen_prelude::ObjectFinalize,
+    tokio::{self, runtime},
+    Env, JsFunction, JsObject, Status,
+};
 use napi_derive::napi;
 use parking_lot::RwLock;
 
@@ -20,6 +24,7 @@ pub struct Provider {
     contract_decoder: Arc<RwLock<edr_solidity::contract_decoder::ContractDecoder>>,
     provider: Arc<dyn SyncProvider>,
     runtime: runtime::Handle,
+    dropped_provider_sender: std::sync::mpsc::Sender<Arc<dyn SyncProvider>>,
     #[cfg(feature = "scenarios")]
     scenario_file: Option<napi::tokio::sync::Mutex<napi::tokio::fs::File>>,
 }
@@ -30,6 +35,7 @@ impl Provider {
         provider: Arc<dyn SyncProvider>,
         runtime: runtime::Handle,
         contract_decoder: Arc<RwLock<edr_solidity::contract_decoder::ContractDecoder>>,
+        dropped_provider_sender: std::sync::mpsc::Sender<Arc<dyn SyncProvider>>,
         #[cfg(feature = "scenarios")] scenario_file: Option<
             napi::tokio::sync::Mutex<napi::tokio::fs::File>,
         >,
@@ -38,6 +44,7 @@ impl Provider {
             contract_decoder,
             provider,
             runtime,
+            dropped_provider_sender,
             #[cfg(feature = "scenarios")]
             scenario_file,
         }
@@ -164,21 +171,39 @@ impl Provider {
 impl ObjectFinalize for Provider {
     fn finalize(self, _env: Env) -> napi::Result<()> {
         let Self {
-            provider, runtime, ..
+            provider,
+            dropped_provider_sender,
+            runtime,
+            ..
         } = self;
 
-        // Move deallocation of the provider to a separate thread to avoid blocking the
-        // JS thread. This is necessary because the provider may be running thread-safe
-        // functions on a background thread. If so, this would cause a deadlock.
-        //
-        // This creates a detached task, which will be automatically executed and
-        // cleaned up by Tokio when it finishes. `await`ing the `JoinHandle` would just
-        // inform us of the task's completion, but we explicitly do not want to do that
-        // to avoid blocking the JS thread.
-        runtime.spawn_blocking(move || {
-            drop(provider);
-        });
+        if let Err(std::sync::mpsc::SendError(provider)) = dropped_provider_sender.send(provider) {
+            // If this happens, the dedicated thread for deallocating providers has panicked
+            // or shut down.
+            drop_provider_on_tokio_slow(runtime, provider);
+        }
 
         Ok(())
     }
+}
+
+/// Move deallocation of the provider to a separate thread to avoid blocking the
+/// JS thread. This is necessary because the provider may be running thread-safe
+/// functions on a background thread. If so, this would cause a deadlock.
+///
+/// This creates a detached task, which will be automatically executed and
+/// cleaned up by Tokio when it finishes. `await`ing the `JoinHandle` would just
+/// inform us of the task's completion, but we explicitly do not want to do that
+/// to avoid blocking the JS thread.
+///
+/// This is marked as `#[cold]` and `#[inline(never)]` to hint to the compiler
+/// that this code is unlikely to be executed, which can help with performance
+/// optimizations on the common path where the provider is successfully sent to
+/// the dedicated thread for deallocation.
+#[cold]
+#[inline(never)]
+fn drop_provider_on_tokio_slow(runtime: tokio::runtime::Handle, provider: Arc<dyn SyncProvider>) {
+    runtime.spawn_blocking(move || {
+        drop(provider);
+    });
 }

--- a/crates/edr_napi/src/provider.rs
+++ b/crates/edr_napi/src/provider.rs
@@ -6,17 +6,16 @@ use std::sync::Arc;
 
 use edr_napi_core::provider::SyncProvider;
 use edr_solidity::compiler::create_models_and_decode_bytecodes;
-use napi::{
-    bindgen_prelude::ObjectFinalize,
-    tokio::{self, runtime},
-    Env, JsFunction, JsObject, Status,
-};
+use napi::{bindgen_prelude::ObjectFinalize, tokio::runtime, Env, JsFunction, JsObject, Status};
 use napi_derive::napi;
 use parking_lot::RwLock;
 
 pub use self::factory::ProviderFactory;
 use self::response::Response;
-use crate::{call_override::CallOverrideCallback, contract_decoder::ContractDecoder};
+use crate::{
+    async_deallocator::AsyncDeallocatorSender, call_override::CallOverrideCallback,
+    contract_decoder::ContractDecoder,
+};
 
 /// A JSON-RPC provider for Ethereum.
 #[napi(custom_finalize)]
@@ -24,7 +23,7 @@ pub struct Provider {
     contract_decoder: Arc<RwLock<edr_solidity::contract_decoder::ContractDecoder>>,
     provider: Arc<dyn SyncProvider>,
     runtime: runtime::Handle,
-    dropped_provider_sender: std::sync::mpsc::Sender<Arc<dyn SyncProvider>>,
+    dropped_provider_sender: AsyncDeallocatorSender<Arc<dyn SyncProvider>>,
     #[cfg(feature = "scenarios")]
     scenario_file: Option<napi::tokio::sync::Mutex<napi::tokio::fs::File>>,
 }
@@ -35,7 +34,7 @@ impl Provider {
         provider: Arc<dyn SyncProvider>,
         runtime: runtime::Handle,
         contract_decoder: Arc<RwLock<edr_solidity::contract_decoder::ContractDecoder>>,
-        dropped_provider_sender: std::sync::mpsc::Sender<Arc<dyn SyncProvider>>,
+        dropped_provider_sender: AsyncDeallocatorSender<Arc<dyn SyncProvider>>,
         #[cfg(feature = "scenarios")] scenario_file: Option<
             napi::tokio::sync::Mutex<napi::tokio::fs::File>,
         >,
@@ -173,37 +172,14 @@ impl ObjectFinalize for Provider {
         let Self {
             provider,
             dropped_provider_sender,
-            runtime,
             ..
         } = self;
 
-        if let Err(std::sync::mpsc::SendError(provider)) = dropped_provider_sender.send(provider) {
-            // If this happens, the dedicated thread for deallocating providers has panicked
-            // or shut down.
-            drop_provider_on_tokio_slow(runtime, provider);
-        }
+        // Off-loads deallocation to a background thread to avoid blocking the
+        // JS thread (the provider may be running thread-safe functions on a
+        // background thread; dropping it here would deadlock).
+        dropped_provider_sender.deallocate(provider);
 
         Ok(())
     }
-}
-
-/// Move deallocation of the provider to a separate thread to avoid blocking the
-/// JS thread. This is necessary because the provider may be running thread-safe
-/// functions on a background thread. If so, this would cause a deadlock.
-///
-/// This creates a detached task, which will be automatically executed and
-/// cleaned up by Tokio when it finishes. `await`ing the `JoinHandle` would just
-/// inform us of the task's completion, but we explicitly do not want to do that
-/// to avoid blocking the JS thread.
-///
-/// This is marked as `#[cold]` and `#[inline(never)]` to hint to the compiler
-/// that this code is unlikely to be executed, which can help with performance
-/// optimizations on the common path where the provider is successfully sent to
-/// the dedicated thread for deallocation.
-#[cold]
-#[inline(never)]
-fn drop_provider_on_tokio_slow(runtime: tokio::runtime::Handle, provider: Arc<dyn SyncProvider>) {
-    runtime.spawn_blocking(move || {
-        drop(provider);
-    });
 }

--- a/crates/edr_napi/test/logs.ts
+++ b/crates/edr_napi/test/logs.ts
@@ -4,9 +4,6 @@ import chalk, { Chalk } from "chalk";
 import {
   AccountOverride,
   ContractDecoder,
-  // Ignore this on testNoBuild
-  // @ts-ignore
-  createProviderWithMockTimer,
   l1GenesisState,
   l1HardforkFromString,
   MineOrdering,
@@ -20,6 +17,7 @@ import {
 import {
   deployContract,
   getBlockNumber,
+  getContext,
   getGasPrice,
   sendTransaction,
   sleep,
@@ -264,6 +262,8 @@ const providerConfig = {
 };
 
 describe("Provider logs", function () {
+  const context = getContext();
+
   describe("Interval mining", function () {
     let gasPrice: bigint;
     let logger: FakeModulesLogger;
@@ -294,7 +294,9 @@ describe("Provider logs", function () {
         },
       };
 
-      provider = await createProviderWithMockTimer(
+      // Ignore this on testNoBuild
+      // @ts-ignore
+      provider = await context.createProviderWithMockTimer(
         {
           ...providerConfig,
           genesisState: providerConfig.genesisState.concat(


### PR DESCRIPTION
## Context

EDR can deadlock when a provider is dropped, as evidenced in #1426. The root cause is that V8 runs the provider's finalizer on the JS main thread. For a provider with interval mining enabled, that finalizer must shut down the `IntervalMiner` background task, which itself holds a blocking TSFN that dispatches on the JS main thread. On the right timing this creates a circular dependency:

> JS thread waits for mining task → mining task waits for JS thread.

## Solution

Detach provider drop from the JS main thread by moving it to a Tokio blocking thread via `spawn_blocking`. The JS thread hands off ownership of the provider to the new thread and returns immediately, allowing the event loop to keep running and TSFNs to dispatch normally. The actual `drop` then happens on the blocking thread, where there is no conflict.

Rust's ownership model ensures the transfer is sound: the provider and runtime handle are moved into the closure, so deallocation happens exactly once when the blocking task completes. No additional synchronisation is needed.

This is a definitive fix rather than a workaround: the deadlock cycle is broken at the architectural level rather than bounded by a timeout.

### Validation

- Confirmed deadlock is no longer reproducible with the reproducer script from #1426 (`js/deadlock-repro/run.sh`).
- Confirmed no memory leaks via valgrind across N=5, N=100, and N=500 providers:
  `definitely lost: 0 bytes` in all runs, with leak numbers flat across all N values.
