### PR TITLE
docs(edr_napi): note SubscriptionEvent.result any→unknown in 0.14.0

### DIFF
--- a/crates/edr_napi/CHANGELOG.md
+++ b/crates/edr_napi/CHANGELOG.md
@@ -13,6 +13,7 @@
 - cfff1da: Raised the minimum supported Node.js version to 22. Node.js 20 has reached end-of-life and is no longer supported; the package now targets Node.js 22, 24, and 26.
 - 99e2d33: - Changed the `reason`, `counterexample`, and `valueSnapshotGroups` fields on `TestResult` to class getters returning `T | undefined`.
   - Changed `SuiteResult` from a class to a plain object; field shapes are unchanged.
+  - Changed the `result` field on `SubscriptionEvent` from `any` to `unknown`.
   - Fixed exceptions thrown by the `decodeConsoleLogInputsCallback` and `printLineCallback` logger callbacks from being swallowed or crashing the process. They now surface as JSON-RPC internal-error responses carrying the JS error message.
 
 ### Patch Changes


### PR DESCRIPTION
Quick fix to changelog file. I've already adapted https://github.com/NomicFoundation/edr/releases/tag/%40nomicfoundation%2Fedr%400.14.0

# Claude summary

The napi-rs v3 migration (`99e2d33`, released in 0.14.0) changed the `result` field on `SubscriptionEvent` from `any` to `unknown` in the generated `index.d.ts` typings, but the 0.14.0 changeset entry never documented it.

This adds the missing bullet to the `99e2d33` entry under `## 0.14.0` in `crates/edr_napi/CHANGELOG.md` so consumers relying on the loosened `any` are aware of the stricter `unknown` and the cast/narrowing it now requires.

Docs-only change; no code or generated typings affected.