### PR TITLE
ci(renovate): add renovate:no-rebase stopUpdatingLabel

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
   "schedule": ["before 9am on Monday"],
   "minimumReleaseAge": "7 days",
   "internalChecksFilter": "strict",
+  "stopUpdatingLabel": "renovate:no-rebase",
   "ignorePaths": [
     "**/fixture-projects/**",
     "hardhat-tests/**",


### PR DESCRIPTION
Added a `renovate:no-rebase` label that can be used to stop Renovate from auto-rebasing a PR. Good when you want to pause a PR like https://github.com/NomicFoundation/edr/pull/1418 from consuming CI and the perf runner. 

(added the label to this PR just to show I've added it)