### PR TITLE
fix(deps): enable regex unicode-perl feature at the workspace level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -332,7 +332,9 @@ log = { version = "0.4.17", default-features = false }
 parking_lot = { version = "0.12.1", default-features = false }
 paste = { version = "1.0.14", default-features = false }
 proptest = "1.7.0"
-regex = { version = "1", default-features = false }
+# `unicode-perl` provides the Unicode word boundary (`\b`) used by edr_rpc_client's URL_REGEX.
+# Listed here rather than per-crate so isolated builds match feature-unified ones (e.g. `cargo test -p edr_rpc_client`).
+regex = { version = "1", default-features = false, features = ["unicode-perl"] }
 semver = { version = "1.0.28", default-features = false }
 sha2 = { version = "0.10.9", default-features = false }
 sha3 = { version = "0.10.8", default-features = false }


### PR DESCRIPTION
Explicit `unicode-perl` feature enabled for `regex` package, as otherwise  `cargo test -p edr_rpc_client` fails locally.

# Claude summary
edr_rpc_client's URL_REGEX (API-key redaction in RPC error messages) uses a Unicode word boundary (\b), which requires regex's unicode-perl feature to build its NFA. The workspace pins regex with default-features = false, so that feature is only present when feature unification in a larger build pulls it in transitively.

In the unified workspace build (and CI) it is on, so the regex builds fine. But building edr_rpc_client in isolation (cargo test -p edr_rpc_client) leaves regex featureless and URL_REGEX panics at first use with 'error building NFA'. This is invisible to cargo-hack, which only runs check (no test execution, --no-dev-deps).

Declare the feature at the workspace level rather than per-crate, matching the existing serde_json precedent, so isolated builds match feature-unified ones. The regex pattern is left unchanged.