### PR TITLE
fix: use `GITHUB_TOKEN` for non-baseline regression benchmark runs

### DIFF
--- a/.github/workflows/hh3-regression-benchmark.yml
+++ b/.github/workflows/hh3-regression-benchmark.yml
@@ -88,6 +88,10 @@ jobs:
     # are comparable to Hardhat's own regression baselines.
     runs-on: hardhat-linux-amd64-self-hosted
     timeout-minutes: 180
+    permissions:
+      # Lets the short-lived GITHUB_TOKEN used on non-baseline runs read commit
+      # metadata via the REST API (see "Store benchmark result").
+      contents: read
     env:
       # Hardhat is checked out into ./hardhat; the EDR repo is the workspace root.
       HH: ${{ github.workspace }}/hardhat
@@ -330,7 +334,12 @@ jobs:
           gh-repository: github.com/nomic-foundation-automation/edr-benchmark-results
           gh-pages-branch: main
           benchmark-data-dir-path: hardhat3
-          github-token: ${{ secrets.BENCHMARK_GITHUB_TOKEN }}
+          # Baseline (main push) runs push to the external results repo, which
+          # needs the cross-repo PAT. Non-baseline runs (PR/dispatch and the
+          # `/bench` issue_comment path) never push — the token is only used to
+          # read commit metadata and to clone the (public) results repo for
+          # comparison — so use the short-lived GITHUB_TOKEN.
+          github-token: ${{ needs.setup.outputs.is_baseline == 'true' && secrets.BENCHMARK_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           # Only push a new baseline on main-branch pushes; PRs/dispatch only compare.
           auto-push: ${{ needs.setup.outputs.is_baseline == 'true' }}
           alert-threshold: "110%"


### PR DESCRIPTION
### Problem

The `/bench` (`issue_comment`) path of the Hardhat 3 Regression Benchmark failed at **Store benchmark result** with: *"the 'Nomic Foundation' enterprise forbids access via a fine-grained personal access token if the token's lifetime is greater than 366 days."* `edr-benchmark.yml` and main-push baselines kept working.

### Analysis

`github-action-benchmark` resolves commit metadata before touching git. On `push` it reads `head_commit`; on `pull_request` it reads the `pull_request` payload; on `issue_comment` neither exists, so it falls back to `repos.getCommit` via the REST API using `BENCHMARK_GITHUB_TOKEN`. That call targets `NomicFoundation/edr` (under the enterprise → PAT-lifetime policy rejects it), whereas the git clone/push targets `nomic-foundation-automation/edr-benchmark-results` (not under the enterprise → works). So only the comment path hits the blocked REST call. Dropping the token isn't an option — it's required whenever `gh-repository` is set and by `getCommit` itself.

### Fix

On non-baseline runs `auto-push` is `false`, so the PAT is only used to read commit metadata and clone the (public) results repo for comparison — both work with the ephemeral `GITHUB_TOKEN`, which isn't a PAT and isn't subject to the policy. The PAT is kept only for the baseline (main-push) path that actually pushes.

- `github-token` now selects `BENCHMARK_GITHUB_TOKEN` when `is_baseline == 'true'`, else `GITHUB_TOKEN`.
- The `regression-benchmark` job gains `permissions: contents: read` so `GITHUB_TOKEN` can read commit metadata.

`contents: read` is sufficient: `comment-on-alert`/`comment-always` are off (a 110% breach only writes the summary and fails via `fail-on-alert`), the PR notification is handled by the separate `report` job, and the results repo is public so the comparison clone works.
