### PR TITLE
fix: explicitly add local tag to satisfy pnpm requirement

### DIFF
--- a/scripts/publish_to_verdaccio.sh
+++ b/scripts/publish_to_verdaccio.sh
@@ -107,11 +107,20 @@ if [ -n "$NPMRC" ]; then
   export NPM_CONFIG_USERCONFIG="$NPMRC"
 fi
 
+# npm refuses to publish a prerelease (a version with a `-<pre-release>` segment,
+# e.g. `0.12.1-local.<sha>`) to the implicit `latest` dist-tag, so publish those
+# under an explicit tag. Consumers pin the exact version, so the tag name is only
+# there to satisfy npm.
+PUBLISH_ARGS=(--registry="$REGISTRY" --no-git-checks --access public)
+case "$VERSION" in
+  *-*) PUBLISH_ARGS+=(--tag local) ;;
+esac
+
 # Publish the platform package first so the main package's dependency resolves.
 echo ">> Publishing @nomicfoundation/edr-$PLATFORM@$VERSION"
-( cd "$PLATFORM_DIR" && pnpm publish --registry="$REGISTRY" --no-git-checks --access public )
+( cd "$PLATFORM_DIR" && pnpm publish "${PUBLISH_ARGS[@]}" )
 
 echo ">> Publishing @nomicfoundation/edr@$VERSION"
-( cd "$NAPI_DIR" && pnpm publish --registry="$REGISTRY" --no-git-checks --access public )
+( cd "$NAPI_DIR" && pnpm publish "${PUBLISH_ARGS[@]}" )
 
 echo ">> Done. Published @nomicfoundation/edr@$VERSION (+ -$PLATFORM) to $REGISTRY"


### PR DESCRIPTION
The previous set of fixes in #1490 worked, but now we hit another CI failure with `pnpm` (see [logs](https://productionresultssa18.blob.core.windows.net/actions-results/f162e2b0-2b09-41cd-bb4d-72d0d90fd13c/workflow-job-run-2ed37c08-4cec-545e-894d-13c2bdfb2a05/logs/job/job-logs.txt?rsct=text%2Fplain&se=2026-06-19T14%3A13%3A56Z&sig=w5Zr8OJmI2zs8X1PdWnI8Sgw5kbEvSLiI3f9xdAhPOk%3D&ske=2026-06-19T16%3A53%3A48Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2026-06-19T12%3A53%3A48Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-11-05&sp=r&spr=https&sr=b&st=2026-06-19T14%3A03%3A51Z&sv=2025-11-05)).

It requires the published packages to have a tag specified, so we set the tag to `local` 