### PR TITLE
perf: record only the top of the stack for non-verbose raw traces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7045,8 +7045,7 @@ dependencies = [
 [[package]]
 name = "revm-inspectors"
 version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731b682530a732ef9c189ef831589128e2ce34d4a306c956322ae2dffe009715"
+source = "git+https://github.com/nebasuke/revm-inspectors?branch=feat%2Ftop-of-stack-snapshot-0.39#c96538fb42198b88e37771104c5bdf52b31ca706"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -258,7 +258,12 @@ c-kzg = { version = "2.1.4", default-features = false, features = [
     "ethereum_kzg_settings",
 ] }
 
-revm-inspectors = { version = "0.39.0", features = ["serde"] }
+# Temporary fork adding `StackSnapshotType::Top` on the 0.39.0 line; revert to
+# crates.io once paradigmxyz/revm-inspectors#468 is released and EDR is on its
+# revm major.
+revm-inspectors = { git = "https://github.com/nebasuke/revm-inspectors", branch = "feat/top-of-stack-snapshot-0.39", features = [
+    "serde",
+] }
 foundry-fork-db = "0.26"
 
 ## ethers

--- a/crates/edr_napi/test/provider.ts
+++ b/crates/edr_napi/test/provider.ts
@@ -194,6 +194,95 @@ describe("Provider", () => {
       assert.deepEqual(steps[3].stack, [1n, 2n, 3n]);
     });
 
+    it("should include the top of the stack across nested call frames", async function () {
+      const provider = await createGenericProvider(
+        context,
+        tracingProviderOverrides
+      );
+
+      // Deploy a contract with runtime code:
+      // PUSH1 0x0a
+      // PUSH1 0x0b
+      // STOP
+      await provider.handleRequest(
+        JSON.stringify({
+          id: 1,
+          jsonrpc: "2.0",
+          method: "eth_sendTransaction",
+          params: [
+            {
+              from: "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+              // PUSH5 0x600a600b00
+              // PUSH0
+              // MSTORE
+              // PUSH1 5 (length)
+              // PUSH1 27 (offset)
+              // RETURN
+              data: "0x64600a600b005f526005601bf3",
+              gas: "0x" + 1_000_000n.toString(16),
+            },
+          ],
+        })
+      );
+
+      const calleeAddress = 0x5fbdb2315678afecb367f032d93f642f64180aa3n;
+
+      const responseObject = await provider.handleRequest(
+        JSON.stringify({
+          id: 2,
+          jsonrpc: "2.0",
+          method: "eth_sendTransaction",
+          params: [
+            {
+              from: "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+              // PUSH1 0 (x5: return length & offset, args length & offset, value)
+              // PUSH20 <callee address>
+              // PUSH2 0xffff (gas)
+              // CALL
+              // PUSH1 0x2a
+              // STOP
+              data: "0x60006000600060006000735fbdb2315678afecb367f032d93f642f64180aa361fffff1602a00",
+              gas: "0x" + 1_000_000n.toString(16),
+            },
+          ],
+        })
+      );
+
+      const rawTraces = responseObject.traces();
+      assert.lengthOf(rawTraces, 1);
+
+      const trace = rawTraces[0];
+      const steps = collectSteps(trace);
+
+      assert.lengthOf(steps, 13);
+      assert.deepEqual(
+        steps.map((step) => step.depth),
+        [0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0]
+      );
+
+      assert.deepEqual(
+        steps.map((step) => step.stack),
+        [
+          // Caller frame: PUSH1 0 (x5), PUSH20, PUSH2, CALL
+          [],
+          [0n],
+          [0n],
+          [0n],
+          [0n],
+          [0n],
+          [calleeAddress],
+          [0xffffn],
+          // Callee frame: PUSH1 0x0a, PUSH1 0x0b, STOP
+          [],
+          [0x0an],
+          [0x0bn],
+          // Caller frame: PUSH1 0x2a sees the CALL success flag, then STOP
+          [1n],
+          [0x2an],
+        ]
+      );
+    });
+
     it("should not include memory by default", async function () {
       const provider = await createGenericProvider(
         context,

--- a/crates/edr_provider/src/observability.rs
+++ b/crates/edr_provider/src/observability.rs
@@ -163,9 +163,18 @@ impl EvmObserver {
         let tracing_config = if config.verbose_raw_tracing {
             TracingInspectorConfig::all()
         } else {
+            // The stack-trace and internal-OOG paths read pcs and statuses,
+            // never step stacks, so snapshots are only needed when traces are
+            // included in responses.
+            let stack_snapshots = if config.include_call_traces == IncludeTraces::None {
+                StackSnapshotType::None
+            } else {
+                StackSnapshotType::Top
+            };
+
             TracingInspectorConfig::default_parity()
                 .set_steps(true)
-                .set_stack_snapshots(StackSnapshotType::Full)
+                .set_stack_snapshots(stack_snapshots)
         };
 
         Self {


### PR DESCRIPTION
On top of #1301 (`feat/tracing-back-compat`) to resolve the benchmark regression of up to 2.45x reported there. Supersedes #1536: this directly uses `StackSnapshotType::Top` (paradigmxyz/revm-inspectors#468) from a fork branch that backports it onto the 0.39.0 release EDR already pins.

Note there is an expected performance regression compared to not producing traces, see below. This holds only for Hardhat 2.

| Benchmark suite | Current: 1379aaa1d8fec926e832cf216d1a2a02bd173775 | Previous: 46b2d018a1797d1ed0733339bdc54ef23721ff97 | Ratio |
|-|-|-|-|
| `All Scenarios` | `245310.748094` ms | `214303.369506` ms | `1.14` |
| `neptune-mutual-blue-protocol_8db6480` | `25903.104518` ms | `22167.746617` ms | `1.17` |
| `openzeppelin-contracts_0a5fba7a` | `11628.837737000002` ms | `9068.634355999999` ms | `1.28` |
| `rocketpool_6a9dbfd8` | `14754.833111` ms | `13019.832804000001` ms | `1.13` |
| `safe-contracts_914d0f8` | `730.062472` ms | `657.7373329999999` ms | `1.11` |
| `seaport_585b2ef8` | `5946.402571` ms | `4910.134137999999` ms | `1.21` |
| `synthetix_9a3a109f` | `181693.82570000002` ms | `160506.680113` ms | `1.13` |
| `uniswap-v3-core_d8b1c63` | `4653.681985` ms | `3972.6041450000002` ms | `1.17` |


# Claude summary

## Problem

To expose the top of the stack through the non-verbose `Response::traces()` output, #1301 sets `StackSnapshotType::Full`, which clones the entire EVM stack (up to 1024 words) on every step of every transaction. The cost is paid unconditionally — even when the arena is discarded (`includeCallTraces` defaults to `IncludeTraces::None`, the Hardhat 3 default). The consumer only ever reads `step.stack.last()` in non-verbose mode, and no released `revm-inspectors` (0.33–0.41) offers a top-of-stack-only snapshot type.

## Approach

Use the real thing: `StackSnapshotType::Top` from paradigmxyz/revm-inspectors#468 records a single-element (or empty) snapshot per step — one `U256` copy instead of a full stack clone — into the same `step.stack` field, so `.last()` consumers are unchanged. When `includeCallTraces` is `None`, snapshots are skipped entirely: the stack-trace and internal-OOG paths read pcs and statuses, never step stacks.

Since upstream #468 targets the revm-41 line and EDR pins revm-inspectors 0.39.0 / revm 38, the dependency temporarily points at `nebasuke/revm-inspectors` branch `feat/top-of-stack-snapshot-0.39` — the upstream PR commit cherry-picked onto the 0.39.0 release commit (applied cleanly, full test suite green including the two new stack snapshot tests). Once #468 is released and EDR moves to its revm major, the dependency reverts to crates.io with a version bump and this PR's diff shrinks to the config gating.

Resulting cost per configuration:

| Configuration | Before | After |
|---|---|---|
| `includeCallTraces: None` (Hardhat 3 default) | full stack clone per step | zero — identical to `main` |
| `includeCallTraces: All`, non-verbose (Hardhat 2) | full stack clone per step | one `U256` copy per step (the historical baseline) |
| verbose | full stack clone per step (`all()`) | unchanged |

## Changes

- `Cargo.toml` / `Cargo.lock`: `revm-inspectors` from the fork branch, pinned in the lockfile to the backport commit. Git sources are skipped by cargo-cooldown-check; nothing else re-resolved.
- `crates/edr_provider/src/observability.rs`: non-verbose tracing config selects `StackSnapshotType::Top`, or `StackSnapshotType::None` when traces can't be included in responses.
- `crates/edr_napi/test/provider.ts`: nested-call-frames top-of-stack integration test carried over from #1536; step semantics (`Some([])` for an empty stack, `Some([top])` otherwise) are additionally pinned down by the fork's own `tests/it/stack.rs`.

## Testing

- Fork backport branch: full `cargo test` green (30 integration tests + `test_top_stack_snapshots` + `test_top_stack_snapshots_match_the_top_of_full_snapshots`).
- EDR: `cargo check --no-default-features` (workspace), `cargo test --all-features -p edr_solidity -p edr_provider` (remote-fork tests requiring `ALCHEMY_URL` excluded locally), and the napi mocha tests matching "top of the stack" against a rebuilt binding.