### PR TITLE
refactor: reusable cancellable thread synchronisation component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3138,6 +3138,7 @@ version = "0.3.8"
 dependencies = [
  "alloy-sol-types",
  "crossbeam-channel",
+ "derive-where",
  "derive_more 2.1.1",
  "edr_artifact",
  "edr_block_header",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3169,6 +3169,7 @@ dependencies = [
  "edr_solidity_tests",
  "edr_state_api",
  "edr_tracing",
+ "edr_utils_sync",
  "foundry-cheatcodes",
  "foundry-compilers",
  "mimalloc",
@@ -3914,6 +3915,14 @@ name = "edr_utils"
 version = "0.3.8"
 dependencies = [
  "edr_primitives",
+]
+
+[[package]]
+name = "edr_utils_sync"
+version = "0.3.8"
+dependencies = [
+ "crossbeam-channel",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ members = [
     "crates/test/mem_pool",
     "crates/test/receipt",
     "crates/test/transaction",
+    "crates/utils/sync",
     "crates/tool/cli",
     "crates/tool/solidity",
     "crates/tool/op_chain_config_generator",
@@ -195,6 +196,7 @@ edr_test_utils = { path = "crates/edr_test_utils" }
 edr_tracing = { path = "crates/tracing" }
 edr_transaction = { path = "crates/edr_transaction" }
 edr_utils = { path = "crates/edr_utils" }
+edr_utils_sync = { path = "crates/utils/sync" }
 
 foundry-cheatcodes = { path = "crates/foundry/cheatcodes" }
 foundry-cheatcodes-spec = { path = "crates/foundry/cheatcodes/spec" }

--- a/crates/edr_napi/Cargo.toml
+++ b/crates/edr_napi/Cargo.toml
@@ -40,6 +40,7 @@ edr_state_api.workspace = true
 edr_signer.workspace = true
 edr_solidity.workspace = true
 edr_tracing.workspace = true
+edr_utils_sync.workspace = true
 mimalloc = { version = "0.1.39", default-features = false, features = [
     "local_dynamic_tls",
 ] }

--- a/crates/edr_napi/Cargo.toml
+++ b/crates/edr_napi/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib"]
 alloy-sol-types.workspace = true
 crossbeam-channel = "0.5"
 derive_more.workspace = true
+derive-where.workspace = true
 edr_artifact.workspace = true
 edr_block_header.workspace = true
 edr_block_miner.workspace = true

--- a/crates/edr_napi/src/async_deallocator.rs
+++ b/crates/edr_napi/src/async_deallocator.rs
@@ -1,6 +1,7 @@
 use std::io;
 
 use crossbeam_channel::{select_biased, unbounded, SendError, Sender};
+use derive_where::derive_where;
 use edr_utils_sync::CancellableThread;
 use napi::tokio::runtime;
 
@@ -64,7 +65,7 @@ impl<T: Send + 'static> AsyncDeallocator<T> {
 ///
 /// [`Self::deallocate`] is infallible from the caller's perspective: if the
 /// dedicated thread is unavailable, it falls back to the tokio blocking pool.
-#[derive(Clone)]
+#[derive_where(Clone)]
 pub struct AsyncDeallocatorSender<T: Send + 'static> {
     sender: Sender<T>,
     runtime: runtime::Handle,

--- a/crates/edr_napi/src/async_deallocator.rs
+++ b/crates/edr_napi/src/async_deallocator.rs
@@ -14,7 +14,9 @@ use napi::tokio::runtime;
 pub struct AsyncDeallocator<T: Send + 'static> {
     sender: Sender<T>,
     runtime: runtime::Handle,
-    thread: Option<CancellableThread>,
+    // Dropping this disconnects the cancellation channel and joins the
+    // dedicated thread, so no explicit shutdown is needed.
+    _thread: CancellableThread,
 }
 
 impl<T: Send + 'static> AsyncDeallocator<T> {
@@ -29,7 +31,7 @@ impl<T: Send + 'static> AsyncDeallocator<T> {
                     // `select_biased!` picks the first listed branch when multiple
                     // arms are ready, so cancellation always wins over pending work.
                     select_biased! {
-                        // Cancellation channel was disconnected by AsyncDeallocator::drop.
+                        // Cancellation channel was disconnected by dropping the CancellableThread.
                         recv(cancellation_receiver) -> _ => break,
                         recv(receiver) -> msg => match msg {
                             Ok(value) => drop(value),
@@ -44,7 +46,7 @@ impl<T: Send + 'static> AsyncDeallocator<T> {
         Ok(Self {
             sender,
             runtime,
-            thread: Some(thread),
+            _thread: thread,
         })
     }
 
@@ -54,14 +56,6 @@ impl<T: Send + 'static> AsyncDeallocator<T> {
         AsyncDeallocatorSender {
             sender: self.sender.clone(),
             runtime: self.runtime.clone(),
-        }
-    }
-}
-
-impl<T: Send + 'static> Drop for AsyncDeallocator<T> {
-    fn drop(&mut self) {
-        if let Some(thread) = self.thread.take() {
-            thread.cancel_and_join();
         }
     }
 }

--- a/crates/edr_napi/src/async_deallocator.rs
+++ b/crates/edr_napi/src/async_deallocator.rs
@@ -1,6 +1,7 @@
-use std::{convert::Infallible, thread::JoinHandle};
+use std::io;
 
-use crossbeam_channel::{bounded, select_biased, unbounded, SendError, Sender};
+use crossbeam_channel::{select_biased, unbounded, SendError, Sender};
+use edr_utils_sync::CancellableThread;
 use napi::tokio::runtime;
 
 /// Owns a dedicated OS thread that drops values of type `T` outside of the
@@ -10,58 +11,41 @@ use napi::tokio::runtime;
 /// If the dedicated thread is no longer accepting work (e.g. because the
 /// owning [`AsyncDeallocator`] has been dropped, or the thread has panicked),
 /// `deallocate` falls back to dropping the value on the tokio blocking pool.
-///
-/// # Shutdown via channel disconnection
-///
-/// On `Drop`, the dedicated thread is signalled to exit by **disconnecting**
-/// a dedicated cancellation channel — that is, by dropping its `Sender`,
-/// rather than by sending a sentinel message. The channel's item type is
-/// [`std::convert::Infallible`], so the compiler statically guarantees that no
-/// message can ever be sent on it; thus guaranteeing that disconnection is the
-/// only event that can ever occur on it.
-///
-/// This idiom is described in the async-std book's
-/// [Handling Disconnection](https://book.async.rs/tutorial/handling_disconnection.html)
-/// chapter: "Closing a channel is a synchronization event, so we don't need
-/// to send a shutdown message, we can just drop the sender. This way, we
-/// statically guarantee that we issue shutdown exactly once, even if we
-/// early return via `?` or panic."
 pub struct AsyncDeallocator<T: Send + 'static> {
     sender: Sender<T>,
     runtime: runtime::Handle,
-    cancellation_sender: Option<Sender<Infallible>>,
-    thread: Option<JoinHandle<()>>,
+    thread: Option<CancellableThread>,
 }
 
 impl<T: Send + 'static> AsyncDeallocator<T> {
     /// Constructs a new instance.
-    pub fn new(runtime: runtime::Handle) -> Self {
+    pub fn new(runtime: runtime::Handle) -> io::Result<Self> {
         let (sender, receiver) = unbounded::<T>();
-        // See the "Shutdown via channel disconnection" section of
-        // [`AsyncDeallocator`]'s docs for why this channel is parameterized
-        // with `Infallible` and signalled by sender-drop.
-        let (cancellation_sender, cancellation_receiver) = bounded::<Infallible>(1);
 
-        let thread = std::thread::spawn(move || loop {
-            // `select_biased!` picks the first listed branch when multiple
-            // arms are ready, so cancellation always wins over pending work.
-            select_biased! {
-                // Cancellation channel was disconnected by AsyncDeallocator::drop.
-                recv(cancellation_receiver) -> _ => break,
-                recv(receiver) -> msg => match msg {
-                    Ok(value) => drop(value),
-                    // All senders dropped; no more work can arrive.
-                    Err(_) => break,
-                },
-            }
-        });
+        let thread = CancellableThread::spawn(
+            "async-deallocator".to_owned(),
+            move |cancellation_receiver| {
+                loop {
+                    // `select_biased!` picks the first listed branch when multiple
+                    // arms are ready, so cancellation always wins over pending work.
+                    select_biased! {
+                        // Cancellation channel was disconnected by AsyncDeallocator::drop.
+                        recv(cancellation_receiver) -> _ => break,
+                        recv(receiver) -> msg => match msg {
+                            Ok(value) => drop(value),
+                            // All senders dropped; no more work can arrive.
+                            Err(_) => break,
+                        },
+                    }
+                }
+            },
+        )?;
 
-        Self {
+        Ok(Self {
             sender,
             runtime,
-            cancellation_sender: Some(cancellation_sender),
             thread: Some(thread),
-        }
+        })
     }
 
     /// Returns a cloneable handle for enqueueing values to be dropped on the
@@ -76,14 +60,8 @@ impl<T: Send + 'static> AsyncDeallocator<T> {
 
 impl<T: Send + 'static> Drop for AsyncDeallocator<T> {
     fn drop(&mut self) {
-        // Drop the cancellation sender, disconnecting the cancellation
-        // channel and waking the dropper thread.
-        self.cancellation_sender.take();
-
-        if let Some(handle) = self.thread.take()
-            && let Err(error) = handle.join()
-        {
-            tracing::error!("AsyncDeallocator thread panicked: {error:?}");
+        if let Some(thread) = self.thread.take() {
+            thread.cancel_and_join();
         }
     }
 }
@@ -92,18 +70,10 @@ impl<T: Send + 'static> Drop for AsyncDeallocator<T> {
 ///
 /// [`Self::deallocate`] is infallible from the caller's perspective: if the
 /// dedicated thread is unavailable, it falls back to the tokio blocking pool.
+#[derive(Clone)]
 pub struct AsyncDeallocatorSender<T: Send + 'static> {
     sender: Sender<T>,
     runtime: runtime::Handle,
-}
-
-impl<T: Send + 'static> Clone for AsyncDeallocatorSender<T> {
-    fn clone(&self) -> Self {
-        Self {
-            sender: self.sender.clone(),
-            runtime: self.runtime.clone(),
-        }
-    }
 }
 
 impl<T: Send + 'static> AsyncDeallocatorSender<T> {

--- a/crates/edr_napi/src/context.rs
+++ b/crates/edr_napi/src/context.rs
@@ -541,7 +541,12 @@ impl Context {
         Ok(Self {
             provider_factories: HashMap::default(),
             solidity_test_runner_factories: HashMap::default(),
-            provider_deallocator: AsyncDeallocator::new(runtime),
+            provider_deallocator: AsyncDeallocator::new(runtime).map_err(|error| {
+                napi::Error::new(
+                    napi::Status::GenericFailure,
+                    format!("Failed to spawn the provider deallocator thread: {error}"),
+                )
+            })?,
             #[cfg(feature = "tracing")]
             _tracing_write_guard: guard,
         })

--- a/crates/utils/sync/Cargo.toml
+++ b/crates/utils/sync/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "edr_utils_sync"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+crossbeam-channel = "0.5"
+tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/utils/sync/src/cancellable_thread.rs
+++ b/crates/utils/sync/src/cancellable_thread.rs
@@ -1,0 +1,65 @@
+use std::{convert::Infallible, io, thread::JoinHandle};
+
+use crossbeam_channel::{bounded, Receiver, Sender};
+
+/// Owns a dedicated OS thread together with a cancellation channel used to
+/// shut it down. The closure passed to [`Self::spawn`] receives the receiving
+/// end of that channel and should treat its disconnection as the signal to
+/// return.
+///
+/// # Shutdown via channel disconnection
+///
+/// On [`Self::cancel_and_join`], the thread is signalled to exit by
+/// **disconnecting** the cancellation channel — that is, by dropping its
+/// `Sender`, rather than by sending a sentinel message. The channel's item
+/// type is [`std::convert::Infallible`], so the compiler statically guarantees
+/// that no message can ever be sent on it; thus guaranteeing that
+/// disconnection is the only event that can ever occur on it.
+///
+/// This idiom is described in the async-std book's
+/// [Handling Disconnection](https://book.async.rs/tutorial/handling_disconnection.html)
+/// chapter: "Closing a channel is a synchronization event, so we don't need
+/// to send a shutdown message, we can just drop the sender. This way, we
+/// statically guarantee that we issue shutdown exactly once, even if we
+/// early return via `?` or panic."
+pub struct CancellableThread {
+    cancellation_sender: Sender<Infallible>,
+    thread: JoinHandle<()>,
+}
+
+impl CancellableThread {
+    /// Spawns `f` on a dedicated OS thread, handing it the receiving end of a
+    /// cancellation channel.
+    ///
+    /// See the "Shutdown via channel disconnection" section of
+    /// [`CancellableThread`]'s docs for why this channel is parameterized
+    /// with `Infallible` and signalled by sender-drop.
+    pub fn spawn<F>(name: String, f: F) -> io::Result<Self>
+    where
+        F: FnOnce(Receiver<Infallible>) + Send + 'static,
+    {
+        let (cancellation_sender, cancellation_receiver) = bounded::<Infallible>(1);
+
+        let thread = std::thread::Builder::new()
+            .name(name)
+            .spawn(move || f(cancellation_receiver))?;
+
+        Ok(Self {
+            cancellation_sender,
+            thread,
+        })
+    }
+
+    /// Signals the thread to exit by disconnecting the cancellation channel,
+    /// then waits for it to finish.
+    pub fn cancel_and_join(self) {
+        // Drop the cancellation sender, disconnecting the cancellation
+        // channel and waking the thread.
+        drop(self.cancellation_sender);
+
+        let thread_name = self.thread.thread().name().unwrap_or("unnamed").to_owned();
+        if let Err(error) = self.thread.join() {
+            tracing::error!("'{thread_name}' thread panicked: {error:?}");
+        }
+    }
+}

--- a/crates/utils/sync/src/cancellable_thread.rs
+++ b/crates/utils/sync/src/cancellable_thread.rs
@@ -9,7 +9,7 @@ use crossbeam_channel::{bounded, Receiver, Sender};
 ///
 /// # Shutdown via channel disconnection
 ///
-/// On [`Self::cancel_and_join`], the thread is signalled to exit by
+/// When a `CancellableThread` is dropped, the thread is signalled to exit by
 /// **disconnecting** the cancellation channel — that is, by dropping its
 /// `Sender`, rather than by sending a sentinel message. The channel's item
 /// type is [`std::convert::Infallible`], so the compiler statically guarantees
@@ -23,6 +23,12 @@ use crossbeam_channel::{bounded, Receiver, Sender};
 /// statically guarantee that we issue shutdown exactly once, even if we
 /// early return via `?` or panic."
 pub struct CancellableThread {
+    inner: Option<Inner>,
+}
+
+/// The owned state of a [`CancellableThread`]: the cancellation channel's
+/// sender and the handle to the dedicated thread.
+struct Inner {
     cancellation_sender: Sender<Infallible>,
     thread: JoinHandle<()>,
 }
@@ -45,21 +51,31 @@ impl CancellableThread {
             .spawn(move || f(cancellation_receiver))?;
 
         Ok(Self {
-            cancellation_sender,
-            thread,
+            inner: Some(Inner {
+                cancellation_sender,
+                thread,
+            }),
         })
     }
+}
 
+impl Drop for CancellableThread {
     /// Signals the thread to exit by disconnecting the cancellation channel,
     /// then waits for it to finish.
-    pub fn cancel_and_join(self) {
-        // Drop the cancellation sender, disconnecting the cancellation
-        // channel and waking the thread.
-        drop(self.cancellation_sender);
+    fn drop(&mut self) {
+        if let Some(Inner {
+            cancellation_sender,
+            thread,
+        }) = self.inner.take()
+        {
+            // Drop the cancellation sender, disconnecting the cancellation
+            // channel and waking the thread.
+            drop(cancellation_sender);
 
-        let thread_name = self.thread.thread().name().unwrap_or("unnamed").to_owned();
-        if let Err(error) = self.thread.join() {
-            tracing::error!("'{thread_name}' thread panicked: {error:?}");
+            let thread_name = thread.thread().name().unwrap_or("unnamed").to_owned();
+            if let Err(error) = thread.join() {
+                tracing::error!("'{thread_name}' thread panicked: {error:?}");
+            }
         }
     }
 }

--- a/crates/utils/sync/src/lib.rs
+++ b/crates/utils/sync/src/lib.rs
@@ -1,0 +1,7 @@
+//! Synchronization utilities used across the EDR codebase.
+
+#![warn(missing_docs)]
+
+mod cancellable_thread;
+
+pub use self::cancellable_thread::CancellableThread;


### PR DESCRIPTION
Turns the synchronisation pattern used by the `AsyncDeallocator` into a reusable building block.