### PR TITLE
fix(edr_tool_cli): enable napi dyn-symbols so the standalone binary links

### DIFF
--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -294,6 +294,26 @@ jobs:
       - name: Run lint script
         run: pnpm run lint
 
+  link-standalone-bins:
+    name: Link standalone binaries
+    runs-on: ubuntu-24.04
+    needs: check-edr
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-rust
+
+      # edr_tool_cli links napi but runs without a Node host, so it needs napi's
+      # `dyn-symbols`. Nothing else in CI links it standalone: check jobs don't
+      # link, and --all-targets builds hide a missing `dyn-symbols` by unifying it
+      # in from edr_napi_core's tests. This scoped build reproduces the standalone
+      # link the scheduled block-replay workflows depend on; --release matches how
+      # they build it.
+      - name: Build standalone binaries that link napi
+        run: cargo build --locked --release --bin edr_tool_cli
+
   edr-napi-typings-file:
     name: Check that edr_napi typings file is up to date
     runs-on: ubuntu-24.04

--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -282,6 +282,7 @@ jobs:
         with:
           persist-credentials: false
 
+      - uses: ./.github/actions/setup-rust
       - uses: ./.github/actions/setup-node
 
       - name: Test workflow scripts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3840,6 +3840,7 @@ dependencies = [
  "flate2",
  "indicatif",
  "mimalloc",
+ "napi",
  "reqwest 0.13.4",
  "serde",
  "serde_json",

--- a/crates/tool/cli/Cargo.toml
+++ b/crates/tool/cli/Cargo.toml
@@ -26,6 +26,10 @@ edr_test_block_replay.workspace = true
 flate2 = "1.0.28"
 indicatif = { version = "0.18.4", features = ["rayon"] }
 mimalloc = { version = "0.1.39", default-features = false }
+# This standalone binary links napi code (via edr_napi_core's napi::Error) but
+# runs with no Node host to supply the N-API symbols. `dyn-symbols` resolves them
+# at runtime instead of as link-time externs, so the binary links.
+napi = { version = "3", default-features = false, features = ["dyn-symbols"] }
 reqwest = { version = "0.13.0", features = ["blocking"] }
 serde.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
* Added `dyn-symbols` to `edr_tool_cli` used to replay blocks. Note that this is slightly unusual use case, as it directly depends on a specific EDR crate. 
* I've added the `edr_tool_cli` to CI so that it doesn't regress. 
* I double-checked, and the current setup is fine for HH2/HH3. 
* I noticed we forgot to add setup-rust to Build and lint, so I did that as well, as it will help with caching. 



# Claude summary
## Problem

The scheduled `test-recent-optimism-block` and `test-recent-mainnet-block` workflows fail to build, dying at link:

```
rust-lld: error: undefined symbol: napi_reference_unref
rust-lld: error: undefined symbol: napi_delete_reference
  >>> ...(<napi::error::Error<S> as core::ops::drop::Drop>::drop)
```

Both run `cargo replay-block`, which builds `edr_tool_cli` as a standalone release binary.

## Root cause

#1534 moved `dyn-symbols` from `[dependencies]` to `[dev-dependencies]` in `edr_napi` and `edr_napi_core`, to keep runtime (libloading) N-API symbol resolution out of the published addon. That's correct for the addon, but **dev-dependency features don't propagate to a downstream crate's normal build.**

`edr_tool_cli` is a standalone binary (not loaded by Node) that links napi code via `edr_napi_core` — specifically `napi::Error<S>`'s `Drop`, which references `napi_reference_unref`/`napi_delete_reference`. With `dyn-symbols` now dev-only on `edr_napi_core`, `edr_tool_cli`'s release build compiles `napi-sys` in link-time-extern mode, and there's no Node host to supply those symbols → undefined-symbol link error. (The code path is never executed at runtime; the tool never builds a JS-ref-bearing error. It only needs to *link*.)

**Why PR CI didn't catch it:** the coverage/nextest jobs build `--workspace --all-targets`, which builds `edr_napi_core`'s test target and thus activates its dev-dep `dyn-symbols`; resolver v2 then unifies that into the shared `napi` build, so `edr_tool_cli` links. `cargo replay-block` builds *only* the `edr_tool_cli` bin (no `edr_napi_core` test target in the graph), so nothing pulls `dyn-symbols` and the link fails. Only the scheduled block-replay workflows build the binary standalone, so the break surfaced on the next cron run rather than on the #1534 PR.

## Fix

Enable `dyn-symbols` directly on `edr_tool_cli` rather than reverting #1534:

```toml
napi = { version = "3", default-features = false, features = ["dyn-symbols"] }
```

This is scoped to this binary's build and leaves the published addon untouched — the addon publish path (`napi build`, scoped to `-p edr_napi`) doesn't include `edr_tool_cli` in its graph, so the goal of #1534 (addon links Node's symbols directly, no libloading) is preserved.

## Testing

- Reproduced the exact CI failure by building `cargo build --locked --release --bin edr_tool_cli` on current `main` — identical undefined-symbol error.
- With this change, the binary links cleanly (`Finished release`).
- Confirmed via `nm -D` that the isolated `edr_napi` cdylib still builds in extern mode (64 undefined `napi_*` symbols, no libloading machinery) — i.e. the artifact HH2/HH3 consume is unchanged.
- Swept the workspace: `edr_tool_cli` is the only napi-linking standalone binary (`edr_tool_solidity` and `edr_tool_op_chain_config_generator` don't link napi), so this one change covers both scheduled workflows and all four `edr_tool_cli` cargo aliases.

## Prevention

Added a dedicated `link-standalone-bins` CI job that links the binary in isolation (`cargo build --locked --release --bin edr_tool_cli`). This is deliberately a scoped `build`, not part of a `--workspace --all-targets` invocation: `cargo check` never links (so it can't catch a missing N-API symbol), and `--all-targets` builds unify `dyn-symbols` in from `edr_napi_core`'s test target, masking its absence for the standalone binary. The scoped build reproduces the standalone link the scheduled block-replay workflows depend on, so this regression class now fails on PRs instead of on the next cron run. The job uses `setup-rust` for cross-run caching and `--release` to match how those workflows build it.

Also adds `setup-rust` to the pre-existing `build-and-lint` job (a separate commit): it compiles the napi addon via `pnpm run build:dev` but had only ever used `setup-node`, so its Rust build ran cold with no rust-cache.

## Note

The `[dev-dependencies]` approach chosen in #1534 keeps the addon clean as long as it's built scoped, which the `napi build` publish path does. A whole-workspace `cargo build --workspace`/`--all-targets` would unify `dyn-symbols` back into the shipped `.so` — not a concern for the current publish path, noted only as a property of the dev-dependency approach.
