### PR TITLE
perf: capture only the top of the stack for non-verbose raw traces

### DIFF
--- a/crates/edr_napi/test/provider.ts
+++ b/crates/edr_napi/test/provider.ts
@@ -194,6 +194,95 @@ describe("Provider", () => {
       assert.deepEqual(steps[3].stack, [1n, 2n, 3n]);
     });
 
+    it("should include the top of the stack across nested call frames", async function () {
+      const provider = await createGenericProvider(
+        context,
+        tracingProviderOverrides
+      );
+
+      // Deploy a contract with runtime code:
+      // PUSH1 0x0a
+      // PUSH1 0x0b
+      // STOP
+      await provider.handleRequest(
+        JSON.stringify({
+          id: 1,
+          jsonrpc: "2.0",
+          method: "eth_sendTransaction",
+          params: [
+            {
+              from: "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+              // PUSH5 0x600a600b00
+              // PUSH0
+              // MSTORE
+              // PUSH1 5 (length)
+              // PUSH1 27 (offset)
+              // RETURN
+              data: "0x64600a600b005f526005601bf3",
+              gas: "0x" + 1_000_000n.toString(16),
+            },
+          ],
+        })
+      );
+
+      const calleeAddress = 0x5fbdb2315678afecb367f032d93f642f64180aa3n;
+
+      const responseObject = await provider.handleRequest(
+        JSON.stringify({
+          id: 2,
+          jsonrpc: "2.0",
+          method: "eth_sendTransaction",
+          params: [
+            {
+              from: "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+              // PUSH1 0 (x5: return length & offset, args length & offset, value)
+              // PUSH20 <callee address>
+              // PUSH2 0xffff (gas)
+              // CALL
+              // PUSH1 0x2a
+              // STOP
+              data: "0x60006000600060006000735fbdb2315678afecb367f032d93f642f64180aa361fffff1602a00",
+              gas: "0x" + 1_000_000n.toString(16),
+            },
+          ],
+        })
+      );
+
+      const rawTraces = responseObject.traces();
+      assert.lengthOf(rawTraces, 1);
+
+      const trace = rawTraces[0];
+      const steps = collectSteps(trace);
+
+      assert.lengthOf(steps, 13);
+      assert.deepEqual(
+        steps.map((step) => step.depth),
+        [0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0]
+      );
+
+      assert.deepEqual(
+        steps.map((step) => step.stack),
+        [
+          // Caller frame: PUSH1 0 (x5), PUSH20, PUSH2, CALL
+          [],
+          [0n],
+          [0n],
+          [0n],
+          [0n],
+          [0n],
+          [calleeAddress],
+          [0xffffn],
+          // Callee frame: PUSH1 0x0a, PUSH1 0x0b, STOP
+          [],
+          [0x0an],
+          [0x0bn],
+          // Caller frame: PUSH1 0x2a sees the CALL success flag, then STOP
+          [1n],
+          [0x2an],
+        ]
+      );
+    });
+
     it("should not include memory by default", async function () {
       const provider = await createGenericProvider(
         context,

--- a/crates/edr_provider/src/observability.rs
+++ b/crates/edr_provider/src/observability.rs
@@ -24,7 +24,7 @@ use edr_state_api::State;
 use foundry_evm_traces::CallTraceArena;
 use parking_lot::RwLock;
 use revm_inspector::JournalExt;
-use revm_inspectors::tracing::{StackSnapshotType, TracingInspector, TracingInspectorConfig};
+use revm_inspectors::tracing::{TracingInspector, TracingInspectorConfig};
 
 use crate::{
     console_log::ConsoleLogCollector,
@@ -163,10 +163,17 @@ impl EvmObserver {
         let tracing_config = if config.verbose_raw_tracing {
             TracingInspectorConfig::all()
         } else {
-            TracingInspectorConfig::default_parity()
-                .set_steps(true)
-                .set_stack_snapshots(StackSnapshotType::Full)
+            TracingInspectorConfig::default_parity().set_steps(true)
         };
+
+        // Released `revm_inspectors` versions can only record full stack
+        // snapshots, which is prohibitively expensive, so the top of the
+        // stack that non-verbose raw traces expose per step is captured
+        // separately. Capture is skipped when traces can't be included in
+        // responses: the stack-trace and internal-OOG paths read pcs and
+        // statuses, never step stacks.
+        let record_top_of_stack =
+            !config.verbose_raw_tracing && config.include_call_traces != IncludeTraces::None;
 
         Self {
             bytecode_collector: ExecutedBytecodeCollector::default(),
@@ -183,6 +190,7 @@ impl EvmObserver {
             tracing_inspector: SolidityTracingInspector::new(
                 TracingInspector::new(tracing_config),
                 config.contract_decoder,
+                record_top_of_stack,
             ),
         }
     }

--- a/crates/edr_solidity/src/tracing.rs
+++ b/crates/edr_solidity/src/tracing.rs
@@ -7,7 +7,10 @@ use edr_chain_spec_evm::{ContextTrait, Inspector};
 use edr_primitives::{Address, Bytes, HashMap, HashSet, U256};
 use parking_lot::RwLock;
 use revm_inspector::JournalExt;
-use revm_inspectors::tracing::{CallTraceArena, TracingInspector};
+use revm_inspectors::tracing::{
+    types::{CallTraceNode, TraceMemberOrder},
+    CallTraceArena, TracingInspector,
+};
 use revm_interpreter::CallOutcome;
 
 use crate::contract_decoder::ContractDecoder;
@@ -17,12 +20,36 @@ use crate::contract_decoder::ContractDecoder;
 pub struct SolidityTracingInspector {
     decoder: Arc<RwLock<ContractDecoder>>,
     inspector: TracingInspector,
+    record_top_of_stack: bool,
+    stack_tops: Vec<Option<U256>>,
 }
 
 impl SolidityTracingInspector {
     /// Constructs a new [`SolidityTracingInspector`] instance.
-    pub fn new(inspector: TracingInspector, decoder: Arc<RwLock<ContractDecoder>>) -> Self {
-        Self { decoder, inspector }
+    ///
+    /// When `record_top_of_stack` is enabled, the top-of-stack value at the
+    /// start of each step is captured and written into the `stack` field of
+    /// the collected traces' steps, as a cheap alternative to
+    /// [`revm_inspectors::tracing::StackSnapshotType::Full`], which clones the
+    /// entire stack on every step.
+    pub fn new(
+        inspector: TracingInspector,
+        decoder: Arc<RwLock<ContractDecoder>>,
+        record_top_of_stack: bool,
+    ) -> Self {
+        debug_assert!(
+            !record_top_of_stack
+                || (inspector.config().record_steps
+                    && inspector.config().record_opcodes_filter.is_none()),
+            "captured stack tops are matched to steps by position, so every step must be recorded"
+        );
+
+        Self {
+            decoder,
+            inspector,
+            record_top_of_stack,
+            stack_tops: Vec::new(),
+        }
     }
 
     /// Collects the [`TracingInspector`]'s traces and ABI decodes them.
@@ -32,6 +59,8 @@ impl SolidityTracingInspector {
         precompile_addresses: &HashSet<Address>,
     ) -> Result<CallTraceArena, serde_json::Error> {
         let mut arena = self.inspector.into_traces();
+
+        write_stack_tops(&mut arena, &self.stack_tops);
 
         let mut decoder = self.decoder.write();
         decoder.populate_call_trace_arena(
@@ -51,9 +80,12 @@ impl SolidityTracingInspector {
         precompile_addresses: &HashSet<Address>,
     ) -> Result<CallTraceArena, serde_json::Error> {
         let mut arena = std::mem::take(self.inspector.traces_mut());
+        let stack_tops = std::mem::take(&mut self.stack_tops);
 
         // Reset the inspector
         self.inspector.fuse();
+
+        write_stack_tops(&mut arena, &stack_tops);
 
         let mut decoder = self.decoder.write();
         decoder.populate_call_trace_arena(
@@ -63,6 +95,65 @@ impl SolidityTracingInspector {
         )?;
 
         Ok(arena)
+    }
+}
+
+/// Writes captured per-step top-of-stack values into the arena's steps,
+/// consuming them in execution order: each node's `ordering`, descending
+/// depth-first into child calls.
+fn write_stack_tops(arena: &mut CallTraceArena, stack_tops: &[Option<U256>]) {
+    if stack_tops.is_empty() {
+        return;
+    }
+
+    let mut tops = stack_tops.iter();
+    write_node_stack_tops(arena.nodes_mut(), 0, &mut tops);
+    debug_assert_eq!(
+        tops.len(),
+        0,
+        "captured more stack tops than recorded steps"
+    );
+}
+
+fn write_node_stack_tops(
+    nodes: &mut [CallTraceNode],
+    node_idx: usize,
+    tops: &mut std::slice::Iter<'_, Option<U256>>,
+) {
+    let ordering = nodes
+        .get(node_idx)
+        .expect("node indices come from the arena's own children lists")
+        .ordering
+        .clone();
+
+    for entry in ordering {
+        match entry {
+            TraceMemberOrder::Step(step_idx) => {
+                let Some(top) = tops.next() else {
+                    debug_assert!(false, "recorded more steps than captured stack tops");
+                    return;
+                };
+
+                let step = nodes
+                    .get_mut(node_idx)
+                    .expect("node indices come from the arena's own children lists")
+                    .trace
+                    .steps
+                    .get_mut(step_idx)
+                    .expect("step indices in `ordering` point into this node's steps");
+                step.stack = top.map(|top| Box::from([top]));
+            }
+            TraceMemberOrder::Call(child_idx) => {
+                let child_node_idx = *nodes
+                    .get(node_idx)
+                    .expect("node indices come from the arena's own children lists")
+                    .children
+                    .get(child_idx)
+                    .expect("call indices in `ordering` point into this node's children");
+                write_node_stack_tops(nodes, child_node_idx, tops);
+            }
+            TraceMemberOrder::Log(_) => {}
+        }
     }
 }
 
@@ -80,6 +171,9 @@ impl<ContextT: ContextTrait<Journal: JournalExt>> Inspector<ContextT> for Solidi
         interp: &mut revm_interpreter::Interpreter<revm_interpreter::interpreter::EthInterpreter>,
         context: &mut ContextT,
     ) {
+        if self.record_top_of_stack {
+            self.stack_tops.push(interp.stack.data().last().copied());
+        }
         self.inspector.step(interp, context);
     }
 
@@ -142,5 +236,104 @@ impl<ContextT: ContextTrait<Journal: JournalExt>> Inspector<ContextT> for Solidi
 
     fn selfdestruct(&mut self, contract: Address, target: Address, value: U256) {
         Inspector::<ContextT>::selfdestruct(&mut self.inspector, contract, target, value);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use edr_primitives::bytecode::opcode::OpCode;
+    use revm_inspectors::tracing::types::{CallTraceStep, TraceMemberOrder};
+
+    use super::*;
+
+    fn step() -> CallTraceStep {
+        CallTraceStep {
+            pc: 0,
+            op: OpCode::STOP,
+            stack: None,
+            push_stack: None,
+            memory: None,
+            returndata: Bytes::new(),
+            gas_remaining: 0,
+            gas_refund_counter: 0,
+            gas_used: 0,
+            gas_cost: 0,
+            storage_change: None,
+            status: None,
+            immediate_bytes: None,
+            decoded: None,
+        }
+    }
+
+    /// Root with three steps interleaved with a log and a child call:
+    /// execution order is root step 0, root step 1, child steps 0-1, root
+    /// step 2.
+    fn nested_arena() -> CallTraceArena {
+        let mut arena = CallTraceArena::default();
+
+        let root = &mut arena.nodes_mut()[0];
+        root.children = vec![1];
+        root.trace.steps = vec![step(), step(), step()];
+        root.ordering = vec![
+            TraceMemberOrder::Step(0),
+            TraceMemberOrder::Log(0),
+            TraceMemberOrder::Step(1),
+            TraceMemberOrder::Call(0),
+            TraceMemberOrder::Step(2),
+        ];
+
+        let mut child = CallTraceNode {
+            parent: Some(0),
+            idx: 1,
+            ..CallTraceNode::default()
+        };
+        child.trace.steps = vec![step(), step()];
+        child.ordering = vec![TraceMemberOrder::Step(0), TraceMemberOrder::Step(1)];
+        arena.nodes_mut().push(child);
+
+        arena
+    }
+
+    fn stack_of(arena: &CallTraceArena, node_idx: usize, step_idx: usize) -> Option<&[U256]> {
+        arena.nodes()[node_idx].trace.steps[step_idx]
+            .stack
+            .as_deref()
+    }
+
+    #[test]
+    fn write_stack_tops_follows_execution_order_across_frames() {
+        let mut arena = nested_arena();
+
+        write_stack_tops(
+            &mut arena,
+            &[
+                None,
+                Some(U256::from(1)),
+                Some(U256::from(10)),
+                Some(U256::from(11)),
+                Some(U256::from(2)),
+            ],
+        );
+
+        assert_eq!(stack_of(&arena, 0, 0), None);
+        assert_eq!(stack_of(&arena, 0, 1), Some(&[U256::from(1)][..]));
+        assert_eq!(stack_of(&arena, 0, 2), Some(&[U256::from(2)][..]));
+        assert_eq!(stack_of(&arena, 1, 0), Some(&[U256::from(10)][..]));
+        assert_eq!(stack_of(&arena, 1, 1), Some(&[U256::from(11)][..]));
+    }
+
+    #[test]
+    fn write_stack_tops_preserves_verbose_mode_full_stacks() {
+        let mut arena = nested_arena();
+        let full_stack = [U256::from(1), U256::from(2)];
+        arena.nodes_mut()[0].trace.steps[0].stack = Some(Box::from(full_stack));
+
+        write_stack_tops(&mut arena, &[]);
+
+        assert_eq!(stack_of(&arena, 0, 0), Some(&full_stack[..]));
+        assert_eq!(stack_of(&arena, 0, 1), None);
+        assert_eq!(stack_of(&arena, 0, 2), None);
+        assert_eq!(stack_of(&arena, 1, 0), None);
+        assert_eq!(stack_of(&arena, 1, 1), None);
     }
 }

--- a/crates/edr_solidity/src/tracing.rs
+++ b/crates/edr_solidity/src/tracing.rs
@@ -120,6 +120,8 @@ fn write_node_stack_tops(
     node_idx: usize,
     tops: &mut std::slice::Iter<'_, Option<U256>>,
 ) {
+    // Cloned so that `nodes` can be mutably borrowed in the loop; the entries
+    // are `Copy` and this only runs once per node at collection time.
     let ordering = nodes
         .get(node_idx)
         .expect("node indices come from the arena's own children lists")


### PR DESCRIPTION
On top of #1301 (`feat/tracing-back-compat`) to resolve the benchmark regression of up to 2.45x reported there.

PR filed on paradigmxyz/revm-inspectors#468 to add a `StackSnapshotType::Top`. We will need to upgrade to revm 41 when it does merge. 

# Claude summary

## Problem

To expose the top of the stack through the non-verbose `Response::traces()` output, #1301 sets `StackSnapshotType::Full`, which clones the entire EVM stack on every step of every transaction. The cost is paid unconditionally — even when the arena is discarded (`includeCallTraces` defaults to `IncludeTraces::None`, the Hardhat 3 default). The consumer only ever reads `step.stack.last()` in non-verbose mode, and no released `revm-inspectors` (0.33–0.41) offers a top-of-stack-only snapshot type.

## Approach

Record exactly what the output needs, the way the pre-unification `TraceCollector` did (`Stack::Top`):

- `SolidityTracingInspector::step` captures `interp.stack.last().copied()` — one `U256` copy per step into a flat vector, no per-step allocation.
- At `collect()`/`take()` time, the captured values are written into the arena's steps as single-element `stack` snapshots, following each node's `ordering` depth-first (i.e. execution order, which matches capture order one-to-one).
- The napi conversion, `Response` marshalling, and the JS-visible `TracingStep.stack` semantics are unchanged: non-verbose still reads `step.stack.last()`.

Resulting cost per configuration:

| Configuration | Before | After |
|---|---|---|
| `includeCallTraces: None` (Hardhat 3 default) | full stack clone per step | zero — identical to `main` |
| `includeCallTraces: All`, non-verbose (Hardhat 2) | full stack clone per step | one `U256` copy per step (the historical baseline) |
| verbose | full stack clone per step (`all()`) | unchanged |

## Anticipated questions

- **Why not upstream a top-of-stack `StackSnapshotType`?** Now filed as paradigmxyz/revm-inspectors#468 (`StackSnapshotType::Top`, drop-in for the mechanism here: same `step.stack` field, same pre-op timing, `.last()` consumers unchanged). If accepted, it lands on the revm-41 line, so we can only adopt it after our next revm major bump — at which point the capture, `write_stack_tops`, and the ordering DFS in this PR get deleted in favor of `set_stack_snapshots(StackSnapshotType::Top)`, with the tests kept as the contract. Until then, this PR is the fix that works on revm 38 today, and it stands alone if the upstream PR stalls.
- **Why gate capture on `includeCallTraces != None`?** Arenas are still recorded in that mode (for stack-trace generation and internal-OOG detection), but nothing on those paths reads `step.stack`, so capturing tops would be pure waste on the default path.
- **The `.expect`s in the ordering DFS**: the indices come from the arena's own `ordering`/`children` invariants; a violation means a corrupt arena, where a loud failure beats silently emitting misaligned traces. The two `debug_assert`s guard the capture/step count alignment in both directions; in release builds a mismatch degrades to steps without a stack (rendered as an empty stack), never wrong values.

## Testing

- New unit tests for the ordering DFS: execution-order assignment across interleaved steps/logs/child calls, and preservation of already-recorded (verbose) snapshots when no tops were captured.
- New `edr_napi` test with a nested `CALL` across two contracts, asserting per-step tops in both frames — including the callee frame starting empty and the caller's post-`CALL` step seeing the success flag. This fails loudly on any cross-frame misalignment or off-by-one.
- The existing #1301 contract tests ("top of the stack by default", verbose full stacks, memory, `debug_traceTransaction`/`debug_traceCall`) pass unchanged; `debug_traceTransaction` structLogs are unaffected as they come from the separate `DebugInspector`.
- **The `edr-benchmark` job fails on this PR, and that is expected.** The base branch's hardhat 2.28.6 patch enables `includeCallTraces: All` at provider creation, and the JS scenario benchmark instantiates its provider through that patched hardhat — so benchmarks on this stack now measure the traces-*on* configuration against a stored traces-*off* baseline. The +14–28% alert is the cost of `All` with top-of-stack capture (one `U256` copy per step plus single-element stack snapshots at collect time), i.e. the historical HH2 baseline — down from up to 2.45x with full-stack snapshots, which is the regression this PR fixes. The alert is accepted deliberately. #1541 (stacked on this PR) makes the remaining cost lazy and lets Hardhat 2 only enable trace collection while the vm trace bridge has listeners, which returns the benchmark to the `None` path. (The fluctuating single-suite alerts in the Solidity test runner job are unrelated noise: that path doesn't go through the hardhat provider.)

