### PR TITLE
chore: remove unused tower-http workspace dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -371,7 +371,6 @@ walkdir = "2"
 hyper = "1.0"
 reqwest = { version = "0.12", default-features = false }
 tower = "0.5"
-tower-http = "0.5"
 axum = "0.8"
 
 [workspace.lints.rust]


### PR DESCRIPTION
Similar to https://github.com/NomicFoundation/edr/pull/1446, `tower-http` is an unused dependency (used by Anvil). 