### PR TITLE
Linked to a specific EDR docs page for Hardhat 3.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,5 @@ For a list of EIPs and chain specifications that EDR does not fully support, inc
 
 ## Production Usage
 
-- [Hardhat 3](https://hardhat.org/)
+- [How to use it in Hardhat 3](https://hardhat.org/docs/reference/edr-simulated-networks)
 - [Hardhat 2](https://hardhat.org/hardhat2)


### PR DESCRIPTION
Updated Hardhat 3 documentation link for Simulated Networks by EDR. To: 1-avoid confusing users, 2-instruct how to take advantage of EDR.