### PR TITLE
ci: fix stale cache on self-hosted runner

### DIFF
--- a/.github/workflows/hh3-regression-benchmark.yml
+++ b/.github/workflows/hh3-regression-benchmark.yml
@@ -186,6 +186,22 @@ jobs:
             --registry http://127.0.0.1:4873/ \
             --npmrc "$HH/.verdaccio/.npmrc"
 
+      - name: Clear stale pnpm metadata cache
+        # The self-hosted runner reuses ~/.cache/pnpm across runs. The benchmark
+        # republishes deterministic versions (e.g. hardhat@3.9.1) whose content
+        # changes each run (new @nomicfoundation/edr pin), so a prior run's cached
+        # packument makes `pnpm publish` skip ("already exists") and scenario
+        # installs resolve a stale EDR dependency.
+        #
+        # pnpm 11 ignores `npm_config_cache_dir`, so the metadata cache can't be
+        # relocated.
+        #
+        # The content-addressable store is separate and kept on purpose: it's
+        # keyed by integrity hash, so with fresh metadata pnpm derives the correct
+        # hash and any stale entry is simply never matched. Keeping it is safe and
+        # preserves install speed.
+        run: rm -rf "$HOME/.cache/pnpm"
+
       - name: Run regression benchmark
         working-directory: hardhat
         env:
@@ -193,10 +209,6 @@ jobs:
           # See "Start Verdaccio": bypass pnpm's frozen-lockfile deps check for
           # the repoint-desynced workspace.
           PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN: "false"
-          # Fresh per-run pnpm metadata cache. The default cache persists on the
-          # self-hosted runner and would serve a prior run's manifest if the
-          # version number hasn't changed, so publish/install resolve a stale build.
-          npm_config_cache_dir: ${{ runner.temp }}/pnpm-metadata-cache
         # --force-publish: reuse our already-running Verdaccio (instead of
         #   erroring) and run the global sinceReleasePublish once up front.
         # --use-local: republish the (repointed) hardhat workspace packages and
@@ -343,7 +355,7 @@ jobs:
         # Self-hosted runners don't automatically wipe RUNNER_TEMP between jobs, so we do
         # this manually to avoid polluting future runs.
         if: always()
-        run: rm -rf "$RUNNER_TEMP/edr-e2e-clones" "$RUNNER_TEMP/pnpm-metadata-cache"
+        run: rm -rf "$RUNNER_TEMP/edr-e2e-clones"
 
   report:
     name: Report result to PR


### PR DESCRIPTION
Adds a step that clears pnpm's metadata cache (`rm -rf "$HOME/.cache/pnpm"`) before the HH3 regression benchmark runs, removes the ineffective `npm_config_cache_dir` relocation, and trims the end-of-run cleanup accordingly.

## Why

The benchmark repoints Hardhat at the local EDR build and republishes deterministic versions (e.g. `hardhat@3.9.1`) whose content changes every run (a new `@nomicfoundation/edr@…-local.<sha>` pin). pnpm's metadata cache persists on the self-hosted runner and is keyed by version, so a prior run's cached packument poisoned this run two ways: `pnpm publish` skipped (`"already exists"`) → Validate failed with `Published hardhat latest (3.9.0) != 3.9.1`; and once publishing was forced, scenario installs resolved the stale EDR pin → `ERR_PNPM_FETCH_404` for an EDR tarball this run never published.


The earlier `npm_config_cache_dir` relocation was a no-op: pnpm 11 ignores that variable (and `prefer-online`), so the cache stayed at `~/.cache/pnpm`. Clearing it is the reliable fix. The content-addressable store is intentionally left intact — it's keyed by integrity hash, so with fresh metadata a stale entry is never matched, which keeps installs fast.

## Testing

Reproduced locally with pnpm 11.6.0 + verdaccio 6.2.7 by publishing a deterministic package to one Verdaccio instance, then to a second fresh-storage instance on the same port (so the persistent pnpm cache goes stale, exactly like the runner):

```
# publish side
default `pnpm publish -r`            -> "There are no new packages..." (skips — the bug)
npm_config_prefer_online=true        -> still skips
rm -rf ~/.cache/pnpm; pnpm publish   -> ✅ publishes

# install side (deterministic version whose exact dep pin changes SHA1 -> SHA2; registry has only SHA2)
default / *_prefer_online / --prefer-online  -> resolves stale SHA1 (or "Unknown option")
rm -rf ~/.cache/pnpm; pnpm install            -> ✅ resolves fresh SHA2
```

## Reviewer Notes

I enabled auto-merge, so if you'd like to approve pending changes, please disable auto-merge.