### PR TITLE
ci: adopt Hardhat 3 E2E regression benchmarks

### DIFF
--- a/.claude/skills/setup-verdaccio-env/SKILL.md
+++ b/.claude/skills/setup-verdaccio-env/SKILL.md
@@ -26,39 +26,16 @@ If the Hardhat or EDR directories cannot be found, ask the user to provide the c
 
 ## Steps
 
-### 1. Detect the current platform
+### 1. Build EDR
 
-Detect the platform triple for the napi binary. Use the Node.js `process.platform` and `process.arch` values, plus musl detection, to determine:
-
-- The **binary filename** (e.g. `edr.linux-x64-gnu.node`, `edr.darwin-arm64.node`)
-- The **npm platform directory** under `crates/edr_napi/npm/` (e.g. `linux-x64-gnu`, `darwin-arm64`)
-- The **npm platform package name** (e.g. `@nomicfoundation/edr-linux-x64-gnu`)
-
-The supported platforms can be found as subdirectories of `crates/edr_napi/npm/`. Determine the current platform using `process.platform`, `process.arch`, and musl detection (on Linux). The result must match one of those directory names.
-
-Store the detected suffix for use in subsequent steps (e.g. `linux-x64-gnu`). The binary filename is `edr.<suffix>.node` and the npm package name is `@nomicfoundation/edr-<suffix>`.
-
-### 2. Build EDR
+Build the napi binary for the current platform:
 
 ```bash
 cd /workspaces/edr/crates/edr_napi
 pnpm run <edr-build-script>
 ```
 
-Verify the binary was produced:
-
-```bash
-ls -la /workspaces/edr/crates/edr_napi/edr.<suffix>.node
-```
-
-### 3. Copy the built binary to the platform npm directory
-
-```bash
-cp /workspaces/edr/crates/edr_napi/edr.<suffix>.node \
-   /workspaces/edr/crates/edr_napi/npm/<suffix>/edr.<suffix>.node
-```
-
-### 4. Start Verdaccio
+### 2. Start Verdaccio
 
 The Hardhat repo has a built-in Verdaccio management script.
 
@@ -66,33 +43,26 @@ Before starting verdaccio, verify the `max_body_size` setting in `/workspaces/ha
 
 1. If necessary, edit `/workspaces/hardhat/scripts/verdaccio/start.ts` to include `max_body_size: 100mb` in the config template (before the `log:` line).
 2. Start verdaccio:
-   ```
+   ```bash
    cd /workspaces/hardhat
    pnpm verdaccio start --background
    ```
 
-### 5. Bump and publish EDR packages to Verdaccio
+### 3. Publish the local EDR build to Verdaccio
 
-Read the current version from `crates/edr_napi/package.json`, bump the prerelease number (e.g. `0.12.0-next.29` -> `0.12.0-next.30`).
-
-Apply the same version bump to:
-
-- `crates/edr_napi/package.json` (main `@nomicfoundation/edr` package)
-- `crates/edr_napi/npm/<suffix>/package.json` (platform package `@nomicfoundation/edr-<suffix>`)
-
-Publish both packages (platform package first), using the Verdaccio auth token via `NPM_CONFIG_USERCONFIG`:
+Use the shared helper script. It autodetects the platform triple, stages the built binary into its platform package, compiles the bundled TypeScript helpers, pins both packages to the chosen version, wires the platform dependency, and publishes both (platform package first):
 
 ```bash
-cd /workspaces/edr/crates/edr_napi/npm/<suffix>
-NPM_CONFIG_USERCONFIG=/workspaces/hardhat/.verdaccio/.npmrc \
-  pnpm publish --registry=http://127.0.0.1:4873/ --no-git-checks
-
-cd /workspaces/edr/crates/edr_napi
-NPM_CONFIG_USERCONFIG=/workspaces/hardhat/.verdaccio/.npmrc \
-  pnpm publish --registry=http://127.0.0.1:4873/ --no-git-checks
+cd /workspaces/edr
+scripts/publish_to_verdaccio.sh \
+  --version <version> \
+  --registry http://127.0.0.1:4873/ \
+  --npmrc /workspaces/hardhat/.verdaccio/.npmrc
 ```
 
-### 6. Bump and publish Hardhat packages to Verdaccio
+Choose a `<version>` that does not already exist on npm — bump the prerelease number from `crates/edr_napi/package.json` (e.g. `0.12.0-next.29` -> `0.12.0-next.30`). Verdaccio proxies `@nomicfoundation/*` to npmjs, so re-publishing an existing version fails. Note the chosen `<version>`; the Hardhat EDR dependency update in the next step must match it.
+
+### 4. Bump and publish Hardhat packages to Verdaccio
 
 First, update Hardhat's EDR dependency to the new version:
 
@@ -128,7 +98,7 @@ NPM_CONFIG_USERCONFIG=/workspaces/hardhat/.verdaccio/.npmrc \
 
 Publish in dependency order: `hardhat-errors` and `hardhat-utils` first (they are commonly depended upon), then the rest, then `hardhat` itself last.
 
-### 7. Install in the target repo
+### 5. Install in the target repo
 
 Detect the target repo's package manager by checking which lockfile exists:
 
@@ -149,7 +119,9 @@ rm -rf node_modules
 <detected-install-command>
 ```
 
-### 8. Validate
+### 6. Validate
+
+`<suffix>` below is the platform triple the publish script reported in step 3 (e.g. `linux-x64-gnu`, `darwin-arm64`) — the subdirectory of `crates/edr_napi/npm/` matching this host.
 
 Verify all installed versions match what was published:
 
@@ -169,7 +141,7 @@ nm <target-repo>/node_modules/@nomicfoundation/edr-<suffix>/edr.<suffix>.node 2>
 
 Report the installed versions to the user and confirm the environment is ready.
 
-### 9. Cleanup reminder
+### 7. Cleanup reminder
 
 Remind the user that:
 

--- a/.github/scripts/resolve-regression-trigger.cjs
+++ b/.github/scripts/resolve-regression-trigger.cjs
@@ -1,10 +1,5 @@
 // Resolve refs, authorize, and gate the EDR regression benchmark trigger.
 //
-// Invoked from .github/workflows/edr-regression-benchmark.yml via
-// actions/github-script, which provides the `github`, `context` and `core`
-// objects. Sets the job outputs `should_run`, `edr_ref`, `hardhat_ref` and
-// `is_baseline`.
-//
 // By event:
 //   push                -> baseline run of HEAD against Hardhat main
 //   workflow_dispatch   -> run HEAD against the requested Hardhat ref
@@ -45,7 +40,7 @@ module.exports = async ({ github, context, core }) => {
       }
       core.info(
         `EDR CI for ${sha.slice(0, 12)} not finished yet ` +
-          `(status: ${run?.status ?? "not started"}); waiting...`,
+          `(status: ${run?.status ?? "not started"}); waiting...`
       );
       await new Promise((r) => setTimeout(r, CI_POLL_INTERVAL_MS));
     }
@@ -93,7 +88,7 @@ module.exports = async ({ github, context, core }) => {
     if (!allowed.includes(assoc)) {
       core.warning(
         `Comment author ${comment.user.login} (${assoc}) is not ` +
-          `authorized to trigger benchmarks.`,
+          `authorized to trigger benchmarks.`
       );
     } else {
       const { data: pr } = await github.rest.pulls.get({
@@ -107,7 +102,7 @@ module.exports = async ({ github, context, core }) => {
           "🚫 Regression benchmarks can only run for branches in " +
             "this repository, not forks (the self-hosted runner must " +
             "not execute untrusted code). Push your branch to " +
-            `\`${fullName}\` and comment \`/bench\` again.`,
+            `\`${fullName}\` and comment \`/bench\` again.`
         );
       } else {
         edrRef = pr.head.sha;
@@ -123,13 +118,13 @@ module.exports = async ({ github, context, core }) => {
           shouldRun = true;
           await postComment(
             `🚀 Starting regression benchmark for \`${edrRef.slice(0, 12)}\` ` +
-              `against Hardhat \`${hardhatRef}\`.`,
+              `against Hardhat \`${hardhatRef}\`.`
           );
         } else {
           await postComment(
             "⏳ EDR CI for this commit hasn't passed yet, so the " +
               "regression benchmark was not started. Comment " +
-              "`/bench` again once CI is green.",
+              "`/bench` again once CI is green."
           );
         }
       }
@@ -142,6 +137,6 @@ module.exports = async ({ github, context, core }) => {
   core.setOutput("is_baseline", String(isBaseline));
   core.info(
     `should_run=${shouldRun} edr_ref=${edrRef} ` +
-      `hardhat_ref=${hardhatRef} is_baseline=${isBaseline}`,
+      `hardhat_ref=${hardhatRef} is_baseline=${isBaseline}`
   );
 };

--- a/.github/scripts/resolve-regression-trigger.cjs
+++ b/.github/scripts/resolve-regression-trigger.cjs
@@ -1,0 +1,147 @@
+// Resolve refs, authorize, and gate the EDR regression benchmark trigger.
+//
+// Invoked from .github/workflows/edr-regression-benchmark.yml via
+// actions/github-script, which provides the `github`, `context` and `core`
+// objects. Sets the job outputs `should_run`, `edr_ref`, `hardhat_ref` and
+// `is_baseline`.
+//
+// By event:
+//   push                -> baseline run of HEAD against Hardhat main
+//   workflow_dispatch   -> run HEAD against the requested Hardhat ref
+//   issue_comment        -> a `/bench` comment on a same-repo PR, gated on the
+//                          commenter's permissions and EDR CI being green
+
+// How long to wait for the EDR CI run to conclude before giving up, and how
+// often to re-check while waiting. Tunable independently.
+const CI_WAIT_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
+const CI_POLL_INTERVAL_MS = 30 * 1000; // 30 seconds
+
+module.exports = async ({ github, context, core }) => {
+  const { owner, repo } = context.repo;
+  const fullName = `${owner}/${repo}`;
+  const eventName = context.eventName;
+
+  let shouldRun = false;
+  let edrRef = "";
+  let hardhatRef = "main";
+  let isBaseline = false;
+
+  // Wait for the EDR CI workflow run for `sha` to conclude. Returns true only
+  // if it completed successfully. Polls until CI_WAIT_TIMEOUT_MS elapses.
+  async function waitForEdrCi(sha) {
+    const deadline = Date.now() + CI_WAIT_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      const { data } = await github.rest.actions.listWorkflowRuns({
+        owner,
+        repo,
+        workflow_id: "edr-ci.yml",
+        head_sha: sha,
+        per_page: 1,
+      });
+      const run = data.workflow_runs[0];
+      if (run !== undefined && run.status === "completed") {
+        core.info(`EDR CI run ${run.id} concluded: ${run.conclusion}`);
+        return run.conclusion === "success";
+      }
+      core.info(
+        `EDR CI for ${sha.slice(0, 12)} not finished yet ` +
+          `(status: ${run?.status ?? "not started"}); waiting...`,
+      );
+      await new Promise((r) => setTimeout(r, CI_POLL_INTERVAL_MS));
+    }
+    core.warning("Timed out waiting for EDR CI to conclude");
+    return false;
+  }
+
+  async function postComment(body) {
+    if (eventName !== "issue_comment") return;
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: context.payload.issue.number,
+      body,
+    });
+  }
+
+  if (eventName === "push") {
+    shouldRun = true;
+    edrRef = context.sha;
+    hardhatRef = "main";
+    isBaseline = true;
+  } else if (eventName === "workflow_dispatch") {
+    shouldRun = true;
+    edrRef = context.sha;
+    hardhatRef = context.payload.inputs["hardhat-ref"] || "main";
+    isBaseline = false;
+  } else if (eventName === "issue_comment") {
+    const comment = context.payload.comment;
+    const assoc = comment.author_association;
+    const allowed = ["OWNER", "MEMBER", "COLLABORATOR"];
+
+    // Acknowledge the request.
+    try {
+      await github.rest.reactions.createForIssueComment({
+        owner,
+        repo,
+        comment_id: comment.id,
+        content: "eyes",
+      });
+    } catch (e) {
+      core.warning(`Could not add reaction: ${e.message}`);
+    }
+
+    if (!allowed.includes(assoc)) {
+      core.warning(
+        `Comment author ${comment.user.login} (${assoc}) is not ` +
+          `authorized to trigger benchmarks.`,
+      );
+    } else {
+      const { data: pr } = await github.rest.pulls.get({
+        owner,
+        repo,
+        pull_number: context.payload.issue.number,
+      });
+
+      if (pr.head.repo.full_name !== fullName) {
+        await postComment(
+          "🚫 Regression benchmarks can only run for branches in " +
+            "this repository, not forks (the self-hosted runner must " +
+            "not execute untrusted code). Push your branch to " +
+            `\`${fullName}\` and comment \`/bench\` again.`,
+        );
+      } else {
+        edrRef = pr.head.sha;
+        isBaseline = false;
+
+        const match = comment.body.match(/hardhat-ref=(\S+)/);
+        hardhatRef = match ? match[1] : "main";
+
+        // Gate on EDR CI being green for the PR head before spending
+        // ~3h on the self-hosted runner.
+        const green = await waitForEdrCi(pr.head.sha);
+        if (green) {
+          shouldRun = true;
+          await postComment(
+            `🚀 Starting regression benchmark for \`${edrRef.slice(0, 12)}\` ` +
+              `against Hardhat \`${hardhatRef}\`.`,
+          );
+        } else {
+          await postComment(
+            "⏳ EDR CI for this commit hasn't passed yet, so the " +
+              "regression benchmark was not started. Comment " +
+              "`/bench` again once CI is green.",
+          );
+        }
+      }
+    }
+  }
+
+  core.setOutput("should_run", String(shouldRun));
+  core.setOutput("edr_ref", edrRef);
+  core.setOutput("hardhat_ref", hardhatRef);
+  core.setOutput("is_baseline", String(isBaseline));
+  core.info(
+    `should_run=${shouldRun} edr_ref=${edrRef} ` +
+      `hardhat_ref=${hardhatRef} is_baseline=${isBaseline}`,
+  );
+};

--- a/.github/scripts/resolve-regression-trigger.test.cjs
+++ b/.github/scripts/resolve-regression-trigger.test.cjs
@@ -1,0 +1,158 @@
+// Unit tests for resolve-regression-trigger.cjs.
+//
+// Run with Node's built-in test runner (no extra dependencies):
+//   node --test .github/scripts/
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const resolve = require("./resolve-regression-trigger.cjs");
+
+const OWNER = "NomicFoundation";
+const REPO = "edr";
+const FULL = `${OWNER}/${REPO}`;
+
+// Build a mocked { github, context, core } plus a `captured` record of the
+// side effects the module produced (outputs, logs, comments, reactions).
+function makeDeps({ eventName, sha, payload = {}, ci, pr } = {}) {
+  const captured = {
+    outputs: {},
+    infos: [],
+    warnings: [],
+    comments: [],
+    reactions: [],
+  };
+
+  const core = {
+    setOutput: (k, v) => {
+      captured.outputs[k] = v;
+    },
+    info: (m) => captured.infos.push(m),
+    warning: (m) => captured.warnings.push(m),
+  };
+
+  const github = {
+    rest: {
+      actions: {
+        listWorkflowRuns: async () => ({
+          data: { workflow_runs: ci === undefined ? [] : [ci] },
+        }),
+      },
+      pulls: {
+        get: async () => {
+          if (pr === undefined) throw new Error("pulls.get not expected");
+          return { data: pr };
+        },
+      },
+      issues: {
+        createComment: async ({ body }) => captured.comments.push(body),
+      },
+      reactions: {
+        createForIssueComment: async ({ content }) =>
+          captured.reactions.push(content),
+      },
+    },
+  };
+
+  const context = { repo: { owner: OWNER, repo: REPO }, eventName, sha, payload };
+
+  return { github, context, core, captured };
+}
+
+// A `/bench` comment on a same-repo PR, by an authorized author.
+function commentPayload(body, { assoc = "MEMBER", number = 7 } = {}) {
+  return {
+    comment: { author_association: assoc, user: { login: "dev" }, id: 99, body },
+    issue: { number },
+  };
+}
+
+test("push → baseline run against Hardhat main", async () => {
+  const { captured, ...deps } = makeDeps({
+    eventName: "push",
+    sha: "deadbeefcafe1234",
+  });
+  await resolve(deps);
+  assert.deepEqual(captured.outputs, {
+    should_run: "true",
+    edr_ref: "deadbeefcafe1234",
+    hardhat_ref: "main",
+    is_baseline: "true",
+  });
+});
+
+test("workflow_dispatch → uses the requested hardhat-ref", async () => {
+  const { captured, ...deps } = makeDeps({
+    eventName: "workflow_dispatch",
+    sha: "abc123",
+    payload: { inputs: { "hardhat-ref": "v-next" } },
+  });
+  await resolve(deps);
+  assert.equal(captured.outputs.should_run, "true");
+  assert.equal(captured.outputs.hardhat_ref, "v-next");
+  assert.equal(captured.outputs.is_baseline, "false");
+});
+
+test("workflow_dispatch → defaults hardhat-ref to main", async () => {
+  const { captured, ...deps } = makeDeps({
+    eventName: "workflow_dispatch",
+    sha: "abc123",
+    payload: { inputs: {} },
+  });
+  await resolve(deps);
+  assert.equal(captured.outputs.hardhat_ref, "main");
+});
+
+test("issue_comment → unauthorized author does not run", async () => {
+  const { captured, ...deps } = makeDeps({
+    eventName: "issue_comment",
+    payload: commentPayload("/bench", { assoc: "NONE" }),
+  });
+  await resolve(deps);
+  assert.equal(captured.outputs.should_run, "false");
+  assert.equal(captured.warnings.length, 1);
+  assert.deepEqual(captured.reactions, ["eyes"]); // request acknowledged
+  assert.deepEqual(captured.comments, []); // but nothing posted
+});
+
+test("issue_comment → fork PR is rejected", async () => {
+  const { captured, ...deps } = makeDeps({
+    eventName: "issue_comment",
+    payload: commentPayload("/bench"),
+    pr: { head: { repo: { full_name: "attacker/edr" }, sha: "f0f0f0" } },
+  });
+  await resolve(deps);
+  assert.equal(captured.outputs.should_run, "false");
+  assert.equal(captured.comments.length, 1);
+  assert.match(captured.comments[0], /can only run for branches in/);
+});
+
+test("issue_comment → same-repo PR with green CI runs and parses hardhat-ref", async () => {
+  const { captured, ...deps } = makeDeps({
+    eventName: "issue_comment",
+    payload: commentPayload("/bench hardhat-ref=feature/x"),
+    pr: { head: { repo: { full_name: FULL }, sha: "1234567890ab" } },
+    ci: { id: 1, status: "completed", conclusion: "success" },
+  });
+  await resolve(deps);
+  assert.equal(captured.outputs.should_run, "true");
+  assert.equal(captured.outputs.edr_ref, "1234567890ab");
+  assert.equal(captured.outputs.hardhat_ref, "feature/x");
+  assert.equal(captured.outputs.is_baseline, "false");
+  assert.equal(captured.comments.length, 1);
+  assert.match(captured.comments[0], /Starting regression benchmark/);
+});
+
+test("issue_comment → same-repo PR with failing CI does not run", async () => {
+  const { captured, ...deps } = makeDeps({
+    eventName: "issue_comment",
+    payload: commentPayload("/bench"),
+    pr: { head: { repo: { full_name: FULL }, sha: "1234567890ab" } },
+    ci: { id: 1, status: "completed", conclusion: "failure" },
+  });
+  await resolve(deps);
+  assert.equal(captured.outputs.should_run, "false");
+  assert.equal(captured.outputs.hardhat_ref, "main"); // no hardhat-ref= in body
+  assert.equal(captured.comments.length, 1);
+  assert.match(captured.comments[0], /hasn't passed yet/);
+});

--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -288,6 +288,9 @@ jobs:
 
       - uses: ./.github/actions/setup-node
 
+      - name: Test workflow scripts
+        run: pnpm run test:workflows
+
       - name: Install package
         run: pnpm install --frozen-lockfile --prefer-offline
       - name: Run build script

--- a/.github/workflows/hh3-regression-benchmark.yml
+++ b/.github/workflows/hh3-regression-benchmark.yml
@@ -1,0 +1,262 @@
+name: Hardhat 3 Regression Benchmark
+
+# Benchmarks the *local* EDR build under test against Hardhat's E2E regression
+# scenarios. Unlike Hardhat's own regression-benchmark (which uses whatever EDR
+# is pinned on npm), this workflow builds EDR locally, publishes it to a local
+# Verdaccio registry, repoints Hardhat's `@nomicfoundation/edr` dependency at it,
+# and then runs Hardhat's `pnpm bench:regression --use-local`.
+
+on:
+  # Records baselines for main.
+  push:
+    branches:
+      - "main"
+  # Manual runs, optionally against a specific Hardhat ref.
+  workflow_dispatch:
+    inputs:
+      hardhat-ref:
+        description: "The branch, tag or SHA of Hardhat to benchmark against"
+        required: false
+        type: string
+        default: "main"
+  # ChatOps: comment `/bench` (optionally `/bench hardhat-ref=<branch|sha|PR>`)
+  # on a same-repo PR. Authorization + gating happens in the `setup` job.
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.ref }}
+  # Don't cancel in-progress baseline runs on main so baselines aren't lost.
+  cancel-in-progress: ${{ github.event_name != 'push' }}
+
+jobs:
+  setup:
+    name: Resolve refs and authorize
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    permissions:
+      contents: read # read PR head / checkout metadata
+      pull-requests: read # pulls.get to resolve PR head + fork check
+      issues: write # post status comments + reactions on the PR
+      actions: read # list EDR CI workflow runs for the CI-green gate
+    # For comment events, only proceed for `/bench` comments on a PR. Other
+    # events (push/workflow_dispatch) always evaluate inside the script.
+    if: >-
+      github.event_name != 'issue_comment' || (github.event.issue.pull_request != null &&
+       startsWith(github.event.comment.body, '/bench'))
+
+
+    outputs:
+      should_run: ${{ steps.resolve.outputs.should_run }}
+      edr_ref: ${{ steps.resolve.outputs.edr_ref }}
+      hardhat_ref: ${{ steps.resolve.outputs.hardhat_ref }}
+      is_baseline: ${{ steps.resolve.outputs.is_baseline }}
+    steps:
+      # Sparse-checkout only the workflow scripts so the github-script step can
+      # require the resolver module below.
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          sparse-checkout: .github/scripts
+          persist-credentials: false
+
+      - id: resolve
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const resolve = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/resolve-regression-trigger.cjs`);
+            await resolve({ github, context, core });
+
+  regression-benchmark:
+    name: Regression benchmark
+    needs: setup
+    if: needs.setup.outputs.should_run == 'true'
+    environment: github-action-benchmark
+    # Use Hardhat's dedicated self-hosted runner for stable measurements that
+    # are comparable to Hardhat's own regression baselines.
+    runs-on: hardhat-linux-amd64-self-hosted
+    timeout-minutes: 180
+    env:
+      # Hardhat is checked out into ./hardhat; the EDR repo is the workspace root.
+      HH: ${{ github.workspace }}/hardhat
+      # Known clone dir, shared by the benchmark and validation steps so the
+      # installed EDR can be inspected after the run.
+      E2E_CLONE_DIR: ${{ github.workspace }}/hardhat/e2e-clones
+    steps:
+      - name: Checkout EDR
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ needs.setup.outputs.edr_ref }}
+          persist-credentials: false
+
+      - name: Checkout Hardhat
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: NomicFoundation/hardhat
+          ref: ${{ needs.setup.outputs.hardhat_ref }}
+          path: hardhat
+          # `sinceReleasePublish` needs the full history + release tags to
+          # decide which workspace packages to (re)publish.
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+
+      # cspell:disable-next-line
+      - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall
+
+      - uses: ./.github/actions/setup-node
+        with:
+          # Match Hardhat main's expected Node version.
+          node-version: "24"
+      - uses: ./.github/actions/setup-rust
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y hyperfine jq
+
+      - name: Compute sentinel versions
+        run: |
+          set -euo pipefail
+          EDR_BASE=$(node -p "require('./crates/edr_napi/package.json').version")
+          HH_BASE=$(node -p "require('./hardhat/packages/hardhat/package.json').version")
+          SHORT_SHA="${{ needs.setup.outputs.edr_ref }}"
+          SHORT_SHA="${SHORT_SHA:0:12}"
+          echo "EDR_VER=${EDR_BASE}-local.${SHORT_SHA}" >> "$GITHUB_ENV"
+          echo "HH_VER=${HH_BASE}-edr.${SHORT_SHA}" >> "$GITHUB_ENV"
+
+      - name: Install EDR dependencies
+        run: sfw pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Build EDR
+        working-directory: crates/edr_napi
+        run: pnpm build
+
+      - name: Install Hardhat dependencies
+        working-directory: hardhat
+        run: sfw pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Build Hardhat
+        working-directory: hardhat
+        run: |
+          pnpm build
+          # pnpm 11 skips creating bin symlinks whose target isn't built at
+          # install time; relink now that build output exists. See pnpm/pnpm#10524.
+          pnpm rebuild -r
+
+      - name: Repoint Hardhat at the local EDR build
+        working-directory: hardhat
+        # Repoint the EDR dependency, and bump the hardhat package's own version
+        # so `decidePublishAction` returns "publish" (not "skip") and
+        # `--use-local` republishes hardhat carrying our EDR dependency, even
+        # right after a Hardhat release.
+        run: |
+          set -euo pipefail
+          npm pkg set "dependencies.@nomicfoundation/edr=$EDR_VER" --prefix packages/hardhat
+          npm pkg set version="$HH_VER" --prefix packages/hardhat
+
+      - name: Start Verdaccio
+        working-directory: hardhat
+        run: pnpm verdaccio start --background
+
+      - name: Publish local EDR to Verdaccio
+        # Reuses Hardhat's pre-seeded Verdaccio auth.
+        run: |
+          bash ./scripts/publish_to_verdaccio.sh \
+            --version "$EDR_VER" \
+            --registry http://127.0.0.1:4873/ \
+            --npmrc "$HH/.verdaccio/.npmrc"
+
+      - name: Run regression benchmark
+        working-directory: hardhat
+        env:
+          ALCHEMY_URL: ${{ secrets.ALCHEMY_URL }}
+        # --force-publish: reuse our already-running Verdaccio (instead of
+        #   erroring) and run the global sinceReleasePublish once up front.
+        # --use-local: republish the (repointed) hardhat workspace packages and
+        #   pin each scenario's hardhat/@nomicfoundation deps to Verdaccio.
+        run: |
+          pnpm bench:regression \
+            --use-local \
+            --force-publish \
+            --force-checkout \
+            --e2e-clone-dir "$E2E_CLONE_DIR" \
+            --output regression-report.json
+
+      - name: Validate scenarios used the local EDR build
+        working-directory: hardhat
+        run: |
+          set -euo pipefail
+
+          echo "== Check A: published hardhat carries the local EDR =="
+          MANIFEST=$(curl -sf http://127.0.0.1:4873/hardhat)
+          LATEST=$(echo "$MANIFEST" | jq -r '."dist-tags".latest')
+          EDR_DEP=$(echo "$MANIFEST" | jq -r --arg v "$LATEST" \
+            '.versions[$v].dependencies["@nomicfoundation/edr"] // empty')
+          echo "hardhat dist-tags.latest=$LATEST (expected $HH_VER)"
+          echo "  -> @nomicfoundation/edr=$EDR_DEP (expected $EDR_VER)"
+          if [ "$LATEST" != "$HH_VER" ]; then
+            echo "::error::Published hardhat latest ($LATEST) != $HH_VER"
+            exit 1
+          fi
+          if [ "$EDR_DEP" != "$EDR_VER" ]; then
+            echo "::error::Published hardhat depends on EDR $EDR_DEP, expected $EDR_VER"
+            exit 1
+          fi
+
+          echo "== Check B: scenarios installed the local EDR build =="
+          found=0
+          fail=0
+          for d in "$E2E_CLONE_DIR"/*/; do
+            [ -d "$d" ] || continue
+            while IFS= read -r pj; do
+              found=1
+              name=$(jq -r .name "$pj")
+              version=$(jq -r .version "$pj")
+              if [ "$version" != "$EDR_VER" ]; then
+                echo "::error::$name in $pj is $version, expected $EDR_VER"
+                fail=1
+              else
+                echo "OK: $name@$version ($pj)"
+              fi
+            done < <(find "$d" \
+              \( -path '*/node_modules/@nomicfoundation/edr/package.json' \
+                 -o -path '*/node_modules/@nomicfoundation/edr-linux-x64-gnu/package.json' \) \
+              2>/dev/null)
+
+            # yarn Plug'n'Play scenarios have no node_modules; fall back to the lockfile.
+            if [ -f "$d/.pnp.cjs" ] || [ -f "$d/.pnp.loader.mjs" ]; then
+              if grep -rqs -- "$EDR_VER" "$d/yarn.lock"; then
+                found=1
+                echo "OK (PnP lockfile): $d"
+              else
+                echo "::warning::PnP scenario $d: $EDR_VER not found in yarn.lock"
+              fi
+            fi
+          done
+
+          if [ "$found" -eq 0 ]; then
+            echo "::error::No installed @nomicfoundation/edr found in any scenario clone — local EDR was NOT used"
+            exit 1
+          fi
+          if [ "$fail" -ne 0 ]; then
+            exit 1
+          fi
+          echo "All inspected scenarios use the local EDR build ($EDR_VER)."
+
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
+        with:
+          tool: customSmallerIsBetter
+          output-file-path: hardhat/regression-report.json
+          gh-repository: github.com/nomic-foundation-automation/edr-benchmark-results
+          gh-pages-branch: main
+          benchmark-data-dir-path: hardhat3
+          github-token: ${{ secrets.BENCHMARK_GITHUB_TOKEN }}
+          # Only push a new baseline on main-branch pushes; PRs/dispatch only compare.
+          auto-push: ${{ needs.setup.outputs.is_baseline == 'true' }}
+          alert-threshold: "110%"
+          # Fail the run on a regression for comparisons; never break main.
+          fail-on-alert: ${{ needs.setup.outputs.is_baseline != 'true' }}
+          summary-always: true

--- a/book/src/02_development/03_local_release.md
+++ b/book/src/02_development/03_local_release.md
@@ -2,9 +2,14 @@
 
 These are instructions for releasing the [EDR NPM package](../../crates/edr_napi/package.json) locally for debugging purposes.
 
-1. Install and start [Verdaccio](./02_verdaccio.md).
-2. Go to the [edr_napi](../../crates/edr_napi/) directory.
-3. Run `pnpm build`.
-4. Look for the NAPI binary that was built for your platform. It has the format `edr.<PLATFORM>.node`. For example on Apple Silicon Macs, it's called `edr.darwin-arm64.node`.
-5. Move the NAPI binary to the appropriate platform-specific package in the [npm](../../crates/edr_napi/npm) directory. For example, on Apple Silicon Macs: `mv edr.darwin-arm64.node npm/darwin-arm64`.
-6. Complete the Verdaccio [publish steps](./02_verdaccio.md#usage) in the [edr_napi](../../crates/edr_napi/) directory. You can ignore the warnings about not finding NAPI binaries for other platforms.
+1. Install and start [Verdaccio](./02_verdaccio.md), and log in (`pnpm login --registry=http://localhost:4873/`).
+2. Build the NAPI package for your platform: run `pnpm build` in the [edr_napi](../../crates/edr_napi/) directory (or `pnpm build:dev` for a faster, unoptimized build).
+3. Publish the local build with the helper script, which stages the native binary into its platform package, pins the version, wires the platform dependency, and publishes both packages:
+
+   ```bash
+   scripts/publish_to_verdaccio.sh --version <version> --registry http://localhost:4873/
+   ```
+
+   Pick a `--version` that differs from any version already on npm (e.g. `0.12.1-local.1`), because Verdaccio proxies `@nomicfoundation/*` to npmjs and will reject re-publishing an existing version. The platform package is autodetected; pass `--help` for all options.
+
+> The script mutates tracked files under `crates/edr_napi/`. Reset them afterwards with `git checkout -- crates/edr_napi`.

--- a/book/src/02_development/03_local_release.md
+++ b/book/src/02_development/03_local_release.md
@@ -7,7 +7,7 @@ These are instructions for releasing the [EDR NPM package](../../crates/edr_napi
 3. Publish the local build with the helper script, which stages the native binary into its platform package, pins the version, wires the platform dependency, and publishes both packages:
 
    ```bash
-   scripts/publish_to_verdaccio.sh --version <version> --registry http://localhost:4873/
+   ../../scripts/publish_to_verdaccio.sh --version <version> --registry http://localhost:4873/
    ```
 
    Pick a `--version` that differs from any version already on npm (e.g. `0.12.1-local.1`), because Verdaccio proxies `@nomicfoundation/*` to npmjs and will reject re-publishing an existing version. The platform package is autodetected; pass `--help` for all options.

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "lint": "syncpack lint && pnpm run prettier && pnpm run --recursive lint",
     "lint:fix": "syncpack format && pnpm run prettier:fix && pnpm run --recursive lint:fix",
     "prettier": "prettier --check \".github/**/*.{yml,ts,js}\" \"**/*.md\"",
-    "prettier:fix": "pnpm run prettier --write"
+    "prettier:fix": "pnpm run prettier --write",
+    "test:workflows": "node --test \".github/scripts/*.test.cjs\""
   }
 }

--- a/scripts/detect_edr_platform.cjs
+++ b/scripts/detect_edr_platform.cjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+//
+// Print the EDR napi platform-package suffix for the current host (e.g.
+// `linux-x64-gnu`, `darwin-arm64`) to stdout, or exit non-zero on an
+// unsupported platform. The suffix matches a subdirectory of
+// `crates/edr_napi/npm/` and the `@nomicfoundation/edr-<suffix>` package name.
+//
+// Used by scripts/publish_to_verdaccio.sh.
+
+const { platform, arch } = process;
+
+let libc = "";
+if (platform === "linux") {
+  try {
+    const out = require("child_process").execSync("ldd --version 2>&1 || true", {
+      encoding: "utf8",
+    });
+    libc = /musl/i.test(out) ? "musl" : "gnu";
+  } catch {
+    libc = "gnu";
+  }
+}
+
+const map = {
+  "darwin-arm64": "darwin-arm64",
+  "darwin-x64": "darwin-x64",
+  "win32-x64": "win32-x64-msvc",
+  "linux-x64": `linux-x64-${libc}`,
+  "linux-arm64": `linux-arm64-${libc}`,
+};
+
+const suffix = map[`${platform}-${arch}`];
+if (suffix === undefined) {
+  console.error(`Unsupported platform: ${platform}-${arch}`);
+  process.exit(1);
+}
+
+process.stdout.write(suffix);

--- a/scripts/publish_to_verdaccio.sh
+++ b/scripts/publish_to_verdaccio.sh
@@ -49,9 +49,15 @@ usage() {
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    --version) VERSION="$2"; shift 2 ;;
-    --registry) REGISTRY="$2"; shift 2 ;;
-    --npmrc) NPMRC="$2"; shift 2 ;;
+    --version)
+      [ $# -ge 2 ] || { echo "error: --version requires a value" >&2; usage >&2; exit 1; }
+      VERSION="$2"; shift 2 ;;
+    --registry)
+      [ $# -ge 2 ] || { echo "error: --registry requires a value" >&2; usage >&2; exit 1; }
+      REGISTRY="$2"; shift 2 ;;
+    --npmrc)
+      [ $# -ge 2 ] || { echo "error: --npmrc requires a value" >&2; usage >&2; exit 1; }
+      NPMRC="$2"; shift 2 ;;
     -h|--help) usage; exit 0 ;;
     *) echo "error: unknown argument: $1" >&2; usage >&2; exit 1 ;;
   esac

--- a/scripts/publish_to_verdaccio.sh
+++ b/scripts/publish_to_verdaccio.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+# Publish a locally-built EDR NAPI package to a (Verdaccio) registry.
+#
+# This is the single source of truth for the "build EDR locally and publish it
+# to Verdaccio" flow used by:
+#   - book/src/02_development/03_local_release.md (manual local release)
+#   - .claude/skills/setup-verdaccio-env/SKILL.md
+#   - .github/workflows/edr-regression-benchmark.yml
+#
+# It stages the prebuilt native binary into its platform package, compiles the
+# bundled TypeScript helpers, pins both the main and platform packages to the
+# requested version, wires the main package's dependency on the platform
+# package, and publishes both (platform package first).
+#
+# It deliberately does NOT run scripts/prepublish.sh: that injects all 7 platform
+# packages as hard dependencies, but a local build only produces (and publishes)
+# the current platform. We wire the single platform dependency instead — which is
+# all `crates/edr_napi/index.js` needs to load the binding on this platform.
+#
+# The native binary must already be built (e.g. `pnpm build` in crates/edr_napi)
+# and EDR's dependencies installed (the TypeScript compile needs the local `tsc`).
+#
+# NOTE: This mutates tracked files in crates/edr_napi (package.json versions, the
+# wired dependency, the staged .node binary, coverage.sol and dist/). Reset them
+# with `git checkout -- crates/edr_napi` afterwards.
+#
+# Usage:
+#   scripts/publish_to_verdaccio.sh --version <ver> [options]
+#
+# Options:
+#   --version <ver>     Version to publish, e.g. 0.12.1-local.abcdef (required)
+#   --registry <url>    Target registry (default: http://127.0.0.1:4873/)
+#   --npmrc <path>      npmrc with the registry auth token (sets
+#                       NPM_CONFIG_USERCONFIG); omit if already logged in
+#   -h, --help          Show this help
+#
+# The platform package (e.g. linux-x64-gnu) is autodetected from this host.
+
+set -euo pipefail
+
+REGISTRY="http://127.0.0.1:4873/"
+VERSION=""
+NPMRC=""
+
+usage() {
+  sed -n '2,/^set -euo/p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//; $d'
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --version) VERSION="$2"; shift 2 ;;
+    --registry) REGISTRY="$2"; shift 2 ;;
+    --npmrc) NPMRC="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "error: unknown argument: $1" >&2; usage >&2; exit 1 ;;
+  esac
+done
+
+if [ -z "$VERSION" ]; then
+  echo "error: --version is required" >&2
+  usage >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+NAPI_DIR="$REPO_ROOT/crates/edr_napi"
+
+# Detect the platform package suffix (e.g. linux-x64-gnu) from this host.
+PLATFORM="$(node "$SCRIPT_DIR/detect_edr_platform.cjs")"
+
+PLATFORM_DIR="$NAPI_DIR/npm/$PLATFORM"
+BINARY="edr.$PLATFORM.node"
+
+if [ ! -d "$PLATFORM_DIR" ]; then
+  echo "error: no platform package for '$PLATFORM' (expected $PLATFORM_DIR)" >&2
+  echo "       known platforms: $(cd "$NAPI_DIR/npm" && echo */ | tr -d '/')" >&2
+  exit 1
+fi
+
+echo ">> Publishing @nomicfoundation/edr@$VERSION ($PLATFORM) to $REGISTRY"
+
+if [ ! -f "$NAPI_DIR/$BINARY" ]; then
+  echo "error: native binary $BINARY not found in $NAPI_DIR" >&2
+  echo "       build it first (e.g. 'pnpm build' in crates/edr_napi)" >&2
+  exit 1
+fi
+
+echo ">> Staging $BINARY into the platform package"
+cp "$NAPI_DIR/$BINARY" "$PLATFORM_DIR/$BINARY"
+
+# The published package's `files`/`exports` reference coverage.sol and dist/src
+# (the `@nomicfoundation/edr/coverage` export), so produce them.
+echo ">> Compiling bundled TypeScript helpers"
+cp "$REPO_ROOT/data/contracts/coverage.sol" "$NAPI_DIR/coverage.sol"
+( cd "$NAPI_DIR" && pnpm exec tsc )
+
+echo ">> Pinning versions and wiring the platform dependency"
+( cd "$NAPI_DIR"
+  npm pkg set version="$VERSION"
+  npm pkg set version="$VERSION" --prefix "npm/$PLATFORM"
+  npm pkg set "dependencies.@nomicfoundation/edr-$PLATFORM=$VERSION"
+)
+
+if [ -n "$NPMRC" ]; then
+  export NPM_CONFIG_USERCONFIG="$NPMRC"
+fi
+
+# Publish the platform package first so the main package's dependency resolves.
+echo ">> Publishing @nomicfoundation/edr-$PLATFORM@$VERSION"
+( cd "$PLATFORM_DIR" && pnpm publish --registry="$REGISTRY" --no-git-checks --access public )
+
+echo ">> Publishing @nomicfoundation/edr@$VERSION"
+( cd "$NAPI_DIR" && pnpm publish --registry="$REGISTRY" --no-git-checks --access public )
+
+echo ">> Done. Published @nomicfoundation/edr@$VERSION (+ -$PLATFORM) to $REGISTRY"

--- a/scripts/publish_to_verdaccio.sh
+++ b/scripts/publish_to_verdaccio.sh
@@ -2,12 +2,6 @@
 #
 # Publish a locally-built EDR NAPI package to a (Verdaccio) registry.
 #
-# This is the single source of truth for the "build EDR locally and publish it
-# to Verdaccio" flow used by:
-#   - book/src/02_development/03_local_release.md (manual local release)
-#   - .claude/skills/setup-verdaccio-env/SKILL.md
-#   - .github/workflows/edr-regression-benchmark.yml
-#
 # It stages the prebuilt native binary into its platform package, compiles the
 # bundled TypeScript helpers, pins both the main and platform packages to the
 # requested version, wires the main package's dependency on the platform


### PR DESCRIPTION
## Summary

Adds a CI workflow that benchmarks the **local EDR build under test** against Hardhat's E2E regression scenarios, so EDR PRs and `main` can catch EDR-side performance regressions — Hardhat's own `regression-benchmark` can't, since it uses whatever `@nomicfoundation/edr` is pinned on npm.

## How it works

The new [`hh3-regression-benchmark.yml`](.github/workflows/hh3-regression-benchmark.yml) builds EDR locally, publishes it to the Verdaccio registry that Hardhat's `bench:regression --use-local` already spins up, repoints Hardhat's `@nomicfoundation/edr` dependency at it, and runs the benchmark — so scenarios pull the local EDR transitively through the locally-published `hardhat` package.

- EDR reaches scenarios only via the `hardhat` package, so we publish a uniquely-versioned local EDR (`<base>-local.<sha>`) and repoint `packages/hardhat` at it; we also bump the `hardhat` package version (`<base>-edr.<sha>`) so `--use-local`'s `decidePublishAction` republishes it instead of skipping (which would silently fall back to npm EDR).
- We skip `prepublish.sh` (it would wire all 7 platform packages as hard deps) and wire only the built `linux-x64-gnu` platform dependency, which is all the npm-installed main package needs to load its native binding.
- The build/stage/version/wire/publish flow is factored into a reusable [`scripts/publish_to_verdaccio.sh`](scripts/publish_to_verdaccio.sh) (platform autodetected via `detect_edr_platform.cjs`), now also the single source of truth for the local-release docs and the `setup-verdaccio-env` skill.

## Triggers & gating

- `push: main` records baselines; `workflow_dispatch` runs manually (optional `hardhat-ref` input); a `/bench` comment on a same-repo PR runs an ad-hoc comparison (optionally `/bench hardhat-ref=<branch|sha|PR>`).
- A `setup` job resolves refs and authorizes entirely with the default `GITHUB_TOKEN` (no PAT): it requires the commenter to be OWNER/MEMBER/COLLABORATOR, rejects fork PRs (keeps untrusted code off the self-hosted `hardhat-linux-amd64-self-hosted` runner), and gates on EDR CI being green for the PR head before spending 1h+ on the benchmark.
- The gating logic lives in [`resolve-regression-trigger.cjs`](.github/scripts/resolve-regression-trigger.cjs) (extracted from inline github-script so it's testable) and is covered by Node-test unit tests run as `pnpm test:workflows` in the `edr-ci` workflow.

## Validation

- I locally tested that the `publish_to_verdaccio.sh` script works in combination with `pnpm bench:regression`
- I temporarily added a validation job that fails unless it can prove the local EDR build was actually used: it asserts Verdaccio's published `hardhat` carries the sentinel EDR version, and scans each scenario's installed `node_modules` for that version (hard-failing if none is found).

  This can be removed once we confirm that the locally published version of EDR is being used.

## Notes

- Results are stored to `nomic-foundation-automation/edr-benchmark-results` under `hardhat3`; baselines push only on `main`, PRs/dispatch only compare.
- The workflow only becomes active once merged to `main` — its `issue_comment`/`workflow_dispatch`/`push` triggers resolve from the default branch, so `/bench` can't be exercised on this PR (the resolver unit tests do run here via `edr-ci`).
