### PR TITLE
fix(ci): keep NAPI typing file in sync on release bump

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -17,4 +17,8 @@ cd ./crates/edr_napi
 # Run `napi version` to update version in cross-platform packages
 pnpm napi version
 
-cd ../.. 
+# Regenerate index.js/index.d.ts so napi-rs v3 updates the version check
+# to match the bump (otherwise the edr-napi-typings-file CI check fails).
+pnpm build:typingFile
+
+cd ../..


### PR DESCRIPTION
## Problem
The "Open release PR" CI check is failing because `index.js` is not up to date.
See job logs: https://github.com/NomicFoundation/edr/actions/runs/28939118926/job/85856852162

## Context
NAPIv3 changed the platform check it performs when selecting which platform addon to load. On v2 it only checked against the platform; on v3 it validates the version matches as well as the platform. 
This means the generated files need to be regenerated whenever the package version is bumped, since the expected version is now baked into `index.js`.

**Reference**:
- See `index.js` on NAPIv2: https://github.com/NomicFoundation/edr/blob/9a6a88db0fa1559f8d45755eb83f6c2d9b68ed2c/crates/edr_napi/index.js
- See `index.js` on NAPIv3: https://github.com/NomicFoundation/edr/blob/main/crates/edr_napi/index.js

## Solution
"Open release PR" is the job responsible for bumping the version, so it should also regenerate the files. 
This PR adds a `pnpm build:typingFile` step to `scripts/release.sh` after the version bump.