### PR TITLE
build(edr_napi): move dyn-symbols to dev-dependencies (#1533)

### DIFF
--- a/crates/edr_napi/Cargo.toml
+++ b/crates/edr_napi/Cargo.toml
@@ -46,11 +46,8 @@ mimalloc = { version = "0.1.39", default-features = false, features = [
     "local_dynamic_tls",
 ] }
 # The `async` feature ensures that a tokio runtime is available.
-# `dyn-symbols` lets test binaries that keep napi code alive link outside a Node host.
-# TODO(#1533): gate `dyn-symbols` behind a non-default feature so it stays out of the published addon.
 napi = { version = "3", default-features = false, features = [
     "async",
-    "dyn-symbols",
     "error_anyhow",
     "napi8",
     "serde-json",
@@ -94,6 +91,12 @@ openssl-sys = { version = "0.9.93", features = ["vendored"] }
 [build-dependencies]
 # napi-build has no v3 release; 2.x is current for napi 3.
 napi-build = "2.3"
+
+[dev-dependencies]
+# `dyn-symbols` resolves N-API symbols at runtime so standalone test binaries
+# link without a Node host. Kept out of [dependencies] so the published addon
+# links against Node's symbols directly and doesn't ship libloading resolution.
+napi = { version = "3", default-features = false, features = ["dyn-symbols"] }
 
 [features]
 op = ["dep:edr_op"]

--- a/crates/edr_napi_core/Cargo.toml
+++ b/crates/edr_napi_core/Cargo.toml
@@ -27,13 +27,8 @@ edr_solidity_tests.workspace = true
 edr_transaction.workspace = true
 foundry-cheatcodes.workspace = true
 itertools = { version = "0.15.0", default-features = false }
-# `dyn-symbols` (an upstream default) resolves N-API symbols at runtime via
-# libloading instead of link-time externs. Without it, this crate's unit-test
-# binary fails to link: the tests keep `napi::Error` paths alive, and its Drop
-# references N-API symbols that only a Node host provides.
 napi = { version = "3", default-features = false, features = [
     "async",
-    "dyn-symbols",
     "error_anyhow",
     "napi8",
     "serde-json",
@@ -43,6 +38,13 @@ serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+
+[dev-dependencies]
+# `dyn-symbols` resolves N-API symbols at runtime so this crate's unit-test
+# binary links without a Node host: the tests keep `napi::Error` Drop paths
+# alive, which reference N-API symbols only a Node host provides. Kept out of
+# [dependencies] so nothing downstream ships libloading resolution.
+napi = { version = "3", default-features = false, features = ["dyn-symbols"] }
 
 [features]
 tracing = [


### PR DESCRIPTION
Resolves #1533. Follow-up to the [napi-rs v3 migration (#1385)](https://github.com/NomicFoundation/edr/pull/1385#discussion_r3514213369).

## Problem

`dyn-symbols` was enabled on the **normal** `[dependencies].napi` of `edr_napi` and `edr_napi_core`. It makes napi resolve N-API symbols at runtime via `libloading` instead of link-time externs.

- **Standalone test binaries** need it: they lack a Node host and keep `napi::Error` Drop paths alive, which reference N-API symbols only a Node host provides — without `dyn-symbols` they fail to link.
- **The published `.node` addon** does *not* need it: as a cdylib loaded into Node, the symbols resolve at load time. So we were shipping `libloading`-based runtime resolution in every release for no reason.

## Fix

Move `dyn-symbols` from `[dependencies]` to `[dev-dependencies]` in both crates.

With resolver v2 (this workspace), dev-dependency features are unified into the build **only when a test/example/bench target is being built**. That maps exactly onto the need:

- `cargo test` / `cargo llvm-cov --all-targets` → dev-deps active → `dyn-symbols` on → test binaries link.
- `napi build` (published addon — plain `cargo build` of the cdylib, no test targets) → dev-deps excluded → `dyn-symbols` and its `libloading` resolution stay out of the shipped `.node`.

No CI or `package.json` changes are needed — the split rides Cargo's built-in test-vs-build target distinction. This is why it's preferable to folding `dyn-symbols` into `test-mock` (which would require passing `--features test-mock` on every test invocation).

## Verification

- `cargo test -p edr_napi_core --no-run --locked` → unit-test binary links (the exact failure mode `dyn-symbols` guards).
- `cargo check -p edr_napi_core -p edr_napi --no-default-features --locked` → both crates resolve cleanly in the lib-only, no-dev-deps configuration matching the published feature set.
- `Cargo.lock` unchanged — no dependency churn.
