### PR TITLE
ci: fix permission for post-regression run comment

### DIFF
--- a/.github/workflows/hh3-regression-benchmark.yml
+++ b/.github/workflows/hh3-regression-benchmark.yml
@@ -371,6 +371,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write # post the result comment on the PR
+      pull-requests: write # post status comments/reactions on the PR
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:


### PR DESCRIPTION
The comment that reports the result of a HH3 regression benchmark run failed due to a missing permission. This PR adds the permission.

See [logs](https://github.com/NomicFoundation/edr/actions/runs/28245224509/job/83702722015)