### PR TITLE
fix: failing CI for regression benchmark

### DIFF
--- a/.github/scripts/resolve-regression-trigger.cjs
+++ b/.github/scripts/resolve-regression-trigger.cjs
@@ -56,7 +56,8 @@ module.exports = async ({ github, context, core }) => {
     try {
       await fn();
     } catch (e) {
-      core.warning(`${description} failed (ignored): ${e.message}`);
+      const message = e instanceof Error ? e.message : String(e);
+      core.warning(`${description} failed (ignored): ${message}`);
     }
   }
 

--- a/.github/scripts/resolve-regression-trigger.cjs
+++ b/.github/scripts/resolve-regression-trigger.cjs
@@ -48,22 +48,28 @@ module.exports = async ({ github, context, core }) => {
     return false;
   }
 
+  // Cosmetic side effects (reactions, status comments) must never fail the job:
+  // the gating decision (`should_run`) is the only thing that matters. Run them
+  // through this wrapper so any API rejection — insufficient token permissions,
+  // rate limits, transient 5xx — degrades to a warning instead of aborting.
+  async function bestEffort(description, fn) {
+    try {
+      await fn();
+    } catch (e) {
+      core.warning(`${description} failed (ignored): ${e.message}`);
+    }
+  }
+
   async function postComment(body) {
     if (eventName !== "issue_comment") return;
-    // A read-only GITHUB_TOKEN (e.g. when the repo's default workflow
-    // permissions are read-only) rejects comment writes with 403. Posting the
-    // status is cosmetic; the gating decision (`should_run`) is what matters, so
-    // degrade to a warning instead of aborting the job.
-    try {
-      await github.rest.issues.createComment({
+    await bestEffort("Posting status comment", () =>
+      github.rest.issues.createComment({
         owner,
         repo,
         issue_number: context.payload.issue.number,
         body,
-      });
-    } catch (e) {
-      core.warning(`Could not post comment: ${e.message}`);
-    }
+      })
+    );
   }
 
   if (eventName === "push") {
@@ -82,16 +88,14 @@ module.exports = async ({ github, context, core }) => {
     const allowed = ["OWNER", "MEMBER", "COLLABORATOR"];
 
     // Acknowledge the request.
-    try {
-      await github.rest.reactions.createForIssueComment({
+    await bestEffort("Adding reaction", () =>
+      github.rest.reactions.createForIssueComment({
         owner,
         repo,
         comment_id: comment.id,
         content: "eyes",
-      });
-    } catch (e) {
-      core.warning(`Could not add reaction: ${e.message}`);
-    }
+      })
+    );
 
     if (!allowed.includes(assoc)) {
       core.warning(

--- a/.github/scripts/resolve-regression-trigger.cjs
+++ b/.github/scripts/resolve-regression-trigger.cjs
@@ -50,12 +50,20 @@ module.exports = async ({ github, context, core }) => {
 
   async function postComment(body) {
     if (eventName !== "issue_comment") return;
-    await github.rest.issues.createComment({
-      owner,
-      repo,
-      issue_number: context.payload.issue.number,
-      body,
-    });
+    // A read-only GITHUB_TOKEN (e.g. when the repo's default workflow
+    // permissions are read-only) rejects comment writes with 403. Posting the
+    // status is cosmetic; the gating decision (`should_run`) is what matters, so
+    // degrade to a warning instead of aborting the job.
+    try {
+      await github.rest.issues.createComment({
+        owner,
+        repo,
+        issue_number: context.payload.issue.number,
+        body,
+      });
+    } catch (e) {
+      core.warning(`Could not post comment: ${e.message}`);
+    }
   }
 
   if (eventName === "push") {

--- a/.github/workflows/hh3-regression-benchmark.yml
+++ b/.github/workflows/hh3-regression-benchmark.yml
@@ -25,7 +25,14 @@ on:
     types: [created]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.issue.number || github.ref }}
+  # Group by PR (comment events) or ref (push/dispatch) so re-triggering `/bench`
+  # on a PR supersedes the previous run.
+  #
+  # Every comment triggers a workflow run. The job-level `if` skips non-`/bench`
+  # ones, but that runs after concurrency is evaluated, so an unrelated comment
+  # can cancel an in-progress benchmark. Give those skipped runs a unique group
+  # so they collide with nothing.
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.ref }}${{ (github.event_name == 'issue_comment' && !startsWith(github.event.comment.body, '/bench')) && format('-skip-{0}', github.run_id) || '' }}
   # Don't cancel in-progress baseline runs on main so baselines aren't lost.
   cancel-in-progress: ${{ github.event_name != 'push' }}
 
@@ -36,7 +43,7 @@ jobs:
     timeout-minutes: 40
     permissions:
       contents: read # read PR head / checkout metadata
-      pull-requests: read # pulls.get to resolve PR head + fork check
+      pull-requests: write # pulls.get + post status comments/reactions on the PR
       issues: write # post status comments + reactions on the PR
       actions: read # list EDR CI workflow runs for the CI-green gate
     # For comment events, only proceed for `/bench` comments on a PR. Other

--- a/.github/workflows/hh3-regression-benchmark.yml
+++ b/.github/workflows/hh3-regression-benchmark.yml
@@ -88,15 +88,6 @@ jobs:
       # Known clone dir, shared by the benchmark and validation steps so the
       # installed EDR can be inspected after the run.
       E2E_CLONE_DIR: ${{ github.workspace }}/hardhat/e2e-clones
-      # The "Repoint Hardhat at the local EDR build" step deliberately desyncs
-      # packages/hardhat/package.json from Hardhat's pnpm-lock.yaml (the
-      # `-local.<sha>` sentinel only exists in Verdaccio, published later). Stop
-      # pnpm from running a frozen-lockfile deps check before `pnpm <script>`/bin
-      # invocations (`pnpm verdaccio ...`, `pnpm bench:regression ...`), which
-      # would otherwise abort with ERR_PNPM_OUTDATED_LOCKFILE. The explicit
-      # `pnpm install --frozen-lockfile` steps run before the repoint and still
-      # validate normally.
-      PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN: "false"
     steps:
       - name: Checkout EDR
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -174,6 +165,14 @@ jobs:
 
       - name: Start Verdaccio
         working-directory: hardhat
+        # The preceding repoint desyncs packages/hardhat/package.json from
+        # pnpm-lock.yaml (the `-local.<sha>` sentinel only exists in Verdaccio,
+        # published later), so disable pnpm's pre-run frozen-lockfile deps check
+        # for this `pnpm <bin>` invocation — it would otherwise abort with
+        # ERR_PNPM_OUTDATED_LOCKFILE. Scoped to this step so the earlier
+        # `pnpm build`/`rebuild` steps keep their verification.
+        env:
+          PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN: "false"
         run: pnpm verdaccio start --background
 
       - name: Publish local EDR to Verdaccio
@@ -188,6 +187,9 @@ jobs:
         working-directory: hardhat
         env:
           ALCHEMY_URL: ${{ secrets.ALCHEMY_URL }}
+          # See "Start Verdaccio": bypass pnpm's frozen-lockfile deps check for
+          # the repoint-desynced workspace.
+          PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN: "false"
         # --force-publish: reuse our already-running Verdaccio (instead of
         #   erroring) and run the global sinceReleasePublish once up front.
         # --use-local: republish the (repointed) hardhat workspace packages and

--- a/.github/workflows/hh3-regression-benchmark.yml
+++ b/.github/workflows/hh3-regression-benchmark.yml
@@ -81,6 +81,15 @@ jobs:
       # Known clone dir, shared by the benchmark and validation steps so the
       # installed EDR can be inspected after the run.
       E2E_CLONE_DIR: ${{ github.workspace }}/hardhat/e2e-clones
+      # The "Repoint Hardhat at the local EDR build" step deliberately desyncs
+      # packages/hardhat/package.json from Hardhat's pnpm-lock.yaml (the
+      # `-local.<sha>` sentinel only exists in Verdaccio, published later). Stop
+      # pnpm from running a frozen-lockfile deps check before `pnpm <script>`/bin
+      # invocations (`pnpm verdaccio ...`, `pnpm bench:regression ...`), which
+      # would otherwise abort with ERR_PNPM_OUTDATED_LOCKFILE. The explicit
+      # `pnpm install --frozen-lockfile` steps run before the repoint and still
+      # validate normally.
+      PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN: "false"
     steps:
       - name: Checkout EDR
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
Fixes several issues with the original CI workflow:
- prevents failed comments from causing the whole job to fail
- posting comments required write permissions for the pull request
- pnpm prohibits modifying the lockfile in CI by default. This needs to be disabled as we purposefully modify the EDR dependency version
- Comments to any issue would cancel the `/bench` command's CI workflow as they would come in under the same concurrency group. This is fixed by assigning non-`/bench` comments to a different concurrency group