### PR TITLE
test(hardhat): fund impersonated accounts in forked-provider tests

### DIFF
--- a/hardhat-tests/test/internal/hardhat-network/provider/forked-provider.ts
+++ b/hardhat-tests/test/internal/hardhat-network/provider/forked-provider.ts
@@ -123,6 +123,12 @@ describe("Forked provider", function () {
               await this.provider.send("hardhat_impersonateAccount", [
                 BITFINEX_WALLET_ADDRESS.toString(),
               ]);
+              // Fork is at the latest block, so don't rely on the impersonated
+              // account's live balance to cover the transaction.
+              await this.provider.send("hardhat_setBalance", [
+                BITFINEX_WALLET_ADDRESS.toString(),
+                numberToRpcQuantity(10n ** 20n),
+              ]);
 
               const getWrappedBalance = async () => {
                 const balanceOfSelector = `0x70a08231${leftPad32(
@@ -167,6 +173,12 @@ describe("Forked provider", function () {
 
               await this.provider.send("hardhat_impersonateAccount", [
                 BITFINEX_WALLET_ADDRESS.toString(),
+              ]);
+              // Fork is at the latest block, so don't rely on the impersonated
+              // account's live balance to cover the transaction.
+              await this.provider.send("hardhat_setBalance", [
+                BITFINEX_WALLET_ADDRESS.toString(),
+                numberToRpcQuantity(10n ** 20n),
               ]);
 
               await this.provider.send("eth_sendTransaction", [
@@ -401,6 +413,12 @@ describe("Forked provider", function () {
           await this.provider.send("hardhat_impersonateAccount", [
             BITFINEX_WALLET_ADDRESS.toString(),
           ]);
+          // Fork is at the latest block, so don't rely on the impersonated
+          // account's live balance to cover the transaction.
+          await this.provider.send("hardhat_setBalance", [
+            BITFINEX_WALLET_ADDRESS.toString(),
+            numberToRpcQuantity(10n ** 20n),
+          ]);
 
           await this.provider.send("eth_sendTransaction", [
             {
@@ -433,6 +451,12 @@ describe("Forked provider", function () {
           // Impersonate the DAI exchange contract
           await this.provider.send("hardhat_impersonateAccount", [
             daiExchangeAddress,
+          ]);
+          // Fork is at the latest block, so don't rely on the impersonated
+          // account's live balance to cover the transaction.
+          await this.provider.send("hardhat_setBalance", [
+            daiExchangeAddress,
+            numberToRpcQuantity(10n ** 20n),
           ]);
 
           // Transfer 10^18 DAI from the exchange contract to the EMPTY_ACCOUNT_ADDRESS


### PR DESCRIPTION
Recent PR runs started failing, due to the funds from a BitFinex wallet we were copying was now empty. E.g. https://github.com/NomicFoundation/edr/actions/runs/27625633654. Adapted the tests to instead set a balance so we don't depend on live balances, but can keep depending on a latest block. 

# Claude summary
These forked-provider tests fork mainnet at the latest block and then send transactions from a hardcoded remote account (the Bitfinex wallet, and the Uniswap DAI exchange contract). They relied on that account's *live* balance to cover gas — an accidental coupling to live chain state. When the Bitfinex wallet's balance dropped below the gas threshold the four tests began failing with "Sender doesn't have enough funds" on both Alchemy and Infura (and on main), unrelated to any code change.

Fund the impersonated sender with hardhat_setBalance after impersonating, so the tests stay deterministic while still exercising the latest fork block. The assertions check recipient balances and past-block state, not the sender's real balance, so this doesn't weaken coverage.

Leaves the deliberate fork-at-latest behavior intact; only decouples from the sender's live balance.