### PR TITLE
ci: comment on completion of `/bench` regression run

### DIFF
--- a/.github/scripts/resolve-regression-trigger.cjs
+++ b/.github/scripts/resolve-regression-trigger.cjs
@@ -15,6 +15,7 @@ module.exports = async ({ github, context, core }) => {
   const { owner, repo } = context.repo;
   const fullName = `${owner}/${repo}`;
   const eventName = context.eventName;
+  const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
 
   let shouldRun = false;
   let edrRef = "";
@@ -130,8 +131,8 @@ module.exports = async ({ github, context, core }) => {
         if (green) {
           shouldRun = true;
           await postComment(
-            `🚀 Starting regression benchmark for \`${edrRef.slice(0, 12)}\` ` +
-              `against Hardhat \`${hardhatRef}\`.`
+            `🚀 [Starting regression benchmark](${runUrl}) for ` +
+              `\`${edrRef.slice(0, 12)}\` against Hardhat \`${hardhatRef}\`.`
           );
         } else {
           await postComment(

--- a/.github/workflows/hh3-regression-benchmark.yml
+++ b/.github/workflows/hh3-regression-benchmark.yml
@@ -355,7 +355,7 @@ jobs:
     if: >-
       !cancelled()
         && github.event_name == 'issue_comment'
-        && needs.setup.outputs.should_run == 'true'
+        && needs.regression-benchmark.result != 'skipped'
     runs-on: ubuntu-latest
     permissions:
       issues: write # post the result comment on the PR

--- a/.github/workflows/hh3-regression-benchmark.yml
+++ b/.github/workflows/hh3-regression-benchmark.yml
@@ -344,3 +344,46 @@ jobs:
         # this manually to avoid polluting future runs.
         if: always()
         run: rm -rf "$RUNNER_TEMP/edr-e2e-clones" "$RUNNER_TEMP/pnpm-metadata-cache"
+
+  report:
+    name: Report result to PR
+    needs: [setup, regression-benchmark]
+    # 1. run on benchmark failure but skip when the run is superseded (concurrency)
+    # 2. Only report back to the PR for `/bench` comment triggers
+    # 3. Only report back if the benchmark actually started
+    # prettier-ignore
+    if: >-
+      !cancelled()
+        && github.event_name == 'issue_comment'
+        && needs.setup.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write # post the result comment on the PR
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          RESULT: ${{ needs.regression-benchmark.result }}
+          EDR_REF: ${{ needs.setup.outputs.edr_ref }}
+          HARDHAT_REF: ${{ needs.setup.outputs.hardhat_ref }}
+        with:
+          script: |
+            const { RESULT, EDR_REF, HARDHAT_REF } = process.env;
+            const runUrl =
+              `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}` +
+              `/actions/runs/${context.runId}`;
+            const target =
+              `\`${EDR_REF.slice(0, 12)}\` against Hardhat \`${HARDHAT_REF}\``;
+            const body =
+              RESULT === "success"
+                ? `✅ Regression benchmark passed for ${target}.\n\n` +
+                  `[View workflow run](${runUrl})`
+                : `❌ Regression benchmark failed for ${target}. This is either ` +
+                  `a detected performance regression or an infrastructure ` +
+                  `failure — see the run for details.\n\n` +
+                  `[View workflow run](${runUrl})`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body,
+            });


### PR DESCRIPTION
When a HH3 regression benchmark run is triggered by `/bench`, there was no easy way to find the results. Instead you'd have to go to the "Actions" tab and find it manually.

This PR makes that easier for `/bench`-triggered runs by:
1. Adding a link to the "🚀 Starting regression benchmark for" message
2. Posting a comment upon completion of the regression benchmark, notifying about success/failure incl. a link.