### PR TITLE
feat: add support for negative test filtering in Solidity tests

### DIFF
--- a/.changeset/sparkly-donkeys-worry.md
+++ b/.changeset/sparkly-donkeys-worry.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": minor
+---
+
+Added a new `excludeTestPattern` option to the Solidity test runner config for negative test name filtering

--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -837,6 +837,12 @@ export interface SolidityTestRunnerConfigArgs {
    */
   testPattern?: string
   /**
+   * A regex pattern to exclude tests. If provided, test methods that match
+   * the pattern will not be executed or reported as a test result. Applied
+   * after `test_pattern`.
+   */
+  excludeTestPattern?: string
+  /**
    * Controls whether to generate a gas report after running the tests.
    * Enabling this also enables collection of all traces and EVM isolation
    * mode.

--- a/crates/edr_napi/src/solidity_tests/config.rs
+++ b/crates/edr_napi/src/solidity_tests/config.rs
@@ -168,6 +168,10 @@ pub struct SolidityTestRunnerConfigArgs {
     /// A regex pattern to filter tests. If provided, only test methods that
     /// match the pattern will be executed and reported as a test result.
     pub test_pattern: Option<String>,
+    /// A regex pattern to exclude tests. If provided, test methods that match
+    /// the pattern will not be executed or reported as a test result. Applied
+    /// after `test_pattern`.
+    pub exclude_test_pattern: Option<String>,
     /// Controls whether to generate a gas report after running the tests.
     /// Enabling this also enables collection of all traces and EVM isolation
     /// mode.
@@ -255,6 +259,7 @@ impl SolidityTestRunnerConfigArgs {
             include_traces,
             observability,
             test_pattern,
+            exclude_test_pattern,
             generate_gas_report,
             test_function_overrides,
             eip712_canonical_types,
@@ -262,6 +267,13 @@ impl SolidityTestRunnerConfigArgs {
 
         let test_pattern = TestFilterConfig {
             test_pattern: test_pattern
+                .as_ref()
+                .map(|p| {
+                    p.parse()
+                        .map_err(|error| napi::Error::new(Status::InvalidArg, error))
+                })
+                .transpose()?,
+            exclude_test_pattern: exclude_test_pattern
                 .as_ref()
                 .map(|p| {
                     p.parse()
@@ -530,7 +542,18 @@ impl SolidityTestRunnerConfigArgs {
                     .map_err(|e| napi::Error::new(Status::InvalidArg, e))
             })
             .transpose()?;
-        Ok(TestFilterConfig { test_pattern })
+        let exclude_test_pattern = self
+            .exclude_test_pattern
+            .as_ref()
+            .map(|p| {
+                p.parse()
+                    .map_err(|e| napi::Error::new(Status::InvalidArg, e))
+            })
+            .transpose()?;
+        Ok(TestFilterConfig {
+            test_pattern,
+            exclude_test_pattern,
+        })
     }
 }
 

--- a/crates/edr_napi/test/solidity-tests.ts
+++ b/crates/edr_napi/test/solidity-tests.ts
@@ -171,4 +171,71 @@ describe("Solidity Tests", () => {
       }
     }
   });
+
+  it("excludes tests according to pattern", async function () {
+    const artifacts = [
+      loadContract("./data/artifacts/default/SetupConsistencyCheck.json"),
+    ];
+    // All artifacts are test suites.
+    const testSuites = artifacts.map((artifact) => artifact.id);
+
+    const [, results] = await runAllSolidityTests(
+      context,
+      L1_CHAIN_TYPE,
+      artifacts,
+      testSuites,
+      {
+        disableTransactionGasCap: true,
+        projectRoot: __dirname,
+        hardfork: l1HardforkToString(l1HardforkLatest()),
+        excludeTestPattern: "Multiply",
+      }
+    );
+
+    assert.equal(results.length, artifacts.length);
+
+    for (const res of results) {
+      if (res.id.name.includes("SetupConsistencyCheck")) {
+        assert.equal(res.testResults.length, 1);
+        assert.equal(res.testResults[0].name, "testAdd()");
+      } else {
+        assert.fail("Unexpected test suite name: " + res.id.name);
+      }
+    }
+  });
+
+  it("combines testPattern and excludeTestPattern", async function () {
+    const artifacts = [
+      loadContract("./data/artifacts/default/SetupConsistencyCheck.json"),
+    ];
+    // All artifacts are test suites.
+    const testSuites = artifacts.map((artifact) => artifact.id);
+
+    const [, results] = await runAllSolidityTests(
+      context,
+      L1_CHAIN_TYPE,
+      artifacts,
+      testSuites,
+      {
+        disableTransactionGasCap: true,
+        projectRoot: __dirname,
+        hardfork: l1HardforkToString(l1HardforkLatest()),
+        // `testPattern` selects both `testAdd` and `testMultiply`, while
+        // `excludeTestPattern` removes `testMultiply`, leaving only `testAdd`.
+        testPattern: "test",
+        excludeTestPattern: "Multiply",
+      }
+    );
+
+    assert.equal(results.length, artifacts.length);
+
+    for (const res of results) {
+      if (res.id.name.includes("SetupConsistencyCheck")) {
+        assert.equal(res.testResults.length, 1);
+        assert.equal(res.testResults[0].name, "testAdd()");
+      } else {
+        assert.fail("Unexpected test suite name: " + res.id.name);
+      }
+    }
+  });
 });

--- a/crates/edr_napi_core/src/solidity/config.rs
+++ b/crates/edr_napi_core/src/solidity/config.rs
@@ -408,7 +408,10 @@ mod tests {
             collect_stack_traces: CollectStackTraces::OnFailure,
             include_traces: IncludeTraces::default(),
             on_collected_coverage_fn: None,
-            test_pattern: TestFilterConfig { test_pattern: None },
+            test_pattern: TestFilterConfig {
+                test_pattern: None,
+                exclude_test_pattern: None,
+            },
             generate_gas_report: None,
             test_function_overrides: None,
         }

--- a/crates/edr_solidity_tests/src/test_filter.rs
+++ b/crates/edr_solidity_tests/src/test_filter.rs
@@ -16,6 +16,7 @@ pub trait TestFilter: Send + Sync {
 
 pub struct TestFilterConfig {
     pub test_pattern: Option<Regex>,
+    pub exclude_test_pattern: Option<Regex>,
 }
 
 impl TestFilter for TestFilterConfig {
@@ -23,6 +24,10 @@ impl TestFilter for TestFilterConfig {
         self.test_pattern
             .as_ref()
             .is_none_or(|p| p.is_match(test_name))
+            && self
+                .exclude_test_pattern
+                .as_ref()
+                .is_none_or(|p| !p.is_match(test_name))
     }
 
     fn matches_contract(&self, _contract_name: &str) -> bool {
@@ -40,7 +45,10 @@ mod tests {
 
     #[test]
     fn test_pattern_none() {
-        let config = TestFilterConfig { test_pattern: None };
+        let config = TestFilterConfig {
+            test_pattern: None,
+            exclude_test_pattern: None,
+        };
 
         assert!(config.matches_test("test_foo"));
         assert!(config.matches_test("test_bar"));
@@ -50,9 +58,33 @@ mod tests {
     fn test_pattern_some() {
         let config = TestFilterConfig {
             test_pattern: Some("f?o+".parse().unwrap()),
+            exclude_test_pattern: None,
         };
 
         assert!(config.matches_test("test_foo"));
         assert!(!config.matches_test("test_bar"));
+    }
+
+    #[test]
+    fn exclude_test_pattern_some() {
+        let config = TestFilterConfig {
+            test_pattern: None,
+            exclude_test_pattern: Some("f?o+".parse().unwrap()),
+        };
+
+        assert!(!config.matches_test("test_foo"));
+        assert!(config.matches_test("test_bar"));
+    }
+
+    #[test]
+    fn test_pattern_and_exclude_test_pattern() {
+        let config = TestFilterConfig {
+            test_pattern: Some("test_".parse().unwrap()),
+            exclude_test_pattern: Some("bar".parse().unwrap()),
+        };
+
+        assert!(config.matches_test("test_foo"));
+        assert!(!config.matches_test("test_bar"));
+        assert!(!config.matches_test("other_foo"));
     }
 }


### PR DESCRIPTION
This PR adds a new `excludeTestPattern` option to the Solidity test runner, which allows negative test name filtering. The exclusion pattern works both separately and in combination with the positive filtering from `testPattern`. In cases where both are specified, they are applied in `testPattern` -> `excludeTestPattern` order.