### PR TITLE
fix: broken CI check for generated OP chain types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4728,6 +4728,9 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
 ]
 
 [[package]]
@@ -5623,6 +5626,7 @@ dependencies = [
  "cc",
  "libc",
  "libz-sys",
+ "openssl-sys",
  "pkg-config",
 ]
 

--- a/crates/tool/op_chain_config_generator/Cargo.toml
+++ b/crates/tool/op_chain_config_generator/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
-git2 = "0.21.0"
+git2 = { version = "0.21.0", default-features = false, features = ["https"] }
 itertools.workspace = true
 log.workspace = true
 op-revm.workspace = true


### PR DESCRIPTION
https://github.com/rust-lang/git2-rs/pull/1168 changed the `default-features`. When we adopted a new version of `git2` in https://github.com/NomicFoundation/edr/pull/1483, we didn't update the included features, breaking [this CI workflow](https://github.com/NomicFoundation/edr/actions/runs/27761633928).

By adding the `"https"` feature, the issue should be resolved.