### PR TITLE
build: extend typescript-eslint recommended-type-checked preset

### DIFF
--- a/config/eslint/eslintrc.js
+++ b/config/eslint/eslintrc.js
@@ -4,10 +4,27 @@ module.exports = {
     es6: true,
     node: true,
   },
-  extends: ["plugin:prettier/recommended"],
+  extends: [
+    "plugin:@typescript-eslint/recommended-type-checked",
+    "plugin:prettier/recommended",
+  ],
   parser: "@typescript-eslint/parser",
   plugins: ["import", "mocha", "@typescript-eslint"],
   rules: {
+    // The `recommended-type-checked` preset (extended above) is the baseline.
+    // Everything below is our delta on top of it:
+    //   1. the `no-unsafe-*` / `no-explicit-any` family is turned OFF — this
+    //      repo's test/RPC code is pervasively `any` (dynamic JSON payloads),
+    //      so enforcing it would mean thousands of low-value assertions;
+    //   2. the remaining entries are stricter or stylistic rules the preset
+    //      does not include, or preset rules we run with non-default options.
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-unsafe-argument": "off",
+    "@typescript-eslint/no-unsafe-assignment": "off",
+    "@typescript-eslint/no-unsafe-call": "off",
+    "@typescript-eslint/no-unsafe-member-access": "off",
+    "@typescript-eslint/no-unsafe-return": "off",
+    "@typescript-eslint/no-unsafe-unary-minus": "off",
     "@typescript-eslint/adjacent-overload-signatures": "error",
     "@typescript-eslint/array-type": [
       "error",
@@ -15,7 +32,6 @@ module.exports = {
         default: "array-simple",
       },
     ],
-    "@typescript-eslint/await-thenable": "error",
     "@typescript-eslint/no-restricted-types": [
       "error",
       {
@@ -119,10 +135,6 @@ module.exports = {
         format: null,
       },
     ],
-    "@typescript-eslint/no-empty-object-type": "error",
-    "@typescript-eslint/no-floating-promises": "error",
-    "@typescript-eslint/no-misused-new": "error",
-    "@typescript-eslint/no-namespace": "error",
     "@typescript-eslint/no-redeclare": "error",
     "@typescript-eslint/no-shadow": [
       "error",
@@ -130,8 +142,6 @@ module.exports = {
         hoist: "all",
       },
     ],
-    "@typescript-eslint/no-this-alias": "error",
-    "@typescript-eslint/no-unused-expressions": "error",
     "@typescript-eslint/no-unused-vars": [
       "error",
       {
@@ -141,8 +151,6 @@ module.exports = {
     ],
     "@typescript-eslint/prefer-for-of": "error",
     "@typescript-eslint/prefer-function-type": "error",
-    "@typescript-eslint/prefer-namespace-keyword": "error",
-    "@typescript-eslint/restrict-plus-operands": "error",
     "@typescript-eslint/restrict-template-expressions": [
       "error",
       {
@@ -207,7 +215,6 @@ module.exports = {
     "no-sequences": "error",
     "no-sparse-arrays": "error",
     "no-template-curly-in-string": "error",
-    "no-throw-literal": "error",
     "no-undef-init": "error",
     "no-unsafe-finally": "error",
     "no-unused-labels": "error",

--- a/config/eslint/eslintrc.js
+++ b/config/eslint/eslintrc.js
@@ -25,6 +25,24 @@ module.exports = {
     "@typescript-eslint/no-unsafe-member-access": "off",
     "@typescript-eslint/no-unsafe-return": "off",
     "@typescript-eslint/no-unsafe-unary-minus": "off",
+    // `@ts-ignore` is banned by default in favor of `@ts-expect-error`, but the
+    // napi test suites legitimately need it: feature-gated exports (op / mock)
+    // are absent only in the `testNoBuild` build, so `@ts-expect-error` would
+    // report an unused directive in the normal build. Require a description.
+    "@typescript-eslint/ban-ts-comment": [
+      "error",
+      {
+        "ts-ignore": "allow-with-description",
+      },
+    ],
+    // chai's `AssertionError` type does not extend `Error`, so throwing it (as
+    // our async assertion helpers do) trips only-throw-error. Allow it.
+    "@typescript-eslint/only-throw-error": [
+      "error",
+      {
+        allow: [{ from: "package", name: "AssertionError", package: "chai" }],
+      },
+    ],
     "@typescript-eslint/adjacent-overload-signatures": "error",
     "@typescript-eslint/array-type": [
       "error",

--- a/crates/edr_napi/test/coverage.ts
+++ b/crates/edr_napi/test/coverage.ts
@@ -104,6 +104,7 @@ describe("Code coverage", () => {
     networkId: 123n,
     observability: {
       codeCoverage: {
+        // eslint-disable-next-line @typescript-eslint/require-await -- napi callback signature is (…) => Promise<void>
         onCollectedCoverageCallback: async (coverage: Uint8Array[]) => {
           coverageReporter.hits.push(...coverage);
         },
@@ -207,6 +208,7 @@ describe("Code coverage", () => {
           ),
           observability: {
             codeCoverage: {
+              // eslint-disable-next-line @typescript-eslint/require-await -- napi callback signature is (…) => Promise<void>
               onCollectedCoverageCallback: async (_coverage: Uint8Array[]) => {
                 throw new Error(ERROR_MESSAGE);
               },
@@ -263,6 +265,7 @@ describe("Code coverage", () => {
         hardfork: l1HardforkToString(l1HardforkLatest()),
         observability: {
           codeCoverage: {
+            // eslint-disable-next-line @typescript-eslint/require-await -- napi callback signature is (…) => Promise<void>
             onCollectedCoverageCallback: async (coverage: Uint8Array[]) => {
               coverageReporter.hits.push(...coverage);
             },
@@ -296,6 +299,7 @@ describe("Code coverage", () => {
         hardfork: l1HardforkToString(l1HardforkLatest()),
         observability: {
           codeCoverage: {
+            // eslint-disable-next-line @typescript-eslint/require-await -- napi callback signature is (…) => Promise<void>
             onCollectedCoverageCallback: async (_coverage: Uint8Array[]) => {
               throw new Error(ERROR_MESSAGE);
             },

--- a/crates/edr_napi/test/coverage.ts
+++ b/crates/edr_napi/test/coverage.ts
@@ -316,7 +316,7 @@ describe("Code coverage", () => {
           assert.equal(testResult.status, TestStatus.Failure);
           assert.isDefined(testResult.reason);
           assert(
-            testResult.reason!.includes(ERROR_MESSAGE),
+            testResult.reason.includes(ERROR_MESSAGE),
             `Test failure reason should contain the expected error. Found: ${testResult.reason}`
           );
         }

--- a/crates/edr_napi/test/errors.ts
+++ b/crates/edr_napi/test/errors.ts
@@ -2,7 +2,7 @@ import { assert } from "chai";
 import { ReturnData } from "..";
 
 describe("Errors", () => {
-  it("check error message", async function () {
+  it("check error message", function () {
     // ABI encoded Error(string) of "Test error"
     const validData = new Uint8Array([
       0x08, 0xc3, 0x79, 0xa0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
@@ -42,7 +42,7 @@ describe("Errors", () => {
     );
   });
 
-  it("check panic message", async function () {
+  it("check panic message", function () {
     // ABI encoded Panic(uint256) of 0x11
     const validData = new Uint8Array([
       0x4e, 0x48, 0x7b, 0x71, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,

--- a/crates/edr_napi/test/gasReport.ts
+++ b/crates/edr_napi/test/gasReport.ts
@@ -164,7 +164,7 @@ describe("Gas reports", function () {
         "No gas report received after deployment"
       );
 
-      let gasReport = gasReporter.report!;
+      let gasReport = gasReporter.report;
 
       assert.equal(
         Object.keys(gasReport.contracts).length,
@@ -286,7 +286,7 @@ describe("Gas reports", function () {
         "No gas report received after deployment"
       );
 
-      let gasReport = gasReporter.report!;
+      let gasReport = gasReporter.report;
 
       assert.equal(
         Object.keys(gasReport.contracts).length,
@@ -478,7 +478,7 @@ describe("Gas reports", function () {
       });
 
       assert.isDefined(proxyGasReporter.report);
-      const gasReport = proxyGasReporter.report!;
+      const gasReport = proxyGasReporter.report;
 
       const contractReport =
         gasReport.contracts[
@@ -530,7 +530,7 @@ describe("Gas reports", function () {
       });
 
       assert.isDefined(proxyGasReporter.report);
-      const gasReport = proxyGasReporter.report!;
+      const gasReport = proxyGasReporter.report;
 
       assert.equal(
         Object.keys(gasReport.contracts).length,
@@ -607,7 +607,7 @@ describe("Gas reports", function () {
       );
 
       assert.isDefined(proxyGasReporter.report);
-      const gasReport = proxyGasReporter.report!;
+      const gasReport = proxyGasReporter.report;
 
       assert.equal(
         Object.keys(gasReport.contracts).length,
@@ -683,7 +683,7 @@ describe("Gas reports", function () {
       assert.isDefined(txHash1, "Transaction hash should be defined");
 
       assert.isDefined(proxyGasReporter.report);
-      let gasReport = proxyGasReporter.report!;
+      let gasReport = proxyGasReporter.report;
 
       assert.equal(
         Object.keys(gasReport.contracts).length,

--- a/crates/edr_napi/test/gasReport.ts
+++ b/crates/edr_napi/test/gasReport.ts
@@ -132,6 +132,7 @@ describe("Gas reports", function () {
         ),
         observability: {
           gasReport: {
+            // eslint-disable-next-line @typescript-eslint/require-await -- napi callback signature is (…) => Promise<void>
             onCollectedGasReportCallback: async (report: GasReport) => {
               gasReporter.report = report;
             },
@@ -444,6 +445,7 @@ describe("Gas reports", function () {
           ),
           observability: {
             gasReport: {
+              // eslint-disable-next-line @typescript-eslint/require-await -- napi callback signature is (…) => Promise<void>
               onCollectedGasReportCallback: async (report: GasReport) => {
                 proxyGasReporter.report = report;
               },

--- a/crates/edr_napi/test/helpers.ts
+++ b/crates/edr_napi/test/helpers.ts
@@ -45,7 +45,7 @@ export function getContext(): EdrContext {
 export function collectSteps(
   trace: Array<TracingMessage | TracingStep | TracingMessageResult>
 ): TracingStep[] {
-  return trace.filter((traceItem) => "pc" in traceItem) as TracingStep[];
+  return trace.filter((traceItem) => "pc" in traceItem);
 }
 
 /**
@@ -54,9 +54,7 @@ export function collectSteps(
 export function collectMessages(
   trace: Array<TracingMessage | TracingStep | TracingMessageResult>
 ): TracingMessage[] {
-  return trace.filter(
-    (traceItem) => "isStaticCall" in traceItem
-  ) as TracingMessage[];
+  return trace.filter((traceItem) => "isStaticCall" in traceItem);
 }
 
 export async function deployContract(

--- a/crates/edr_napi/test/helpers.ts
+++ b/crates/edr_napi/test/helpers.ts
@@ -120,6 +120,7 @@ export function toBuffer(x: Parameters<typeof toBytes>[0]) {
 
 // Load a contract built with Hardhat into a test suite
 export function loadContract(artifactPath: string): Artifact {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports -- dynamic, module-relative artifact path (fs would resolve against cwd)
   const compiledContract = require(artifactPath);
 
   const id: ArtifactId = {

--- a/crates/edr_napi/test/instrument.ts
+++ b/crates/edr_napi/test/instrument.ts
@@ -27,7 +27,7 @@ describe("Code coverage", () => {
   const incrementSourceCode = readSourceCode();
 
   describe("instrumentation", function () {
-    it("Statement coverage", async function () {
+    it("Statement coverage", function () {
       const result = addStatementCoverageInstrumentation(
         incrementSourceCode,
         "instrumentation.sol",

--- a/crates/edr_napi/test/issues.ts
+++ b/crates/edr_napi/test/issues.ts
@@ -105,7 +105,7 @@ describe("Provider", () => {
       })
     );
   });
-  it("Invalid build info", async function () {
+  it("Invalid build info", function () {
     // Test data taken from CI run:
     // <https://github.com/NomicFoundation/hardhat/actions/runs/14475363227/job/40604573807?pr=6577>
     const config = {

--- a/crates/edr_napi/test/logs.ts
+++ b/crates/edr_napi/test/logs.ts
@@ -7,8 +7,7 @@ import {
   l1GenesisState,
   l1HardforkFromString,
   MineOrdering,
-  // Ignore this on testNoBuild
-  // @ts-ignore
+  // @ts-ignore MockTime is absent in the testNoBuild (no test-mock) build
   MockTime,
   Provider,
   SHANGHAI,
@@ -294,8 +293,7 @@ describe("Provider logs", function () {
         },
       };
 
-      // Ignore this on testNoBuild
-      // @ts-ignore
+      // @ts-ignore createProviderWithMockTimer is absent in the testNoBuild (no test-mock) build
       provider = await context.createProviderWithMockTimer(
         {
           ...providerConfig,

--- a/crates/edr_napi/test/mock.ts
+++ b/crates/edr_napi/test/mock.ts
@@ -25,8 +25,7 @@ describe("Provider (Mock)", () => {
     // Local tests indicate <100.000ms timeout is enough, but CI may be slower.
     this.timeout(300_000);
 
-    // Ignore this on testNoBuild
-    // @ts-ignore
+    // @ts-ignore createMockProvider is absent in the testNoBuild (no test-mock) build
     const provider = context.createMockProvider(parsedJson);
 
     // This is a transaction that has a very large response.

--- a/crates/edr_napi/test/op.ts
+++ b/crates/edr_napi/test/op.ts
@@ -14,19 +14,19 @@ import {
   SubscriptionEvent,
   // HACK: There is no way to exclude tsc type checking for a file from the
   // CLI, so we ignore the error here to allow `pnpm testNoBuild` to pass.
-  // @ts-ignore
+  // @ts-ignore op exports are absent in the testNoBuild build
   OP_CHAIN_TYPE,
-  // @ts-ignore
+  // @ts-ignore op exports are absent in the testNoBuild build
   opGenesisState,
-  // @ts-ignore
+  // @ts-ignore op exports are absent in the testNoBuild build
   opHardforkFromString,
-  // @ts-ignore
+  // @ts-ignore op exports are absent in the testNoBuild build
   opHardforkToString,
-  // @ts-ignore
+  // @ts-ignore op exports are absent in the testNoBuild build
   opLatestHardfork,
-  // @ts-ignore
+  // @ts-ignore op exports are absent in the testNoBuild build
   opProviderFactory,
-  // @ts-ignore
+  // @ts-ignore op exports are absent in the testNoBuild build
   opSolidityTestRunnerFactory,
   ContractDecoder,
 } from "..";

--- a/hardhat-tests/test/edr-override.ts
+++ b/hardhat-tests/test/edr-override.ts
@@ -4,7 +4,7 @@ import path from "path";
 // The tests under `hardhat-tests` assume that the EDR version used by
 // Hardhat is the one in the workspace, instead of the one installed
 // from npm. This test checks that this is the case.
-it("uses the workspace version of EDR", async function () {
+it("uses the workspace version of EDR", function () {
   const hardhatPath = require.resolve("hardhat");
 
   const edrPath = require.resolve("@nomicfoundation/edr", {

--- a/hardhat-tests/test/helpers/environment.ts
+++ b/hardhat-tests/test/helpers/environment.ts
@@ -12,6 +12,7 @@ export function useEnvironment(configPath?: string) {
     if (configPath !== undefined) {
       process.env.HARDHAT_CONFIG = configPath;
     }
+    // eslint-disable-next-line @typescript-eslint/no-require-imports -- runtime require: must load after HARDHAT_CONFIG is set above
     this.env = require("hardhat/internal/lib/hardhat-lib");
   });
 

--- a/hardhat-tests/test/internal/hardhat-network/helpers/transactions.ts
+++ b/hardhat-tests/test/internal/hardhat-network/helpers/transactions.ts
@@ -127,7 +127,7 @@ export async function sendTransactionFromTxParams(
   }
 
   if (txParams.to !== undefined) {
-    rpcTxParams.to = bufferToHex(txParams.to!);
+    rpcTxParams.to = bufferToHex(txParams.to);
   }
   return provider.send("eth_sendTransaction", [rpcTxParams]);
 }

--- a/hardhat-tests/test/internal/hardhat-network/helpers/useHelpers.ts
+++ b/hardhat-tests/test/internal/hardhat-network/helpers/useHelpers.ts
@@ -30,7 +30,7 @@ declare module "mocha" {
  * @deprecated
  */
 export function useHelpers() {
-  beforeEach("Initialize helpers", async function () {
+  beforeEach("Initialize helpers", function () {
     if (this.provider === undefined) {
       throw new Error("useHelpers has to be called after useProvider");
     }
@@ -82,7 +82,7 @@ export function useHelpers() {
     };
   });
 
-  afterEach("Remove helpers", async function () {
+  afterEach("Remove helpers", function () {
     delete (this as any).sendTx;
     delete (this as any).assertLatestBlockTxs;
     delete (this as any).assertPendingTxs;

--- a/hardhat-tests/test/internal/hardhat-network/provider/baseFeePerGas.ts
+++ b/hardhat-tests/test/internal/hardhat-network/provider/baseFeePerGas.ts
@@ -109,7 +109,7 @@ describe("Block's baseFeePerGas", function () {
 
                 const blockNumber = await this.provider.send("eth_blockNumber");
                 const { forkClient } = await makeForkClient({
-                  jsonRpcUrl: ALCHEMY_URL!,
+                  jsonRpcUrl: ALCHEMY_URL,
                 });
 
                 const remoteLatestBlockBaseFeePerGas =

--- a/hardhat-tests/test/internal/hardhat-network/provider/hardhat-network-options.ts
+++ b/hardhat-tests/test/internal/hardhat-network/provider/hardhat-network-options.ts
@@ -6,7 +6,6 @@ import {
   dateToTimestampSeconds,
   parseDateString,
 } from "hardhat/internal/util/date";
-import { HardhatNetworkConfig } from "hardhat/types";
 import { useEnvironment } from "../../../helpers/environment";
 import { expectErrorAsync } from "../../../helpers/errors";
 import { useFixtureProject } from "../../../helpers/project";

--- a/hardhat-tests/test/internal/hardhat-network/provider/hardhat-network-options.ts
+++ b/hardhat-tests/test/internal/hardhat-network/provider/hardhat-network-options.ts
@@ -72,9 +72,8 @@ describe("Hardhat Network special options", function () {
         ["latest", false]
       );
 
-      const hardhatNetworkConfig = this.env.config.networks
-        .hardhat as HardhatNetworkConfig;
-      const initialDateString = hardhatNetworkConfig.initialDate!;
+      const hardhatNetworkConfig = this.env.config.networks.hardhat;
+      const initialDateString = hardhatNetworkConfig.initialDate;
       const initialDate = dateToTimestampSeconds(
         parseDateString(initialDateString)
       );

--- a/hardhat-tests/test/internal/hardhat-network/provider/modules/debug/traceTransaction.ts
+++ b/hardhat-tests/test/internal/hardhat-network/provider/modules/debug/traceTransaction.ts
@@ -259,7 +259,7 @@ describe("Debug module", function () {
         this.skip();
       }
       const forkConfig: ForkConfig = {
-        jsonRpcUrl: ALCHEMY_URL!,
+        jsonRpcUrl: ALCHEMY_URL,
         blockNumber: 11_954_000,
       };
 
@@ -396,7 +396,7 @@ describe("Debug module", function () {
         this.skip();
       }
       const forkConfig: ForkConfig = {
-        jsonRpcUrl: ALCHEMY_URL!,
+        jsonRpcUrl: ALCHEMY_URL,
         blockNumber: 15_204_358,
       };
 

--- a/hardhat-tests/test/internal/hardhat-network/provider/modules/eth/methods/getTransactionByHash.ts
+++ b/hardhat-tests/test/internal/hardhat-network/provider/modules/eth/methods/getTransactionByHash.ts
@@ -278,12 +278,12 @@ describe("Eth module", function () {
           // Also equalize left padding (signedTx has a leading 0)
           assert.equal(
             toBuffer(fetchedTx.r).toString("hex"),
-            toBuffer(signedTx.r!).toString("hex")
+            toBuffer(signedTx.r).toString("hex")
           );
 
           assert.equal(
             toBuffer(fetchedTx.s).toString("hex"),
-            toBuffer(signedTx.s!).toString("hex")
+            toBuffer(signedTx.s).toString("hex")
           );
         });
 

--- a/hardhat-tests/test/internal/hardhat-network/provider/modules/eth/websocket.ts
+++ b/hardhat-tests/test/internal/hardhat-network/provider/modules/eth/websocket.ts
@@ -308,7 +308,11 @@ describe("Eth module", function () {
                 parsedMessage.params?.subscription === subscription
               ) {
                 ws.removeListener("message", listener);
-                reject();
+                reject(
+                  new Error(
+                    `Unexpected message for subscription ${subscription}`
+                  )
+                );
               }
             };
 
@@ -344,7 +348,7 @@ describe("Eth module", function () {
       describe("ethers.WebSocketProvider", function () {
         let provider: ethers.WebSocketProvider;
 
-        beforeEach(async function () {
+        beforeEach(function () {
           if (this.serverInfo !== undefined) {
             const { address, port } = this.serverInfo;
             provider = new ethers.WebSocketProvider(`ws://${address}:${port}`);
@@ -354,9 +358,11 @@ describe("Eth module", function () {
         });
 
         it("'block' event works", async function () {
-          const onBlock = new Promise((resolve) =>
-            provider.on("block", resolve)
-          );
+          const onBlock = new Promise((resolve) => {
+            // ethers v6 `.on()` returns a Promise; the executor expects void and
+            // the subscription settling is covered by the sleep below.
+            void provider.on("block", resolve);
+          });
 
           // If we call evm_mine immediately, the event won't be triggered
           // ideally `.on` would be async and resolve when the subscription is
@@ -368,9 +374,9 @@ describe("Eth module", function () {
         });
 
         it("'pending' event works", async function () {
-          const onPending = new Promise((resolve) =>
-            provider.on("pending", resolve)
-          );
+          const onPending = new Promise((resolve) => {
+            void provider.on("pending", resolve);
+          });
           await sleep(100);
 
           const signer = await provider.getSigner();
@@ -391,9 +397,9 @@ describe("Eth module", function () {
           );
           const contract = await Factory.deploy();
 
-          const onContractEvent = new Promise((resolve) =>
-            contract.on("StateModified", resolve)
-          );
+          const onContractEvent = new Promise((resolve) => {
+            void contract.on("StateModified", resolve);
+          });
           await sleep(100);
 
           await contract.modifiesState(1);

--- a/hardhat-tests/test/internal/hardhat-network/stack-traces/execution.ts
+++ b/hardhat-tests/test/internal/hardhat-network/stack-traces/execution.ts
@@ -16,6 +16,7 @@ function toBuffer(x: Parameters<typeof toBytes>[0]) {
   return Buffer.from(toBytes(x));
 }
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- ethereumjs-abi ships no type declarations
 const abi = require("ethereumjs-abi");
 
 const senderPrivateKey =

--- a/hardhat-tests/test/internal/hardhat-network/stack-traces/test.ts
+++ b/hardhat-tests/test/internal/hardhat-network/stack-traces/test.ts
@@ -810,7 +810,7 @@ describe("Stack traces", function () {
 });
 
 describe("Solidity support", function () {
-  it("check that the latest tested version matches the one that EDR exports", async function () {
+  it("check that the latest tested version matches the one that EDR exports", function () {
     const latestSupportedVersion = getLatestTestedSolcVersion();
     const edrLatestSupportedVersion = latestSupportedSolidityVersion();
 

--- a/hardhat-tests/test/internal/hardhat-network/stack-traces/test.ts
+++ b/hardhat-tests/test/internal/hardhat-network/stack-traces/test.ts
@@ -367,7 +367,7 @@ function compareStackTraces(
 
       assert.isTrue(
         expectedValue === actualValue,
-        `Stack trace of tx ${txIndex} entry ${i} has value ${actualValue!.toString(
+        `Stack trace of tx ${txIndex} entry ${i} has value ${actualValue.toString(
           10
         )} and should have ${expectedValue.toString(10)}`
       );
@@ -387,7 +387,7 @@ function compareStackTraces(
         `Stack trace of tx ${txIndex} entry ${i} should have an errorCode`
       );
 
-      const actualErrorCodeHex = actualErrorCode!.toString(16);
+      const actualErrorCodeHex = actualErrorCode.toString(16);
 
       assert.isTrue(
         expected.errorCode === actualErrorCodeHex,
@@ -431,7 +431,7 @@ function compareStackTraces(
 
         if (optimizer === undefined) {
           assert.equal(
-            actual.sourceReference!.line,
+            actual.sourceReference.line,
             expected.sourceReference.line,
             `Stack trace of tx ${txIndex} entry ${i} have different line numbers`
           );
@@ -532,7 +532,7 @@ async function runTest(
         tx,
         provider,
         compilerOutput,
-        contract!
+        contract
       );
     }
 
@@ -599,7 +599,7 @@ function linkBytecode(
       for (const ref of references) {
         code = linkHexStringBytecode(
           code,
-          address!.address.toString("hex"),
+          address.address.toString("hex"),
           ref.start
         );
       }

--- a/js/benchmark/src/index.ts
+++ b/js/benchmark/src/index.ts
@@ -772,7 +772,7 @@ async function generateForgeReport(csvInputPath: string): Promise<string> {
     columns: true,
     skip_empty_lines: true,
     skip_records_with_empty_values: true,
-  }) as CompareForgeRow[];
+  });
 
   // Parse data rows and filter only actual tests (rows with test names)
   const testRows = parseResult.filter((row) => {

--- a/js/benchmark/src/index.ts
+++ b/js/benchmark/src/index.ts
@@ -149,12 +149,12 @@ async function main(): Promise<boolean> {
         }
       }
     } else {
-      await benchmarkAllScenarios(benchmarkOutputPath);
+      benchmarkAllScenarios(benchmarkOutputPath);
     }
   } else if (args.command === "verify-provider-benchmark") {
     return verify(benchmarkOutputPath);
   } else if (args.command === "report-provider-benchmark") {
-    await report(benchmarkOutputPath);
+    report(benchmarkOutputPath);
   } else if (args.command === "solidity-tests-benchmark") {
     await runSolidityTestsBenchmark(benchmarkOutputPath);
   } else if (args.command === "solidity-tests") {
@@ -220,7 +220,7 @@ async function main(): Promise<boolean> {
       return false;
     }
 
-    const reportResults = await generateForgeReport(args.csv_input);
+    const reportResults = generateForgeReport(args.csv_input);
     console.log(reportResults);
   } else {
     const _exhaustiveCheck: never = args.command;
@@ -241,7 +241,7 @@ async function repoArgToRepoPath(
   return setupRepo(repoData, tool);
 }
 
-async function report(benchmarkResultPath: string) {
+function report(benchmarkResultPath: string) {
   const benchmarkResult: Record<string, BenchmarkResult> = JSON.parse(
     fs.readFileSync(benchmarkResultPath, "utf-8")
   );
@@ -267,7 +267,7 @@ async function report(benchmarkResultPath: string) {
   console.log(JSON.stringify(reports));
 }
 
-async function verify(benchmarkResultPath: string) {
+function verify(benchmarkResultPath: string) {
   let success = true;
   const benchmarkResult = JSON.parse(
     fs.readFileSync(benchmarkResultPath, "utf-8")
@@ -341,7 +341,7 @@ function setDifference<T>(a: Set<T>, b: Set<T>): Set<T> {
   return new Set(Array.from(a).filter((item) => !b.has(item)));
 }
 
-async function benchmarkAllScenarios(outPath: string) {
+function benchmarkAllScenarios(outPath: string) {
   const result: any = {};
   let totalTime = 0;
   let totalFailures = 0;
@@ -632,7 +632,7 @@ function getScenarioFileNames(): string[] {
   return scenarioFiles.filter((fileName) => fileName.endsWith(".jsonl.gz"));
 }
 
-async function runSolidityTestsInSubprocess(repo: string): Promise<string> {
+function runSolidityTestsInSubprocess(repo: string): string {
   const args = [
     "--noconcurrent_sweeping",
     "--noconcurrent_recompilation",
@@ -685,7 +685,7 @@ async function runCompareTests(
   for (let i = 0; i < count; i++) {
     // Run EDR test in subprocess
     console.error(`EDR run ${i + 1}/${count}`);
-    const edrResultsCsv = await runSolidityTestsInSubprocess(hardhatRepoPath);
+    const edrResultsCsv = runSolidityTestsInSubprocess(hardhatRepoPath);
 
     // Parse EDR CSV results
     const edrParseResult = parse(edrResultsCsv, {
@@ -765,10 +765,10 @@ interface CompareForgeRow {
 }
 
 // Compares the sum the test execution times. Shouldn't compare suite execution times as there is unpredictability due to nested parallelism in test suites.
-async function generateForgeReport(csvInputPath: string): Promise<string> {
+function generateForgeReport(csvInputPath: string): string {
   const csvContent = fs.readFileSync(csvInputPath, "utf-8");
 
-  const parseResult = parse(csvContent, {
+  const parseResult: CompareForgeRow[] = parse(csvContent, {
     columns: true,
     skip_empty_lines: true,
     skip_records_with_empty_values: true,

--- a/js/benchmark/src/solidity-tests.ts
+++ b/js/benchmark/src/solidity-tests.ts
@@ -31,6 +31,7 @@ import {
 import {
   FsAccessPermission,
   SuiteResult,
+  TestStatus,
   EdrContext,
   StandardTestKind,
   FuzzTestKind,
@@ -443,7 +444,7 @@ function getForgeTestType(kind: ForgeTestKind): string {
   } else if (kind.Standard !== undefined || kind.Unit !== undefined) {
     return "unit";
   } else {
-    throw new Error(`Unknown test type: ${kind}`);
+    throw new Error(`Unknown test type: ${JSON.stringify(kind)}`);
   }
 }
 
@@ -704,7 +705,7 @@ function assertNoFailures(results: SuiteResult[]) {
   const failed = new Set();
   for (const res of results) {
     for (const r of res.testResults) {
-      if (r.status !== "Success") {
+      if (r.status !== TestStatus.Success) {
         failed.add(`${res.id.name} ${r.name} ${r.status} reason:\n${r.reason}`);
       }
     }


### PR DESCRIPTION
Updated the eslint rules to be based off the `recommended-type-checked` preset, as that seems to be the new standard. I disabled whichever didn't make sense, and performed some automatic/manual fixes to adhere to the new lints. 

# Claude Summary
## What this does

Replaces the hand-maintained rule allowlist with the upstream **`recommended-type-checked` preset** as the baseline, so future typescript-eslint releases surface new high-value rules automatically instead of requiring a manual allowlist edit each release. The config now carries only our deltas on top of the preset.

*(Previously scoped as a manual cherry-pick of individual rules on top of #1524; pivoted to extending the preset directly. #1393 and #1524 have since merged, so this is now based directly on `main`.)*

## The `any` decision

Extending `strict-type-checked` outright produces **~2,500 violations**, ~2,237 from the `no-unsafe-*` / `no-explicit-any` family alone — this repo's test/RPC/benchmark code is pervasively `any` (dynamic JSON-RPC payloads, fixtures). So the preset is extended but that whole family is turned **off**; enforcing it would mean thousands of low-value assertions.

## Deltas kept on top of the preset

- **Reconfigured for real false-positives:**
  - `ban-ts-comment` → allow `@ts-ignore` *with description* (napi suites need it for feature-gated `op`/`mock` exports absent only in the `testNoBuild` build, where `@ts-expect-error` would report an unused directive).
  - `only-throw-error` → allow chai's `AssertionError` (its type doesn't extend `Error`).
- **Kept explicit:** the stricter/stylistic rules the preset omits, and preset rules we run with custom options.
- **Dropped as redundant:** explicit rules the preset now provides at the same severity (`await-thenable`, `no-empty-object-type`, `no-floating-promises`, `no-misused-new`, `no-namespace`, `no-this-alias`, `no-unused-expressions`, `prefer-namespace-keyword`, `restrict-plus-operands`) plus core `no-throw-literal` (superseded by the type-aware `only-throw-error`).

## Findings the preset surfaced (all fixed)

| Rule | count | Fix |
|---|---:|---|
| `no-unnecessary-type-assertion` | 23 | pure `eslint --fix` |
| `require-await` | 20 | drop `async` where no async work; napi coverage/gasReport callbacks keep `async` (generated `=> Promise<void>` signature) with an inline-disable |
| `no-misused-promises` | 3 | ethers v6 `.on()` returns a Promise — wrap the `new Promise` executor body and `void` the call |
| `no-require-imports` | 3 | genuine runtime requires — inline-disable each with reason |
| `no-base-to-string` | 1 | `JSON.stringify` the `ForgeTestKind` before interpolating |
| `no-unsafe-enum-comparison` | 1 | compare against `TestStatus.Success`, not the raw `"Success"` |
| `prefer-promise-reject-errors` | 1 | reject with an `Error` |
| `no-unused-vars` | 2 | fallout from `--fix` removing sole type-import uses |

## Notes

No consumer-facing change (dev tooling + benchmark/test tweaks) → no changeset. `pnpm run lint` clean, packages typecheck.
