### PR TITLE
perf: make raw trace collection demand-driven

### DIFF
--- a/crates/edr_generic/tests/integration/issues/issue_570.rs
+++ b/crates/edr_generic/tests/integration/issues/issue_570.rs
@@ -92,7 +92,7 @@ async fn issue_570_env_var() -> anyhow::Result<()> {
         MethodInvocation::DebugTraceTransaction(transaction_hash, None),
     ))?;
 
-    assert!(!result.call_trace_arenas.is_empty());
+    assert!(!result.call_traces.is_empty());
 
     Ok(())
 }

--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -80,6 +80,16 @@ export declare class Provider {
    * `false` to disable this.
    */
   setVerboseTracing(verboseTracing: boolean): Promise<void>
+  /**
+   * Sets which transactions' call traces are included in responses'
+   * `traces()`, for requests handled from this point on.
+   *
+   * Traces that are not included are never collected, so consumers that
+   * only read traces conditionally (e.g. when VM event listeners are
+   * attached) can avoid the collection cost by keeping this at
+   * `IncludeTraces.None` while there are no readers.
+   */
+  setIncludeCallTraces(includeCallTraces: IncludeTraces): Promise<void>
 }
 
 export declare class ProviderFactory {

--- a/crates/edr_napi/src/mock.rs
+++ b/crates/edr_napi/src/mock.rs
@@ -38,4 +38,6 @@ impl SyncProvider for MockProvider {
     }
 
     fn set_verbose_tracing(&self, _enabled: bool) {}
+
+    fn set_include_call_traces(&self, _include_call_traces: edr_solidity::config::IncludeTraces) {}
 }

--- a/crates/edr_napi/src/mock.rs
+++ b/crates/edr_napi/src/mock.rs
@@ -25,7 +25,7 @@ impl SyncProvider for MockProvider {
             .map(|data| edr_napi_core::spec::Response {
                 data,
                 stack_trace_result: None,
-                call_trace_arenas: Vec::new(),
+                call_traces: Vec::new(),
                 verbose: false,
             })
             .map_err(|error| napi::Error::new(napi::Status::GenericFailure, error.to_string()))

--- a/crates/edr_napi/src/provider.rs
+++ b/crates/edr_napi/src/provider.rs
@@ -18,7 +18,7 @@ pub use self::factory::ProviderFactory;
 use self::response::Response;
 use crate::{
     async_deallocator::AsyncDeallocatorSender, call_override::CallOverrideCallback,
-    contract_decoder::ContractDecoder,
+    contract_decoder::ContractDecoder, solidity_tests::config::IncludeTraces,
 };
 
 /// A JSON-RPC provider for Ethereum.
@@ -183,6 +183,28 @@ impl Provider {
         self.runtime
             .spawn_blocking(move || {
                 provider.set_verbose_tracing(verbose_tracing);
+            })
+            .await
+            .map_err(|error| napi::Error::new(Status::GenericFailure, error.to_string()))
+    }
+
+    /// Sets which transactions' call traces are included in responses'
+    /// `traces()`, for requests handled from this point on.
+    ///
+    /// Traces that are not included are never collected, so consumers that
+    /// only read traces conditionally (e.g. when VM event listeners are
+    /// attached) can avoid the collection cost by keeping this at
+    /// `IncludeTraces.None` while there are no readers.
+    #[napi(catch_unwind)]
+    pub async fn set_include_call_traces(
+        &self,
+        include_call_traces: IncludeTraces,
+    ) -> napi::Result<()> {
+        let provider = self.provider.clone();
+
+        self.runtime
+            .spawn_blocking(move || {
+                provider.set_include_call_traces(include_call_traces.into());
             })
             .await
             .map_err(|error| napi::Error::new(Status::GenericFailure, error.to_string()))

--- a/crates/edr_napi/src/provider/response.rs
+++ b/crates/edr_napi/src/provider/response.rs
@@ -60,9 +60,9 @@ impl Response {
     #[napi(catch_unwind)]
     pub fn call_traces(&self) -> Vec<CallTrace> {
         self.inner
-            .call_trace_arenas
+            .call_traces
             .iter()
-            .map(|call_trace_arena| CallTrace::from_arena_node(call_trace_arena, 0))
+            .map(|call_traces| CallTrace::from_arena_node(&call_traces.arena, 0))
             .collect()
     }
 
@@ -72,9 +72,9 @@ impl Response {
     #[napi(catch_unwind)]
     pub fn traces(&self) -> Vec<Vec<Either3<TracingMessage, TracingStep, TracingMessageResult>>> {
         self.inner
-            .call_trace_arenas
+            .call_traces
             .iter()
-            .map(|arena| raw_trace_from_call_trace_arena(arena, self.inner.verbose))
+            .map(|call_traces| raw_trace_from_call_trace_arena(call_traces, self.inner.verbose))
             .collect()
     }
 }

--- a/crates/edr_napi/src/trace.rs
+++ b/crates/edr_napi/src/trace.rs
@@ -7,8 +7,8 @@
 
 use edr_chain_spec::EvmHaltReason;
 use edr_chain_spec_evm::interpreter::{return_revert, InstructionResult, SuccessOrHalt};
-use edr_primitives::{bytecode::opcode::OpCode, Address};
-use edr_solidity::nested_trace::is_calllike_op;
+use edr_primitives::{bytecode::opcode::OpCode, Address, U256};
+use edr_solidity::{nested_trace::is_calllike_op, tracing::CallTraces};
 use edr_solidity_tests::traces::{CallKind, CallTrace, CallTraceArena, CallTraceNode};
 use napi::bindgen_prelude::{BigInt, Either, Either3, Uint8Array};
 use napi_derive::napi;
@@ -121,15 +121,34 @@ pub(crate) fn u256_to_bigint(v: &edr_primitives::U256) -> BigInt {
 
 type RawTrace = Either3<TracingMessage, TracingStep, TracingMessageResult>;
 
-/// Converts a `CallTraceArena` into a flat vector of `RawTrace` messages,
+/// Converts collected call traces into a flat vector of `RawTrace` messages,
 /// following the order that `EthereumJS` would have produced.
+///
+/// Captured stack tops are consumed in step order during the traversal; they
+/// are only materialized as JS values here, so transactions whose traces are
+/// never read don't pay for per-step stack snapshots.
 pub(crate) fn raw_trace_from_call_trace_arena(
-    arena: &CallTraceArena,
+    call_traces: &CallTraces,
     verbose: bool,
 ) -> Vec<RawTrace> {
+    let CallTraces { arena, stack_tops } = call_traces;
+
     let mut result = Vec::new();
     if let Some(node) = arena.nodes().first() {
-        convert_node(arena, node, false, node.trace.caller, verbose, &mut result);
+        let mut tops = (!stack_tops.is_empty()).then(|| stack_tops.iter());
+        convert_node(
+            arena,
+            node,
+            false,
+            node.trace.caller,
+            verbose,
+            &mut tops,
+            &mut result,
+        );
+        debug_assert!(
+            tops.as_ref().is_none_or(|tops| tops.len() == 0),
+            "captured more stack tops than steps in the arena"
+        );
     }
     result
 }
@@ -142,6 +161,7 @@ fn convert_node(
     mut is_static_call: bool,
     original_caller: Address,
     verbose: bool,
+    tops: &mut Option<std::slice::Iter<'_, Option<U256>>>,
     output: &mut Vec<Either3<TracingMessage, TracingStep, TracingMessageResult>>,
 ) {
     let trace = &node.trace;
@@ -181,6 +201,10 @@ fn convert_node(
         // Historically, Hardhat 2 didn't record the first step if it was a STOP opcode,
         // so we skip it to maintain compatibility with existing traces.
         steps.next();
+        // The skipped step still captured a stack top.
+        if let Some(tops) = tops.as_mut() {
+            tops.next();
+        }
     }
 
     let mut child_index = 0;
@@ -194,18 +218,32 @@ fn convert_node(
             opcode: TracingOpcode {
                 name: OpCode::name_by_op(step.op.get()).to_string(),
             },
-            stack: if verbose {
-                // Full stack
-                step.stack
-                    .as_ref()
-                    .map(|s| s.iter().map(u256_to_bigint).collect())
-                    .unwrap_or_default()
-            } else {
-                // Top of stack only
-                step.stack
-                    .as_ref()
-                    .and_then(|s| s.last().map(|v| vec![u256_to_bigint(v)]))
-                    .unwrap_or_default()
+            stack: match tops.as_mut() {
+                // Tops are only captured in configurations where the arena
+                // records no stack snapshots, so they take precedence.
+                Some(tops) => {
+                    let top = tops.next().unwrap_or_else(|| {
+                        debug_assert!(false, "more steps in the arena than captured stack tops");
+                        &None
+                    });
+                    top.as_ref()
+                        .map(|top| vec![u256_to_bigint(top)])
+                        .unwrap_or_default()
+                }
+                None if verbose => {
+                    // Full stack
+                    step.stack
+                        .as_ref()
+                        .map(|s| s.iter().map(u256_to_bigint).collect())
+                        .unwrap_or_default()
+                }
+                None => {
+                    // Top of stack only
+                    step.stack
+                        .as_ref()
+                        .and_then(|s| s.last().map(|v| vec![u256_to_bigint(v)]))
+                        .unwrap_or_default()
+                }
             },
             memory: step.memory.as_ref().and_then(|m| {
                 if verbose {
@@ -239,6 +277,7 @@ fn convert_node(
                             _ => child_node.trace.caller,
                         },
                         verbose,
+                        tops,
                         output,
                     );
                 }
@@ -294,4 +333,131 @@ fn should_skip_call(trace: &CallTrace) -> bool {
         && trace
             .status
             .is_some_and(|status| matches!(status, return_revert!()))
+}
+
+#[cfg(test)]
+mod tests {
+    use edr_primitives::Bytes;
+    use edr_solidity_tests::traces::CallTraceStep;
+
+    use super::*;
+
+    fn step(op: OpCode) -> CallTraceStep {
+        CallTraceStep {
+            pc: 0,
+            op,
+            stack: None,
+            push_stack: None,
+            memory: None,
+            returndata: Bytes::new(),
+            gas_remaining: 0,
+            gas_refund_counter: 0,
+            gas_used: 0,
+            gas_cost: 0,
+            storage_change: None,
+            status: None,
+            immediate_bytes: None,
+            decoded: None,
+        }
+    }
+
+    /// Root with three steps, the second of which calls into a child frame
+    /// with two steps: execution order is root step 0, root step 1 (`CALL`),
+    /// child steps 0-1, root step 2.
+    fn nested_arena() -> CallTraceArena {
+        let mut arena = CallTraceArena::default();
+
+        let root = &mut arena.nodes_mut()[0];
+        root.children = vec![1];
+        root.trace.steps = vec![step(OpCode::PUSH1), step(OpCode::CALL), step(OpCode::PUSH1)];
+
+        let mut child = CallTraceNode {
+            parent: Some(0),
+            idx: 1,
+            ..CallTraceNode::default()
+        };
+        child.trace.depth = 1;
+        child.trace.steps = vec![step(OpCode::PUSH1), step(OpCode::PUSH1)];
+        arena.nodes_mut().push(child);
+
+        arena
+    }
+
+    /// Extracts the emitted steps' stacks as `u64` values.
+    fn emitted_stacks(output: &[RawTrace]) -> Vec<Vec<u64>> {
+        output
+            .iter()
+            .filter_map(|item| match item {
+                Either3::B(step) => Some(
+                    step.stack
+                        .iter()
+                        .map(|value| {
+                            assert!(!value.sign_bit);
+                            value.words[0]
+                        })
+                        .collect(),
+                ),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn tops(values: &[Option<u64>]) -> Vec<Option<U256>> {
+        values.iter().map(|top| top.map(U256::from)).collect()
+    }
+
+    #[test]
+    fn stack_tops_follow_execution_order_across_frames() {
+        let call_traces = CallTraces {
+            arena: nested_arena(),
+            stack_tops: tops(&[Some(10), Some(11), None, Some(20), Some(12)]),
+        };
+
+        let output = raw_trace_from_call_trace_arena(&call_traces, false);
+
+        assert_eq!(
+            emitted_stacks(&output),
+            [
+                vec![10], // root step 0
+                vec![11], // root step 1 (CALL)
+                vec![],   // child step 0: empty stack
+                vec![20], // child step 1
+                vec![12], // root step 2
+            ]
+        );
+    }
+
+    #[test]
+    fn skipped_leading_stop_step_still_consumes_a_stack_top() {
+        let mut arena = CallTraceArena::default();
+        arena.nodes_mut()[0].trace.steps = vec![step(OpCode::STOP), step(OpCode::PUSH1)];
+
+        let call_traces = CallTraces {
+            arena,
+            stack_tops: tops(&[Some(1), Some(2)]),
+        };
+
+        let output = raw_trace_from_call_trace_arena(&call_traces, false);
+
+        assert_eq!(emitted_stacks(&output), [vec![2]]);
+    }
+
+    #[test]
+    fn without_captured_tops_recorded_stacks_are_used() {
+        let mut arena = CallTraceArena::default();
+        let recorded = [U256::from(1), U256::from(2)];
+        arena.nodes_mut()[0].trace.steps = vec![step(OpCode::PUSH1)];
+        arena.nodes_mut()[0].trace.steps[0].stack = Some(Box::from(recorded));
+
+        let call_traces = CallTraces {
+            arena,
+            stack_tops: Vec::new(),
+        };
+
+        let verbose = raw_trace_from_call_trace_arena(&call_traces, true);
+        assert_eq!(emitted_stacks(&verbose), [vec![1, 2]]);
+
+        let non_verbose = raw_trace_from_call_trace_arena(&call_traces, false);
+        assert_eq!(emitted_stacks(&non_verbose), [vec![2]]);
+    }
 }

--- a/crates/edr_napi/test/provider.ts
+++ b/crates/edr_napi/test/provider.ts
@@ -283,6 +283,48 @@ describe("Provider", () => {
       );
     });
 
+    it("should follow setIncludeCallTraces toggles for subsequent requests", async function () {
+      const provider = await createGenericProvider(context, {
+        genesisState: fundedGenesisState(),
+        observability: {},
+      });
+
+      const sendTransaction = (id: number) =>
+        provider.handleRequest(
+          JSON.stringify({
+            id,
+            jsonrpc: "2.0",
+            method: "eth_sendTransaction",
+            params: [
+              {
+                from: "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                // PUSH1 1
+                // STOP
+                data: "0x600100",
+                gas: "0x" + 1_000_000n.toString(16),
+              },
+            ],
+          })
+        );
+
+      const withDefault = await sendTransaction(1);
+      assert.lengthOf(withDefault.traces(), 0);
+
+      await provider.setIncludeCallTraces(IncludeTraces.All);
+      const withTraces = await sendTransaction(2);
+      const rawTraces = withTraces.traces();
+      assert.lengthOf(rawTraces, 1);
+      const steps = collectSteps(rawTraces[0]);
+      assert.deepEqual(
+        steps.map((step) => step.stack),
+        [[], [1n]]
+      );
+
+      await provider.setIncludeCallTraces(IncludeTraces.None);
+      const withDisabled = await sendTransaction(3);
+      assert.lengthOf(withDisabled.traces(), 0);
+    });
+
     it("should not include memory by default", async function () {
       const provider = await createGenericProvider(
         context,

--- a/crates/edr_napi_core/src/logger.rs
+++ b/crates/edr_napi_core/src/logger.rs
@@ -266,7 +266,7 @@ impl<ChainSpecT: ProviderSpec<TimerT>, TimerT: Clone + TimeSinceEpoch>
     ) -> Result<(), LoggerError> {
         let CallResultWithMetadata {
             address_to_executed_code,
-            call_trace_arena,
+            call_traces,
             console_log_inputs,
             execution_result,
             precompile_addresses,
@@ -277,7 +277,7 @@ impl<ChainSpecT: ProviderSpec<TimerT>, TimerT: Clone + TimeSinceEpoch>
         let contract_decoder = self.contract_decoder.clone();
         self.indented(|logger| {
             logger.log_contract_and_function_name::<true>(
-                call_trace_arena,
+                &call_traces.arena,
                 address_to_executed_code,
                 precompile_addresses,
             );
@@ -297,7 +297,7 @@ impl<ChainSpecT: ProviderSpec<TimerT>, TimerT: Clone + TimeSinceEpoch>
                     execution_result,
                     None,
                     address_to_executed_code,
-                    call_trace_arena,
+                    &call_traces.arena,
                     contract_decoder.as_ref(),
                 )
             {
@@ -315,7 +315,7 @@ impl<ChainSpecT: ProviderSpec<TimerT>, TimerT: Clone + TimeSinceEpoch>
     ) -> Result<(), LoggerError> {
         let EstimateGasFailure {
             address_to_executed_code,
-            call_trace_arena,
+            call_traces,
             encoded_console_logs,
             precompile_addresses,
             transaction_failure,
@@ -325,7 +325,7 @@ impl<ChainSpecT: ProviderSpec<TimerT>, TimerT: Clone + TimeSinceEpoch>
 
         self.indented(|logger| {
             logger.log_contract_and_function_name::<true>(
-                call_trace_arena,
+                &call_traces.arena,
                 address_to_executed_code,
                 precompile_addresses,
             );
@@ -654,7 +654,7 @@ impl<ChainSpecT: ProviderSpec<TimerT>, TimerT: Clone + TimeSinceEpoch>
         let contract_decoder = self.contract_decoder.clone();
         self.indented(|logger| {
             logger.log_contract_and_function_name::<false>(
-                &observed_data.call_trace_arena,
+                &observed_data.call_traces.arena,
                 &observed_data.address_to_executed_code,
                 precompile_addresses,
             );
@@ -679,7 +679,7 @@ impl<ChainSpecT: ProviderSpec<TimerT>, TimerT: Clone + TimeSinceEpoch>
                     result,
                     Some(transaction_hash),
                     &observed_data.address_to_executed_code,
-                    &observed_data.call_trace_arena,
+                    &observed_data.call_traces.arena,
                     contract_decoder.as_ref(),
                 );
 
@@ -1039,7 +1039,7 @@ impl<ChainSpecT: ProviderSpec<TimerT>, TimerT: Clone + TimeSinceEpoch>
         let contract_decoder = self.contract_decoder.clone();
         self.indented(|logger| {
             logger.log_contract_and_function_name::<false>(
-                &transaction_observed_data.call_trace_arena,
+                &transaction_observed_data.call_traces.arena,
                 &transaction_observed_data.address_to_executed_code,
                 &block_result.precompile_addresses,
             );
@@ -1074,7 +1074,7 @@ impl<ChainSpecT: ProviderSpec<TimerT>, TimerT: Clone + TimeSinceEpoch>
                     transaction_result,
                     Some(transaction_hash),
                     &transaction_observed_data.address_to_executed_code,
-                    &transaction_observed_data.call_trace_arena,
+                    &transaction_observed_data.call_traces.arena,
                     contract_decoder.as_ref(),
                 );
 

--- a/crates/edr_napi_core/src/provider.rs
+++ b/crates/edr_napi_core/src/provider.rs
@@ -4,6 +4,7 @@ use std::{str::FromStr as _, sync::Arc};
 
 use edr_provider::{time::TimeSinceEpoch, InvalidRequestReason, SyncCallOverride};
 use edr_rpc_client::jsonrpc;
+use edr_solidity::config::IncludeTraces;
 
 pub use self::config::{Config, ConfigOption};
 use crate::spec::{Response, SyncNapiSpec};
@@ -22,6 +23,10 @@ pub trait SyncProvider: Send + Sync {
 
     /// Set the verbose tracing flag to the provided value.
     fn set_verbose_tracing(&self, enabled: bool);
+
+    /// Sets which transactions' call traces are included in responses, for
+    /// requests handled from this point on.
+    fn set_include_call_traces(&self, include_call_traces: IncludeTraces);
 }
 
 impl<ChainSpecT: SyncNapiSpec<TimerT>, TimerT: Clone + TimeSinceEpoch> SyncProvider
@@ -82,5 +87,9 @@ impl<ChainSpecT: SyncNapiSpec<TimerT>, TimerT: Clone + TimeSinceEpoch> SyncProvi
 
     fn set_verbose_tracing(&self, enabled: bool) {
         self.set_verbose_tracing(enabled);
+    }
+
+    fn set_include_call_traces(&self, include_call_traces: IncludeTraces) {
+        self.set_include_call_traces(include_call_traces);
     }
 }

--- a/crates/edr_napi_core/src/spec.rs
+++ b/crates/edr_napi_core/src/spec.rs
@@ -8,8 +8,7 @@ use edr_provider::{
     SyncProviderSpec,
 };
 use edr_rpc_client::jsonrpc;
-use edr_solidity::solidity_stack_trace::StackTraceCreationResult;
-use edr_solidity_tests::traces::CallTraceArena;
+use edr_solidity::{solidity_stack_trace::StackTraceCreationResult, tracing::CallTraces};
 use edr_transaction::{IsEip155, IsEip4844, TransactionMut, TransactionType};
 use napi::{Either, Status};
 
@@ -27,7 +26,7 @@ pub struct Response {
     /// Error if there was an error computing the stack trace.
     pub stack_trace_result: Option<StackTraceCreationResult<String>>,
     /// This may contain zero or more traces, depending on the (batch) request
-    pub call_trace_arenas: Vec<CallTraceArena>,
+    pub call_traces: Vec<CallTraces>,
     /// Whether verbose raw tracing was enabled when this response was created.
     pub verbose: bool,
 }
@@ -37,7 +36,7 @@ impl From<String> for Response {
         Response {
             data: Either::A(value),
             stack_trace_result: None,
-            call_trace_arenas: Vec::new(),
+            call_traces: Vec::new(),
             verbose: false,
         }
     }
@@ -115,10 +114,10 @@ pub fn cast_provider_result_to_response<
     });
 
     // We can take the traces as they won't be used for anything else
-    let call_trace_arenas = match &mut response {
-        Ok(response) => std::mem::take(&mut response.call_trace_arenas),
+    let call_traces = match &mut response {
+        Ok(response) => std::mem::take(&mut response.call_traces),
         Err(edr_provider::ProviderError::TransactionFailed(failure)) => {
-            std::mem::take(&mut failure.call_trace_arenas)
+            std::mem::take(&mut failure.call_traces)
         }
         Err(_) => Vec::new(),
     };
@@ -128,7 +127,7 @@ pub fn cast_provider_result_to_response<
     marshal_response_data(response).map(|data| Response {
         data,
         stack_trace_result,
-        call_trace_arenas,
+        call_traces,
         verbose,
     })
 }

--- a/crates/edr_provider/src/data.rs
+++ b/crates/edr_provider/src/data.rs
@@ -446,6 +446,10 @@ where
         self.observability.verbose_raw_tracing = verbose_tracing;
     }
 
+    pub fn set_include_call_traces(&mut self, include_call_traces: IncludeTraces) {
+        self.observability.include_call_traces = include_call_traces;
+    }
+
     pub fn verbose_tracing(&self) -> bool {
         self.observability.verbose_raw_tracing
     }

--- a/crates/edr_provider/src/data.rs
+++ b/crates/edr_provider/src/data.rs
@@ -63,7 +63,7 @@ use edr_runtime::{
 use edr_signer::{
     public_key_to_address, FakeSign as _, RecoveryMessage, Sign as _, SignatureWithRecoveryId,
 };
-use edr_solidity::{config::IncludeTraces, contract_decoder::ContractDecoder};
+use edr_solidity::{config::IncludeTraces, contract_decoder::ContractDecoder, tracing::CallTraces};
 use edr_state_api::{
     account::{Account, AccountInfo, AccountStatus},
     irregular::IrregularState,
@@ -74,7 +74,6 @@ use edr_transaction::{
     TransactionAndBlock, TransactionMut, TransactionType, TxKind,
 };
 use edr_utils::{random::RandomHashGenerator, CastArcInto};
-use foundry_evm_traces::CallTraceArena;
 use gas::gas_used_ratio;
 use indexmap::IndexMap;
 use itertools::izip;
@@ -127,14 +126,14 @@ const DEFAULT_SKIP_UNSUPPORTED_TRANSACTION_TYPES: bool = false;
 /// The result of executing an `eth_call`.
 #[derive(Clone, Debug)]
 pub struct CallResult<HaltReasonT: HaltReasonTrait> {
-    pub call_trace_arena: Option<CallTraceArena>,
+    pub call_traces: Option<CallTraces>,
     pub execution_result: ExecutionResult<HaltReasonT>,
 }
 
 pub struct CallResultWithMetadata<HaltReasonT: HaltReasonTrait> {
     /// Mapping of contract address to executed bytecode
     pub address_to_executed_code: HashMap<Address, Bytes>,
-    pub call_trace_arena: CallTraceArena,
+    pub call_traces: CallTraces,
     pub console_log_inputs: Vec<Bytes>,
     pub execution_result: ExecutionResult<HaltReasonT>,
     /// The set of precompile addresses that were available during execution.
@@ -145,18 +144,18 @@ impl<HaltReasonT: HaltReasonTrait> CallResultWithMetadata<HaltReasonT> {
     /// Converts into a [`CallResult`], discarding metadata.
     pub fn into_call_result(self, include_traces: IncludeTraces) -> CallResult<HaltReasonT> {
         CallResult {
-            call_trace_arena: include_traces
+            call_traces: include_traces
                 .should_include(|| !self.execution_result.is_success())
-                .then_some(self.call_trace_arena),
+                .then_some(self.call_traces),
             execution_result: self.execution_result,
         }
     }
 
     /// Returns the call traces if they should be included, consuming `self`.
-    pub fn into_call_traces(self, include_traces: IncludeTraces) -> Option<CallTraceArena> {
+    pub fn into_call_traces(self, include_traces: IncludeTraces) -> Option<CallTraces> {
         include_traces
             .should_include(|| !self.execution_result.is_success())
-            .then_some(self.call_trace_arena)
+            .then_some(self.call_traces)
     }
 }
 
@@ -166,7 +165,7 @@ impl<HaltReasonT: HaltReasonTrait> From<ObservedExecution<ExecutionResultWithMet
     fn from(value: ObservedExecution<ExecutionResultWithMetadata<HaltReasonT>>) -> Self {
         Self {
             address_to_executed_code: value.evm_observed_data.address_to_executed_code,
-            call_trace_arena: value.evm_observed_data.call_trace_arena,
+            call_traces: value.evm_observed_data.call_traces,
             console_log_inputs: value.evm_observed_data.encoded_console_logs,
             execution_result: value.execution_result.result,
             precompile_addresses: value.execution_result.precompile_addresses,
@@ -194,7 +193,7 @@ impl<BlockT, HaltReasonT: HaltReasonTrait, SignedTransactionT>
     pub fn into_hash_and_call_traces(
         self,
         include_call_traces: IncludeTraces,
-    ) -> (B256, Vec<CallTraceArena>) {
+    ) -> (B256, Vec<CallTraces>) {
         let Self {
             transaction_hash,
             mining_results,
@@ -1580,7 +1579,7 @@ where
                     execution_result,
                     transaction.kind(),
                     transaction.data().clone(),
-                    &inspector_data.call_trace_arena,
+                    &inspector_data.call_traces.arena,
                     &inspector_data.address_to_executed_code,
                 ) {
                     Ok(()) => (),
@@ -1899,7 +1898,7 @@ where
                 state: state.as_ref(),
             });
 
-            let (execution_result, call_trace_arena) =
+            let (execution_result, call_traces) =
                 observed_execution.into_result_and_filtered_traces();
 
             let geth_trace = debug_inspector
@@ -1914,7 +1913,7 @@ where
 
             Ok(DebugTraceResultWithCallTraces {
                 result: geth_trace,
-                call_trace_arenas: call_trace_arena.into_iter().collect(),
+                call_traces: call_traces.into_iter().collect(),
             })
         })?
     }
@@ -2317,14 +2316,14 @@ where
                 &call_result.execution_result,
                 None,
                 &call_result.address_to_executed_code,
-                &call_result.call_trace_arena,
+                &call_result.call_traces.arena,
                 self.contract_decoder.as_ref(),
             )
         {
             return Err(ProviderError::TransactionFailed(Box::new(
                 TransactionFailureWithCallTraces {
                     failure,
-                    call_trace_arenas: call_result
+                    call_traces: call_result
                         .into_call_traces(self.observability.include_call_traces)
                         .into_iter()
                         .collect(),
@@ -2399,7 +2398,7 @@ where
                     observed_execution.result(),
                     kind,
                     input.clone(),
-                    &observed_execution.evm_observed_data.call_trace_arena,
+                    &observed_execution.evm_observed_data.call_traces.arena,
                     &observed_execution.evm_observed_data.address_to_executed_code,
                 ) {
                     Ok(report) => report,

--- a/crates/edr_provider/src/data/gas.rs
+++ b/crates/edr_provider/src/data/gas.rs
@@ -20,7 +20,7 @@ use edr_evm::ExecutionResultWithMetadata;
 use edr_precompile::PrecompileFn;
 use edr_primitives::{Address, HashMap, U256};
 use edr_receipt::ReceiptTrait as _;
-use edr_solidity::contract_decoder::ContractDecoder;
+use edr_solidity::{contract_decoder::ContractDecoder, tracing::CallTraces};
 use edr_state_api::DynState;
 use edr_transaction::TransactionMut;
 use foundry_evm_traces::CallTraceArena;
@@ -39,7 +39,7 @@ use crate::{
 };
 
 pub struct EstimateGasResult {
-    pub call_trace_arenas: Vec<CallTraceArena>,
+    pub call_traces: Vec<CallTraces>,
     pub estimation: u64,
 }
 
@@ -81,12 +81,12 @@ impl GasEstimationMode {
         match self {
             GasEstimationMode::TopLevelSuccess => Ok(gas.tx_gas_used()),
             GasEstimationMode::NoInternalOutOfGas => {
-                if has_internal_oog(&evm_observed_data.call_trace_arena) {
+                if has_internal_oog(&evm_observed_data.call_traces.arena) {
                     Err(TransactionFailure::halt(
                         TransactionFailureReason::InternalCallOutOfGas,
                         None,
                         &evm_observed_data.address_to_executed_code,
-                        &evm_observed_data.call_trace_arena,
+                        &evm_observed_data.call_traces.arena,
                         contract_decoder,
                     ))
                 } else {
@@ -170,7 +170,7 @@ fn binary_search_estimation<ChainSpecT: ProviderChainSpec<SignedTransaction: Tra
     const MAX_ITERATIONS: usize = 20;
 
     let mut i = 0;
-    let mut call_trace_arenas = Vec::new();
+    let mut call_traces = Vec::new();
 
     while upper_bound - lower_bound > min_difference(lower_bound) && i < MAX_ITERATIONS {
         let mut mid = lower_bound + (upper_bound - lower_bound) / 2;
@@ -186,7 +186,7 @@ fn binary_search_estimation<ChainSpecT: ProviderChainSpec<SignedTransaction: Tra
             call_trace,
         } = probe_gas_limit(context, observer_config, mid, estimation_mode)?;
 
-        call_trace_arenas.extend(call_trace);
+        call_traces.extend(call_trace);
 
         if accepted {
             upper_bound = mid;
@@ -198,7 +198,7 @@ fn binary_search_estimation<ChainSpecT: ProviderChainSpec<SignedTransaction: Tra
     }
 
     Ok(EstimateGasResult {
-        call_trace_arenas,
+        call_traces,
         estimation: upper_bound,
     })
 }
@@ -224,7 +224,7 @@ pub(super) fn estimate_gas<
         contract_decoder.as_ref(),
     )?;
 
-    let mut call_trace_arenas: Vec<_> = call_trace.into_iter().collect();
+    let mut call_traces: Vec<_> = call_trace.into_iter().collect();
 
     // Ensure that the initial estimation is at least the minimum cost + 1.
     let lowest_estimation = cmp::max(gas_used, minimum_cost + 1);
@@ -234,13 +234,13 @@ pub(super) fn estimate_gas<
         call_trace,
     } = probe_gas_limit(context, observer_config, lowest_estimation, estimation_mode)?;
 
-    call_trace_arenas.extend(call_trace);
+    call_traces.extend(call_trace);
 
     // Return the initial estimation if it was successful
     if accepted {
         return Ok(EstimateGasResult {
             estimation: lowest_estimation,
-            call_trace_arenas,
+            call_traces,
         });
     }
 
@@ -248,7 +248,7 @@ pub(super) fn estimate_gas<
     // This can happen if the execution behavior depends on the available gas.
     // Search upwards for the lowest gas limit the mode accepts.
     let EstimateGasResult {
-        call_trace_arenas: estimation_call_trace_arenas,
+        call_traces: estimation_call_traces,
         estimation,
     } = binary_search_estimation::<ChainSpecT>(
         context,
@@ -259,10 +259,10 @@ pub(super) fn estimate_gas<
         estimation_mode,
     )?;
 
-    call_trace_arenas.extend(estimation_call_trace_arenas);
+    call_traces.extend(estimation_call_traces);
 
     Ok(EstimateGasResult {
-        call_trace_arenas,
+        call_traces,
         estimation,
     })
 }
@@ -271,14 +271,14 @@ pub(super) fn estimate_gas<
 /// collection criteria are met.
 struct GasMeasurement {
     gas_used: u64,
-    call_trace: Option<CallTraceArena>,
+    call_trace: Option<CallTraces>,
 }
 
 /// Whether the estimation mode accepted an execution at a probed gas limit,
 /// along with its call trace when the trace collection criteria are met.
 struct GasProbe {
     accepted: bool,
-    call_trace: Option<CallTraceArena>,
+    call_trace: Option<CallTraces>,
 }
 
 /// Measures the gas used by the transaction executed with its full gas limit,
@@ -320,14 +320,14 @@ fn measure_gas_with_full_limit<
             output,
             None,
             &evm_observed_data.address_to_executed_code,
-            &evm_observed_data.call_trace_arena,
+            &evm_observed_data.call_traces.arena,
             contract_decoder,
         )),
         ExecutionResult::Halt { reason, .. } => Err(TransactionFailure::halt(
             ChainSpecT::cast_halt_reason(reason),
             None,
             &evm_observed_data.address_to_executed_code,
-            &evm_observed_data.call_trace_arena,
+            &evm_observed_data.call_traces.arena,
             contract_decoder,
         )),
     };
@@ -337,7 +337,7 @@ fn measure_gas_with_full_limit<
         Err(transaction_failure) => {
             return Err(Box::new(EstimateGasFailure {
                 address_to_executed_code: evm_observed_data.address_to_executed_code,
-                call_trace_arena: evm_observed_data.call_trace_arena,
+                call_traces: evm_observed_data.call_traces,
                 encoded_console_logs: evm_observed_data.encoded_console_logs,
                 precompile_addresses: execution_result.precompile_addresses,
                 transaction_failure,
@@ -369,17 +369,15 @@ fn probe_gas_limit<ChainSpecT: ProviderChainSpec<SignedTransaction: TransactionM
         observed_limited_execution.result(),
         &observed_limited_execution
             .evm_observed_data
-            .call_trace_arena,
+            .call_traces
+            .arena,
     );
     let should_include_traces = observer_config
         .include_call_traces
         .should_include(|| !accepted);
 
-    let call_trace = should_include_traces.then_some(
-        observed_limited_execution
-            .evm_observed_data
-            .call_trace_arena,
-    );
+    let call_trace =
+        should_include_traces.then_some(observed_limited_execution.evm_observed_data.call_traces);
 
     Ok(GasProbe {
         accepted,

--- a/crates/edr_provider/src/debug_trace.rs
+++ b/crates/edr_provider/src/debug_trace.rs
@@ -10,8 +10,8 @@ use edr_chain_spec_evm::{BlockEnvTrait as _, CfgEnv, DatabaseComponentError, Tra
 use edr_evm::{dry_run_with_inspector, run};
 use edr_primitives::{HashMap, B256, U256};
 use edr_runtime::inspector::DualInspector;
+use edr_solidity::tracing::CallTraces;
 use edr_state_api::{DynState, StateError};
-use foundry_evm_traces::CallTraceArena;
 use revm_inspectors::tracing::{DebugInspector, DebugInspectorError, MuxError, TransactionContext};
 
 use crate::{
@@ -71,7 +71,7 @@ pub fn debug_trace_transaction<'header, ChainSpecT: BlockChainSpec<SignedTransac
                 state: state.as_ref(),
             });
 
-            let (execution_result, call_trace_arena) =
+            let (execution_result, call_traces) =
                 observed_execution.into_result_and_filtered_traces();
 
             let geth_trace = debug_inspector
@@ -89,7 +89,7 @@ pub fn debug_trace_transaction<'header, ChainSpecT: BlockChainSpec<SignedTransac
                 .map_err(DebugTraceError::from_debug_inspector_result_error)?;
 
             return Ok(DebugTraceResultWithCallTraces {
-                call_trace_arenas: call_trace_arena.into_iter().collect(),
+                call_traces: call_traces.into_iter().collect(),
                 result: geth_trace,
             });
         } else {
@@ -244,7 +244,7 @@ impl<TransactionValidationErrorT> JsonRpcError for DebugTraceError<TransactionVa
 /// Result of a `debug_traceTransaction` call with call trace.
 pub struct DebugTraceResultWithCallTraces {
     /// The raw traces of the debugged transaction.
-    pub call_trace_arenas: Vec<CallTraceArena>,
+    pub call_traces: Vec<CallTraces>,
     /// The result of the transaction.
     pub result: GethTrace,
 }

--- a/crates/edr_provider/src/error.rs
+++ b/crates/edr_provider/src/error.rs
@@ -25,6 +25,7 @@ use edr_signer::SignatureError;
 use edr_solidity::{
     contract_decoder::{ContractDecoder, ContractDecoderError},
     solidity_stack_trace::{get_stack_trace, StackTraceCreationResult},
+    tracing::CallTraces,
 };
 use edr_state_api::StateError;
 use foundry_evm_traces::CallTraceArena;
@@ -581,7 +582,7 @@ impl<
 pub struct EstimateGasFailure<HaltReasonT: HaltReasonTrait> {
     /// Mapping of contract address to executed bytecode
     pub address_to_executed_code: HashMap<Address, Bytes>,
-    pub call_trace_arena: CallTraceArena,
+    pub call_traces: CallTraces,
     pub encoded_console_logs: Vec<Bytes>,
     /// The set of precompile addresses that were available during execution.
     pub precompile_addresses: HashSet<Address>,
@@ -597,7 +598,7 @@ impl<HaltReasonT: HaltReasonTrait> std::fmt::Display for EstimateGasFailure<Halt
 #[derive(Clone, Debug, thiserror::Error)]
 pub struct TransactionFailureWithCallTraces<HaltReasonT: HaltReasonTrait> {
     pub failure: TransactionFailure<HaltReasonT>,
-    pub call_trace_arenas: Vec<CallTraceArena>,
+    pub call_traces: Vec<CallTraces>,
 }
 
 impl<HaltReasonT: HaltReasonTrait> std::fmt::Display

--- a/crates/edr_provider/src/lib.rs
+++ b/crates/edr_provider/src/lib.rs
@@ -33,7 +33,7 @@ use core::fmt::Debug;
 
 pub use edr_block_miner::{MineBlockResultWithMetadata, MineBlockResultWithMetadataForChainSpec};
 use edr_primitives::HashSet;
-use foundry_evm_traces::CallTraceArena;
+use edr_solidity::tracing::CallTraces;
 use lazy_static::lazy_static;
 
 pub use self::{
@@ -63,12 +63,12 @@ lazy_static! {
 }
 
 pub type ProviderResultWithCallTraces<T, ChainSpecT> =
-    Result<(T, Vec<CallTraceArena>), ProviderErrorForChainSpec<ChainSpecT>>;
+    Result<(T, Vec<CallTraces>), ProviderErrorForChainSpec<ChainSpecT>>;
 
 #[derive(Clone, Debug)]
 pub struct ResponseWithCallTraces {
     pub result: serde_json::Value,
-    pub call_trace_arenas: Vec<CallTraceArena>,
+    pub call_traces: Vec<CallTraces>,
 }
 
 fn to_json<
@@ -82,7 +82,7 @@ fn to_json<
 
     Ok(ResponseWithCallTraces {
         result: response,
-        call_trace_arenas: Vec::new(),
+        call_traces: Vec::new(),
     })
 }
 
@@ -91,13 +91,13 @@ fn to_json_with_trace<
     ChainSpecT: ProviderSpec<TimerT>,
     TimerT: Clone + TimeSinceEpoch,
 >(
-    value: (T, Option<CallTraceArena>),
+    value: (T, Option<CallTraces>),
 ) -> Result<ResponseWithCallTraces, ProviderErrorForChainSpec<ChainSpecT>> {
     let response = serde_json::to_value(value.0).map_err(ProviderError::Serialization)?;
 
     Ok(ResponseWithCallTraces {
         result: response,
-        call_trace_arenas: value.1.into_iter().collect(),
+        call_traces: value.1.into_iter().collect(),
     })
 }
 
@@ -106,12 +106,12 @@ fn to_json_with_traces<
     ChainSpecT: ProviderSpec<TimerT>,
     TimerT: Clone + TimeSinceEpoch,
 >(
-    value: (T, Vec<CallTraceArena>),
+    value: (T, Vec<CallTraces>),
 ) -> Result<ResponseWithCallTraces, ProviderErrorForChainSpec<ChainSpecT>> {
     let response = serde_json::to_value(value.0).map_err(ProviderError::Serialization)?;
 
     Ok(ResponseWithCallTraces {
         result: response,
-        call_trace_arenas: value.1,
+        call_traces: value.1,
     })
 }

--- a/crates/edr_provider/src/observability.rs
+++ b/crates/edr_provider/src/observability.rs
@@ -18,10 +18,11 @@ use edr_inspector_bytecode::ExecutedBytecodeCollector;
 use edr_primitives::{Address, Bytes, HashMap, HashSet};
 use edr_receipt::ExecutionResult;
 use edr_solidity::{
-    config::IncludeTraces, contract_decoder::ContractDecoder, tracing::SolidityTracingInspector,
+    config::IncludeTraces,
+    contract_decoder::ContractDecoder,
+    tracing::{CallTraces, SolidityTracingInspector},
 };
 use edr_state_api::State;
-use foundry_evm_traces::CallTraceArena;
 use parking_lot::RwLock;
 use revm_inspector::JournalExt;
 use revm_inspectors::tracing::{TracingInspector, TracingInspectorConfig};
@@ -134,9 +135,9 @@ impl JsonRpcError for EvmObserverCollectionError {
 pub struct EvmObservedData {
     /// Mapping of contract address to executed bytecode
     pub address_to_executed_code: HashMap<Address, Bytes>,
-    /// The call trace arena collected during execution, including ABI-decoded
-    /// information.
-    pub call_trace_arena: CallTraceArena,
+    /// The call traces collected during execution, including ABI-decoded
+    /// information and captured top-of-stack values.
+    pub call_traces: CallTraces,
     /// Encoded `console.log` call inputs
     pub encoded_console_logs: Vec<Bytes>,
 }
@@ -146,10 +147,10 @@ impl EvmObservedData {
         self,
         include: IncludeTraces,
         is_success: bool,
-    ) -> Option<CallTraceArena> {
+    ) -> Option<CallTraces> {
         include
             .should_include(|| !is_success)
-            .then_some(self.call_trace_arena)
+            .then_some(self.call_traces)
     }
 }
 
@@ -215,13 +216,13 @@ impl EvmObserver {
         }
 
         let address_to_executed_code = bytecode_collector.collect();
-        let call_trace_arena = tracing_inspector
+        let call_traces = tracing_inspector
             .collect(&address_to_executed_code, precompile_addresses)
             .map_err(EvmObserverCollectionError::AbiDecoding)?;
 
         Ok(EvmObservedData {
             address_to_executed_code,
-            call_trace_arena,
+            call_traces,
             encoded_console_logs: console_logger.into_encoded_messages(),
         })
     }
@@ -246,7 +247,7 @@ impl EvmObserver {
                 .map_err(EvmObserverCollectionError::OnCollectedCoverageCallback)?;
         }
 
-        let call_trace_arena = tracing_inspector
+        let call_traces = tracing_inspector
             .take(&address_to_executed_code, precompile_addresses)
             .map_err(EvmObserverCollectionError::AbiDecoding)?;
 
@@ -254,7 +255,7 @@ impl EvmObserver {
 
         Ok(EvmObservedData {
             address_to_executed_code,
-            call_trace_arena,
+            call_traces,
             encoded_console_logs,
         })
     }
@@ -385,14 +386,14 @@ impl<ExecutionResultT: WithExecutionResult> ObservedExecution<ExecutionResultT> 
     /// Consumes the observed execution, returning the execution result and the
     /// call traces filtered by the observability configuration, using the
     /// EVM-level success of the execution as the success criteria.
-    pub fn into_result_and_filtered_traces(self) -> (ExecutionResultT, Option<CallTraceArena>) {
+    pub fn into_result_and_filtered_traces(self) -> (ExecutionResultT, Option<CallTraces>) {
         let is_success = self.execution_result.result().is_success();
 
-        let call_trace_arena = self
+        let call_traces = self
             .evm_observed_data
             .into_call_traces(self.include_call_traces, is_success);
 
-        (self.execution_result, call_trace_arena)
+        (self.execution_result, call_traces)
     }
 }
 

--- a/crates/edr_provider/src/provider.rs
+++ b/crates/edr_provider/src/provider.rs
@@ -186,13 +186,13 @@ impl<
         for req in request {
             let response = self.handle_single_request(data, req)?;
             results.push(response.result);
-            traces.extend(response.call_trace_arenas);
+            traces.extend(response.call_traces);
         }
 
         let result = serde_json::to_value(results).map_err(ProviderError::Serialization)?;
         Ok(ResponseWithCallTraces {
             result,
-            call_trace_arenas: traces,
+            call_traces: traces,
         })
     }
 

--- a/crates/edr_provider/src/provider.rs
+++ b/crates/edr_provider/src/provider.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use edr_chain_spec::{HardforkChainSpec, TransactionValidation};
-use edr_solidity::contract_decoder::ContractDecoder;
+use edr_solidity::{config::IncludeTraces, contract_decoder::ContractDecoder};
 use edr_transaction::{IsEip155, IsEip4844, TransactionMut, TransactionType};
 use parking_lot::{Mutex, RwLock};
 use tokio::{runtime, sync::Mutex as AsyncMutex, task};
@@ -139,6 +139,13 @@ impl<
     pub fn set_verbose_tracing(&self, enabled: bool) {
         let mut data = task::block_in_place(|| self.runtime.block_on(self.data.lock()));
         data.set_verbose_tracing(enabled);
+    }
+
+    /// Sets which transactions' call traces are included in responses, for
+    /// requests handled from this point on.
+    pub fn set_include_call_traces(&self, include_call_traces: IncludeTraces) {
+        let mut data = task::block_in_place(|| self.runtime.block_on(self.data.lock()));
+        data.set_include_call_traces(include_call_traces);
     }
 
     pub fn verbose_tracing(&self) -> bool {

--- a/crates/edr_provider/src/requests/debug.rs
+++ b/crates/edr_provider/src/requests/debug.rs
@@ -26,7 +26,7 @@ pub fn handle_debug_trace_transaction<
 ) -> ProviderResultWithCallTraces<GethTrace, ChainSpecT> {
     let DebugTraceResultWithCallTraces {
         result,
-        call_trace_arenas,
+        call_traces,
     } = data
         .debug_trace_transaction(&transaction_hash, tracing_options.unwrap_or_default())
         .map_err(|error| match error {
@@ -36,7 +36,7 @@ pub fn handle_debug_trace_transaction<
             _ => error,
         })?;
 
-    Ok((result, call_trace_arenas))
+    Ok((result, call_traces))
 }
 
 pub fn handle_debug_trace_call<ChainSpecT, TimerT>(
@@ -59,12 +59,12 @@ where
 
     let DebugTraceResultWithCallTraces {
         result,
-        call_trace_arenas,
+        call_traces,
     } = data.debug_trace_call(
         transaction,
         &block_spec,
         tracing_options.unwrap_or_default(),
     )?;
 
-    Ok((result, call_trace_arenas))
+    Ok((result, call_traces))
 }

--- a/crates/edr_provider/src/requests/eth/call.rs
+++ b/crates/edr_provider/src/requests/eth/call.rs
@@ -4,7 +4,7 @@ use edr_primitives::Bytes;
 use edr_rpc_eth::StateOverrideOptions;
 use edr_runtime::{overrides::StateOverrides, transaction};
 use edr_signer::FakeSign as _;
-use foundry_evm_traces::CallTraceArena;
+use edr_solidity::tracing::CallTraces;
 
 use crate::{
     data::ProviderData,
@@ -25,7 +25,7 @@ pub fn handle_call_request<
     request: ChainSpecT::RpcCallRequest,
     block_spec: Option<BlockSpec>,
     state_overrides: Option<StateOverrideOptions>,
-) -> Result<(Bytes, Option<CallTraceArena>), ProviderErrorForChainSpec<ChainSpecT>> {
+) -> Result<(Bytes, Option<CallTraces>), ProviderErrorForChainSpec<ChainSpecT>> {
     let block_spec = resolve_block_spec_for_call_request(block_spec);
 
     let state_overrides =
@@ -35,7 +35,7 @@ pub fn handle_call_request<
     let result = data.run_call(transaction, &block_spec, &state_overrides)?;
 
     let output = result.execution_result.into_output().unwrap_or_default();
-    Ok((output, result.call_trace_arena))
+    Ok((output, result.call_traces))
 }
 
 pub(crate) fn resolve_block_spec_for_call_request(block_spec: Option<BlockSpec>) -> BlockSpec {

--- a/crates/edr_provider/src/requests/eth/gas.rs
+++ b/crates/edr_provider/src/requests/eth/gas.rs
@@ -44,12 +44,12 @@ pub fn handle_estimate_gas<
         Err(ProviderError::TransactionFailed(Box::new(
             TransactionFailureWithCallTraces {
                 failure: failure.transaction_failure,
-                call_trace_arenas: vec![failure.call_trace_arena],
+                call_traces: vec![failure.call_traces],
             },
         )))
     } else {
         let result = result?;
-        Ok((U64::from(result.estimation), result.call_trace_arenas))
+        Ok((U64::from(result.estimation), result.call_traces))
     }
 }
 

--- a/crates/edr_provider/src/requests/eth/transactions.rs
+++ b/crates/edr_provider/src/requests/eth/transactions.rs
@@ -300,7 +300,7 @@ fn send_raw_transaction_and_log<
                     execution_result,
                     Some(&result.transaction_hash),
                     &observed_data.address_to_executed_code,
-                    &observed_data.call_trace_arena,
+                    &observed_data.call_traces.arena,
                     data.contract_decoder(),
                 )
             },
@@ -313,7 +313,7 @@ fn send_raw_transaction_and_log<
             return Err(ProviderError::TransactionFailed(Box::new(
                 TransactionFailureWithCallTraces {
                     failure,
-                    call_trace_arenas: traces,
+                    call_traces: traces,
                 },
             )));
         }

--- a/crates/edr_provider/tests/integration/issues/issue_533.rs
+++ b/crates/edr_provider/tests/integration/issues/issue_533.rs
@@ -56,7 +56,7 @@ async fn issue_533() -> anyhow::Result<()> {
         MethodInvocation::DebugTraceTransaction(transaction_hash, None),
     ))?;
 
-    assert!(!result.call_trace_arenas.is_empty());
+    assert!(!result.call_traces.is_empty());
 
     Ok(())
 }

--- a/crates/edr_provider/tests/integration/rip7212.rs
+++ b/crates/edr_provider/tests/integration/rip7212.rs
@@ -106,10 +106,11 @@ async fn rip7212_enabled() -> anyhow::Result<()> {
     let nested_trace = NestedTrace::<edr_chain_l1::HaltReason>::from_call_trace_arena(
         &HashMap::default(),
         &HashMap::default(),
-        response
-            .call_trace_arenas
+        &response
+            .call_traces
             .first()
-            .expect("Trace should exist"),
+            .expect("Trace should exist")
+            .arena,
     )
     .expect("Should convert to nested trace");
 
@@ -156,10 +157,11 @@ async fn rip7212_enabled_post_osaka() -> anyhow::Result<()> {
     let nested_trace = NestedTrace::<edr_chain_l1::HaltReason>::from_call_trace_arena(
         &HashMap::default(),
         &HashMap::default(),
-        response
-            .call_trace_arenas
+        &response
+            .call_traces
             .first()
-            .expect("Trace should exist"),
+            .expect("Trace should exist")
+            .arena,
     )
     .expect("Should convert to nested trace");
 

--- a/crates/edr_solidity/src/tracing.rs
+++ b/crates/edr_solidity/src/tracing.rs
@@ -7,10 +7,7 @@ use edr_chain_spec_evm::{ContextTrait, Inspector};
 use edr_primitives::{Address, Bytes, HashMap, HashSet, U256};
 use parking_lot::RwLock;
 use revm_inspector::JournalExt;
-use revm_inspectors::tracing::{
-    types::{CallTraceNode, TraceMemberOrder},
-    CallTraceArena, TracingInspector,
-};
+use revm_inspectors::tracing::{CallTraceArena, TracingInspector};
 use revm_interpreter::CallOutcome;
 
 use crate::contract_decoder::ContractDecoder;
@@ -28,8 +25,8 @@ impl SolidityTracingInspector {
     /// Constructs a new [`SolidityTracingInspector`] instance.
     ///
     /// When `record_top_of_stack` is enabled, the top-of-stack value at the
-    /// start of each step is captured and written into the `stack` field of
-    /// the collected traces' steps, as a cheap alternative to
+    /// start of each step is captured and returned alongside the collected
+    /// traces (see [`CallTraces`]), as a cheap alternative to
     /// [`revm_inspectors::tracing::StackSnapshotType::Full`], which clones the
     /// entire stack on every step.
     pub fn new(
@@ -57,10 +54,8 @@ impl SolidityTracingInspector {
         self,
         address_to_executed_code: &HashMap<Address, Bytes>,
         precompile_addresses: &HashSet<Address>,
-    ) -> Result<CallTraceArena, serde_json::Error> {
+    ) -> Result<CallTraces, serde_json::Error> {
         let mut arena = self.inspector.into_traces();
-
-        write_stack_tops(&mut arena, &self.stack_tops);
 
         let mut decoder = self.decoder.write();
         decoder.populate_call_trace_arena(
@@ -69,7 +64,10 @@ impl SolidityTracingInspector {
             precompile_addresses,
         )?;
 
-        Ok(arena)
+        Ok(CallTraces {
+            arena,
+            stack_tops: self.stack_tops,
+        })
     }
 
     /// Takes the [`TracingInspector`]'s traces and ABI decodes them, replacing
@@ -78,14 +76,12 @@ impl SolidityTracingInspector {
         &mut self,
         address_to_executed_code: &HashMap<Address, Bytes>,
         precompile_addresses: &HashSet<Address>,
-    ) -> Result<CallTraceArena, serde_json::Error> {
+    ) -> Result<CallTraces, serde_json::Error> {
         let mut arena = std::mem::take(self.inspector.traces_mut());
         let stack_tops = std::mem::take(&mut self.stack_tops);
 
         // Reset the inspector
         self.inspector.fuse();
-
-        write_stack_tops(&mut arena, &stack_tops);
 
         let mut decoder = self.decoder.write();
         decoder.populate_call_trace_arena(
@@ -94,69 +90,28 @@ impl SolidityTracingInspector {
             precompile_addresses,
         )?;
 
-        Ok(arena)
+        Ok(CallTraces { arena, stack_tops })
     }
 }
 
-/// Writes captured per-step top-of-stack values into the arena's steps,
-/// consuming them in execution order: each node's `ordering`, descending
-/// depth-first into child calls.
-fn write_stack_tops(arena: &mut CallTraceArena, stack_tops: &[Option<U256>]) {
-    if stack_tops.is_empty() {
-        return;
-    }
-
-    let mut tops = stack_tops.iter();
-    write_node_stack_tops(arena.nodes_mut(), 0, &mut tops);
-    debug_assert_eq!(
-        tops.len(),
-        0,
-        "captured more stack tops than recorded steps"
-    );
-}
-
-fn write_node_stack_tops(
-    nodes: &mut [CallTraceNode],
-    node_idx: usize,
-    tops: &mut std::slice::Iter<'_, Option<U256>>,
-) {
-    // Cloned so that `nodes` can be mutably borrowed in the loop; the entries
-    // are `Copy` and this only runs once per node at collection time.
-    let ordering = nodes
-        .get(node_idx)
-        .expect("node indices come from the arena's own children lists")
-        .ordering
-        .clone();
-
-    for entry in ordering {
-        match entry {
-            TraceMemberOrder::Step(step_idx) => {
-                let Some(top) = tops.next() else {
-                    debug_assert!(false, "recorded more steps than captured stack tops");
-                    return;
-                };
-
-                let step = nodes
-                    .get_mut(node_idx)
-                    .expect("node indices come from the arena's own children lists")
-                    .trace
-                    .steps
-                    .get_mut(step_idx)
-                    .expect("step indices in `ordering` point into this node's steps");
-                step.stack = top.map(|top| Box::from([top]));
-            }
-            TraceMemberOrder::Call(child_idx) => {
-                let child_node_idx = *nodes
-                    .get(node_idx)
-                    .expect("node indices come from the arena's own children lists")
-                    .children
-                    .get(child_idx)
-                    .expect("call indices in `ordering` point into this node's children");
-                write_node_stack_tops(nodes, child_node_idx, tops);
-            }
-            TraceMemberOrder::Log(_) => {}
-        }
-    }
+/// A call trace arena together with the top-of-stack value captured at the
+/// start of each step, in execution order across all call frames.
+///
+/// The values are kept separate from the arena so that per-step stack
+/// snapshots only need to be materialized when the traces are marshalled to a
+/// consumer; writing them into the arena's steps would cost one heap
+/// allocation per step on every transaction, whether or not the traces are
+/// ever read.
+///
+/// `stack_tops` is empty when top-of-stack recording was disabled (e.g.
+/// verbose tracing, which records full stacks in the arena's steps instead).
+#[derive(Clone, Debug, Default)]
+pub struct CallTraces {
+    /// The call trace arena, including ABI-decoded information.
+    pub arena: CallTraceArena,
+    /// The top-of-stack value at the start of each step, in execution order;
+    /// `None` for steps executed with an empty stack.
+    pub stack_tops: Vec<Option<U256>>,
 }
 
 impl<ContextT: ContextTrait<Journal: JournalExt>> Inspector<ContextT> for SolidityTracingInspector {
@@ -238,104 +193,5 @@ impl<ContextT: ContextTrait<Journal: JournalExt>> Inspector<ContextT> for Solidi
 
     fn selfdestruct(&mut self, contract: Address, target: Address, value: U256) {
         Inspector::<ContextT>::selfdestruct(&mut self.inspector, contract, target, value);
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use edr_primitives::bytecode::opcode::OpCode;
-    use revm_inspectors::tracing::types::{CallTraceStep, TraceMemberOrder};
-
-    use super::*;
-
-    fn step() -> CallTraceStep {
-        CallTraceStep {
-            pc: 0,
-            op: OpCode::STOP,
-            stack: None,
-            push_stack: None,
-            memory: None,
-            returndata: Bytes::new(),
-            gas_remaining: 0,
-            gas_refund_counter: 0,
-            gas_used: 0,
-            gas_cost: 0,
-            storage_change: None,
-            status: None,
-            immediate_bytes: None,
-            decoded: None,
-        }
-    }
-
-    /// Root with three steps interleaved with a log and a child call:
-    /// execution order is root step 0, root step 1, child steps 0-1, root
-    /// step 2.
-    fn nested_arena() -> CallTraceArena {
-        let mut arena = CallTraceArena::default();
-
-        let root = &mut arena.nodes_mut()[0];
-        root.children = vec![1];
-        root.trace.steps = vec![step(), step(), step()];
-        root.ordering = vec![
-            TraceMemberOrder::Step(0),
-            TraceMemberOrder::Log(0),
-            TraceMemberOrder::Step(1),
-            TraceMemberOrder::Call(0),
-            TraceMemberOrder::Step(2),
-        ];
-
-        let mut child = CallTraceNode {
-            parent: Some(0),
-            idx: 1,
-            ..CallTraceNode::default()
-        };
-        child.trace.steps = vec![step(), step()];
-        child.ordering = vec![TraceMemberOrder::Step(0), TraceMemberOrder::Step(1)];
-        arena.nodes_mut().push(child);
-
-        arena
-    }
-
-    fn stack_of(arena: &CallTraceArena, node_idx: usize, step_idx: usize) -> Option<&[U256]> {
-        arena.nodes()[node_idx].trace.steps[step_idx]
-            .stack
-            .as_deref()
-    }
-
-    #[test]
-    fn write_stack_tops_follows_execution_order_across_frames() {
-        let mut arena = nested_arena();
-
-        write_stack_tops(
-            &mut arena,
-            &[
-                None,
-                Some(U256::from(1)),
-                Some(U256::from(10)),
-                Some(U256::from(11)),
-                Some(U256::from(2)),
-            ],
-        );
-
-        assert_eq!(stack_of(&arena, 0, 0), None);
-        assert_eq!(stack_of(&arena, 0, 1), Some(&[U256::from(1)][..]));
-        assert_eq!(stack_of(&arena, 0, 2), Some(&[U256::from(2)][..]));
-        assert_eq!(stack_of(&arena, 1, 0), Some(&[U256::from(10)][..]));
-        assert_eq!(stack_of(&arena, 1, 1), Some(&[U256::from(11)][..]));
-    }
-
-    #[test]
-    fn write_stack_tops_preserves_verbose_mode_full_stacks() {
-        let mut arena = nested_arena();
-        let full_stack = [U256::from(1), U256::from(2)];
-        arena.nodes_mut()[0].trace.steps[0].stack = Some(Box::from(full_stack));
-
-        write_stack_tops(&mut arena, &[]);
-
-        assert_eq!(stack_of(&arena, 0, 0), Some(&full_stack[..]));
-        assert_eq!(stack_of(&arena, 0, 1), None);
-        assert_eq!(stack_of(&arena, 0, 2), None);
-        assert_eq!(stack_of(&arena, 1, 0), None);
-        assert_eq!(stack_of(&arena, 1, 1), None);
     }
 }

--- a/patches/hardhat@2.28.6.patch
+++ b/patches/hardhat@2.28.6.patch
@@ -21,7 +21,7 @@ index 660aca206496602e24483581278607023d4e52d3..ea82219d526e39c64215c5cf2aa4b6fb
 +{"version":3,"file":"provider.d.ts","sourceRoot":"","sources":["../../../src/internal/hardhat-network/provider/provider.ts"],"names":[],"mappings":";AAAA,OAAO,KAAK,EACV,SAAS,EAGT,eAAe,EAEf,0BAA0B,EAC1B,gBAAgB,EACjB,MAAM,gBAAgB,CAAC;AAExB,OAAO,KAAK,EACV,UAAU,EAKV,wBAAwB,EAKzB,MAAM,sBAAsB,CAAC;AAK9B,OAAO,EAAE,YAAY,EAAE,MAAM,QAAQ,CAAC;AAoCtC,OAAO,EACL,UAAU,EACV,cAAc,EACd,oBAAoB,EACpB,YAAY,EACb,MAAM,cAAc,CAAC;AAUtB,OAAO,EAAE,YAAY,EAA8B,MAAM,kBAAkB,CAAC;AAO5E,eAAO,MAAM,gBAAgB,+CAA+C,CAAC;AAI7E,wBAAsB,mBAAmB,IAAI,OAAO,CAAC,UAAU,CAAC,CAgB/D;AAED,UAAU,4BAA4B;IACpC,QAAQ,EAAE,MAAM,CAAC;IACjB,OAAO,EAAE,MAAM,CAAC;IAChB,SAAS,EAAE,MAAM,CAAC;IAClB,aAAa,EAAE,MAAM,CAAC;IACtB,WAAW,EAAE,MAAM,CAAC;IACpB,QAAQ,EAAE,OAAO,CAAC;IAClB,cAAc,EAAE,oBAAoB,CAAC;IACrC,YAAY,EAAE,YAAY,CAAC;IAC3B,MAAM,EAAE,0BAA0B,CAAC;IACnC,eAAe,EAAE,cAAc,EAAE,CAAC;IAClC,0BAA0B,EAAE,OAAO,CAAC;IACpC,0BAA0B,EAAE,OAAO,CAAC;IACpC,mBAAmB,EAAE,OAAO,CAAC;IAC7B,4BAA4B,EAAE,OAAO,CAAC;IAEtC,oBAAoB,CAAC,EAAE,MAAM,CAAC;IAC9B,WAAW,CAAC,EAAE,IAAI,CAAC;IACnB,QAAQ,CAAC,EAAE,MAAM,CAAC;IAClB,UAAU,CAAC,EAAE,UAAU,CAAC;IACxB,aAAa,CAAC,EAAE,MAAM,CAAC;IACvB,sBAAsB,EAAE,OAAO,CAAC;IAChC,aAAa,EAAE,OAAO,CAAC;CACxB;AAWD,qBAAa,kBACX,SAAQ,YACR,YAAW,eAAe;IAQxB,OAAO,CAAC,SAAS;IACjB,OAAO,CAAC,QAAQ,CAAC,eAAe;IAChC,OAAO,CAAC,QAAQ,CAAC,aAAa;IAE9B,OAAO,CAAC,KAAK;IAGb,OAAO,CAAC,QAAQ,CAAC,mBAAmB;IAIpC,OAAO,CAAC,QAAQ,CAAC,wBAAwB;IACzC,OAAO,CAAC,QAAQ,CAAC,iBAAiB;IAClC,OAAO,CAAC,QAAQ,CAAC,uBAAuB;IACxC,OAAO,CAAC,QAAQ,CAAC,6BAA6B;IAC9C,OAAO,CAAC,QAAQ,CAAC,yBAAyB;IArB5C,OAAO,CAAC,kBAAkB,CAAK;IAG/B,OAAO,CAAC,qBAAqB,CAAC,CAAuB;IAErD,OAAO;WAqBa,MAAM,CACxB,MAAM,EAAE,4BAA4B,EACpC,YAAY,EAAE,YAAY,EAC1B,aAAa,CAAC,EAAE,wBAAwB,GACvC,OAAO,CAAC,kBAAkB,CAAC;IAsLjB,OAAO,CAAC,IAAI,EAAE,gBAAgB,GAAG,OAAO,CAAC,OAAO,CAAC;YAyJhD,qBAAqB;YAerB,MAAM;YA0EN,wBAAwB;YAexB,kBAAkB;IAIhC,OAAO,CAAC,iBAAiB;IASzB,OAAO,CAAC,4BAA4B;IAOpC,OAAO,CAAC,6BAA6B;CAWtC;AAQD,wBAAsB,4BAA4B,CAChD,4BAA4B,EAAE,4BAA4B,EAC1D,YAAY,EAAE,YAAY,EAC1B,SAAS,CAAC,EAAE,SAAS,GACpB,OAAO,CAAC,eAAe,CAAC,CAY1B"}
 \ No newline at end of file
 diff --git a/internal/hardhat-network/provider/provider.js b/internal/hardhat-network/provider/provider.js
-index 10f3b552eff7297ca16ae3acb5c30e5d97c5498e..daf7c475a43dbfa63c2a14bc9df2a10f3cdeed6c 100644
+index 10f3b552eff7297ca16ae3acb5c30e5d97c5498e..df59fa7b14a92145cf87676d413045c8c63ad96a 100644
 --- a/internal/hardhat-network/provider/provider.js
 +++ b/internal/hardhat-network/provider/provider.js
 @@ -70,9 +70,10 @@ class EdrProviderWrapper extends events_1.EventEmitter {
@@ -38,16 +38,18 @@ index 10f3b552eff7297ca16ae3acb5c30e5d97c5498e..daf7c475a43dbfa63c2a14bc9df2a10f
          super();
          this._provider = _provider;
          this._providerConfig = _providerConfig;
-@@ -82,6 +83,8 @@ class EdrProviderWrapper extends events_1.EventEmitter {
+@@ -82,7 +83,10 @@ class EdrProviderWrapper extends events_1.EventEmitter {
          this._originalGenesisAccounts = _originalGenesisAccounts;
          this._originalCacheDir = _originalCacheDir;
          this._originalChainOverrides = _originalChainOverrides;
 +        this._originalGenesisBlockGasLimit = _originalGenesisBlockGasLimit;
 +        this._originalGenesisBlockTime = _originalGenesisBlockTime;
          this._failedStackTraces = 0;
++        this._callTracesEnabled = false;
      }
      static async create(config, loggerConfig, tracingConfig) {
-@@ -100,9 +103,13 @@ class EdrProviderWrapper extends events_1.EventEmitter {
+         const { GENERIC_CHAIN_TYPE } = (0, napi_rs_1.requireNapiRsModule)("@nomicfoundation/edr");
+@@ -100,9 +104,13 @@ class EdrProviderWrapper extends events_1.EventEmitter {
              };
          });
          const cacheDir = config.forkCachePath;
@@ -63,7 +65,7 @@ index 10f3b552eff7297ca16ae3acb5c30e5d97c5498e..daf7c475a43dbfa63c2a14bc9df2a10f
                  blockNumber: config.forkConfig.blockNumber !== undefined
                      ? BigInt(config.forkConfig.blockNumber)
                      : undefined,
-@@ -112,9 +119,12 @@ class EdrProviderWrapper extends events_1.EventEmitter {
+@@ -112,9 +120,12 @@ class EdrProviderWrapper extends events_1.EventEmitter {
                  url: config.forkConfig.jsonRpcUrl,
              };
          }
@@ -79,7 +81,7 @@ index 10f3b552eff7297ca16ae3acb5c30e5d97c5498e..daf7c475a43dbfa63c2a14bc9df2a10f
          // To accommodate construction ordering, we need an adapter to forward events
          // from the EdrProvider callback to the wrapper's listener
          const eventAdapter = new EdrProviderEventAdapter();
-@@ -122,7 +132,7 @@ class EdrProviderWrapper extends events_1.EventEmitter {
+@@ -122,7 +133,7 @@ class EdrProviderWrapper extends events_1.EventEmitter {
          const replaceLastLineFn = loggerConfig.replaceLastLineFn ?? logger_1.replaceLastLine;
          const hardforkName = (0, hardforks_1.getHardforkName)(config.hardfork);
          const edrHardfork = (0, convertToEdr_1.ethereumsjsHardforkToEdrSpecId)(hardforkName);
@@ -88,7 +90,7 @@ index 10f3b552eff7297ca16ae3acb5c30e5d97c5498e..daf7c475a43dbfa63c2a14bc9df2a10f
          const precompileOverrides = config.enableRip7212
              ? (0, hardforks_1.hardforkGte)(hardforkName, hardforks_1.HardforkName.OSAKA)
                  ? [] // Osaka includes the P256 precompile natively
-@@ -133,27 +143,27 @@ class EdrProviderWrapper extends events_1.EventEmitter {
+@@ -133,25 +144,25 @@ class EdrProviderWrapper extends events_1.EventEmitter {
              allowUnlimitedContractSize: config.allowUnlimitedContractSize,
              bailOnCallFailure: config.throwOnCallFailures,
              bailOnTransactionFailure: config.throwOnTransactionFailures,
@@ -115,12 +117,9 @@ index 10f3b552eff7297ca16ae3acb5c30e5d97c5498e..daf7c475a43dbfa63c2a14bc9df2a10f
              },
 +            network,
              networkId: BigInt(config.networkId),
--            observability: {},
-+            observability: { includeCallTraces: edr_1.IncludeTraces.All },
+             observability: {},
              ownedAccounts,
-             // Turn off the Osaka EIP-7825 per transaction gas limit for HH2
-             // when being run from `solidity-coverage`.
-@@ -194,7 +204,7 @@ class EdrProviderWrapper extends events_1.EventEmitter {
+@@ -194,7 +205,7 @@ class EdrProviderWrapper extends events_1.EventEmitter {
          const minimalEthereumJsNode = {
              _vm: (0, minimal_vm_1.getMinimalEthereumJsVm)(provider),
          };
@@ -129,9 +128,27 @@ index 10f3b552eff7297ca16ae3acb5c30e5d97c5498e..daf7c475a43dbfa63c2a14bc9df2a10f
          // Pass through all events from the provider
          eventAdapter.addListener("ethEvent", wrapper._ethEventListener.bind(wrapper));
          return wrapper;
-@@ -234,10 +244,8 @@ class EdrProviderWrapper extends events_1.EventEmitter {
-         const needsTraces = this._node._vm.evm.events.eventNames().length > 0 ||
-             this._node._vm.events.eventNames().length > 0;
+@@ -223,6 +234,14 @@ class EdrProviderWrapper extends events_1.EventEmitter {
+             method: args.method,
+             params,
+         });
++        const needsTraces = this._node._vm.evm.events.eventNames().length > 0 ||
++            this._node._vm.events.eventNames().length > 0;
++        // Trace collection is expensive, so only enable it while something
++        // consumes the traces.
++        if (needsTraces !== this._callTracesEnabled) {
++            await this._provider.setIncludeCallTraces(needsTraces ? edr_1.IncludeTraces.All : edr_1.IncludeTraces.None);
++            this._callTracesEnabled = needsTraces;
++        }
+         const responseObject = await this._provider.handleRequest(stringifiedArgs);
+         let response;
+         if (typeof responseObject.data === "string") {
+@@ -231,13 +250,9 @@ class EdrProviderWrapper extends events_1.EventEmitter {
+         else {
+             response = responseObject.data;
+         }
+-        const needsTraces = this._node._vm.evm.events.eventNames().length > 0 ||
+-            this._node._vm.events.eventNames().length > 0;
          if (needsTraces) {
 -            const rawTraces = responseObject.traces;
 -            for (const rawTrace of rawTraces) {
@@ -142,7 +159,7 @@ index 10f3b552eff7297ca16ae3acb5c30e5d97c5498e..daf7c475a43dbfa63c2a14bc9df2a10f
                  // beforeTx event
                  if (this._node._vm.events.listenerCount("beforeTx") > 0) {
                      this._node._vm.events.emit("beforeTx");
-@@ -250,7 +258,7 @@ class EdrProviderWrapper extends events_1.EventEmitter {
+@@ -250,7 +265,7 @@ class EdrProviderWrapper extends events_1.EventEmitter {
                          }
                      }
                      // afterMessage event
@@ -151,7 +168,7 @@ index 10f3b552eff7297ca16ae3acb5c30e5d97c5498e..daf7c475a43dbfa63c2a14bc9df2a10f
                          if (this._node._vm.evm.events.listenerCount("afterMessage") > 0) {
                              this._node._vm.evm.events.emit("afterMessage", (0, convertToEdr_1.edrTracingMessageResultToMinimalEVMResult)(traceItem));
                          }
-@@ -270,21 +278,25 @@ class EdrProviderWrapper extends events_1.EventEmitter {
+@@ -270,21 +285,25 @@ class EdrProviderWrapper extends events_1.EventEmitter {
          }
          if ((0, http_1.isErrorResponse)(response)) {
              let error;
@@ -186,7 +203,7 @@ index 10f3b552eff7297ca16ae3acb5c30e5d97c5498e..daf7c475a43dbfa63c2a14bc9df2a10f
                  if (response.error.code === errors_1.InvalidArgumentsError.CODE) {
                      error = new errors_1.InvalidArgumentsError(response.error.message);
                  }
-@@ -304,10 +316,6 @@ class EdrProviderWrapper extends events_1.EventEmitter {
+@@ -304,10 +323,6 @@ class EdrProviderWrapper extends events_1.EventEmitter {
          if (args.method === "web3_clientVersion") {
              return clientVersion(response.result);
          }
@@ -197,7 +214,7 @@ index 10f3b552eff7297ca16ae3acb5c30e5d97c5498e..daf7c475a43dbfa63c2a14bc9df2a10f
          else {
              return response.result;
          }
-@@ -328,14 +336,16 @@ class EdrProviderWrapper extends events_1.EventEmitter {
+@@ -328,14 +343,16 @@ class EdrProviderWrapper extends events_1.EventEmitter {
          const [genesisState, ownedAccounts] = _genesisStateAndOwnedAccounts(forkConfig !== undefined, this._providerConfig.hardfork, this._originalGenesisAccounts);
          this._providerConfig.genesisState = genesisState;
          this._providerConfig.ownedAccounts = ownedAccounts;
@@ -221,7 +238,7 @@ index 10f3b552eff7297ca16ae3acb5c30e5d97c5498e..daf7c475a43dbfa63c2a14bc9df2a10f
                  blockNumber: forkConfig.blockNumber !== undefined
                      ? BigInt(forkConfig.blockNumber)
                      : undefined,
-@@ -346,7 +356,16 @@ class EdrProviderWrapper extends events_1.EventEmitter {
+@@ -346,12 +363,23 @@ class EdrProviderWrapper extends events_1.EventEmitter {
              };
          }
          else {
@@ -239,6 +256,13 @@ index 10f3b552eff7297ca16ae3acb5c30e5d97c5498e..daf7c475a43dbfa63c2a14bc9df2a10f
          }
          const context = await getGlobalEdrContext();
          const provider = await context.createProvider(GENERIC_CHAIN_TYPE, this._providerConfig, this._loggerConfig, this._subscriptionConfig, this._provider.contractDecoder());
+         this._provider = provider;
+         this._node._vm.stateManager.updateProvider(provider);
++        // The new provider starts from the creation-time config.
++        this._callTracesEnabled = false;
+         this.emit(constants_1.HARDHAT_NETWORK_RESET_EVENT);
+         return true;
+     }
 diff --git a/internal/hardhat-network/provider/provider.js.map b/internal/hardhat-network/provider/provider.js.map
 index 2bddfb96c5affd4463f5230e45ffe49e28ff0773..623ba6268d5cfaad3ebf463b73880be2e11a027b 100644
 --- a/internal/hardhat-network/provider/provider.js.map
@@ -403,7 +427,7 @@ index f83df9fdce13dcce820f520b556ec9dce9537ff8..b97968227b38b48845d60e4a93e8dd21
 +{"version":3,"file":"convertToEdr.js","sourceRoot":"","sources":["../../../../src/internal/hardhat-network/provider/utils/convertToEdr.ts"],"names":[],"mappings":";;;AAUA,8CAoB8B;AAC9B,2CAA2C;AAE3C,wDAAiE;AACjE,uDAAuD;AASvD,+EAA+E;AAE/E,SAAgB,8BAA8B,CAAC,QAAsB;IACnE,QAAQ,QAAQ,EAAE;QAChB,KAAK,wBAAY,CAAC,QAAQ;YACxB,OAAO,cAAQ,CAAC;QAClB,KAAK,wBAAY,CAAC,SAAS;YACzB,OAAO,eAAS,CAAC;QACnB,KAAK,wBAAY,CAAC,GAAG;YACnB,OAAO,cAAQ,CAAC;QAClB,KAAK,wBAAY,CAAC,iBAAiB;YACjC,OAAO,eAAS,CAAC;QACnB,KAAK,wBAAY,CAAC,eAAe;YAC/B,OAAO,qBAAe,CAAC;QACzB,KAAK,wBAAY,CAAC,SAAS;YACzB,OAAO,eAAS,CAAC;QACnB,KAAK,wBAAY,CAAC,cAAc;YAC9B,OAAO,oBAAc,CAAC;QACxB,KAAK,wBAAY,CAAC,UAAU;YAC1B,OAAO,gBAAU,CAAC;QACpB,KAAK,wBAAY,CAAC,QAAQ;YACxB,OAAO,cAAQ,CAAC;QAClB,KAAK,wBAAY,CAAC,YAAY;YAC5B,OAAO,kBAAY,CAAC;QACtB,KAAK,wBAAY,CAAC,MAAM;YACtB,OAAO,YAAM,CAAC;QAChB,KAAK,wBAAY,CAAC,MAAM;YACtB,OAAO,YAAM,CAAC;QAChB,KAAK,wBAAY,CAAC,aAAa;YAC7B,OAAO,mBAAa,CAAC;QACvB,KAAK,wBAAY,CAAC,YAAY;YAC5B,OAAO,kBAAY,CAAC;QACtB,KAAK,wBAAY,CAAC,KAAK;YACrB,OAAO,WAAK,CAAC;QACf,KAAK,wBAAY,CAAC,QAAQ;YACxB,OAAO,cAAQ,CAAC;QAClB,KAAK,wBAAY,CAAC,MAAM;YACtB,OAAO,YAAM,CAAC;QAChB,KAAK,wBAAY,CAAC,MAAM;YACtB,OAAO,YAAM,CAAC;QAChB,KAAK,wBAAY,CAAC,KAAK;YACrB,OAAO,WAAK,CAAC;QACf;YACE,MAAM,gBAAgB,GAAU,QAAQ,CAAC;YACzC,MAAM,IAAI,KAAK,CACb,0BAA0B,QAAkB,0BAA0B,CACvE,CAAC;KACL;AACH,CAAC;AA9CD,wEA8CC;AAED,SAAgB,2BAA2B,CAAC,MAAc;IACxD,MAAM,EAAE,MAAM,EAAE,GAAG,IAAA,6BAAmB,EACpC,sBAAsB,CACkB,CAAC;IAE3C,QAAQ,MAAM,EAAE;QACd,KAAK,MAAM,CAAC,QAAQ;YAClB,OAAO,wBAAY,CAAC,QAAQ,CAAC;QAC/B,KAAK,MAAM,CAAC,SAAS;YACnB,OAAO,wBAAY,CAAC,SAAS,CAAC;QAChC,KAAK,MAAM,CAAC,OAAO;YACjB,OAAO,wBAAY,CAAC,GAAG,CAAC;QAC1B,KAAK,MAAM,CAAC,SAAS;YACnB,OAAO,wBAAY,CAAC,iBAAiB,CAAC;QACxC,KAAK,MAAM,CAAC,cAAc;YACxB,OAAO,wBAAY,CAAC,eAAe,CAAC;QACtC,KAAK,MAAM,CAAC,SAAS;YACnB,OAAO,wBAAY,CAAC,SAAS,CAAC;QAChC,KAAK,MAAM,CAAC,cAAc;YACxB,OAAO,wBAAY,CAAC,cAAc,CAAC;QACrC,KAAK,MAAM,CAAC,UAAU;YACpB,OAAO,wBAAY,CAAC,UAAU,CAAC;QACjC,KAAK,MAAM,CAAC,QAAQ;YAClB,OAAO,wBAAY,CAAC,QAAQ,CAAC;QAC/B,KAAK,MAAM,CAAC,WAAW;YACrB,OAAO,wBAAY,CAAC,YAAY,CAAC;QACnC,KAAK,MAAM,CAAC,MAAM;YAChB,OAAO,wBAAY,CAAC,MAAM,CAAC;QAC7B,KAAK,MAAM,CAAC,MAAM;YAChB,OAAO,wBAAY,CAAC,MAAM,CAAC;QAC7B,KAAK,MAAM,CAAC,YAAY;YACtB,OAAO,wBAAY,CAAC,aAAa,CAAC;QACpC,KAAK,MAAM,CAAC,WAAW;YACrB,OAAO,wBAAY,CAAC,YAAY,CAAC;QACnC,KAAK,MAAM,CAAC,KAAK;YACf,OAAO,wBAAY,CAAC,KAAK,CAAC;QAC5B,KAAK,MAAM,CAAC,QAAQ;YAClB,OAAO,wBAAY,CAAC,QAAQ,CAAC;QAC/B,KAAK,MAAM,CAAC,MAAM;YAChB,OAAO,wBAAY,CAAC,MAAM,CAAC;QAC7B,KAAK,MAAM,CAAC,MAAM;YAChB,OAAO,wBAAY,CAAC,MAAM,CAAC;QAC7B,KAAK,MAAM,CAAC,KAAK;YACf,OAAO,wBAAY,CAAC,KAAK,CAAC;QAE5B;YACE,MAAM,IAAI,KAAK,CAAC,oBAAoB,MAAM,0BAA0B,CAAC,CAAC;KACzE;AACH,CAAC;AAhDD,kEAgDC;AAED,SAAgB,mCAAmC,CACjD,MAA4B;IAE5B,IAAI,OAAO,MAAM,KAAK,QAAQ,EAAE;QAC9B,+BAA+B;QAC/B,IAAI,MAAM,KAAK,CAAC,EAAE;YAChB,OAAO,SAAS,CAAC;SAClB;aAAM;YACL,OAAO,MAAM,CAAC,MAAM,CAAC,CAAC;SACvB;KACF;SAAM;QACL,OAAO;YACL,GAAG,EAAE,MAAM,CAAC,MAAM,CAAC,CAAC,CAAC,CAAC;YACtB,GAAG,EAAE,MAAM,CAAC,MAAM,CAAC,CAAC,CAAC,CAAC;SACvB,CAAC;KACH;AACH,CAAC;AAhBD,kFAgBC;AAED,SAAgB,uCAAuC,CACrD,YAA0B;IAE1B,MAAM,EAAE,YAAY,EAAE,GAAG,IAAA,6BAAmB,EAC1C,sBAAsB,CACkB,CAAC;IAE3C,QAAQ,YAAY,EAAE;QACpB,KAAK,MAAM;YACT,OAAO,YAAY,CAAC,IAAI,CAAC;QAC3B,KAAK,UAAU;YACb,OAAO,YAAY,CAAC,QAAQ,CAAC;KAChC;AACH,CAAC;AAbD,0FAaC;AAED,SAAgB,sCAAsC,CACpD,IAAiB;IAEjB,MAAM,sBAAsB,GAA2B;QACrD,EAAE,EAAE,MAAM,CAAC,IAAI,CAAC,EAAE,CAAC;QACnB,KAAK,EAAE,IAAI,CAAC,KAAK;QACjB,MAAM,EAAE;YACN,IAAI,EAAE,IAAI,CAAC,MAAM;SAClB;QACD,KAAK,EAAE,IAAI,CAAC,KAAK;KAClB,CAAC;IAEF,IAAI,IAAI,CAAC,MAAM,KAAK,SAAS,EAAE;QAC7B,sBAAsB,CAAC,MAAM,GAAG,IAAI,CAAC,MAAM,CAAC;KAC7C;IAED,OAAO,sBAAsB,CAAC;AAChC,CAAC;AAjBD,wFAiBC;AAED,SAAgB,yCAAyC,CACvD,oBAA0C;IAE1C,MAAM,EAAE,MAAM,EAAE,eAAe,EAAE,GAAG,oBAAoB,CAAC,eAAe,CAAC;IAEzE,8BAA8B;IAC9B,MAAM,OAAO,GAAG,MAAM,IAAI,MAAM,CAAC;IAEjC,MAAM,gBAAgB,GAAqB;QACzC,UAAU,EAAE;YACV,gBAAgB,EAAE,MAAM,CAAC,OAAO;YAChC,OAAO;SACR;KACF,CAAC;IAEF,gDAAgD;IAChD,IAAI,QAAQ,IAAI,MAAM,EAAE;QACtB,gBAAgB,CAAC,UAAU,CAAC,MAAM,GAAG,MAAM,CAAC,MAAM,CAAC;KACpD;IACD,IAAI,QAAQ,IAAI,MAAM,EAAE;QACtB,MAAM,EAAE,MAAM,EAAE,GAAG,MAAM,CAAC;QAC1B,IAAI,MAAM,YAAY,UAAU,EAAE;YAChC,gBAAgB,CAAC,UAAU,CAAC,MAAM,GAAG,MAAM,CAAC,IAAI,CAAC,MAAM,CAAC,CAAC;SAC1D;aAAM;YACL,gBAAgB,CAAC,UAAU,CAAC,MAAM,GAAG,MAAM,CAAC,IAAI,CAAC,MAAM,CAAC,WAAW,CAAC,CAAC;SACtE;KACF;IAED,IAAI,eAAe,KAAK,SAAS,EAAE;QACjC,gBAAgB,CAAC,UAAU,CAAC,eAAe,GAAG,IAAI,cAAO,CAAC,eAAe,CAAC,CAAC;KAC5E;IAED,OAAO,gBAAgB,CAAC;AAC1B,CAAC;AAjCD,8FAiCC;AAED,SAAgB,iCAAiC,CAC/C,OAAuB;IAEvB,OAAO;QACL,EAAE,EAAE,OAAO,CAAC,EAAE,KAAK,SAAS,CAAC,CAAC,CAAC,IAAI,cAAO,CAAC,OAAO,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,SAAS;QAClE,WAAW,EACT,OAAO,CAAC,WAAW,KAAK,SAAS;YAC/B,CAAC,CAAC,IAAI,cAAO,CAAC,OAAO,CAAC,WAAW,CAAC;YAClC,CAAC,CAAC,SAAS;QACf,IAAI,EAAE,OAAO,CAAC,IAAI;QAClB,KAAK,EAAE,OAAO,CAAC,KAAK;QACpB,MAAM,EAAE,IAAI,cAAO,CAAC,OAAO,CAAC,MAAM,CAAC;QACnC,QAAQ,EAAE,OAAO,CAAC,QAAQ;QAC1B,YAAY,EAAE,OAAO,CAAC,YAAY;KACnC,CAAC;AACJ,CAAC;AAfD,8EAeC;AAED,SAAgB,gBAAgB,CAAC,KAEhC;IACC,IAAI,WAAqC,CAAC;IAC1C,IAAI,KAAK,KAAK,SAAS,EAAE;QACvB,WAAW,GAAG,EAAE,CAAC;QAEjB,KAAK,MAAM,CAAC,IAAI,EAAE,KAAK,CAAC,IAAI,MAAM,CAAC,OAAO,CAAC,KAAK,CAAC,EAAE;YACjD,WAAW,CAAC,IAAI,CAAC;gBACf,IAAI;gBACJ,KAAK;aACN,CAAC,CAAC;SACJ;KACF;IAED,OAAO,WAAW,CAAC;AACrB,CAAC;AAhBD,4CAgBC"}
 \ No newline at end of file
 diff --git a/src/internal/hardhat-network/provider/provider.ts b/src/internal/hardhat-network/provider/provider.ts
-index d299f5c6853ab9dc2521234bbeb431c328fb9db8..2b2fefbafb71e22c5dfb7aec9a07495ffcb3dcb1 100644
+index d299f5c6853ab9dc2521234bbeb431c328fb9db8..ef9c289547c67dbd3fd66431e92e0e97660fc1cc 100644
 --- a/src/internal/hardhat-network/provider/provider.ts
 +++ b/src/internal/hardhat-network/provider/provider.ts
 @@ -21,7 +21,11 @@ import type {
@@ -427,7 +451,15 @@ index d299f5c6853ab9dc2521234bbeb431c328fb9db8..2b2fefbafb71e22c5dfb7aec9a07495f
    edrTracingMessageResultToMinimalEVMResult,
    edrTracingMessageToMinimalMessage,
    edrTracingStepToMinimalInterpreterStep,
-@@ -157,11 +160,14 @@ export class EdrProviderWrapper
+@@ -144,6 +147,7 @@ export class EdrProviderWrapper
+   implements EIP1193Provider
+ {
+   private _failedStackTraces = 0;
++  private _callTracesEnabled = false;
+ 
+   // temporarily added to make smock work with HH+EDR
+   private _callOverrideCallback?: CallOverrideCallback;
+@@ -157,11 +161,14 @@ export class EdrProviderWrapper
        _vm: MinimalEthereumJsVm;
      },
      private readonly _subscriptionConfig: SubscriptionConfig,
@@ -445,7 +477,7 @@ index d299f5c6853ab9dc2521234bbeb431c328fb9db8..2b2fefbafb71e22c5dfb7aec9a07495f
    ) {
      super();
    }
-@@ -200,9 +206,15 @@ export class EdrProviderWrapper
+@@ -200,9 +207,15 @@ export class EdrProviderWrapper
  
      const cacheDir = config.forkCachePath;
  
@@ -463,7 +495,7 @@ index d299f5c6853ab9dc2521234bbeb431c328fb9db8..2b2fefbafb71e22c5dfb7aec9a07495f
          blockNumber:
            config.forkConfig.blockNumber !== undefined
              ? BigInt(config.forkConfig.blockNumber)
-@@ -212,13 +224,13 @@ export class EdrProviderWrapper
+@@ -212,13 +225,13 @@ export class EdrProviderWrapper
          httpHeaders: httpHeadersToEdr(config.forkConfig.httpHeaders),
          url: config.forkConfig.jsonRpcUrl,
        };
@@ -482,7 +514,7 @@ index d299f5c6853ab9dc2521234bbeb431c328fb9db8..2b2fefbafb71e22c5dfb7aec9a07495f
      // To accommodate construction ordering, we need an adapter to forward events
      // from the EdrProvider callback to the wrapper's listener
      const eventAdapter = new EdrProviderEventAdapter();
-@@ -230,7 +242,7 @@ export class EdrProviderWrapper
+@@ -230,7 +243,7 @@ export class EdrProviderWrapper
      const edrHardfork = ethereumsjsHardforkToEdrSpecId(hardforkName);
  
      const [genesisState, ownedAccounts] = _genesisStateAndOwnedAccounts(
@@ -491,7 +523,7 @@ index d299f5c6853ab9dc2521234bbeb431c328fb9db8..2b2fefbafb71e22c5dfb7aec9a07495f
        edrHardfork,
        config.genesisAccounts
      );
-@@ -247,14 +259,12 @@ export class EdrProviderWrapper
+@@ -247,14 +260,12 @@ export class EdrProviderWrapper
        allowUnlimitedContractSize: config.allowUnlimitedContractSize,
        bailOnCallFailure: config.throwOnCallFailures,
        bailOnTransactionFailure: config.throwOnTransactionFailures,
@@ -507,7 +539,7 @@ index d299f5c6853ab9dc2521234bbeb431c328fb9db8..2b2fefbafb71e22c5dfb7aec9a07495f
        initialBaseFeePerGas:
          config.initialBaseFeePerGas !== undefined
            ? BigInt(config.initialBaseFeePerGas!)
-@@ -262,13 +272,15 @@ export class EdrProviderWrapper
+@@ -262,11 +273,13 @@ export class EdrProviderWrapper
        minGasPrice: config.minGasPrice,
        mining: {
          autoMine: config.automine,
@@ -519,12 +551,9 @@ index d299f5c6853ab9dc2521234bbeb431c328fb9db8..2b2fefbafb71e22c5dfb7aec9a07495f
        },
 +      network,
        networkId: BigInt(config.networkId),
--      observability: {},
-+      observability: { includeCallTraces: IncludeTraces.All },
+       observability: {},
        ownedAccounts,
-       // Turn off the Osaka EIP-7825 per transaction gas limit for HH2
-       // when being run from `solidity-coverage`.
-@@ -332,7 +344,9 @@ export class EdrProviderWrapper
+@@ -332,7 +345,9 @@ export class EdrProviderWrapper
        edrSubscriptionConfig,
        config.genesisAccounts,
        cacheDir,
@@ -535,9 +564,34 @@ index d299f5c6853ab9dc2521234bbeb431c328fb9db8..2b2fefbafb71e22c5dfb7aec9a07495f
      );
  
      // Pass through all events from the provider
-@@ -392,11 +406,8 @@ export class EdrProviderWrapper
-       this._node._vm.events.eventNames().length > 0;
+@@ -376,6 +391,19 @@ export class EdrProviderWrapper
+       params,
+     });
  
++    const needsTraces =
++      this._node._vm.evm.events.eventNames().length > 0 ||
++      this._node._vm.events.eventNames().length > 0;
++
++    // Trace collection is expensive, so only enable it while something
++    // consumes the traces.
++    if (needsTraces !== this._callTracesEnabled) {
++      await this._provider.setIncludeCallTraces(
++        needsTraces ? IncludeTraces.All : IncludeTraces.None
++      );
++      this._callTracesEnabled = needsTraces;
++    }
++
+     const responseObject: Response = await this._provider.handleRequest(
+       stringifiedArgs
+     );
+@@ -387,16 +415,9 @@ export class EdrProviderWrapper
+       response = responseObject.data;
+     }
+ 
+-    const needsTraces =
+-      this._node._vm.evm.events.eventNames().length > 0 ||
+-      this._node._vm.events.eventNames().length > 0;
+-
      if (needsTraces) {
 -      const rawTraces = responseObject.traces;
 -      for (const rawTrace of rawTraces) {
@@ -549,7 +603,7 @@ index d299f5c6853ab9dc2521234bbeb431c328fb9db8..2b2fefbafb71e22c5dfb7aec9a07495f
          // beforeTx event
          if (this._node._vm.events.listenerCount("beforeTx") > 0) {
            this._node._vm.events.emit("beforeTx");
-@@ -413,7 +424,7 @@ export class EdrProviderWrapper
+@@ -413,7 +434,7 @@ export class EdrProviderWrapper
              }
            }
            // afterMessage event
@@ -558,7 +612,7 @@ index d299f5c6853ab9dc2521234bbeb431c328fb9db8..2b2fefbafb71e22c5dfb7aec9a07495f
              if (this._node._vm.evm.events.listenerCount("afterMessage") > 0) {
                this._node._vm.evm.events.emit(
                  "afterMessage",
-@@ -442,20 +453,37 @@ export class EdrProviderWrapper
+@@ -442,20 +463,37 @@ export class EdrProviderWrapper
      if (isErrorResponse(response)) {
        let error;
  
@@ -605,7 +659,7 @@ index d299f5c6853ab9dc2521234bbeb431c328fb9db8..2b2fefbafb71e22c5dfb7aec9a07495f
          if (response.error.code === InvalidArgumentsError.CODE) {
            error = new InvalidArgumentsError(response.error.message);
          } else {
-@@ -479,11 +507,6 @@ export class EdrProviderWrapper
+@@ -479,11 +517,6 @@ export class EdrProviderWrapper
      // e.g. `HardhatNetwork/2.19.0/@nomicfoundation/edr/0.2.0-dev`
      if (args.method === "web3_clientVersion") {
        return clientVersion(response.result);
@@ -617,7 +671,7 @@ index d299f5c6853ab9dc2521234bbeb431c328fb9db8..2b2fefbafb71e22c5dfb7aec9a07495f
      } else {
        return response.result;
      }
-@@ -519,18 +542,19 @@ export class EdrProviderWrapper
+@@ -519,18 +552,19 @@ export class EdrProviderWrapper
      this._providerConfig.genesisState = genesisState;
      this._providerConfig.ownedAccounts = ownedAccounts;
  
@@ -646,7 +700,7 @@ index d299f5c6853ab9dc2521234bbeb431c328fb9db8..2b2fefbafb71e22c5dfb7aec9a07495f
          blockNumber:
            forkConfig.blockNumber !== undefined
              ? BigInt(forkConfig.blockNumber)
-@@ -541,7 +565,18 @@ export class EdrProviderWrapper
+@@ -541,7 +575,18 @@ export class EdrProviderWrapper
          url: forkConfig.jsonRpcUrl,
        };
      } else {
@@ -666,6 +720,15 @@ index d299f5c6853ab9dc2521234bbeb431c328fb9db8..2b2fefbafb71e22c5dfb7aec9a07495f
      }
  
      const context = await getGlobalEdrContext();
+@@ -555,6 +600,8 @@ export class EdrProviderWrapper
+ 
+     this._provider = provider;
+     this._node._vm.stateManager.updateProvider(provider);
++    // The new provider starts from the creation-time config.
++    this._callTracesEnabled = false;
+ 
+     this.emit(HARDHAT_NETWORK_RESET_EVENT);
+ 
 diff --git a/src/internal/hardhat-network/provider/utils/convertToEdr.ts b/src/internal/hardhat-network/provider/utils/convertToEdr.ts
 index 7fc17b29c0483c4f72ec471f8be60ce7d563add8..c6be433f86f38b5f5b9339a3274fba60ac22fa13 100644
 --- a/src/internal/hardhat-network/provider/utils/convertToEdr.ts

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   hardhat>@nomicfoundation/edr: workspace:*
 
 patchedDependencies:
-  hardhat@2.28.6: f1aafd8fdf59ec40b7bebdb475978d49722dfa924d5f45d099eeb837dc2e02d4
+  hardhat@2.28.6: eb360a8e69bd32b5263bb0e62a0fcf764d4b0d60cf4594d33f8c720c21102c43
   hardhat@3.4.5: 0de38ef817bceff74a51505ab96d0c87085e888d660f71a437d879da576ba805
 
 importers:
@@ -209,7 +209,7 @@ importers:
         version: 7.0.1
       hardhat:
         specifier: 2.28.6
-        version: 2.28.6(patch_hash=f1aafd8fdf59ec40b7bebdb475978d49722dfa924d5f45d099eeb837dc2e02d4)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)
+        version: 2.28.6(patch_hash=eb360a8e69bd32b5263bb0e62a0fcf764d4b0d60cf4594d33f8c720c21102c43)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)
       mocha:
         specifier: ^11.1.0
         version: 11.7.6
@@ -291,7 +291,7 @@ importers:
         version: 3.4.5(patch_hash=0de38ef817bceff74a51505ab96d0c87085e888d660f71a437d879da576ba805)
       hardhat2:
         specifier: npm:hardhat@2.28.6
-        version: hardhat@2.28.6(patch_hash=f1aafd8fdf59ec40b7bebdb475978d49722dfa924d5f45d099eeb837dc2e02d4)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)
+        version: hardhat@2.28.6(patch_hash=eb360a8e69bd32b5263bb0e62a0fcf764d4b0d60cf4594d33f8c720c21102c43)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)
       lodash:
         specifier: ^4.17.11
         version: 4.17.21
@@ -6340,7 +6340,7 @@ snapshots:
 
   graphemer@1.4.0: {}
 
-  hardhat@2.28.6(patch_hash=f1aafd8fdf59ec40b7bebdb475978d49722dfa924d5f45d099eeb837dc2e02d4)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3):
+  hardhat@2.28.6(patch_hash=eb360a8e69bd32b5263bb0e62a0fcf764d4b0d60cf4594d33f8c720c21102c43)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3):
     dependencies:
       '@ethereumjs/util': 9.1.0
       '@ethersproject/abi': 5.7.0


### PR DESCRIPTION
Follow-up to #1536, resolving the residual benchmark alert (1.12–1.20x on four scenarios) by only paying for trace collection when something consumes the traces.

# Claude summary

## Problem

#1536 replaced full-stack clones with top-of-stack capture, but the `edr-benchmark` runs on it still alerted at 1.12–1.28x against the traces-off baseline. The residual cost of `includeCallTraces: All` was paid **statically** on every transaction, even when nothing ever reads `traces()`:

- per-step single-element `Box<[U256]>` stack snapshots written into the arena at collect time, plus an ordering DFS per transaction;
- the per-step top-of-stack capture itself;
- arenas moved into the napi `Response` and retained until JS GC, instead of being dropped at filter time like the `None` path.

The scenario benchmark — like any Hardhat 2 run without solidity-coverage-style plugins — never reads the traces it was paying for. Hardhat 2 already computes exactly the right signal (`needsTraces`, from its VM event listener counts); it just had no way to act on it.

## Approach (one commit each)

1. **Materialize stack tops lazily at marshal time.** `collect()`/`take()` return the arena bundled with the raw captured tops (`edr_solidity::tracing::CallTraces`); nothing is written into the arena's steps. `Response.traces()` — the only consumer of per-step stacks in non-verbose mode — zips the tops with its existing depth-first step walk, materializing JS values directly. The walk's quirks are handled explicitly: the skipped leading `STOP` step still consumes a captured value, and children skipped by `should_skip_call` have no steps by definition. This removes the per-step allocations and the DFS from every transaction whose traces are never marshalled. Verified on the benchmark: the `All Scenarios` aggregate, synthetix, and rocketpool dropped below the alert threshold; seaport 1.28→1.13, openzeppelin 1.26→1.17, uniswap-v3-core 1.24→1.20 (step-dense, dominated by the remaining capture cost).
2. **`setIncludeCallTraces()`.** A runtime toggle for `includeCallTraces`, mirroring the `setVerboseTracing` plumbing through `SyncProvider`/`Provider`/`ProviderData`. Traces that are not included are never collected: no arenas retained in responses and no top-of-stack capture for subsequent requests.
3. **Hardhat 2 patch: collect only while the vm trace bridge has listeners.** The 2.28.6 patch no longer requests `IncludeTraces.All` statically at provider creation. Instead the wrapper evaluates the bridge's existing `needsTraces` listener check *before* dispatching each request and toggles the setter when the value changes — in practice one napi call per process, since listeners attach at plugin setup. `hardhat_reset` recreates the inner provider from the creation-time config, so the tracked state resets with it. The same change is mirrored on the Hardhat 2 source branch backing NomicFoundation/hardhat#8422 (the patch source stays byte-identical to that branch).

With all three, the scenario benchmark exercises the true `None` path — the same work as the stored baseline — so the gate should go green, while coverage-style consumers pay capture + marshal only while actually listening.

## Anticipated questions

- **Doesn't this invert #1536's plan to adopt `StackSnapshotType::Top` upstream (paradigmxyz/revm-inspectors#468)?** Yes. Upstream `Top` materializes a boxed single-element snapshot per step *during execution* — exactly the allocation the lazy path avoids — so migrating to it would now be a regression. #468 remains useful for other `revm-inspectors` consumers.
- **Why toggle from the hardhat patch instead of defaulting EDR to demand-driven?** EDR can't know whether a consumer will call `traces()`; Hardhat 2's wrapper is the one place that knows (its VM event listener counts). Hardhat 3 consumers configure `includeCallTraces` explicitly per provider, unchanged.
- **Mixed configurations within one process?** The setter only affects requests handled after it; each transaction's arena carries its own captured tops, so responses collected under different settings marshal independently (empty tops fall back to the arena's recorded stacks, e.g. verbose).

## Testing

- The `write_stack_tops` unit tests moved to the napi marshal layer as tests of the zip: execution order across nested call frames, the skipped-leading-`STOP` alignment, and the recorded-stack fallback when no tops were captured.
- New `edr_napi` test: `setIncludeCallTraces` toggles take effect for subsequent requests — traces absent by default, present (with correct per-step tops) after enabling, absent again after disabling.
- The #1536 nested-`CALL` contract test and the #1301 trace tests pass unchanged; typings regenerated (`setIncludeCallTraces` is the only addition).
- `hardhat-tests`: the trace-event-bridge spec still emits `step`/`beforeMessage`/`afterMessage` — proving the listeners → toggle → collect → bridge chain end-to-end — and the `evm`/`hardhat` modules pass against the updated patch.
