### PR TITLE
ci: fix E2E scenario failures in HH3 regression benchmark

### DIFF
--- a/.github/scripts/compute-sentinel-versions.cjs
+++ b/.github/scripts/compute-sentinel-versions.cjs
@@ -1,0 +1,61 @@
+// Compute the sentinel package versions for the Hardhat 3 regression benchmark
+// and append them to $GITHUB_ENV.
+//
+// Requires the env vars EDR_REF and GITHUB_ENV, and a working directory at the
+// EDR repo root (with Hardhat checked out under ./hardhat).
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+// EDR's sentinel is a `-local.<sha>` prerelease. It's only ever consumed as an
+// exact pin (hardhat's `dependencies.@nomicfoundation/edr` and the platform-
+// package wiring), which is not subject to semver range rules — so a prerelease
+// is fine and keeps the benchmarked commit traceable in the version string.
+function edrVersion(edrBaseVersion, shortSha) {
+  return `${edrBaseVersion}-local.${shortSha}`;
+}
+
+// Hardhat's sentinel must be a *release* version (no prerelease tag). The e2e
+// harness pins each scenario's `hardhat` dependency to it, and scenarios pull
+// Hardhat plugins whose `peerDependencies` use ranges like `hardhat@^3.8.0`.
+// node-semver excludes prereleases from such ranges.
+function hardhatVersion(hardhatBaseVersion) {
+  const core = hardhatBaseVersion.split("+")[0].split("-")[0];
+  const [major, minor, patch] = core.split(".").map(Number);
+  if (![major, minor, patch].every(Number.isInteger)) {
+    throw new Error(`Unparseable Hardhat version: ${hardhatBaseVersion}`);
+  }
+  return `${major}.${minor}.${patch + 1}`;
+}
+
+function readVersion(pkgJsonPath) {
+  return JSON.parse(fs.readFileSync(pkgJsonPath, "utf8")).version;
+}
+
+function main() {
+  const { EDR_REF, GITHUB_ENV } = process.env;
+  for (const [name, value] of Object.entries({ EDR_REF, GITHUB_ENV })) {
+    if (!value) throw new Error(`${name} is not set`);
+  }
+
+  const cwd = process.cwd();
+  const versions = {
+    EDR_VER: edrVersion(
+      readVersion(path.join(cwd, "crates/edr_napi/package.json")),
+      EDR_REF.slice(0, 12),
+    ),
+    HH_VER: hardhatVersion(
+      readVersion(path.join(cwd, "hardhat/packages/hardhat/package.json")),
+    ),
+  };
+
+  const lines = Object.entries(versions).map(([k, v]) => `${k}=${v}`);
+  fs.appendFileSync(GITHUB_ENV, lines.join("\n") + "\n");
+  for (const line of lines) console.log(line);
+}
+
+module.exports = { edrVersion, hardhatVersion };
+
+if (require.main === module) {
+  main();
+}

--- a/.github/scripts/compute-sentinel-versions.test.cjs
+++ b/.github/scripts/compute-sentinel-versions.test.cjs
@@ -1,0 +1,37 @@
+// Run with Node's built-in test runner (no extra dependencies):
+//   node --test .github/scripts/
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  edrVersion,
+  hardhatVersion,
+} = require("./compute-sentinel-versions.cjs");
+
+test("edrVersion appends a -local.<sha> prerelease", () => {
+  assert.equal(
+    edrVersion("0.12.1", "dfeb0f9b95f9"),
+    "0.12.1-local.dfeb0f9b95f9",
+  );
+});
+
+test("hardhatVersion bumps the patch of a release version", () => {
+  assert.equal(hardhatVersion("3.9.0"), "3.9.1");
+  assert.equal(hardhatVersion("2.0.0"), "2.0.1");
+});
+
+test("hardhatVersion strips a prerelease tag, then bumps to a release", () => {
+  // The result must be a release (no `-`) so `^3.x` peer ranges match it.
+  assert.equal(hardhatVersion("3.10.0-next.1"), "3.10.1");
+  assert.equal(hardhatVersion("3.9.0-edr.dfeb0f9b95f9"), "3.9.1");
+});
+
+test("hardhatVersion strips build metadata", () => {
+  assert.equal(hardhatVersion("3.9.5+build.7"), "3.9.6");
+});
+
+test("hardhatVersion throws on an unparseable version", () => {
+  assert.throws(() => hardhatVersion("not.a.version"), /Unparseable/);
+  assert.throws(() => hardhatVersion("3.x"), /Unparseable/);
+});

--- a/.github/workflows/hh3-regression-benchmark.yml
+++ b/.github/workflows/hh3-regression-benchmark.yml
@@ -85,8 +85,8 @@ jobs:
     env:
       # Hardhat is checked out into ./hardhat; the EDR repo is the workspace root.
       HH: ${{ github.workspace }}/hardhat
-      # We use a unique clone dir to avoid conflicts with other jobs on the
-      # dedicated CI runner and to allow inspection after the run.
+      # We use a clone dir that's different than Hardhat's CI to avoid overwriting
+      # their CI files and allow inspection before the next workflow run.
       #
       # The clone dir is deliberately outside of the workspace to avoid package
       # managers of the scenarios from picking up the workspace's configuration.

--- a/.github/workflows/hh3-regression-benchmark.yml
+++ b/.github/workflows/hh3-regression-benchmark.yml
@@ -85,9 +85,12 @@ jobs:
     env:
       # Hardhat is checked out into ./hardhat; the EDR repo is the workspace root.
       HH: ${{ github.workspace }}/hardhat
-      # Known clone dir, shared by the benchmark and validation steps so the
-      # installed EDR can be inspected after the run.
-      E2E_CLONE_DIR: ${{ github.workspace }}/hardhat/e2e-clones
+      # We use a unique clone dir to avoid conflicts with other jobs on the
+      # dedicated CI runner and to allow inspection after the run.
+      #
+      # The clone dir is deliberately outside of the workspace to avoid package
+      # managers of the scenarios from picking up the workspace's configuration.
+      E2E_CLONE_DIR: /tmp/edr-e2e-clones
     steps:
       - name: Checkout EDR
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/hh3-regression-benchmark.yml
+++ b/.github/workflows/hh3-regression-benchmark.yml
@@ -127,14 +127,10 @@ jobs:
           sudo apt-get install -y hyperfine jq
 
       - name: Compute sentinel versions
-        run: |
-          set -euo pipefail
-          EDR_BASE=$(node -p "require('./crates/edr_napi/package.json').version")
-          HH_BASE=$(node -p "require('./hardhat/packages/hardhat/package.json').version")
-          SHORT_SHA="${{ needs.setup.outputs.edr_ref }}"
-          SHORT_SHA="${SHORT_SHA:0:12}"
-          echo "EDR_VER=${EDR_BASE}-local.${SHORT_SHA}" >> "$GITHUB_ENV"
-          echo "HH_VER=${HH_BASE}-edr.${SHORT_SHA}" >> "$GITHUB_ENV"
+        # Writes EDR_VER and HH_VER to $GITHUB_ENV
+        env:
+          EDR_REF: ${{ needs.setup.outputs.edr_ref }}
+        run: node .github/scripts/compute-sentinel-versions.cjs
 
       - name: Install EDR dependencies
         run: sfw pnpm install --frozen-lockfile --prefer-offline


### PR DESCRIPTION
After the fix in #1492 , the HH3 regression benchmark CI now fails when running the benchmarks per scenario:
- The end-to-end scenarios being cloned inside the Hardhat workspace forces the scenarios to use Hardhat's configured package manager: pnpm. By moving it to a `/tmp` directory, we avoid this. We still use a unique temp directory to avoid clobbering Hardhat's default of `/tmp/end-to-end`
- The `lidofinance-dual-governance` scenario installs with npm, and npm aborts during dependency resolution because we use the unsupported `-edr.<sha>` postfix when bumping HH3's version. We resolve it by instead bumping the patch-component of the semver and dropping the `edr.<sha>` postfix.