### PR TITLE
build: upgrade to pnpm 11

### DIFF
--- a/.github/workflows/edr-npm-release.yml
+++ b/.github/workflows/edr-npm-release.yml
@@ -164,7 +164,7 @@ jobs:
             curl -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable
             export PATH="/root/.cargo/bin:$PATH"
 
-            npm i -g pnpm@10.34.3 --ignore-scripts
+            npm i -g pnpm@11.9.0 --ignore-scripts
             pnpm -v
             npm i -g sfw
             sfw pnpm install --frozen-lockfile --prefer-offline
@@ -191,7 +191,7 @@ jobs:
             curl -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable
             export PATH="/root/.cargo/bin:$PATH"
 
-            npm i -g pnpm@10.34.3 --ignore-scripts
+            npm i -g pnpm@11.9.0 --ignore-scripts
             pnpm -v
             pnpm install --frozen-lockfile --prefer-offline
             pnpm run build --strip
@@ -284,7 +284,7 @@ jobs:
       - name: Test bindings
         # Setting CI=1 is important to make PNPM install non-interactive
         # https://github.com/pnpm/pnpm/issues/6615#issuecomment-1656945689
-        run: docker run --rm  -e CI=1 -v $(pwd):/build -w /build/crates/edr_napi node:${{ matrix.node }} bash -c "npm install -g pnpm@10.34.3; pnpm testNoBuild"
+        run: docker run --rm  -e CI=1 -v $(pwd):/build -w /build/crates/edr_napi node:${{ matrix.node }} bash -c "npm install -g pnpm@11.9.0; pnpm testNoBuild"
   test-linux-x64-musl-binding:
     name: Test bindings on x86_64-unknown-linux-musl - node@${{ matrix.node }}
     needs:
@@ -318,7 +318,7 @@ jobs:
         run: ls -R .
         shell: bash
       - name: Test bindings
-        run: docker run --rm  -e CI=1 -v $(pwd):/build -w /build/crates/edr_napi node:${{ matrix.node }}-alpine sh -c "npm install -g pnpm@10.34.3; pnpm testNoBuild"
+        run: docker run --rm  -e CI=1 -v $(pwd):/build -w /build/crates/edr_napi node:${{ matrix.node }}-alpine sh -c "npm install -g pnpm@11.9.0; pnpm testNoBuild"
   test-linux-aarch64-gnu-binding:
     name: Test bindings on aarch64-unknown-linux-gnu - node@${{ matrix.node }}
     needs:
@@ -358,7 +358,7 @@ jobs:
           image: node:${{ matrix.node }}
           options: "--platform linux/arm64 -v ${{ github.workspace }}:/build -w /build/crates/edr_napi -e CI=1"
           run: |
-            npm install -g pnpm@10.34.3
+            npm install -g pnpm@11.9.0
             set -e
             pnpm testNoBuild
             ls -la
@@ -400,7 +400,7 @@ jobs:
           image: node:${{ matrix.node }}-alpine
           options: "--platform linux/arm64 -v ${{ github.workspace }}:/build -w /build/crates/edr_napi -e CI=1"
           run: |
-            npm install -g pnpm@10.34.3
+            npm install -g pnpm@11.9.0
             set -e
             pnpm testNoBuild
 
@@ -476,11 +476,16 @@ jobs:
         # we NEED to to this before pnpm artifacts, if not prepublish will try to publish
         run: ../../scripts/prepublish.sh
       - name: Move artifacts
-        run: pnpm artifacts
+        # prepublish.sh (above) adds the platform packages to edr_napi's
+        # package.json but not the lockfile; skip pnpm 11's pre-run frozen
+        # deps check, which would otherwise fail on that intentional desync.
+        run: pnpm --config.verify-deps-before-run=false artifacts
       - name: Copy coverage library into edr_napi crate
         run: cp ../../data/contracts/coverage.sol ./coverage.sol
       - name: Compile TypeScript helpers
-        run: pnpm exec tsc
+        # See "Move artifacts": package.json is intentionally out of sync with
+        # the lockfile here, so skip pnpm 11's pre-run frozen deps check.
+        run: pnpm --config.verify-deps-before-run=false exec tsc
       - name: Create bundle with pnpm root & napi files
         # create custom tar.gz because pnpm pack only packs root package and we need the platform-specific ones as well
         id: pack

--- a/package.json
+++ b/package.json
@@ -9,19 +9,10 @@
   },
   "engines": {
     "node": ">=22.13.0",
-    "pnpm": ">=10.28.2"
+    "pnpm": ">=11"
   },
   "license": "SEE LICENSE IN EACH PACKAGE'S LICENSE FILE",
-  "packageManager": "pnpm@10.34.3",
-  "pnpm": {
-    "overrides": {
-      "hardhat>@nomicfoundation/edr": "workspace:*"
-    },
-    "patchedDependencies": {
-      "hardhat@2.28.4": "patches/hardhat@2.28.4.patch",
-      "hardhat@3.4.5": "patches/hardhat@3.4.5.patch"
-    }
-  },
+  "packageManager": "pnpm@11.9.0",
   "private": true,
   "scripts": {
     "build": "pnpm run --recursive build",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,13 @@ packages:
   - "js/helpers"
   - "js/integration-tests/*"
 
+overrides:
+  hardhat>@nomicfoundation/edr: "workspace:*"
+
+patchedDependencies:
+  hardhat@2.28.4: patches/hardhat@2.28.4.patch
+  hardhat@3.4.5: patches/hardhat@3.4.5.patch
+
 # Delay installs until a version is at least 1 week old
 minimumReleaseAge: 10080
 
@@ -13,3 +20,9 @@ minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
   - "@nomicfoundation/*"
   - "hardhat"
+
+# We run with ignore-scripts=true; none of these need to build.
+allowBuilds:
+  esbuild: false
+  keccak: false
+  secp256k1: false

--- a/renovate.json
+++ b/renovate.json
@@ -116,15 +116,9 @@
       "enabled": false
     },
     {
-      "description": "pnpm/action-setup v6+ ships a pnpm 11 bootstrap that requires Node >= 22.13. Cap at v5 (= v4.4.0 retagged) until the Node-major rule above moves us off Node 20.",
+      "description": "pnpm/action-setup: hold at v5. v6's self-installer bootstraps pnpm via the runner's system npm, which is corrupted on the self-hosted edr-benchmark-runner (v5's install path isn't affected). Lift once that runner's npm is repaired.",
       "matchPackageNames": ["pnpm/action-setup"],
       "allowedVersions": "<6"
-    },
-    {
-      "description": "pnpm major: pnpm 11 requires Node >= 22.13, so it's tied to the Node-major bump above. Blocks `packageManager`, `engines.pnpm`, and the `pnpm@X.Y.Z` customManager hits in workflow YAML. Minor/patch (incl. security) still flow through.",
-      "matchDepNames": ["pnpm"],
-      "matchUpdateTypes": ["major"],
-      "enabled": false
     },
     {
       "description": "TS major: cascades to typescript-eslint and to consumers of EDR's TS-aware bindings. Bump manually when the ecosystem catches up.",


### PR DESCRIPTION
Builds on #1393 (now merged). With Node 20 dropped and CI on Node 24, pnpm 11's `Node >= 22.13` requirement is satisfied, so we can move off the pinned pnpm 10.

I've left the `pnpm/action-setup` bump, as I will need access to the `edr-benchmark-runner` to debug/fix that.

# Claude summary

## Changes
- `packageManager` + the `pnpm@X.Y.Z` workflow pins: `10.34.3` → `11.9.0`
- `engines`: `node >=22.13` (pnpm 11's real floor), `pnpm >=11`
- Moved `overrides` + `patchedDependencies` from `package.json`'s `pnpm` field into `pnpm-workspace.yaml` — pnpm 11 no longer reads that field (the one genuine breaking change).
- Declared `allowBuilds: false` for `esbuild`/`keccak`/`secp256k1`, matching our `ignore-scripts=true` posture.
- Release workflow: `pnpm artifacts` and `pnpm exec tsc` run right after `prepublish.sh` *intentionally* desyncs `edr_napi/package.json` from the lockfile. pnpm 11 defaults `verifyDepsBeforeRun` to `install`, which would trigger a frozen install and fail there — so those two commands pass `--config.verify-deps-before-run=false`.
- Dropped the now-obsolete pnpm-major Renovate gate.

## Follow-up: `pnpm/action-setup` v5 → v6 (deferred)

Intentionally **not** bumped here — kept the Renovate `<6` cap. action-setup reads the pnpm version from `packageManager` regardless of the action version, so v5 installs pnpm 11.9.0 fine; the bump isn't required for this upgrade.

v6's self-installer bootstraps pnpm via the runner's system `npm`, which is **corrupted on the self-hosted `edr-benchmark-runner`** (`externals/node24/bin/npm` → `Cannot find module '../lib/cli.js'`; node itself is fine). v5's install path doesn't touch that npm, so it's unaffected. v6 is confirmed working everywhere the npm is healthy — all GitHub-hosted runners, and the self-hosted regression runner (`hardhat-linux-amd64-self-hosted`).

To adopt v6 later: repair the `edr-benchmark-runner`'s npm (delete the stray `node_modules` / re-extract the node24 externals), then move the three `action-setup` pins to v6 and lift the Renovate cap. That broken npm will bite any node24 action that shells to npm on that runner, so it's worth fixing regardless.
