### PR TITLE
ci: add actionlint + zizmor GitHub Actions linters

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,6 +1,4 @@
-# Self-hosted runner labels actionlint can't know about, so it doesn't flag
-# `runs-on:` as an unknown label. Keep in sync with the runners registered for
-# this repo/org.
+# Self-hosted runner labels, so actionlint doesn't flag `runs-on:` as unknown.
 self-hosted-runner:
   labels:
     - edr-benchmark-runner

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+# Self-hosted runner labels actionlint can't know about, so it doesn't flag
+# `runs-on:` as an unknown label. Keep in sync with the runners registered for
+# this repo/org.
+self-hosted-runner:
+  labels:
+    - edr-benchmark-runner
+    - hardhat-linux-amd64-self-hosted

--- a/.github/actions/setup-llvm-cov/action.yml
+++ b/.github/actions/setup-llvm-cov/action.yml
@@ -15,4 +15,4 @@ runs:
     - name: Pin CARGO_BUILD_TARGET to the host triple
       if: inputs.builds-napi-crate == 'true'
       shell: bash
-      run: echo "CARGO_BUILD_TARGET=$(rustc --print host-tuple)" >> "$GITHUB_ENV"
+      run: echo "CARGO_BUILD_TARGET=$(rustc --print host-tuple)" >> "$GITHUB_ENV" # zizmor: ignore[github-env] rustc output, not external input

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -45,7 +45,7 @@ runs:
     # itself before any later step appends instrumentation flags.
     - name: Augment RUSTFLAGS with platform target features
       shell: bash
-      run: |
+      run: | # zizmor: ignore[github-env] static target-feature flag, not external input
         case "$RUNNER_OS" in
           Windows)
             echo "RUSTFLAGS=${RUSTFLAGS:-} -C target-feature=+crt-static" >> "$GITHUB_ENV"

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -45,7 +45,8 @@ runs:
     # itself before any later step appends instrumentation flags.
     - name: Augment RUSTFLAGS with platform target features
       shell: bash
-      run: | # zizmor: ignore[github-env] static target-feature flag, not external input
+      run:
+        | # zizmor: ignore[github-env] static target-feature flag, not external input
         case "$RUNNER_OS" in
           Windows)
             echo "RUSTFLAGS=${RUSTFLAGS:-} -C target-feature=+crt-static" >> "$GITHUB_ENV"

--- a/.github/workflows/check-changeset-added.yml
+++ b/.github/workflows/check-changeset-added.yml
@@ -14,6 +14,10 @@ on:
       - labeled
       - unlabeled
 
+# Only reads PR files and labels via the API.
+permissions:
+  pull-requests: read
+
 jobs:
   check-if-changeset:
     name: Check that PR has a changeset

--- a/.github/workflows/check-generated-files.yml
+++ b/.github/workflows/check-generated-files.yml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{github.workflow}}-${{github.ref}}
   cancel-in-progress: true

--- a/.github/workflows/edr-benchmark.yml
+++ b/.github/workflows/edr-benchmark.yml
@@ -10,6 +10,11 @@ on:
       - "**"
   workflow_dispatch:
 
+# Benchmark results are pushed to an external repo via BENCHMARK_GITHUB_TOKEN
+# (a PAT), and job summaries need no scope — so GITHUB_TOKEN only reads.
+permissions:
+  contents: read
+
 defaults:
   run:
     working-directory: js/benchmark

--- a/.github/workflows/edr-benchmark.yml
+++ b/.github/workflows/edr-benchmark.yml
@@ -10,8 +10,7 @@ on:
       - "**"
   workflow_dispatch:
 
-# Benchmark results are pushed to an external repo via BENCHMARK_GITHUB_TOKEN
-# (a PAT), and job summaries need no scope — so GITHUB_TOKEN only reads.
+# Results are pushed to an external repo via a PAT, so GITHUB_TOKEN only reads.
 permissions:
   contents: read
 

--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -392,3 +392,39 @@ jobs:
           key: cooldown-check-v1-${{ hashFiles('**/Cargo.lock') }}
 
       - uses: NomicFoundation/cargo-cooldown-check@ac40e701f9f1155741a761ac9039987fb892af4b
+
+  actionlint:
+    name: Lint GitHub Actions workflows
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      # rhysd's official image bundles actionlint + shellcheck + pyflakes, so
+      # `run:`-block linting works with no runner deps. Exits non-zero on any
+      # finding -> blocks. Digest-pinned (Renovate manages docker `uses:` too).
+      - name: Run actionlint
+        uses: docker://rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667
+        with:
+          args: -color
+
+  zizmor:
+    name: Audit GitHub Actions security (zizmor)
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: taiki-e/install-action@9bcaee1dcae34154180f412e2fa69355a7cda9f6 # v2.82.6
+        with:
+          tool: zizmor@1.26.1
+      # GH_TOKEN enables the online audits (known-vulnerabilities, tag->SHA
+      # resolution for unpinned-uses). zizmor exits non-zero on findings -> blocks.
+      - name: Run zizmor
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: zizmor --format github .github

--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -11,8 +11,7 @@ on:
       - "**"
   workflow_dispatch:
 
-# Every job here only reads the repo (checks, tests, docs, build; coverage
-# uploads via CODECOV_TOKEN, not GITHUB_TOKEN). Jobs needing more set their own.
+# Read-only: even the coverage upload uses CODECOV_TOKEN, not GITHUB_TOKEN.
 permissions:
   contents: read
 
@@ -405,9 +404,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-      # rhysd's official image bundles actionlint + shellcheck + pyflakes, so
-      # `run:`-block linting works with no runner deps. Exits non-zero on any
-      # finding -> blocks. Digest-pinned (Renovate manages docker `uses:` too).
+      # Official image bundles shellcheck + pyflakes, so `run:` linting needs no runner deps.
       - name: Run actionlint
         uses: docker://rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667
         with:
@@ -423,8 +420,7 @@ jobs:
       - uses: taiki-e/install-action@9bcaee1dcae34154180f412e2fa69355a7cda9f6 # v2.82.6
         with:
           tool: zizmor@1.26.1
-      # GH_TOKEN enables the online audits (known-vulnerabilities, tag->SHA
-      # resolution for unpinned-uses). zizmor exits non-zero on findings -> blocks.
+      # GH_TOKEN enables the online audits (known-vulnerabilities, tag->SHA resolution).
       - name: Run zizmor
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -214,6 +214,7 @@ jobs:
           FORCE_COLOR: 3
         shell: bash
         run: |
+          # shellcheck disable=SC1090 # generated env from cargo-llvm-cov, not a static file
           source <(cargo llvm-cov show-env --sh)
           pnpm -C crates/edr_napi test
           # `--release` included to match `build:dev` compilation flags
@@ -366,6 +367,7 @@ jobs:
       - name: Run integration tests
         shell: bash
         run: |
+          # shellcheck disable=SC1090 # generated env from cargo-llvm-cov, not a static file
           source <(cargo llvm-cov show-env --sh)
           pnpm run --recursive --filter './js/integration-tests/*' test
           # `--release` included to match `build:dev` compilation flags
@@ -407,6 +409,9 @@ jobs:
       # Official image bundles shellcheck + pyflakes, so `run:` linting needs no runner deps.
       - name: Run actionlint
         uses: docker://rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667
+        env:
+          # Gate on shellcheck warnings/errors; info-level style nits are noise.
+          SHELLCHECK_OPTS: --severity=warning
         with:
           args: -color
 

--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -11,6 +11,11 @@ on:
       - "**"
   workflow_dispatch:
 
+# Every job here only reads the repo (checks, tests, docs, build; coverage
+# uploads via CODECOV_TOKEN, not GITHUB_TOKEN). Jobs needing more set their own.
+permissions:
+  contents: read
+
 concurrency:
   group: ${{github.workflow}}-${{github.ref}}
   cancel-in-progress: true
@@ -396,8 +401,6 @@ jobs:
   actionlint:
     name: Lint GitHub Actions workflows
     runs-on: ubuntu-24.04
-    permissions:
-      contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -413,8 +416,6 @@ jobs:
   zizmor:
     name: Audit GitHub Actions security (zizmor)
     runs-on: ubuntu-24.04
-    permissions:
-      contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/edr-npm-release.yml
+++ b/.github/workflows/edr-npm-release.yml
@@ -95,7 +95,8 @@ jobs:
 
       - name: Check number of targets
         shell: bash
-        run: | # zizmor: ignore[template-injection] strategy.job-total is a controlled integer, not external input
+        run:
+          | # zizmor: ignore[template-injection] strategy.job-total is a controlled integer, not external input
           echo "Number of build jobs: ${{ strategy.job-total }}"
           echo "Expected number of build jobs: $NUMBER_OF_TARGETS"
           test ${{ strategy.job-total }} -eq "$NUMBER_OF_TARGETS"

--- a/.github/workflows/edr-npm-release.yml
+++ b/.github/workflows/edr-npm-release.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Check number of targets
         shell: bash
-        run: |
+        run: | # zizmor: ignore[template-injection] strategy.job-total is a controlled integer, not external input
           echo "Number of build jobs: ${{ strategy.job-total }}"
           echo "Expected number of build jobs: $NUMBER_OF_TARGETS"
           test ${{ strategy.job-total }} -eq "$NUMBER_OF_TARGETS"
@@ -117,7 +117,7 @@ jobs:
       # Release commits build cold: napi codegen relies on proc-macro
       # expansion (napi-rs#1297), so warm-cache builds risk shipping
       # stale or empty index.js / index.d.ts. Don't enable for releases.
-      - name: Cache cargo
+      - name: Cache cargo # zizmor: ignore[cache-poisoning] release builds run cold (guarded below); PR/main caches never feed a publish
         if: needs.check_commit.outputs.tag == ''
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
@@ -352,7 +352,7 @@ jobs:
       - name: Install dependencies
         run: |
           pnpm install --frozen-lockfile --prefer-offline --cpu=arm64 --libc=glibc
-      - name: Setup and run tests
+      - name: Setup and run tests # zizmor: ignore[superfluous-actions] deliberate cross-arch (arm64) test runner
         uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 #v3
         with:
           image: node:${{ matrix.node }}
@@ -394,7 +394,7 @@ jobs:
         shell: bash
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline --cpu=arm64 --libc=musl
-      - name: Setup and run tests
+      - name: Setup and run tests # zizmor: ignore[superfluous-actions] deliberate cross-arch (arm64/musl) test runner
         uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # v3
         with:
           image: node:${{ matrix.node }}-alpine
@@ -531,7 +531,9 @@ jobs:
           name: ${{ needs.prepare.outputs.filename }}
           path: .
       - name: Decompress tarball
-        run: tar -xvzf ${{ needs.prepare.outputs.filename }}
+        env:
+          FILENAME: ${{ needs.prepare.outputs.filename }}
+        run: tar -xvzf "$FILENAME"
       - name: Inspect contents
         run: tree .
       - name: Check number of artifacts
@@ -549,7 +551,8 @@ jobs:
         id: setup-node
         with:
           node-version: 24
-          cache: pnpm
+          # A publish workflow must not restore a poisonable cache.
+          package-manager-cache: false
       - name: Validate that packages have everything for publishing
         run: |
           cd crates/edr_napi
@@ -589,13 +592,6 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-rust
-
-      - name: Cache cooldown data
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
-        with:
-          path: |
-            **/edr-cache/cargo-cooldown-check
-          key: cooldown-check-v1-${{ hashFiles('**/Cargo.lock') }}
 
       - uses: NomicFoundation/cargo-cooldown-check@ac40e701f9f1155741a761ac9039987fb892af4b
 
@@ -672,7 +668,9 @@ jobs:
           name: ${{ needs.prepare.outputs.filename }}
           path: .
       - name: Decompress tarball
-        run: tar -xvzf ${{ needs.prepare.outputs.filename }}
+        env:
+          FILENAME: ${{ needs.prepare.outputs.filename }}
+        run: tar -xvzf "$FILENAME"
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
       - name: Setup node
@@ -682,17 +680,19 @@ jobs:
           node-version: 24
           package-manager-cache: false
       - name: Update npm to make sure it supports Trusted Publishing
-        run: npm install -g npm@v11.6.2
+        run: npm install -g npm@v11.6.2 # zizmor: ignore[adhoc-packages] pinned npm required for Trusted Publishing support
       - name: Publish
+        env:
+          TAG: ${{ needs.check_commit.outputs.tag }}
         run: |
-          if [ "${{ needs.check_commit.outputs.tag}}" = "next" ]
+          if [ "$TAG" = "next" ]
           then
             echo "Publishing pre-release"
-          elif [ "${{ needs.check_commit.outputs.tag}}" = "latest" ]
+          elif [ "$TAG" = "latest" ]
           then
             echo "Publishing release"
           else
-            echo "Unrecognized tag ${{ needs.check_commit.outputs.tag}}. Skipping publish"
+            echo "Unrecognized tag $TAG. Skipping publish"
             exit 1
           fi
 
@@ -702,8 +702,8 @@ jobs:
           # First publish every cross-platform package
           for platform in ./npm/* ; do
             cd $platform
-            pnpm publish --no-git-checks --tag ${{ needs.check_commit.outputs.tag}} --access public
+            pnpm publish --no-git-checks --tag "$TAG" --access public
             cd -
           done
           # Finally Publish edr napi root package (because it depends on the cross-platform ones)
-          pnpm publish --no-git-checks --tag ${{ needs.check_commit.outputs.tag}} --access public
+          pnpm publish --no-git-checks --tag "$TAG" --access public

--- a/.github/workflows/edr-npm-release.yml
+++ b/.github/workflows/edr-npm-release.yml
@@ -285,7 +285,7 @@ jobs:
       - name: Test bindings
         # Setting CI=1 is important to make PNPM install non-interactive
         # https://github.com/pnpm/pnpm/issues/6615#issuecomment-1656945689
-        run: docker run --rm  -e CI=1 -v $(pwd):/build -w /build/crates/edr_napi node:${{ matrix.node }} bash -c "npm install -g pnpm@11.9.0; pnpm testNoBuild"
+        run: docker run --rm  -e CI=1 -v "$(pwd)":/build -w /build/crates/edr_napi node:${{ matrix.node }} bash -c "npm install -g pnpm@11.9.0; pnpm testNoBuild"
   test-linux-x64-musl-binding:
     name: Test bindings on x86_64-unknown-linux-musl - node@${{ matrix.node }}
     needs:
@@ -319,7 +319,7 @@ jobs:
         run: ls -R .
         shell: bash
       - name: Test bindings
-        run: docker run --rm  -e CI=1 -v $(pwd):/build -w /build/crates/edr_napi node:${{ matrix.node }}-alpine sh -c "npm install -g pnpm@11.9.0; pnpm testNoBuild"
+        run: docker run --rm  -e CI=1 -v "$(pwd)":/build -w /build/crates/edr_napi node:${{ matrix.node }}-alpine sh -c "npm install -g pnpm@11.9.0; pnpm testNoBuild"
   test-linux-aarch64-gnu-binding:
     name: Test bindings on aarch64-unknown-linux-gnu - node@${{ matrix.node }}
     needs:
@@ -430,7 +430,7 @@ jobs:
           # matches with release commit
           elif git log -1 --pretty=%B | grep "^edr-[0-9]\+\.[0-9]\+\.[0-9]\+\s*";
           then
-            if [ "$GITHUB_REF" == "refs/heads/main" -o "$GITHUB_REF" == "refs/heads/hh2" ]
+            if [ "$GITHUB_REF" == "refs/heads/main" ] || [ "$GITHUB_REF" == "refs/heads/hh2" ]
             then
               echo "release commit: tag=latest"
               echo "tag=latest" >> "$GITHUB_OUTPUT"
@@ -503,7 +503,7 @@ jobs:
           echo "Creating bundle with necessary files for publishing"
           ROOT_FILES=("package.json" "Cargo.lock" "Cargo.toml" "pnpm-lock.yaml" "pnpm-workspace.yaml")
           ALL_FILES=("${ROOT_FILES[@]}" "${NAPI_FILES[@]}")
-          echo "files to include in tar: ${ALL_FILES[@]}"
+          echo "files to include in tar: ${ALL_FILES[*]}"
           # Using --dereference since LICENSE file are symlinks
           tar --dereference -czvf $FILENAME "${ALL_FILES[@]}"
           echo "FILENAME=$FILENAME"
@@ -541,6 +541,7 @@ jobs:
         shell: bash
         run: |
           # get number of artifacts with unique names
+          # shellcheck disable=SC2011 # .node names are fixed target triples, no special chars
           NUMBER_OF_ARTIFACTS=$(ls -1q crates/edr_napi/npm/*/*.node | xargs -n 1 basename | sort | uniq | wc -l)
           echo "Number of unique artifacts: $NUMBER_OF_ARTIFACTS"
           echo "Expected number of unique artifacts: $NUMBER_OF_TARGETS"

--- a/.github/workflows/hardhat-regression-tests.yml
+++ b/.github/workflows/hardhat-regression-tests.yml
@@ -33,6 +33,10 @@ on:
         required: false
         type: string
 
+# The called reusable workflow only checks out code to run tests.
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run the regression tests

--- a/.github/workflows/hardhat-tests.yml
+++ b/.github/workflows/hardhat-tests.yml
@@ -72,6 +72,7 @@ jobs:
           DEBUG: "hardhat:core:hardhat-network:*"
         shell: bash
         run: |
+          # shellcheck disable=SC1090 # generated env from cargo-llvm-cov, not a static file
           source <(cargo llvm-cov show-env --sh)
           pnpm -C hardhat-tests test
           # `--release` included to match `build:dev` compilation flags

--- a/.github/workflows/hardhat-tests.yml
+++ b/.github/workflows/hardhat-tests.yml
@@ -9,6 +9,9 @@ on:
       - "**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   run-hardhat-tests:
     name: Run Hardhat tests (${{ matrix.os }}, Node ${{ matrix.node }})

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -5,7 +5,6 @@ on:
     branches: ["main"]
   workflow_dispatch:
 
-# Only the deploy job needs Pages write + id-token; keep the rest read-only.
 permissions:
   contents: read
 

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -5,11 +5,9 @@ on:
     branches: ["main"]
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+# Only the deploy job needs Pages write + id-token; keep the rest read-only.
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -52,6 +50,9 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-24.04
     needs: build
+    permissions:
+      pages: write
+      id-token: write
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/test-recent-mainnet-block.yml
+++ b/.github/workflows/test-recent-mainnet-block.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 */8 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test-recent-mainnet-block:
     name: Test recent mainnet block

--- a/.github/workflows/test-recent-optimism-block.yml
+++ b/.github/workflows/test-recent-optimism-block.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 */8 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test-recent-op-block:
     name: Test recent OP block (${{ matrix.network }})


### PR DESCRIPTION
Based on successful usage for Slang, I've added `actionlint` and `zizmor` as they respectively catch syntax and security issues in GitHub actions.

# Claude summary

Adds two static-analysis gates for the repo's own GitHub Actions, which had none before:

- **actionlint** — workflow correctness (syntax, expression validity, `runs-on` labels, and shellcheck over `run:` blocks).
- **zizmor** — GitHub Actions security auditing (excessive permissions, template injection, cache poisoning, etc.).

Both run as blocking jobs in `edr-ci.yml` and fail the check on any finding.

## How they run

| Tool | Mechanism | Notes |
|---|---|---|
| actionlint | `uses: docker://rhysd/actionlint@<digest>` | rhysd's official image, digest-pinned; bundles shellcheck + pyflakes, so no runner deps. |
| zizmor | `taiki-e/install-action` with `tool: zizmor@1.26.1` | Same installer already used for `cargo-hack`. `GH_TOKEN` enables the online audits. |

Both are separate jobs with `permissions: contents: read` and no `needs:`, so they run in parallel with the rest of CI.

`.github/actionlint.yaml` declares the two self-hosted runner labels (`edr-benchmark-runner`, `hardhat-linux-amd64-self-hosted`) so `runs-on:` isn't flagged as unknown.

## Findings resolved

The first run surfaced 43 zizmor findings (plus 4 actionlint). All are resolved so both gates land green:

- **`excessive-permissions` (26)** — added explicit least-privilege `permissions:` blocks across 9 workflows. Scoped per workflow: `contents: read` for the read-only ones (benchmark push and Slack notify use PAT/webhook secrets, not `GITHUB_TOKEN`); `pull-requests: read` for `check-changeset-added`; and mdbook's `pages`/`id-token: write` moved down to the deploy job.
- **`template-injection` (7 of 9)** — routed `needs.*` outputs (`filename`, publish `tag`) through `env:` in `edr-npm-release.yml`; no behaviour change.
- **`cache-poisoning` (2 of 3)** — disabled caching on the publish path: `package-manager-cache: false` on the validation job's setup-node, and removed the cooldown-check cache step (also closes a small gap where a poisoned cache could hide a too-fresh dependency at release).
- **`github-env` (2)** — suppressed as verified-safe (a static `+crt-static` flag and `rustc --print host-tuple` output — neither is external input).

## Suppressions kept (with justifications)

- **`cache-poisoning`** on the build job's cargo cache — releases already build cold (guarded by `if: tag == ''`), so the published artifact never comes from cache; zizmor just can't statically evaluate the `needs.*`-based guard. Fixing it "for real" would drop PR build caching for zero security gain.
- **`template-injection`** on `strategy.job-total` — a controlled integer, not external input.
- **`superfluous-actions`** (×2) — `addnab/docker-run-action` is a deliberate cross-arch (arm64 / arm64-musl) test runner.
- **`adhoc-packages`** — pinned `npm@11.6.2`, required for Trusted Publishing.

## Verification

Ran both tools locally against `.github` — actionlint and zizmor both report **no findings**.

---

**Note:** CI-only change, so apply the **"no changeset needed"** label (otherwise `check-changeset-added` fails).
