### PR TITLE
chore: remove unused tikv-jemallocator workspace dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -357,7 +357,6 @@ tracing-subscriber = "0.3"
 url = "2"
 vergen = { version = "8", default-features = false }
 indexmap = "2.2"
-tikv-jemallocator = "0.5.4"
 num-format = "0.4.4"
 yansi = { version = "1.0", features = ["detect-tty", "detect-env"] }
 tempfile = "3.25"


### PR DESCRIPTION
Removes `tikv-jemallocator` dependency as it's only used by Forge CLI, instead of bumping it (see https://github.com/NomicFoundation/edr/pull/1442).

## Claude Summary

Removes the `tikv-jemallocator = "0.5.4"` entry from the root `[workspace.dependencies]`. It is a dead declaration: no crate consumes it and it isn't present in `Cargo.lock`.

## Background

The declaration was added in #466 (`chore: fork Foundry Forge`, commit `318a25e0d`, 2024-05-27), as part of a block of workspace dependencies copied over from upstream Foundry's root `Cargo.toml` — it sits inline with `indexmap`, `num-format`, `yansi`, and `tempfile`, all Foundry deps.

It was **never wired up**. Pickaxe across the full history confirms it was dead on arrival, not something that fell out of use later:

- No crate has ever set `tikv-jemallocator.workspace = true` (`git log --all -S tikv-jemallocator -- '*/Cargo.toml'` → no hits outside the root declaration).
- No `.rs` file has ever used jemalloc as a global allocator (`git log --all -S jemalloc -- '*.rs'` → no hits).

In upstream Foundry, `tikv-jemallocator` is consumed by exactly one crate — `crates/cli` — as an **optional, unix-only dependency behind a non-default `jemalloc` feature** (`jemalloc = ["dep:tikv-jemallocator"]`; `default = ["optimism"]`). It's wired through `foundry_cli::utils::new_allocator()` and applied via `#[global_allocator]` in the binary entrypoints (`forge`/`cast`/`anvil`/`chisel`); when the feature is off the allocator falls back to mimalloc or `std::alloc::System`. EDR vendored only Foundry's **library** crates (`foundry-evm`, `foundry-cheatcodes`, …) — not `crates/cli` or the binaries — so the sole consumer was never imported, and the workspace-dependency line came across from the upstream root manifest with nothing behind it. EDR's own entrypoints standardize on mimalloc instead:

- `crates/edr_napi/src/lib.rs` → `#[global_allocator] static ALLOC: mimalloc::MiMalloc`
- `crates/tool/cli/src/main.rs` → `#[global_allocator] static ALLOC: mimalloc::MiMalloc` (with the comment *"Matches `edr_napi`. Important for scenarios."*)

## Why now

Renovate keeps opening no-op version-bump PRs for this declaration (most recently #1442, `0.5.4` → `0.6.0`). Since nothing links against it, those bumps are inert. Removing the line closes that PR's need and stops the recurring noise.

## Verification

- `cargo build` (full workspace) — clean, no errors, no unused-dependency warnings.
- `Cargo.lock` unchanged (the crate was never in the graph).

## Supersedes

Closes the need for #1442 — that Renovate PR can be closed once this lands.
