### PR TITLE
fix(ci): floor the HH3 regression benchmark sentinel version at the last npm release

### DIFF
--- a/.github/scripts/compute-sentinel-versions.cjs
+++ b/.github/scripts/compute-sentinel-versions.cjs
@@ -19,20 +19,68 @@ function edrVersion(edrBaseVersion, shortSha) {
 // harness pins each scenario's `hardhat` dependency to it, and scenarios pull
 // Hardhat plugins whose `peerDependencies` use ranges like `hardhat@^3.8.0`.
 // node-semver excludes prereleases from such ranges.
-function hardhatVersion(hardhatBaseVersion) {
-  const core = hardhatBaseVersion.split("+")[0].split("-")[0];
-  const [major, minor, patch] = core.split(".").map(Number);
-  if (![major, minor, patch].every(Number.isInteger)) {
-    throw new Error(`Unparseable Hardhat version: ${hardhatBaseVersion}`);
+//
+// It must also be strictly ahead of the *last npm release*, not just of the
+// checked-out repo's version: the harness's publish step patch-bumps any
+// workspace package whose version doesn't exceed its last release, which would
+// desync the published version from this prediction and fail the workflow's
+// "Validate scenarios used the local EDR build" step. The Hardhat checkout can
+// lag npm (its package.json only catches up when a release lands on the
+// benchmarked ref), so floor the sentinel at the published version before
+// bumping.
+function hardhatVersion(hardhatBaseVersion, lastPublishedVersion) {
+  let core = parseCore(hardhatBaseVersion);
+  if (lastPublishedVersion !== undefined) {
+    const published = parseCore(lastPublishedVersion);
+    if (compareCores(core, published) < 0) {
+      core = published;
+    }
   }
+  const [major, minor, patch] = core;
   return `${major}.${minor}.${patch + 1}`;
+}
+
+// Parses `major.minor.patch` out of a semver string, dropping any prerelease
+// tag or build metadata.
+function parseCore(version) {
+  const core = version.split("+")[0].split("-")[0];
+  const parts = core.split(".").map(Number);
+  if (parts.length !== 3 || !parts.every(Number.isInteger)) {
+    throw new Error(`Unparseable Hardhat version: ${version}`);
+  }
+  return parts;
+}
+
+function compareCores(a, b) {
+  for (let i = 0; i < 3; i++) {
+    if (a[i] !== b[i]) return a[i] - b[i];
+  }
+  return 0;
+}
+
+// The latest release of `pkg`, pinned to the public npm registry on purpose:
+// the sentinel must be computed against the same "last release" the e2e
+// harness's publish step compares to, so it must not be silently repointed by
+// npm configuration (an `.npmrc`, `npm_config_registry`, …). The benchmark's
+// Verdaccio isn't running yet when the sentinels are computed.
+async function npmLatestVersion(pkg) {
+  const url = `https://registry.npmjs.org/${pkg}/latest`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`GET ${url} failed: ${response.status}`);
+  }
+  const { version } = await response.json();
+  if (!version) {
+    throw new Error(`GET ${url} returned no version`);
+  }
+  return version;
 }
 
 function readVersion(pkgJsonPath) {
   return JSON.parse(fs.readFileSync(pkgJsonPath, "utf8")).version;
 }
 
-function main() {
+async function main() {
   const { EDR_REF, GITHUB_ENV } = process.env;
   for (const [name, value] of Object.entries({ EDR_REF, GITHUB_ENV })) {
     if (!value) throw new Error(`${name} is not set`);
@@ -42,10 +90,11 @@ function main() {
   const versions = {
     EDR_VER: edrVersion(
       readVersion(path.join(cwd, "crates/edr_napi/package.json")),
-      EDR_REF.slice(0, 12),
+      EDR_REF.slice(0, 12)
     ),
     HH_VER: hardhatVersion(
       readVersion(path.join(cwd, "hardhat/packages/hardhat/package.json")),
+      await npmLatestVersion("hardhat")
     ),
   };
 
@@ -57,5 +106,8 @@ function main() {
 module.exports = { edrVersion, hardhatVersion };
 
 if (require.main === module) {
-  main();
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
 }

--- a/.github/scripts/compute-sentinel-versions.test.cjs
+++ b/.github/scripts/compute-sentinel-versions.test.cjs
@@ -12,7 +12,7 @@ const {
 test("edrVersion appends a -local.<sha> prerelease", () => {
   assert.equal(
     edrVersion("0.12.1", "dfeb0f9b95f9"),
-    "0.12.1-local.dfeb0f9b95f9",
+    "0.12.1-local.dfeb0f9b95f9"
   );
 });
 
@@ -31,7 +31,27 @@ test("hardhatVersion strips build metadata", () => {
   assert.equal(hardhatVersion("3.9.5+build.7"), "3.9.6");
 });
 
+test("hardhatVersion floors the sentinel at the last npm release", () => {
+  // The repo lags npm: a release shipped that the benchmarked ref hasn't
+  // caught up to. Bumping only the repo version would collide with the
+  // published release, so the e2e harness would re-bump on top and desync the
+  // published version from the sentinel (observed with hardhat 3.9.1 released
+  // while the checkout was at 3.9.0: the harness published 3.9.2).
+  assert.equal(hardhatVersion("3.9.0", "3.9.1"), "3.9.2");
+  assert.equal(hardhatVersion("3.9.0", "4.0.0"), "4.0.1");
+});
+
+test("hardhatVersion keeps the repo version when it is ahead of npm", () => {
+  assert.equal(hardhatVersion("3.10.0", "3.9.1"), "3.10.1");
+  assert.equal(hardhatVersion("3.9.1", "3.9.1"), "3.9.2");
+});
+
+test("hardhatVersion strips a prerelease tag from the published version", () => {
+  assert.equal(hardhatVersion("3.9.0", "3.9.1-beta.1"), "3.9.2");
+});
+
 test("hardhatVersion throws on an unparseable version", () => {
   assert.throws(() => hardhatVersion("not.a.version"), /Unparseable/);
   assert.throws(() => hardhatVersion("3.x"), /Unparseable/);
+  assert.throws(() => hardhatVersion("3.9.0", "3.x"), /Unparseable/);
 });


### PR DESCRIPTION
This PR provides a fix for the scenario where a new HH version has been released after the initial `/bench` run. In this scenario, subsequent runs would fail because the sentinel version would collide with the newly published HH version.

## Claude description of the issue

### The failure chain

1. The sentinel prediction. At job start, compute-sentinel-versions.cjs computes the version the local Hardhat will be republished as: repo version + 1 patch. The checked-out Hardhat repo's packages/hardhat/package.json is at 3.9.0, so it predicted HH_VER=3.9.1. The workflow's repoint step then sets version=3.9.1 on the checkout — per its own comment, that pre-bump exists so Hardhat's harness sees the package as "already bumped" and republishes it at exactly that version.
2. Upstream moved. Hardhat released 3.9.1 to npm on 2026-07-02 (I verified: it's npm's current latest), four days before this run — while the benchmarked Hardhat checkout still says 3.9.0.
3. The harness bumped again. Hardhat's e2e publisher (regression.ts → "Detecting packages changed since release") compares against the last npm release. The other packages log "already bumped to X" (version ahead of release → keep it), but hardhat's repointed 3.9.1 now equals the real npm release 3.9.1, so it logged hardhat (changed since hardhat@3.9.1) → "Bumping patch versions: hardhat 3.9.1 → 3.9.2" and published 3.9.2.
4. Check A compares against the stale prediction: Published hardhat latest (3.9.2) != 3.9.1 → red.