### PR TITLE
chore(ci): stop replaying Base Mainnet blocks

### DIFF
--- a/.github/workflows/test-recent-optimism-block.yml
+++ b/.github/workflows/test-recent-optimism-block.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         network:
           - opt-mainnet
-          - base-mainnet
+          # - base-mainnet # uncomment once EDR supports latest Base hardforks
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:


### PR DESCRIPTION
Base has diverged from the OP Stack. They recently launched a Base-specific hardfork, Azul ([Base documentation](https://docs.base.org/base-chain/specs/upgrades/azul/overview)). As Base's first independent hardfork, Azul introduces changes that aren't part of the standard OP Stack spec that op-revm tracks.

Currently EDR supports neither the Azul hardfork nor Base as a specialized chain type. As a result, the replay-block CI keeps failing due to discrepancies between the simulated block and the on-chain block.