### PR TITLE
test(edr_provider): broaden solx provider-path stack-trace coverage

### DIFF
--- a/crates/edr_provider/tests/integration/solx_stack_trace.rs
+++ b/crates/edr_provider/tests/integration/solx_stack_trace.rs
@@ -203,6 +203,42 @@ fn encode_call_address(signature: &str, addr: Address) -> Bytes {
     Bytes::from(calldata)
 }
 
+fn send_ok(
+    provider: &Provider<L1ChainSpec>,
+    from: Address,
+    to: Address,
+    calldata: Bytes,
+) -> anyhow::Result<()> {
+    provider
+        .handle_request(ProviderRequest::with_single(
+            MethodInvocation::SendTransaction(TransactionRequest {
+                from,
+                to: Some(to),
+                data: Some(calldata),
+                ..TransactionRequest::default()
+            }),
+        ))
+        .map(|_| ())
+        .map_err(|e| anyhow::anyhow!("setup transaction must succeed: {e:?}"))
+}
+
+fn expect_failed_deploy_stack_trace(
+    provider: &Provider<L1ChainSpec>,
+    from: Address,
+    creation: Bytes,
+) -> Vec<StackTraceEntry> {
+    let err = provider
+        .handle_request(ProviderRequest::with_single(
+            MethodInvocation::SendTransaction(TransactionRequest {
+                from,
+                data: Some(creation),
+                ..TransactionRequest::default()
+            }),
+        ))
+        .expect_err("deployment must revert and bail");
+    stack_trace_from_failure(err)
+}
+
 // ---------- variance-axis tests ----------
 
 /// Counter.set(0) reverts via `require(v > 0, "must be positive")`.
@@ -300,7 +336,30 @@ async fn custom_error_variant_surfaces_for_custom_error_scenario() -> anyhow::Re
     Ok(())
 }
 
+// ---------- scenarios-fixture tests ----------
+
 const SCENARIOS_SOURCE: &str = "project/contracts/Scenarios.t.sol";
+
+fn scenarios_provider(
+) -> anyhow::Result<(Provider<L1ChainSpec>, Address, CompilerOutput<SolxBytecode>)> {
+    let (build_info, output) = solx_scenarios_build_info()?;
+    let decoder = ContractDecoder::new(build_info);
+    let (provider, from) = make_provider(decoder)?;
+    Ok((provider, from, output))
+}
+
+fn deploy_scenario(
+    provider: &Provider<L1ChainSpec>,
+    from: Address,
+    output: &CompilerOutput<SolxBytecode>,
+    contract: &str,
+) -> anyhow::Result<Address> {
+    deploy_contract(
+        provider,
+        from,
+        creation_bytes(output, SCENARIOS_SOURCE, contract)?,
+    )
+}
 
 fn contains_ascii(data: &[u8], needle: &str) -> bool {
     data.windows(needle.len()).any(|w| w == needle.as_bytes())
@@ -365,6 +424,264 @@ fn assert_revert_at_line(stack_trace: &[StackTraceEntry], line: u32, reason: &st
         source_reference.source_name,
         brief_trace(stack_trace)
     );
+}
+
+fn expect_scenario_revert(
+    contract: &str,
+    calldata: Bytes,
+    line: u32,
+    reason: &str,
+) -> anyhow::Result<Vec<StackTraceEntry>> {
+    let (provider, from, output) = scenarios_provider()?;
+    let addr = deploy_scenario(&provider, from, &output, contract)?;
+    let stack_trace = expect_failed_call_stack_trace(&provider, from, addr, calldata);
+    assert_revert_at_line(&stack_trace, line, reason);
+    Ok(stack_trace)
+}
+
+fn expect_scenario_panic(contract: &str, signature: &str, code: u64) -> anyhow::Result<()> {
+    let (provider, from, output) = scenarios_provider()?;
+    let addr = deploy_scenario(&provider, from, &output, contract)?;
+    let stack_trace = expect_failed_call_stack_trace(&provider, from, addr, call(signature));
+    let error_code = stack_trace
+        .iter()
+        .find_map(|e| match e {
+            StackTraceEntry::PanicError { error_code, .. } => Some(*error_code),
+            _ => None,
+        })
+        .unwrap_or_else(|| {
+            panic!(
+                "expected a PanicError entry, got:\n{}",
+                brief_trace(&stack_trace)
+            )
+        });
+    assert_eq!(
+        error_code,
+        U256::from(code),
+        "expected panic code {code:#x}, got:\n{}",
+        brief_trace(&stack_trace)
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn panic_code_surfaces_for_assert_failure() -> anyhow::Result<()> {
+    expect_scenario_panic("AssertionFailureTest", "testAssertionFails()", 0x01)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn panic_code_surfaces_for_division_by_zero() -> anyhow::Result<()> {
+    expect_scenario_panic("DivisionByZeroTest", "testDivisionByZero()", 0x12)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn panic_code_surfaces_for_invalid_enum_cast() -> anyhow::Result<()> {
+    expect_scenario_panic("InvalidEnumCastTest", "testInvalidEnumCast()", 0x21)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn panic_code_surfaces_for_pop_on_empty_array() -> anyhow::Result<()> {
+    expect_scenario_panic("PopEmptyArrayTest", "testPopEmpty()", 0x31)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn panic_code_surfaces_for_array_out_of_bounds() -> anyhow::Result<()> {
+    expect_scenario_panic("ArrayOutOfBoundsTest", "testArrayOOB()", 0x32)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn revert_line_discriminates_between_requires() -> anyhow::Result<()> {
+    expect_scenario_revert(
+        "MultipleRequiresTest",
+        call("testMultipleRequires()"),
+        340,
+        "second",
+    )?;
+    Ok(())
+}
+
+/// Resolves through `evm.bytecode.debugInfo` (creation code) rather than
+/// `evm.deployedBytecode.debugInfo`.
+#[tokio::test(flavor = "multi_thread")]
+async fn create_revert_surfaces_for_reverting_constructor() -> anyhow::Result<()> {
+    let (provider, from, output) = scenarios_provider()?;
+    let stack_trace = expect_failed_deploy_stack_trace(
+        &provider,
+        from,
+        creation_bytes(&output, SCENARIOS_SOURCE, "ConstructorRevertContract")?,
+    );
+    assert_revert_at_line(&stack_trace, 57, "constructor boom");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn create_revert_surfaces_through_constructor_helper() -> anyhow::Result<()> {
+    let (provider, from, output) = scenarios_provider()?;
+    let mut creation = creation_bytes(
+        &output,
+        SCENARIOS_SOURCE,
+        "HelperRevertingConstructorContract",
+    )?
+    .to_vec();
+    creation.extend_from_slice(&[0u8; 32]); // constructor(uint256 v = 0)
+    let stack_trace = expect_failed_deploy_stack_trace(&provider, from, Bytes::from(creation));
+    assert_revert_at_line(&stack_trace, 295, "constructor helper boom");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn modifier_revert_points_at_modifier_require() -> anyhow::Result<()> {
+    expect_scenario_revert(
+        "ModifierTarget",
+        encode_call_u256("setIfPositive(uint256)", 0),
+        87,
+        "modifier must be positive",
+    )?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn cross_contract_call_keeps_caller_frame() -> anyhow::Result<()> {
+    let (provider, from, output) = scenarios_provider()?;
+    let caller = deploy_scenario(&provider, from, &output, "CrossContractCallTest")?;
+    send_ok(&provider, from, caller, call("setUp()"))?;
+    let stack_trace =
+        expect_failed_call_stack_trace(&provider, from, caller, call("testCrossContractCall()"));
+    assert_revert_at_line(&stack_trace, 69, "called fail");
+    assert!(
+        stack_trace.iter().any(|e| matches!(
+            e,
+            StackTraceEntry::CallstackEntry { source_reference, .. }
+                if source_reference.contract.as_deref() == Some("CrossContractCallTest")
+        )),
+        "expected a CallstackEntry for CrossContractCallTest, got:\n{}",
+        brief_trace(&stack_trace)
+    );
+    // No separate `Other.fail` callstack frame: the bottom entry already
+    // renders as `Other.fail`, so the intermediate frame dedups against it.
+    assert_trace_shape(
+        &stack_trace,
+        &[
+            "CallstackEntry project/contracts/Scenarios.t.sol:81 (CrossContractCallTest.testCrossContractCall)",
+            "RevertError project/contracts/Scenarios.t.sol:69 (Other.fail)",
+        ],
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn external_recursion_keeps_one_frame_per_call() -> anyhow::Result<()> {
+    let (provider, from, output) = scenarios_provider()?;
+    let addr = deploy_scenario(&provider, from, &output, "DeepRecursionTarget")?;
+    let stack_trace = expect_failed_call_stack_trace(
+        &provider,
+        from,
+        addr,
+        encode_call_u256("recurse(uint256)", 3),
+    );
+    assert_revert_at_line(&stack_trace, 109, "bottomed out");
+    let recursion_frames = stack_trace
+        .iter()
+        .filter(|e| {
+            matches!(
+                e,
+                StackTraceEntry::CallstackEntry { source_reference, .. }
+                    if source_reference.function.as_deref() == Some("recurse")
+            )
+        })
+        .count();
+    assert!(
+        recursion_frames >= 3,
+        "expected >= 3 recurse callstack frames, got {recursion_frames}:\n{}",
+        brief_trace(&stack_trace)
+    );
+    assert_trace_shape(
+        &stack_trace,
+        &[
+            "CallstackEntry project/contracts/Scenarios.t.sol:111 (DeepRecursionTarget.recurse)",
+            "CallstackEntry project/contracts/Scenarios.t.sol:111 (DeepRecursionTarget.recurse)",
+            "CallstackEntry project/contracts/Scenarios.t.sol:111 (DeepRecursionTarget.recurse)",
+            "RevertError project/contracts/Scenarios.t.sol:109 (DeepRecursionTarget.recurse)",
+        ],
+    );
+    Ok(())
+}
+
+/// solx's optimizer may unroll the recursion, so only the bottom revert
+/// line is pinned.
+#[tokio::test(flavor = "multi_thread")]
+async fn internal_recursion_pins_bottom_revert_line() -> anyhow::Result<()> {
+    expect_scenario_revert(
+        "InternalRecurseTest",
+        call("testInternalRecurse()"),
+        348,
+        "internal bottom",
+    )?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn internal_helper_revert_points_at_helper_require() -> anyhow::Result<()> {
+    expect_scenario_revert(
+        "InternalHelperChainContract",
+        encode_call_u256("set(uint256)", 0),
+        149,
+        "must be positive",
+    )?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn internal_library_revert_points_into_library() -> anyhow::Result<()> {
+    expect_scenario_revert(
+        "LibraryRevertTest",
+        call("testLibraryRevert()"),
+        229,
+        "lib boom",
+    )?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fallback_revert_points_at_fallback_body() -> anyhow::Result<()> {
+    expect_scenario_revert(
+        "FallbackRevertTarget",
+        call("nonExistent()"),
+        259,
+        "fallback boom",
+    )?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn receive_revert_points_at_receive_body() -> anyhow::Result<()> {
+    expect_scenario_revert("ReceiveRevertTarget", Bytes::new(), 276, "receive boom")?;
+    Ok(())
+}
+
+/// solx may emit both JUMP-derived and inlined frames at the dispatch
+/// points, so only the bottom revert line is pinned.
+#[tokio::test(flavor = "multi_thread")]
+async fn mutual_recursion_pins_bottom_revert_line() -> anyhow::Result<()> {
+    let (provider, from, output) = scenarios_provider()?;
+    let a = deploy_scenario(&provider, from, &output, "MutualA")?;
+    let b = deploy_scenario(&provider, from, &output, "MutualB")?;
+    send_ok(
+        &provider,
+        from,
+        a,
+        encode_call_address("setOther(address)", b),
+    )?;
+    send_ok(
+        &provider,
+        from,
+        b,
+        encode_call_address("setOther(address)", a),
+    )?;
+    let stack_trace =
+        expect_failed_call_stack_trace(&provider, from, a, encode_call_u256("pingA(uint256)", 2));
+    assert_revert_at_line(&stack_trace, 377, "mutual bottom");
+    Ok(())
 }
 
 // ---------- StackTraceScenarios fixture tests ----------

--- a/crates/edr_provider/tests/integration/solx_stack_trace.rs
+++ b/crates/edr_provider/tests/integration/solx_stack_trace.rs
@@ -6,7 +6,7 @@
 //! provider-side surface and exercises a small slice of the
 //! [`StackTraceEntry`] variants we can hit from the existing solx fixtures.
 
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use anyhow::Context;
 use edr_chain_l1::{rpc::TransactionRequest, L1ChainSpec};
@@ -24,6 +24,7 @@ use edr_solidity::{
         SolxBytecode,
     },
     contract_decoder::ContractDecoder,
+    library_utils::link_hex_string_bytecode,
     solidity_stack_trace::{StackTraceCreationResult, StackTraceEntry},
 };
 use parking_lot::RwLock;
@@ -734,6 +735,26 @@ fn deploy_stack_trace_scenario(
     )
 }
 
+/// Substitutes the deployed library address at every `linkReferences`
+/// position, through the production `link_hex_string_bytecode` path.
+fn link_library(bytecode: &SolxBytecode, library: Address) -> anyhow::Result<String> {
+    let library_count: usize = bytecode.link_references.values().map(HashMap::len).sum();
+    anyhow::ensure!(
+        library_count == 1,
+        "bytecode references {library_count} libraries; link_library takes one address"
+    );
+    let mut linked = bytecode.object.clone();
+    for reference in bytecode
+        .link_references
+        .values()
+        .flat_map(HashMap::values)
+        .flatten()
+    {
+        linked = link_hex_string_bytecode(linked, &hex::encode(library), reference.start)?;
+    }
+    Ok(linked)
+}
+
 #[track_caller]
 fn assert_single_variant<'a>(
     stack_trace: &'a [StackTraceEntry],
@@ -753,6 +774,124 @@ fn assert_single_variant<'a>(
         brief_trace(stack_trace)
     );
     entry
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn function_not_payable_error_surfaces() -> anyhow::Result<()> {
+    let (provider, from, output) = stack_trace_scenarios_provider()?;
+    let addr = deploy_stack_trace_scenario(&provider, from, &output, "NotPayable")?;
+    let stack_trace = expect_failed_call_with_value_stack_trace(
+        &provider,
+        from,
+        addr,
+        encode_call_u256("store(uint256)", 1),
+        U256::from(1u64),
+    );
+    let entry = assert_single_variant(
+        &stack_trace,
+        |e| matches!(e, StackTraceEntry::FunctionNotPayableError { .. }),
+        "FunctionNotPayableError",
+    );
+    let source_reference = entry
+        .source_reference()
+        .expect("FunctionNotPayableError carries a source reference");
+    assert_eq!(source_reference.function.as_deref(), Some("store"));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn unrecognized_function_without_fallback_error_surfaces() -> anyhow::Result<()> {
+    let (provider, from, output) = stack_trace_scenarios_provider()?;
+    let addr = deploy_stack_trace_scenario(&provider, from, &output, "NoFallback")?;
+    let stack_trace = expect_failed_call_stack_trace(&provider, from, addr, call("nonExistent()"));
+    assert_single_variant(
+        &stack_trace,
+        |e| {
+            matches!(
+                e,
+                StackTraceEntry::UnrecognizedFunctionWithoutFallbackError { .. }
+            )
+        },
+        "UnrecognizedFunctionWithoutFallbackError",
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn missing_fallback_or_receive_error_surfaces() -> anyhow::Result<()> {
+    let (provider, from, output) = stack_trace_scenarios_provider()?;
+    let addr = deploy_stack_trace_scenario(&provider, from, &output, "NoFallback")?;
+    let stack_trace = expect_failed_call_with_value_stack_trace(
+        &provider,
+        from,
+        addr,
+        Bytes::new(),
+        U256::from(1u64),
+    );
+    assert_single_variant(
+        &stack_trace,
+        |e| matches!(e, StackTraceEntry::MissingFallbackOrReceiveError { .. }),
+        "MissingFallbackOrReceiveError",
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fallback_not_payable_error_surfaces() -> anyhow::Result<()> {
+    let (provider, from, output) = stack_trace_scenarios_provider()?;
+    let addr = deploy_stack_trace_scenario(&provider, from, &output, "NonPayableFallback")?;
+    let stack_trace = expect_failed_call_with_value_stack_trace(
+        &provider,
+        from,
+        addr,
+        call("nonExistent()"),
+        U256::from(1u64),
+    );
+    assert_single_variant(
+        &stack_trace,
+        |e| matches!(e, StackTraceEntry::FallbackNotPayableError { .. }),
+        "FallbackNotPayableError",
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fallback_not_payable_and_no_receive_error_surfaces() -> anyhow::Result<()> {
+    let (provider, from, output) = stack_trace_scenarios_provider()?;
+    let addr = deploy_stack_trace_scenario(&provider, from, &output, "NonPayableFallback")?;
+    let stack_trace = expect_failed_call_with_value_stack_trace(
+        &provider,
+        from,
+        addr,
+        Bytes::new(),
+        U256::from(1u64),
+    );
+    assert_single_variant(
+        &stack_trace,
+        |e| {
+            matches!(
+                e,
+                StackTraceEntry::FallbackNotPayableAndNoReceiveError { .. }
+            )
+        },
+        "FallbackNotPayableAndNoReceiveError",
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn invalid_params_error_surfaces_for_truncated_calldata() -> anyhow::Result<()> {
+    let (provider, from, output) = stack_trace_scenarios_provider()?;
+    let addr = deploy_stack_trace_scenario(&provider, from, &output, "RequiresArgs")?;
+    let mut calldata = selector("needsBoth(uint256,uint256)").as_slice().to_vec();
+    calldata.extend_from_slice(&[0u8; 32]); // only one of the two words
+    let stack_trace = expect_failed_call_stack_trace(&provider, from, addr, Bytes::from(calldata));
+    assert_single_variant(
+        &stack_trace,
+        |e| matches!(e, StackTraceEntry::InvalidParamsError { .. }),
+        "InvalidParamsError",
+    );
+    Ok(())
 }
 
 #[track_caller]
@@ -804,6 +943,50 @@ async fn noncontract_account_call_surfaces_as_returndata_size_error() -> anyhow:
         encode_call_address("callGet(address)", eoa),
     );
     assert_returndata_size_error_at_call_get(&stack_trace);
+    Ok(())
+}
+
+/// External (public) library function reached through a linked contract:
+/// exercises `linkReferences` placeholder substitution and DELEGATECALL
+/// frame decoding into the library's own debugInfo.
+#[tokio::test(flavor = "multi_thread")]
+async fn linked_external_library_revert_points_into_library() -> anyhow::Result<()> {
+    let (provider, from, output) = stack_trace_scenarios_provider()?;
+    let library = deploy_stack_trace_scenario(&provider, from, &output, "ExternalLib")?;
+
+    let unlinked = &output
+        .contracts
+        .get(STACK_TRACE_SCENARIOS_SOURCE)
+        .and_then(|m| m.get("UsesExternalLib"))
+        .context("fixture missing UsesExternalLib")?
+        .evm
+        .bytecode;
+    let linked = link_library(unlinked, library)?;
+    let user = deploy_contract(&provider, from, Bytes::from(hex::decode(&linked)?))?;
+
+    let stack_trace = expect_failed_call_stack_trace(&provider, from, user, call("go()"));
+    assert_revert_at_line(&stack_trace, 53, "external lib boom");
+    assert_trace_shape(
+        &stack_trace,
+        &[
+            "CallstackEntry project/contracts/StackTraceScenarios.sol:59 (UsesExternalLib.go)",
+            "RevertError project/contracts/StackTraceScenarios.sol:53 (ExternalLib.fail)",
+        ],
+    );
+    Ok(())
+}
+
+/// Calling a deployed library's external function directly.
+#[tokio::test(flavor = "multi_thread")]
+async fn direct_library_call_error_surfaces() -> anyhow::Result<()> {
+    let (provider, from, output) = stack_trace_scenarios_provider()?;
+    let library = deploy_stack_trace_scenario(&provider, from, &output, "ExternalLib")?;
+    let stack_trace = expect_failed_call_stack_trace(&provider, from, library, call("fail()"));
+    assert_single_variant(
+        &stack_trace,
+        |e| matches!(e, StackTraceEntry::DirectLibraryCallError { .. }),
+        "DirectLibraryCallError",
+    );
     Ok(())
 }
 

--- a/crates/edr_provider/tests/integration/solx_stack_trace.rs
+++ b/crates/edr_provider/tests/integration/solx_stack_trace.rs
@@ -1,10 +1,38 @@
 #![cfg(feature = "test-utils")]
 
 //! Verifies the solx (DWARF) stack-trace path through the JSON-RPC
-//! provider. Solidity-test runs are exercised by the JS parity sweep in
-//! `js/integration-tests/solx-parity-sweep`; this file pins the
-//! provider-side surface and exercises a small slice of the
-//! [`StackTraceEntry`] variants we can hit from the existing solx fixtures.
+//! provider. Sections mirror the inference pipeline in `edr_solidity`, so
+//! each test names the path it pins:
+//!
+//! - **Provider plumbing**: end-to-end smoke on the minimal Counter fixture.
+//! - **Pre-execution guards** (`infer_before_tracing_call_message`):
+//!   payability, missing function/fallback/receive, direct library calls.
+//! - **Calldata decoding** (`check_last_instruction`): `InvalidParamsError`.
+//! - **Revert/panic/custom attribution** (`check_revert_or_invalid_opcode`):
+//!   panic codes with statement anchors, custom-error decoding, revert-line
+//!   discrimination.
+//! - **Callstack reconstruction** (frame push/pop, submessage splicing,
+//!   `filter_redundant_frames`): cross-contract frames, recursion, internal
+//!   helpers/libraries, linked external libraries, fallback/receive bodies.
+//! - **Modifiers** (`fix_initial_modifier` + `SolxTraceStrategy` revert
+//!   attribution): plain, nested, cross-contract, and bare-revert modifiers.
+//! - **Create path** (creation-code `debugInfo`): reverting constructors.
+//! - **Submessage checks** (`check_last_submessage`): returndata-size errors.
+//! - **Mode-3 twins**: optimizer mode 3 artifacts reach the
+//!   declaration-attributed and unmapped-revert strategy paths that mode-1
+//!   DWARF (statement-attributed since solx 0.1.6) no longer hits.
+//!
+//! Deliberately not covered here: message-kind dispatch (precompiles,
+//! unrecognized contracts, contract-too-large) and other location-free
+//! classifications already pinned by the solc corpus, create-side guards,
+//! the solc-opcode-pattern rewrites in
+//! `mapped_inline_internal_functions_heuristics`, out-of-gas rewrites,
+//! proxy propagation, and the `eth_call` channel — follow-up material.
+//! Solidity-test runs are exercised by the JS parity sweep in
+//! `js/integration-tests/solx-parity-sweep`.
+//!
+//! Line pins are goldens: after a solx upgrade a shifted anchor is expected
+//! drift (update the pin), a lost frame is a regression.
 
 use std::{collections::HashMap, sync::Arc};
 
@@ -25,10 +53,15 @@ use edr_solidity::{
     },
     contract_decoder::ContractDecoder,
     library_utils::link_hex_string_bytecode,
-    solidity_stack_trace::{StackTraceCreationResult, StackTraceEntry},
+    solidity_stack_trace::{SourceReference, StackTraceCreationResult, StackTraceEntry},
 };
 use parking_lot::RwLock;
 use tokio::runtime;
+
+// ---------- fixture assembly ----------
+
+const SCENARIOS_SOURCE: &str = "project/contracts/Scenarios.t.sol";
+const STACK_TRACE_SCENARIOS_SOURCE: &str = "project/contracts/StackTraceScenarios.sol";
 
 /// The `include_str!` literals stay at the call sites — the macro needs a
 /// literal path.
@@ -90,12 +123,13 @@ fn solx_stack_trace_scenarios_build_info(
     )
 }
 
+// ---------- provider setup and deployment ----------
+
 /// Builds a local provider seeded with `decoder`, with bail-on-failure set
 /// so a reverting tx surfaces as [`ProviderError::TransactionFailed`].
 fn make_provider(decoder: ContractDecoder) -> anyhow::Result<(Provider<L1ChainSpec>, Address)> {
     let mut config = create_test_config_with(MinimalProviderConfig::local_with_accounts());
     config.bail_on_transaction_failure = true;
-    config.bail_on_call_failure = true;
 
     let from = public_key_to_address(
         config
@@ -117,6 +151,47 @@ fn make_provider(decoder: ContractDecoder) -> anyhow::Result<(Provider<L1ChainSp
     Ok((provider, from))
 }
 
+fn scenarios_provider(
+) -> anyhow::Result<(Provider<L1ChainSpec>, Address, CompilerOutput<SolxBytecode>)> {
+    let (build_info, output) = solx_scenarios_build_info()?;
+    let decoder = ContractDecoder::new(build_info);
+    let (provider, from) = make_provider(decoder)?;
+    Ok((provider, from, output))
+}
+
+fn stack_trace_scenarios_provider(
+) -> anyhow::Result<(Provider<L1ChainSpec>, Address, CompilerOutput<SolxBytecode>)> {
+    let (build_info, output) = solx_stack_trace_scenarios_build_info(
+        include_str!(
+            "../../../edr_solidity/fixtures/solx_compiler_input_stack_trace_scenarios.json"
+        ),
+        include_str!(
+            "../../../edr_solidity/fixtures/solx_compiler_output_stack_trace_scenarios.json"
+        ),
+    )?;
+    let decoder = ContractDecoder::new(build_info);
+    let (provider, from) = make_provider(decoder)?;
+    Ok((provider, from, output))
+}
+
+/// Same scenarios compiled at optimizer mode 3: mode-1 DWARF is
+/// statement-attributed since solx 0.1.6, so only these artifacts reach
+/// the declaration-attributed and unmapped-revert inference paths.
+fn stack_trace_scenarios_mode3_provider(
+) -> anyhow::Result<(Provider<L1ChainSpec>, Address, CompilerOutput<SolxBytecode>)> {
+    let (build_info, output) = solx_stack_trace_scenarios_build_info(
+        include_str!(
+            "../../../edr_solidity/fixtures/solx_compiler_input_stack_trace_scenarios_mode3.json"
+        ),
+        include_str!(
+            "../../../edr_solidity/fixtures/solx_compiler_output_stack_trace_scenarios_mode3.json"
+        ),
+    )?;
+    let decoder = ContractDecoder::new(build_info);
+    let (provider, from) = make_provider(decoder)?;
+    Ok((provider, from, output))
+}
+
 fn creation_bytes(
     output: &CompilerOutput<SolxBytecode>,
     file: &str,
@@ -131,6 +206,54 @@ fn creation_bytes(
     Ok(Bytes::from(hex::decode(&evm.bytecode.object)?))
 }
 
+fn deploy_scenario(
+    provider: &Provider<L1ChainSpec>,
+    from: Address,
+    output: &CompilerOutput<SolxBytecode>,
+    contract: &str,
+) -> anyhow::Result<Address> {
+    deploy_contract(
+        provider,
+        from,
+        creation_bytes(output, SCENARIOS_SOURCE, contract)?,
+    )
+}
+
+fn deploy_stack_trace_scenario(
+    provider: &Provider<L1ChainSpec>,
+    from: Address,
+    output: &CompilerOutput<SolxBytecode>,
+    contract: &str,
+) -> anyhow::Result<Address> {
+    deploy_contract(
+        provider,
+        from,
+        creation_bytes(output, STACK_TRACE_SCENARIOS_SOURCE, contract)?,
+    )
+}
+
+/// Substitutes the deployed library address at every `linkReferences`
+/// position, through the production `link_hex_string_bytecode` path.
+fn link_library(bytecode: &SolxBytecode, library: Address) -> anyhow::Result<String> {
+    let library_count: usize = bytecode.link_references.values().map(HashMap::len).sum();
+    anyhow::ensure!(
+        library_count == 1,
+        "bytecode references {library_count} libraries; link_library takes one address"
+    );
+    let mut linked = bytecode.object.clone();
+    for reference in bytecode
+        .link_references
+        .values()
+        .flat_map(HashMap::values)
+        .flatten()
+    {
+        linked = link_hex_string_bytecode(linked, &hex::encode(library), reference.start)?;
+    }
+    Ok(linked)
+}
+
+// ---------- calldata encoding ----------
+
 fn selector(signature: &str) -> Selector {
     let hash = keccak256(signature.as_bytes());
     Selector::from(
@@ -139,6 +262,28 @@ fn selector(signature: &str) -> Selector {
             .expect("keccak256 output is 32 bytes"),
     )
 }
+
+/// No-argument calldata: just the 4-byte selector.
+fn call(signature: &str) -> Bytes {
+    Bytes::copy_from_slice(selector(signature).as_slice())
+}
+
+fn encode_call_u256(signature: &str, v: u64) -> Bytes {
+    let mut calldata = Vec::with_capacity(36);
+    calldata.extend_from_slice(selector(signature).as_slice());
+    calldata.extend_from_slice(&U256::from(v).to_be_bytes::<32>());
+    Bytes::from(calldata)
+}
+
+fn encode_call_address(signature: &str, addr: Address) -> Bytes {
+    let mut calldata = Vec::with_capacity(36);
+    calldata.extend_from_slice(selector(signature).as_slice());
+    calldata.extend_from_slice(&[0u8; 12]);
+    calldata.extend_from_slice(addr.as_slice());
+    Bytes::from(calldata)
+}
+
+// ---------- execution and stack-trace extraction ----------
 
 /// Pulls the stack trace out of the failure and returns it directly to
 /// avoid naming `TransactionFailureWithCallTraces` (its module is private).
@@ -184,24 +329,21 @@ fn expect_failed_call_with_value_stack_trace(
     stack_trace_from_failure(err)
 }
 
-/// No-argument calldata: just the 4-byte selector.
-fn call(signature: &str) -> Bytes {
-    Bytes::copy_from_slice(selector(signature).as_slice())
-}
-
-fn encode_call_u256(signature: &str, v: u64) -> Bytes {
-    let mut calldata = Vec::with_capacity(36);
-    calldata.extend_from_slice(selector(signature).as_slice());
-    calldata.extend_from_slice(&U256::from(v).to_be_bytes::<32>());
-    Bytes::from(calldata)
-}
-
-fn encode_call_address(signature: &str, addr: Address) -> Bytes {
-    let mut calldata = Vec::with_capacity(36);
-    calldata.extend_from_slice(selector(signature).as_slice());
-    calldata.extend_from_slice(&[0u8; 12]);
-    calldata.extend_from_slice(addr.as_slice());
-    Bytes::from(calldata)
+fn expect_failed_deploy_stack_trace(
+    provider: &Provider<L1ChainSpec>,
+    from: Address,
+    creation: Bytes,
+) -> Vec<StackTraceEntry> {
+    let err = provider
+        .handle_request(ProviderRequest::with_single(
+            MethodInvocation::SendTransaction(TransactionRequest {
+                from,
+                data: Some(creation),
+                ..TransactionRequest::default()
+            }),
+        ))
+        .expect_err("deployment must revert and bail");
+    stack_trace_from_failure(err)
 }
 
 fn send_ok(
@@ -223,144 +365,7 @@ fn send_ok(
         .map_err(|e| anyhow::anyhow!("setup transaction must succeed: {e:?}"))
 }
 
-fn expect_failed_deploy_stack_trace(
-    provider: &Provider<L1ChainSpec>,
-    from: Address,
-    creation: Bytes,
-) -> Vec<StackTraceEntry> {
-    let err = provider
-        .handle_request(ProviderRequest::with_single(
-            MethodInvocation::SendTransaction(TransactionRequest {
-                from,
-                data: Some(creation),
-                ..TransactionRequest::default()
-            }),
-        ))
-        .expect_err("deployment must revert and bail");
-    stack_trace_from_failure(err)
-}
-
-// ---------- variance-axis tests ----------
-
-/// Counter.set(0) reverts via `require(v > 0, "must be positive")`.
-/// Pin: stack trace surfaces a [`StackTraceEntry::RevertError`] referencing
-/// Counter.sol. Covers the provider-flow plumbing end-to-end and
-/// the `RevertError` axis.
-#[tokio::test(flavor = "multi_thread")]
-async fn revert_error_variant_surfaces_for_counter() -> anyhow::Result<()> {
-    let (build_info, output) = solx_counter_build_info()?;
-    let decoder = ContractDecoder::new(build_info);
-    let (provider, from) = make_provider(decoder)?;
-
-    let counter = deploy_contract(
-        &provider,
-        from,
-        creation_bytes(&output, "Counter.sol", "Counter")?,
-    )?;
-
-    let stack_trace = expect_failed_call_stack_trace(
-        &provider,
-        from,
-        counter,
-        encode_call_u256("set(uint256)", 0),
-    );
-
-    assert!(
-        stack_trace
-            .iter()
-            .any(|e| matches!(e, StackTraceEntry::RevertError { .. })),
-        "expected a RevertError entry, got: {stack_trace:#?}"
-    );
-    assert!(
-        stack_trace.iter().any(|e| e
-            .source_reference()
-            .is_some_and(|s| s.source_name.ends_with("Counter.sol"))),
-        "expected an entry referencing Counter.sol, got: {stack_trace:#?}"
-    );
-    Ok(())
-}
-
-/// OverflowTest.testOverflow does `x = x + 1` with `x = uint256.max` →
-/// panic 0x11. Pin: stack trace surfaces a [`StackTraceEntry::PanicError`].
-/// Covers the `PanicError` axis.
-#[tokio::test(flavor = "multi_thread")]
-async fn panic_error_variant_surfaces_for_overflow_scenario() -> anyhow::Result<()> {
-    let (build_info, output) = solx_scenarios_build_info()?;
-    let decoder = ContractDecoder::new(build_info);
-    let (provider, from) = make_provider(decoder)?;
-
-    let addr = deploy_contract(
-        &provider,
-        from,
-        creation_bytes(&output, "project/contracts/Scenarios.t.sol", "OverflowTest")?,
-    )?;
-
-    let stack_trace = expect_failed_call_stack_trace(&provider, from, addr, call("testOverflow()"));
-
-    assert!(
-        stack_trace
-            .iter()
-            .any(|e| matches!(e, StackTraceEntry::PanicError { .. })),
-        "expected a PanicError entry, got: {stack_trace:#?}"
-    );
-    Ok(())
-}
-
-/// CustomErrorTest.testCustomError does `revert MyError(42, "...")`.
-/// Pin: stack trace surfaces a [`StackTraceEntry::CustomError`].
-/// Covers the `CustomError` axis.
-#[tokio::test(flavor = "multi_thread")]
-async fn custom_error_variant_surfaces_for_custom_error_scenario() -> anyhow::Result<()> {
-    let (build_info, output) = solx_scenarios_build_info()?;
-    let decoder = ContractDecoder::new(build_info);
-    let (provider, from) = make_provider(decoder)?;
-
-    let addr = deploy_contract(
-        &provider,
-        from,
-        creation_bytes(
-            &output,
-            "project/contracts/Scenarios.t.sol",
-            "CustomErrorTest",
-        )?,
-    )?;
-
-    let stack_trace =
-        expect_failed_call_stack_trace(&provider, from, addr, call("testCustomError()"));
-
-    assert!(
-        stack_trace
-            .iter()
-            .any(|e| matches!(e, StackTraceEntry::CustomError { .. })),
-        "expected a CustomError entry, got: {stack_trace:#?}"
-    );
-    Ok(())
-}
-
-// ---------- scenarios-fixture tests ----------
-
-const SCENARIOS_SOURCE: &str = "project/contracts/Scenarios.t.sol";
-
-fn scenarios_provider(
-) -> anyhow::Result<(Provider<L1ChainSpec>, Address, CompilerOutput<SolxBytecode>)> {
-    let (build_info, output) = solx_scenarios_build_info()?;
-    let decoder = ContractDecoder::new(build_info);
-    let (provider, from) = make_provider(decoder)?;
-    Ok((provider, from, output))
-}
-
-fn deploy_scenario(
-    provider: &Provider<L1ChainSpec>,
-    from: Address,
-    output: &CompilerOutput<SolxBytecode>,
-    contract: &str,
-) -> anyhow::Result<Address> {
-    deploy_contract(
-        provider,
-        from,
-        creation_bytes(output, SCENARIOS_SOURCE, contract)?,
-    )
-}
+// ---------- assertions ----------
 
 fn contains_ascii(data: &[u8], needle: &str) -> bool {
     data.windows(needle.len()).any(|w| w == needle.as_bytes())
@@ -397,6 +402,44 @@ fn assert_trace_shape(stack_trace: &[StackTraceEntry], expected: &[&str]) {
         "trace shape drifted — a gained frame may be a solx/inference \
          improvement (update the pin), a lost frame is a regression"
     );
+}
+
+#[track_caller]
+fn assert_single_variant<'a>(
+    stack_trace: &'a [StackTraceEntry],
+    matcher: impl Fn(&StackTraceEntry) -> bool,
+    variant: &str,
+) -> &'a StackTraceEntry {
+    let mut matches = stack_trace.iter().filter(|e| matcher(e));
+    let entry = matches.next().unwrap_or_else(|| {
+        panic!(
+            "expected a {variant} entry, got:\n{}",
+            brief_trace(stack_trace)
+        )
+    });
+    assert!(
+        matches.next().is_none(),
+        "expected a single {variant} entry, got:\n{}",
+        brief_trace(stack_trace)
+    );
+    entry
+}
+
+/// Asserts a single entry of `variant` and returns its source anchor.
+#[track_caller]
+fn assert_single_variant_anchor<'a>(
+    stack_trace: &'a [StackTraceEntry],
+    matcher: impl Fn(&StackTraceEntry) -> bool,
+    variant: &str,
+) -> &'a SourceReference {
+    assert_single_variant(stack_trace, matcher, variant)
+        .source_reference()
+        .unwrap_or_else(|| {
+            panic!(
+                "expected the {variant} entry to carry a source reference, got:\n{}",
+                brief_trace(stack_trace)
+            )
+        })
 }
 
 #[track_caller]
@@ -440,54 +483,329 @@ fn expect_scenario_revert(
     Ok(stack_trace)
 }
 
-fn expect_scenario_panic(contract: &str, signature: &str, code: u64) -> anyhow::Result<()> {
+/// Pins both the decoded panic code and the statement the panic is
+/// anchored to.
+fn expect_scenario_panic(
+    contract: &str,
+    signature: &str,
+    code: u64,
+    line: u32,
+) -> anyhow::Result<()> {
     let (provider, from, output) = scenarios_provider()?;
     let addr = deploy_scenario(&provider, from, &output, contract)?;
     let stack_trace = expect_failed_call_stack_trace(&provider, from, addr, call(signature));
-    let error_code = stack_trace
-        .iter()
-        .find_map(|e| match e {
-            StackTraceEntry::PanicError { error_code, .. } => Some(*error_code),
-            _ => None,
-        })
-        .unwrap_or_else(|| {
-            panic!(
-                "expected a PanicError entry, got:\n{}",
-                brief_trace(&stack_trace)
-            )
-        });
-    assert_eq!(
+    let entry = assert_single_variant(
+        &stack_trace,
+        |e| matches!(e, StackTraceEntry::PanicError { .. }),
+        "PanicError",
+    );
+    let StackTraceEntry::PanicError {
         error_code,
+        source_reference,
+    } = entry
+    else {
+        unreachable!("assert_single_variant matched a PanicError");
+    };
+    assert_eq!(
+        *error_code,
         U256::from(code),
         "expected panic code {code:#x}, got:\n{}",
+        brief_trace(&stack_trace)
+    );
+    let source_reference = source_reference.as_ref().unwrap_or_else(|| {
+        panic!(
+            "expected the PanicError to carry a source reference, got:\n{}",
+            brief_trace(&stack_trace)
+        )
+    });
+    assert_eq!(
+        source_reference.line,
+        line,
+        "expected the panic statement line, got:\n{}",
+        brief_trace(&stack_trace)
+    );
+    Ok(())
+}
+
+// ---------- provider plumbing smoke ----------
+
+/// Counter.set(0) reverts via `require(v > 0, "must be positive")`.
+/// Pin: stack trace surfaces a [`StackTraceEntry::RevertError`] referencing
+/// Counter.sol. Covers the provider-flow plumbing end-to-end on a second,
+/// minimal artifact assembly (the Counter fixture).
+#[tokio::test(flavor = "multi_thread")]
+async fn revert_error_surfaces_end_to_end_for_counter() -> anyhow::Result<()> {
+    let (build_info, output) = solx_counter_build_info()?;
+    let decoder = ContractDecoder::new(build_info);
+    let (provider, from) = make_provider(decoder)?;
+
+    let counter = deploy_contract(
+        &provider,
+        from,
+        creation_bytes(&output, "Counter.sol", "Counter")?,
+    )?;
+
+    let stack_trace = expect_failed_call_stack_trace(
+        &provider,
+        from,
+        counter,
+        encode_call_u256("set(uint256)", 0),
+    );
+
+    assert!(
+        stack_trace
+            .iter()
+            .any(|e| matches!(e, StackTraceEntry::RevertError { .. })),
+        "expected a RevertError entry, got: {stack_trace:#?}"
+    );
+    assert!(
+        stack_trace.iter().any(|e| e
+            .source_reference()
+            .is_some_and(|s| s.source_name.ends_with("Counter.sol"))),
+        "expected an entry referencing Counter.sol, got: {stack_trace:#?}"
+    );
+    Ok(())
+}
+
+// ---------- pre-execution guards (infer_before_tracing_call_message) ------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn function_not_payable_error_surfaces() -> anyhow::Result<()> {
+    let (provider, from, output) = stack_trace_scenarios_provider()?;
+    let addr = deploy_stack_trace_scenario(&provider, from, &output, "NotPayable")?;
+    let stack_trace = expect_failed_call_with_value_stack_trace(
+        &provider,
+        from,
+        addr,
+        encode_call_u256("store(uint256)", 1),
+        U256::from(1u64),
+    );
+    let anchor = assert_single_variant_anchor(
+        &stack_trace,
+        |e| matches!(e, StackTraceEntry::FunctionNotPayableError { .. }),
+        "FunctionNotPayableError",
+    );
+    assert_eq!(
+        (anchor.function.as_deref(), anchor.line),
+        (Some("store"), 12),
+        "expected the `store` declaration as anchor, got:\n{}",
         brief_trace(&stack_trace)
     );
     Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn unrecognized_function_without_fallback_error_surfaces() -> anyhow::Result<()> {
+    let (provider, from, output) = stack_trace_scenarios_provider()?;
+    let addr = deploy_stack_trace_scenario(&provider, from, &output, "NoFallback")?;
+    let stack_trace = expect_failed_call_stack_trace(&provider, from, addr, call("nonExistent()"));
+    let anchor = assert_single_variant_anchor(
+        &stack_trace,
+        |e| {
+            matches!(
+                e,
+                StackTraceEntry::UnrecognizedFunctionWithoutFallbackError { .. }
+            )
+        },
+        "UnrecognizedFunctionWithoutFallbackError",
+    );
+    assert_eq!(
+        (anchor.contract.as_deref(), anchor.line),
+        (Some("NoFallback"), 17),
+        "expected the contract declaration as anchor, got:\n{}",
+        brief_trace(&stack_trace)
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn missing_fallback_or_receive_error_surfaces() -> anyhow::Result<()> {
+    let (provider, from, output) = stack_trace_scenarios_provider()?;
+    let addr = deploy_stack_trace_scenario(&provider, from, &output, "NoFallback")?;
+    let stack_trace = expect_failed_call_with_value_stack_trace(
+        &provider,
+        from,
+        addr,
+        Bytes::new(),
+        U256::from(1u64),
+    );
+    let anchor = assert_single_variant_anchor(
+        &stack_trace,
+        |e| matches!(e, StackTraceEntry::MissingFallbackOrReceiveError { .. }),
+        "MissingFallbackOrReceiveError",
+    );
+    assert_eq!(
+        (anchor.contract.as_deref(), anchor.line),
+        (Some("NoFallback"), 17),
+        "expected the contract declaration as anchor, got:\n{}",
+        brief_trace(&stack_trace)
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fallback_not_payable_error_surfaces() -> anyhow::Result<()> {
+    let (provider, from, output) = stack_trace_scenarios_provider()?;
+    let addr = deploy_stack_trace_scenario(&provider, from, &output, "NonPayableFallback")?;
+    let stack_trace = expect_failed_call_with_value_stack_trace(
+        &provider,
+        from,
+        addr,
+        call("nonExistent()"),
+        U256::from(1u64),
+    );
+    let anchor = assert_single_variant_anchor(
+        &stack_trace,
+        |e| matches!(e, StackTraceEntry::FallbackNotPayableError { .. }),
+        "FallbackNotPayableError",
+    );
+    assert_eq!(
+        anchor.line,
+        26,
+        "expected the fallback declaration as anchor, got:\n{}",
+        brief_trace(&stack_trace)
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fallback_not_payable_and_no_receive_error_surfaces() -> anyhow::Result<()> {
+    let (provider, from, output) = stack_trace_scenarios_provider()?;
+    let addr = deploy_stack_trace_scenario(&provider, from, &output, "NonPayableFallback")?;
+    let stack_trace = expect_failed_call_with_value_stack_trace(
+        &provider,
+        from,
+        addr,
+        Bytes::new(),
+        U256::from(1u64),
+    );
+    let anchor = assert_single_variant_anchor(
+        &stack_trace,
+        |e| {
+            matches!(
+                e,
+                StackTraceEntry::FallbackNotPayableAndNoReceiveError { .. }
+            )
+        },
+        "FallbackNotPayableAndNoReceiveError",
+    );
+    assert_eq!(
+        anchor.line,
+        26,
+        "expected the fallback declaration as anchor, got:\n{}",
+        brief_trace(&stack_trace)
+    );
+    Ok(())
+}
+
+/// Calling a deployed library's external function directly.
+#[tokio::test(flavor = "multi_thread")]
+async fn direct_library_call_error_surfaces() -> anyhow::Result<()> {
+    let (provider, from, output) = stack_trace_scenarios_provider()?;
+    let library = deploy_stack_trace_scenario(&provider, from, &output, "ExternalLib")?;
+    let stack_trace = expect_failed_call_stack_trace(&provider, from, library, call("fail()"));
+    let anchor = assert_single_variant_anchor(
+        &stack_trace,
+        |e| matches!(e, StackTraceEntry::DirectLibraryCallError { .. }),
+        "DirectLibraryCallError",
+    );
+    assert_eq!(
+        (anchor.function.as_deref(), anchor.line),
+        (Some("fail"), 52),
+        "expected the called library function as anchor, got:\n{}",
+        brief_trace(&stack_trace)
+    );
+    Ok(())
+}
+
+// ---------- calldata decoding (check_last_instruction) ----------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn invalid_params_error_surfaces_for_truncated_calldata() -> anyhow::Result<()> {
+    let (provider, from, output) = stack_trace_scenarios_provider()?;
+    let addr = deploy_stack_trace_scenario(&provider, from, &output, "RequiresArgs")?;
+    let mut calldata = selector("needsBoth(uint256,uint256)").as_slice().to_vec();
+    calldata.extend_from_slice(&[0u8; 32]); // only one of the two words
+    let stack_trace = expect_failed_call_stack_trace(&provider, from, addr, Bytes::from(calldata));
+    let anchor = assert_single_variant_anchor(
+        &stack_trace,
+        |e| matches!(e, StackTraceEntry::InvalidParamsError { .. }),
+        "InvalidParamsError",
+    );
+    assert_eq!(
+        (anchor.function.as_deref(), anchor.line),
+        (Some("needsBoth"), 32),
+        "expected the called function declaration as anchor, got:\n{}",
+        brief_trace(&stack_trace)
+    );
+    Ok(())
+}
+
+// ---------- revert/panic/custom (check_revert_or_invalid_opcode) ----------
+
+#[tokio::test(flavor = "multi_thread")]
 async fn panic_code_surfaces_for_assert_failure() -> anyhow::Result<()> {
-    expect_scenario_panic("AssertionFailureTest", "testAssertionFails()", 0x01)
+    expect_scenario_panic("AssertionFailureTest", "testAssertionFails()", 0x01, 18)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn panic_code_surfaces_for_arithmetic_overflow() -> anyhow::Result<()> {
+    expect_scenario_panic("OverflowTest", "testOverflow()", 0x11, 26)
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn panic_code_surfaces_for_division_by_zero() -> anyhow::Result<()> {
-    expect_scenario_panic("DivisionByZeroTest", "testDivisionByZero()", 0x12)
+    expect_scenario_panic("DivisionByZeroTest", "testDivisionByZero()", 0x12, 34)
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn panic_code_surfaces_for_invalid_enum_cast() -> anyhow::Result<()> {
-    expect_scenario_panic("InvalidEnumCastTest", "testInvalidEnumCast()", 0x21)
+    expect_scenario_panic("InvalidEnumCastTest", "testInvalidEnumCast()", 0x21, 169)
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn panic_code_surfaces_for_pop_on_empty_array() -> anyhow::Result<()> {
-    expect_scenario_panic("PopEmptyArrayTest", "testPopEmpty()", 0x31)
+    expect_scenario_panic("PopEmptyArrayTest", "testPopEmpty()", 0x31, 177)
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn panic_code_surfaces_for_array_out_of_bounds() -> anyhow::Result<()> {
-    expect_scenario_panic("ArrayOutOfBoundsTest", "testArrayOOB()", 0x32)
+    expect_scenario_panic("ArrayOutOfBoundsTest", "testArrayOOB()", 0x32, 42)
+}
+
+/// `revert MyError(42, "custom error")`: pins the known-selector decode of
+/// custom-error arguments into the message, not just the entry variant.
+#[tokio::test(flavor = "multi_thread")]
+async fn custom_error_decodes_name_and_args() -> anyhow::Result<()> {
+    let (provider, from, output) = scenarios_provider()?;
+    let addr = deploy_scenario(&provider, from, &output, "CustomErrorTest")?;
+    let stack_trace =
+        expect_failed_call_stack_trace(&provider, from, addr, call("testCustomError()"));
+    let entry = assert_single_variant(
+        &stack_trace,
+        |e| matches!(e, StackTraceEntry::CustomError { .. }),
+        "CustomError",
+    );
+    let StackTraceEntry::CustomError {
+        message,
+        source_reference,
+    } = entry
+    else {
+        unreachable!("assert_single_variant matched a CustomError");
+    };
+    assert_eq!(
+        message,
+        r#"reverted with custom error 'MyError(42, "custom error")'"#,
+        "got:\n{}",
+        brief_trace(&stack_trace)
+    );
+    assert_eq!(
+        source_reference.line,
+        51,
+        "expected the revert statement line, got:\n{}",
+        brief_trace(&stack_trace)
+    );
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -500,6 +818,230 @@ async fn revert_line_discriminates_between_requires() -> anyhow::Result<()> {
     )?;
     Ok(())
 }
+
+// ---------- callstack reconstruction (frames, submessages, recursion) ------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn cross_contract_call_keeps_caller_frame() -> anyhow::Result<()> {
+    let (provider, from, output) = scenarios_provider()?;
+    let caller = deploy_scenario(&provider, from, &output, "CrossContractCallTest")?;
+    send_ok(&provider, from, caller, call("setUp()"))?;
+    let stack_trace =
+        expect_failed_call_stack_trace(&provider, from, caller, call("testCrossContractCall()"));
+    assert_revert_at_line(&stack_trace, 69, "called fail");
+    // No separate `Other.fail` callstack frame: the bottom entry already
+    // renders as `Other.fail`, so the intermediate frame dedups against it.
+    assert_trace_shape(
+        &stack_trace,
+        &[
+            "CallstackEntry project/contracts/Scenarios.t.sol:81 (CrossContractCallTest.testCrossContractCall)",
+            "RevertError project/contracts/Scenarios.t.sol:69 (Other.fail)",
+        ],
+    );
+    Ok(())
+}
+
+/// One frame per external call, not collapsed by `filter_redundant_frames`
+/// (solx `recursion_start_idx` = 0).
+#[tokio::test(flavor = "multi_thread")]
+async fn external_recursion_keeps_one_frame_per_call() -> anyhow::Result<()> {
+    let (provider, from, output) = scenarios_provider()?;
+    let addr = deploy_scenario(&provider, from, &output, "DeepRecursionTarget")?;
+    let stack_trace = expect_failed_call_stack_trace(
+        &provider,
+        from,
+        addr,
+        encode_call_u256("recurse(uint256)", 3),
+    );
+    assert_revert_at_line(&stack_trace, 109, "bottomed out");
+    assert_trace_shape(
+        &stack_trace,
+        &[
+            "CallstackEntry project/contracts/Scenarios.t.sol:111 (DeepRecursionTarget.recurse)",
+            "CallstackEntry project/contracts/Scenarios.t.sol:111 (DeepRecursionTarget.recurse)",
+            "CallstackEntry project/contracts/Scenarios.t.sol:111 (DeepRecursionTarget.recurse)",
+            "RevertError project/contracts/Scenarios.t.sol:109 (DeepRecursionTarget.recurse)",
+        ],
+    );
+    Ok(())
+}
+
+/// solx's optimizer may unroll the recursion, so only the bottom revert
+/// line is pinned.
+#[tokio::test(flavor = "multi_thread")]
+async fn internal_recursion_pins_bottom_revert_line() -> anyhow::Result<()> {
+    expect_scenario_revert(
+        "InternalRecurseTest",
+        call("testInternalRecurse()"),
+        348,
+        "internal bottom",
+    )?;
+    Ok(())
+}
+
+/// solx may emit both JUMP-derived and inlined frames at the dispatch
+/// points, so only the bottom revert line is pinned.
+#[tokio::test(flavor = "multi_thread")]
+async fn mutual_recursion_pins_bottom_revert_line() -> anyhow::Result<()> {
+    let (provider, from, output) = scenarios_provider()?;
+    let a = deploy_scenario(&provider, from, &output, "MutualA")?;
+    let b = deploy_scenario(&provider, from, &output, "MutualB")?;
+    send_ok(
+        &provider,
+        from,
+        a,
+        encode_call_address("setOther(address)", b),
+    )?;
+    send_ok(
+        &provider,
+        from,
+        b,
+        encode_call_address("setOther(address)", a),
+    )?;
+    let stack_trace =
+        expect_failed_call_stack_trace(&provider, from, a, encode_call_u256("pingA(uint256)", 2));
+    assert_revert_at_line(&stack_trace, 377, "mutual bottom");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn internal_helper_revert_points_at_helper_require() -> anyhow::Result<()> {
+    expect_scenario_revert(
+        "InternalHelperChainContract",
+        encode_call_u256("set(uint256)", 0),
+        149,
+        "must be positive",
+    )?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn internal_library_revert_points_into_library() -> anyhow::Result<()> {
+    expect_scenario_revert(
+        "LibraryRevertTest",
+        call("testLibraryRevert()"),
+        229,
+        "lib boom",
+    )?;
+    Ok(())
+}
+
+/// External (public) library function reached through a linked contract:
+/// exercises `linkReferences` placeholder substitution and DELEGATECALL
+/// frame decoding into the library's own debugInfo.
+#[tokio::test(flavor = "multi_thread")]
+async fn linked_external_library_revert_points_into_library() -> anyhow::Result<()> {
+    let (provider, from, output) = stack_trace_scenarios_provider()?;
+    let library = deploy_stack_trace_scenario(&provider, from, &output, "ExternalLib")?;
+
+    let unlinked = &output
+        .contracts
+        .get(STACK_TRACE_SCENARIOS_SOURCE)
+        .and_then(|m| m.get("UsesExternalLib"))
+        .context("fixture missing UsesExternalLib")?
+        .evm
+        .bytecode;
+    let linked = link_library(unlinked, library)?;
+    let user = deploy_contract(&provider, from, Bytes::from(hex::decode(&linked)?))?;
+
+    let stack_trace = expect_failed_call_stack_trace(&provider, from, user, call("go()"));
+    assert_revert_at_line(&stack_trace, 53, "external lib boom");
+    assert_trace_shape(
+        &stack_trace,
+        &[
+            "CallstackEntry project/contracts/StackTraceScenarios.sol:59 (UsesExternalLib.go)",
+            "RevertError project/contracts/StackTraceScenarios.sol:53 (ExternalLib.fail)",
+        ],
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fallback_revert_points_at_fallback_body() -> anyhow::Result<()> {
+    expect_scenario_revert(
+        "FallbackRevertTarget",
+        call("nonExistent()"),
+        259,
+        "fallback boom",
+    )?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn receive_revert_points_at_receive_body() -> anyhow::Result<()> {
+    expect_scenario_revert("ReceiveRevertTarget", Bytes::new(), 276, "receive boom")?;
+    Ok(())
+}
+
+// ---------- modifiers (fix_initial_modifier + strategy attribution) ----------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn modifier_revert_points_at_modifier_require() -> anyhow::Result<()> {
+    expect_scenario_revert(
+        "ModifierTarget",
+        encode_call_u256("setIfPositive(uint256)", 0),
+        87,
+        "modifier must be positive",
+    )?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn nested_modifier_revert_points_at_the_failing_require() -> anyhow::Result<()> {
+    let (provider, from, output) = stack_trace_scenarios_provider()?;
+    let addr = deploy_stack_trace_scenario(&provider, from, &output, "ValidatedCounter")?;
+    let stack_trace = expect_failed_call_stack_trace(
+        &provider,
+        from,
+        addr,
+        encode_call_u256("bumpIfValid(uint256)", 13),
+    );
+    assert_revert_at_line(&stack_trace, 80, "unlucky");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn cross_contract_modifier_revert_keeps_called_function_frame() -> anyhow::Result<()> {
+    let (provider, from, output) = stack_trace_scenarios_provider()?;
+    let addr = deploy_stack_trace_scenario(&provider, from, &output, "ValidatedCounterCaller")?;
+    let stack_trace = expect_failed_call_stack_trace(
+        &provider,
+        from,
+        addr,
+        encode_call_u256("callBump(uint256)", 13),
+    );
+    assert_revert_at_line(&stack_trace, 80, "unlucky");
+    assert_trace_shape(
+        &stack_trace,
+        &[
+            "CallstackEntry project/contracts/StackTraceScenarios.sol:99 (ValidatedCounterCaller.callBump)",
+            "CallstackEntry project/contracts/StackTraceScenarios.sol:86 (ValidatedCounter.bumpIfValid)",
+            "RevertError project/contracts/StackTraceScenarios.sol:80 (ValidatedCounter.validates)",
+        ],
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn bare_modifier_revert_attributes_to_the_revert_statement() -> anyhow::Result<()> {
+    let (provider, from, output) = stack_trace_scenarios_provider()?;
+    let addr = deploy_stack_trace_scenario(&provider, from, &output, "GuardedBareRevert")?;
+    let stack_trace = expect_failed_call_stack_trace(&provider, from, addr, call("fire()"));
+    let anchor = assert_single_variant_anchor(
+        &stack_trace,
+        |e| matches!(e, StackTraceEntry::RevertError { .. }),
+        "RevertError",
+    );
+    assert_eq!(
+        (anchor.line, anchor.function.as_deref()),
+        (68, Some("guarded")),
+        "expected the `revert()` statement line inside the modifier, got:\n{}",
+        brief_trace(&stack_trace)
+    );
+    Ok(())
+}
+
+// ---------- create path (creation-code debugInfo) ----------
 
 /// Resolves through `evm.bytecode.debugInfo` (creation code) rather than
 /// `evm.deployedBytecode.debugInfo`.
@@ -530,369 +1072,7 @@ async fn create_revert_surfaces_through_constructor_helper() -> anyhow::Result<(
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn modifier_revert_points_at_modifier_require() -> anyhow::Result<()> {
-    expect_scenario_revert(
-        "ModifierTarget",
-        encode_call_u256("setIfPositive(uint256)", 0),
-        87,
-        "modifier must be positive",
-    )?;
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn cross_contract_call_keeps_caller_frame() -> anyhow::Result<()> {
-    let (provider, from, output) = scenarios_provider()?;
-    let caller = deploy_scenario(&provider, from, &output, "CrossContractCallTest")?;
-    send_ok(&provider, from, caller, call("setUp()"))?;
-    let stack_trace =
-        expect_failed_call_stack_trace(&provider, from, caller, call("testCrossContractCall()"));
-    assert_revert_at_line(&stack_trace, 69, "called fail");
-    assert!(
-        stack_trace.iter().any(|e| matches!(
-            e,
-            StackTraceEntry::CallstackEntry { source_reference, .. }
-                if source_reference.contract.as_deref() == Some("CrossContractCallTest")
-        )),
-        "expected a CallstackEntry for CrossContractCallTest, got:\n{}",
-        brief_trace(&stack_trace)
-    );
-    // No separate `Other.fail` callstack frame: the bottom entry already
-    // renders as `Other.fail`, so the intermediate frame dedups against it.
-    assert_trace_shape(
-        &stack_trace,
-        &[
-            "CallstackEntry project/contracts/Scenarios.t.sol:81 (CrossContractCallTest.testCrossContractCall)",
-            "RevertError project/contracts/Scenarios.t.sol:69 (Other.fail)",
-        ],
-    );
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn external_recursion_keeps_one_frame_per_call() -> anyhow::Result<()> {
-    let (provider, from, output) = scenarios_provider()?;
-    let addr = deploy_scenario(&provider, from, &output, "DeepRecursionTarget")?;
-    let stack_trace = expect_failed_call_stack_trace(
-        &provider,
-        from,
-        addr,
-        encode_call_u256("recurse(uint256)", 3),
-    );
-    assert_revert_at_line(&stack_trace, 109, "bottomed out");
-    let recursion_frames = stack_trace
-        .iter()
-        .filter(|e| {
-            matches!(
-                e,
-                StackTraceEntry::CallstackEntry { source_reference, .. }
-                    if source_reference.function.as_deref() == Some("recurse")
-            )
-        })
-        .count();
-    assert!(
-        recursion_frames >= 3,
-        "expected >= 3 recurse callstack frames, got {recursion_frames}:\n{}",
-        brief_trace(&stack_trace)
-    );
-    assert_trace_shape(
-        &stack_trace,
-        &[
-            "CallstackEntry project/contracts/Scenarios.t.sol:111 (DeepRecursionTarget.recurse)",
-            "CallstackEntry project/contracts/Scenarios.t.sol:111 (DeepRecursionTarget.recurse)",
-            "CallstackEntry project/contracts/Scenarios.t.sol:111 (DeepRecursionTarget.recurse)",
-            "RevertError project/contracts/Scenarios.t.sol:109 (DeepRecursionTarget.recurse)",
-        ],
-    );
-    Ok(())
-}
-
-/// solx's optimizer may unroll the recursion, so only the bottom revert
-/// line is pinned.
-#[tokio::test(flavor = "multi_thread")]
-async fn internal_recursion_pins_bottom_revert_line() -> anyhow::Result<()> {
-    expect_scenario_revert(
-        "InternalRecurseTest",
-        call("testInternalRecurse()"),
-        348,
-        "internal bottom",
-    )?;
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn internal_helper_revert_points_at_helper_require() -> anyhow::Result<()> {
-    expect_scenario_revert(
-        "InternalHelperChainContract",
-        encode_call_u256("set(uint256)", 0),
-        149,
-        "must be positive",
-    )?;
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn internal_library_revert_points_into_library() -> anyhow::Result<()> {
-    expect_scenario_revert(
-        "LibraryRevertTest",
-        call("testLibraryRevert()"),
-        229,
-        "lib boom",
-    )?;
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn fallback_revert_points_at_fallback_body() -> anyhow::Result<()> {
-    expect_scenario_revert(
-        "FallbackRevertTarget",
-        call("nonExistent()"),
-        259,
-        "fallback boom",
-    )?;
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn receive_revert_points_at_receive_body() -> anyhow::Result<()> {
-    expect_scenario_revert("ReceiveRevertTarget", Bytes::new(), 276, "receive boom")?;
-    Ok(())
-}
-
-/// solx may emit both JUMP-derived and inlined frames at the dispatch
-/// points, so only the bottom revert line is pinned.
-#[tokio::test(flavor = "multi_thread")]
-async fn mutual_recursion_pins_bottom_revert_line() -> anyhow::Result<()> {
-    let (provider, from, output) = scenarios_provider()?;
-    let a = deploy_scenario(&provider, from, &output, "MutualA")?;
-    let b = deploy_scenario(&provider, from, &output, "MutualB")?;
-    send_ok(
-        &provider,
-        from,
-        a,
-        encode_call_address("setOther(address)", b),
-    )?;
-    send_ok(
-        &provider,
-        from,
-        b,
-        encode_call_address("setOther(address)", a),
-    )?;
-    let stack_trace =
-        expect_failed_call_stack_trace(&provider, from, a, encode_call_u256("pingA(uint256)", 2));
-    assert_revert_at_line(&stack_trace, 377, "mutual bottom");
-    Ok(())
-}
-
-// ---------- StackTraceScenarios fixture tests ----------
-
-const STACK_TRACE_SCENARIOS_SOURCE: &str = "project/contracts/StackTraceScenarios.sol";
-
-fn stack_trace_scenarios_provider(
-) -> anyhow::Result<(Provider<L1ChainSpec>, Address, CompilerOutput<SolxBytecode>)> {
-    let (build_info, output) = solx_stack_trace_scenarios_build_info(
-        include_str!(
-            "../../../edr_solidity/fixtures/solx_compiler_input_stack_trace_scenarios.json"
-        ),
-        include_str!(
-            "../../../edr_solidity/fixtures/solx_compiler_output_stack_trace_scenarios.json"
-        ),
-    )?;
-    let decoder = ContractDecoder::new(build_info);
-    let (provider, from) = make_provider(decoder)?;
-    Ok((provider, from, output))
-}
-
-/// Same scenarios compiled at optimizer mode 3: mode-1 DWARF is
-/// statement-attributed since solx 0.1.6, so only these artifacts reach
-/// the declaration-attributed and unmapped-revert inference paths.
-fn stack_trace_scenarios_mode3_provider(
-) -> anyhow::Result<(Provider<L1ChainSpec>, Address, CompilerOutput<SolxBytecode>)> {
-    let (build_info, output) = solx_stack_trace_scenarios_build_info(
-        include_str!(
-            "../../../edr_solidity/fixtures/solx_compiler_input_stack_trace_scenarios_mode3.json"
-        ),
-        include_str!(
-            "../../../edr_solidity/fixtures/solx_compiler_output_stack_trace_scenarios_mode3.json"
-        ),
-    )?;
-    let decoder = ContractDecoder::new(build_info);
-    let (provider, from) = make_provider(decoder)?;
-    Ok((provider, from, output))
-}
-
-fn deploy_stack_trace_scenario(
-    provider: &Provider<L1ChainSpec>,
-    from: Address,
-    output: &CompilerOutput<SolxBytecode>,
-    contract: &str,
-) -> anyhow::Result<Address> {
-    deploy_contract(
-        provider,
-        from,
-        creation_bytes(output, STACK_TRACE_SCENARIOS_SOURCE, contract)?,
-    )
-}
-
-/// Substitutes the deployed library address at every `linkReferences`
-/// position, through the production `link_hex_string_bytecode` path.
-fn link_library(bytecode: &SolxBytecode, library: Address) -> anyhow::Result<String> {
-    let library_count: usize = bytecode.link_references.values().map(HashMap::len).sum();
-    anyhow::ensure!(
-        library_count == 1,
-        "bytecode references {library_count} libraries; link_library takes one address"
-    );
-    let mut linked = bytecode.object.clone();
-    for reference in bytecode
-        .link_references
-        .values()
-        .flat_map(HashMap::values)
-        .flatten()
-    {
-        linked = link_hex_string_bytecode(linked, &hex::encode(library), reference.start)?;
-    }
-    Ok(linked)
-}
-
-#[track_caller]
-fn assert_single_variant<'a>(
-    stack_trace: &'a [StackTraceEntry],
-    matcher: impl Fn(&StackTraceEntry) -> bool,
-    variant: &str,
-) -> &'a StackTraceEntry {
-    let mut matches = stack_trace.iter().filter(|e| matcher(e));
-    let entry = matches.next().unwrap_or_else(|| {
-        panic!(
-            "expected a {variant} entry, got:\n{}",
-            brief_trace(stack_trace)
-        )
-    });
-    assert!(
-        matches.next().is_none(),
-        "expected a single {variant} entry, got:\n{}",
-        brief_trace(stack_trace)
-    );
-    entry
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn function_not_payable_error_surfaces() -> anyhow::Result<()> {
-    let (provider, from, output) = stack_trace_scenarios_provider()?;
-    let addr = deploy_stack_trace_scenario(&provider, from, &output, "NotPayable")?;
-    let stack_trace = expect_failed_call_with_value_stack_trace(
-        &provider,
-        from,
-        addr,
-        encode_call_u256("store(uint256)", 1),
-        U256::from(1u64),
-    );
-    let entry = assert_single_variant(
-        &stack_trace,
-        |e| matches!(e, StackTraceEntry::FunctionNotPayableError { .. }),
-        "FunctionNotPayableError",
-    );
-    let source_reference = entry
-        .source_reference()
-        .expect("FunctionNotPayableError carries a source reference");
-    assert_eq!(source_reference.function.as_deref(), Some("store"));
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn unrecognized_function_without_fallback_error_surfaces() -> anyhow::Result<()> {
-    let (provider, from, output) = stack_trace_scenarios_provider()?;
-    let addr = deploy_stack_trace_scenario(&provider, from, &output, "NoFallback")?;
-    let stack_trace = expect_failed_call_stack_trace(&provider, from, addr, call("nonExistent()"));
-    assert_single_variant(
-        &stack_trace,
-        |e| {
-            matches!(
-                e,
-                StackTraceEntry::UnrecognizedFunctionWithoutFallbackError { .. }
-            )
-        },
-        "UnrecognizedFunctionWithoutFallbackError",
-    );
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn missing_fallback_or_receive_error_surfaces() -> anyhow::Result<()> {
-    let (provider, from, output) = stack_trace_scenarios_provider()?;
-    let addr = deploy_stack_trace_scenario(&provider, from, &output, "NoFallback")?;
-    let stack_trace = expect_failed_call_with_value_stack_trace(
-        &provider,
-        from,
-        addr,
-        Bytes::new(),
-        U256::from(1u64),
-    );
-    assert_single_variant(
-        &stack_trace,
-        |e| matches!(e, StackTraceEntry::MissingFallbackOrReceiveError { .. }),
-        "MissingFallbackOrReceiveError",
-    );
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn fallback_not_payable_error_surfaces() -> anyhow::Result<()> {
-    let (provider, from, output) = stack_trace_scenarios_provider()?;
-    let addr = deploy_stack_trace_scenario(&provider, from, &output, "NonPayableFallback")?;
-    let stack_trace = expect_failed_call_with_value_stack_trace(
-        &provider,
-        from,
-        addr,
-        call("nonExistent()"),
-        U256::from(1u64),
-    );
-    assert_single_variant(
-        &stack_trace,
-        |e| matches!(e, StackTraceEntry::FallbackNotPayableError { .. }),
-        "FallbackNotPayableError",
-    );
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn fallback_not_payable_and_no_receive_error_surfaces() -> anyhow::Result<()> {
-    let (provider, from, output) = stack_trace_scenarios_provider()?;
-    let addr = deploy_stack_trace_scenario(&provider, from, &output, "NonPayableFallback")?;
-    let stack_trace = expect_failed_call_with_value_stack_trace(
-        &provider,
-        from,
-        addr,
-        Bytes::new(),
-        U256::from(1u64),
-    );
-    assert_single_variant(
-        &stack_trace,
-        |e| {
-            matches!(
-                e,
-                StackTraceEntry::FallbackNotPayableAndNoReceiveError { .. }
-            )
-        },
-        "FallbackNotPayableAndNoReceiveError",
-    );
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn invalid_params_error_surfaces_for_truncated_calldata() -> anyhow::Result<()> {
-    let (provider, from, output) = stack_trace_scenarios_provider()?;
-    let addr = deploy_stack_trace_scenario(&provider, from, &output, "RequiresArgs")?;
-    let mut calldata = selector("needsBoth(uint256,uint256)").as_slice().to_vec();
-    calldata.extend_from_slice(&[0u8; 32]); // only one of the two words
-    let stack_trace = expect_failed_call_stack_trace(&provider, from, addr, Bytes::from(calldata));
-    assert_single_variant(
-        &stack_trace,
-        |e| matches!(e, StackTraceEntry::InvalidParamsError { .. }),
-        "InvalidParamsError",
-    );
-    Ok(())
-}
+// ---------- submessage checks (check_last_submessage) ----------
 
 #[track_caller]
 fn assert_returndata_size_error_at_call_get(stack_trace: &[StackTraceEntry]) {
@@ -946,119 +1126,6 @@ async fn noncontract_account_call_surfaces_as_returndata_size_error() -> anyhow:
     Ok(())
 }
 
-/// External (public) library function reached through a linked contract:
-/// exercises `linkReferences` placeholder substitution and DELEGATECALL
-/// frame decoding into the library's own debugInfo.
-#[tokio::test(flavor = "multi_thread")]
-async fn linked_external_library_revert_points_into_library() -> anyhow::Result<()> {
-    let (provider, from, output) = stack_trace_scenarios_provider()?;
-    let library = deploy_stack_trace_scenario(&provider, from, &output, "ExternalLib")?;
-
-    let unlinked = &output
-        .contracts
-        .get(STACK_TRACE_SCENARIOS_SOURCE)
-        .and_then(|m| m.get("UsesExternalLib"))
-        .context("fixture missing UsesExternalLib")?
-        .evm
-        .bytecode;
-    let linked = link_library(unlinked, library)?;
-    let user = deploy_contract(&provider, from, Bytes::from(hex::decode(&linked)?))?;
-
-    let stack_trace = expect_failed_call_stack_trace(&provider, from, user, call("go()"));
-    assert_revert_at_line(&stack_trace, 53, "external lib boom");
-    assert_trace_shape(
-        &stack_trace,
-        &[
-            "CallstackEntry project/contracts/StackTraceScenarios.sol:59 (UsesExternalLib.go)",
-            "RevertError project/contracts/StackTraceScenarios.sol:53 (ExternalLib.fail)",
-        ],
-    );
-    Ok(())
-}
-
-/// Calling a deployed library's external function directly.
-#[tokio::test(flavor = "multi_thread")]
-async fn direct_library_call_error_surfaces() -> anyhow::Result<()> {
-    let (provider, from, output) = stack_trace_scenarios_provider()?;
-    let library = deploy_stack_trace_scenario(&provider, from, &output, "ExternalLib")?;
-    let stack_trace = expect_failed_call_stack_trace(&provider, from, library, call("fail()"));
-    assert_single_variant(
-        &stack_trace,
-        |e| matches!(e, StackTraceEntry::DirectLibraryCallError { .. }),
-        "DirectLibraryCallError",
-    );
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn nested_modifier_revert_points_at_the_failing_require() -> anyhow::Result<()> {
-    let (provider, from, output) = stack_trace_scenarios_provider()?;
-    let addr = deploy_stack_trace_scenario(&provider, from, &output, "ValidatedCounter")?;
-    let stack_trace = expect_failed_call_stack_trace(
-        &provider,
-        from,
-        addr,
-        encode_call_u256("bumpIfValid(uint256)", 13),
-    );
-    assert_revert_at_line(&stack_trace, 80, "unlucky");
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn cross_contract_modifier_revert_keeps_called_function_frame() -> anyhow::Result<()> {
-    let (provider, from, output) = stack_trace_scenarios_provider()?;
-    let addr = deploy_stack_trace_scenario(&provider, from, &output, "ValidatedCounterCaller")?;
-    let stack_trace = expect_failed_call_stack_trace(
-        &provider,
-        from,
-        addr,
-        encode_call_u256("callBump(uint256)", 13),
-    );
-    assert_revert_at_line(&stack_trace, 80, "unlucky");
-    let callee_frame = stack_trace.iter().any(|e| {
-        matches!(e, StackTraceEntry::CallstackEntry { source_reference, .. }
-            if source_reference.function.as_deref() == Some("bumpIfValid")
-                && source_reference.line == 86)
-    });
-    assert!(
-        callee_frame,
-        "expected a CallstackEntry for bumpIfValid at its declaration \
-         (line 86), got:\n{}",
-        brief_trace(&stack_trace)
-    );
-    assert_trace_shape(
-        &stack_trace,
-        &[
-            "CallstackEntry project/contracts/StackTraceScenarios.sol:99 (ValidatedCounterCaller.callBump)",
-            "CallstackEntry project/contracts/StackTraceScenarios.sol:86 (ValidatedCounter.bumpIfValid)",
-            "RevertError project/contracts/StackTraceScenarios.sol:80 (ValidatedCounter.validates)",
-        ],
-    );
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn bare_modifier_revert_attributes_to_the_revert_statement() -> anyhow::Result<()> {
-    let (provider, from, output) = stack_trace_scenarios_provider()?;
-    let addr = deploy_stack_trace_scenario(&provider, from, &output, "GuardedBareRevert")?;
-    let stack_trace = expect_failed_call_stack_trace(&provider, from, addr, call("fire()"));
-    let entry = assert_single_variant(
-        &stack_trace,
-        |e| matches!(e, StackTraceEntry::RevertError { .. }),
-        "RevertError",
-    );
-    let source_reference = entry
-        .source_reference()
-        .expect("entry carries a source reference");
-    assert_eq!(
-        (source_reference.line, source_reference.function.as_deref()),
-        (68, Some("guarded")),
-        "expected the `revert()` statement line inside the modifier, got:\n{}",
-        brief_trace(&stack_trace)
-    );
-    Ok(())
-}
-
 // ---------- mode-3 twins: pin the compat inference paths ----------
 
 #[tokio::test(flavor = "multi_thread")]
@@ -1106,16 +1173,13 @@ async fn mode3_bare_modifier_revert_recovers_the_failing_function() -> anyhow::R
     let (provider, from, output) = stack_trace_scenarios_mode3_provider()?;
     let addr = deploy_stack_trace_scenario(&provider, from, &output, "GuardedBareRevert")?;
     let stack_trace = expect_failed_call_stack_trace(&provider, from, addr, call("fire()"));
-    let entry = assert_single_variant(
+    let anchor = assert_single_variant_anchor(
         &stack_trace,
         |e| matches!(e, StackTraceEntry::RevertError { .. }),
         "RevertError",
     );
-    let source_reference = entry
-        .source_reference()
-        .expect("entry carries a source reference");
     assert_eq!(
-        (source_reference.line, source_reference.function.as_deref()),
+        (anchor.line, anchor.function.as_deref()),
         (67, Some("guarded")),
         "expected the guard line inside the modifier, got:\n{}",
         brief_trace(&stack_trace)

--- a/crates/edr_provider/tests/integration/solx_stack_trace.rs
+++ b/crates/edr_provider/tests/integration/solx_stack_trace.rs
@@ -9,15 +9,13 @@
 use std::sync::Arc;
 
 use anyhow::Context;
-use edr_chain_l1::{
-    rpc::{receipt::L1RpcTransactionReceipt, TransactionRequest},
-    L1ChainSpec,
-};
-use edr_primitives::{hex, keccak256, Address, Bytes, Selector, B256, U256};
+use edr_chain_l1::{rpc::TransactionRequest, L1ChainSpec};
+use edr_primitives::{hex, keccak256, Address, Bytes, Selector, U256};
 use edr_provider::{
-    test_utils::{create_test_config_with, MinimalProviderConfig},
+    test_utils::{create_test_config_with, deploy_contract, MinimalProviderConfig},
     time::CurrentTime,
-    MethodInvocation, NoopLogger, Provider, ProviderError, ProviderRequest,
+    MethodInvocation, NoopLogger, Provider, ProviderError, ProviderErrorForChainSpec,
+    ProviderRequest,
 };
 use edr_signer::public_key_to_address;
 use edr_solidity::{
@@ -26,21 +24,20 @@ use edr_solidity::{
         SolxBytecode,
     },
     contract_decoder::ContractDecoder,
-    solidity_stack_trace::{SourceReference, StackTraceCreationResult, StackTraceEntry},
+    solidity_stack_trace::{StackTraceCreationResult, StackTraceEntry},
 };
 use parking_lot::RwLock;
 use tokio::runtime;
 
-fn solx_counter_build_info() -> anyhow::Result<(BuildInfoConfig, CompilerOutput<SolxBytecode>)> {
-    let mut input: CompilerInput = serde_json::from_str(include_str!(
-        "../../../edr_solidity/fixtures/solx_compiler_input.json"
-    ))?;
-    input.sources.get_mut("Counter.sol").unwrap().content =
-        include_str!("../../../edr_solidity/fixtures/sources/Counter.sol").to_owned();
-
-    let output: CompilerOutput<SolxBytecode> = serde_json::from_str(include_str!(
-        "../../../edr_solidity/fixtures/solx_compiler_output.json"
-    ))?;
+/// The `include_str!` literals stay at the call sites — the macro needs a
+/// literal path.
+fn assemble_build_info(
+    mut input: CompilerInput,
+    source_key: &str,
+    source_content: &str,
+    output: CompilerOutput<SolxBytecode>,
+) -> anyhow::Result<(BuildInfoConfig, CompilerOutput<SolxBytecode>)> {
+    input.sources.get_mut(source_key).unwrap().content = source_content.to_owned();
 
     let identified_contracts =
         extract_solx_contract_metadata("0.8.34".to_owned(), input, output.clone())?;
@@ -54,59 +51,42 @@ fn solx_counter_build_info() -> anyhow::Result<(BuildInfoConfig, CompilerOutput<
     ))
 }
 
+fn solx_counter_build_info() -> anyhow::Result<(BuildInfoConfig, CompilerOutput<SolxBytecode>)> {
+    assemble_build_info(
+        serde_json::from_str(include_str!(
+            "../../../edr_solidity/fixtures/solx_compiler_input.json"
+        ))?,
+        "Counter.sol",
+        include_str!("../../../edr_solidity/fixtures/sources/Counter.sol"),
+        serde_json::from_str(include_str!(
+            "../../../edr_solidity/fixtures/solx_compiler_output.json"
+        ))?,
+    )
+}
+
 fn solx_scenarios_build_info() -> anyhow::Result<(BuildInfoConfig, CompilerOutput<SolxBytecode>)> {
-    let mut input: CompilerInput = serde_json::from_str(include_str!(
-        "../../../edr_solidity/fixtures/solx_compiler_input_scenarios.json"
-    ))?;
-
-    input
-        .sources
-        .get_mut("project/contracts/Scenarios.t.sol")
-        .unwrap()
-        .content =
-        include_str!("../../../edr_solidity/fixtures/sources/Scenarios.t.sol").to_owned();
-
-    let output: CompilerOutput<SolxBytecode> = serde_json::from_str(include_str!(
-        "../../../edr_solidity/fixtures/solx_compiler_output_scenarios.json"
-    ))?;
-
-    let identified_contracts =
-        extract_solx_contract_metadata("0.8.34".to_owned(), input, output.clone())?;
-
-    Ok((
-        BuildInfoConfig {
-            identified_contracts,
-            ignore_contracts: None,
-        },
-        output,
-    ))
+    assemble_build_info(
+        serde_json::from_str(include_str!(
+            "../../../edr_solidity/fixtures/solx_compiler_input_scenarios.json"
+        ))?,
+        SCENARIOS_SOURCE,
+        include_str!("../../../edr_solidity/fixtures/sources/Scenarios.t.sol"),
+        serde_json::from_str(include_str!(
+            "../../../edr_solidity/fixtures/solx_compiler_output_scenarios.json"
+        ))?,
+    )
 }
 
 fn solx_stack_trace_scenarios_build_info(
     input_json: &str,
     output_json: &str,
 ) -> anyhow::Result<(BuildInfoConfig, CompilerOutput<SolxBytecode>)> {
-    let mut input: CompilerInput = serde_json::from_str(input_json)?;
-
-    input
-        .sources
-        .get_mut(STACK_TRACE_SCENARIOS_SOURCE)
-        .unwrap()
-        .content =
-        include_str!("../../../edr_solidity/fixtures/sources/StackTraceScenarios.sol").to_owned();
-
-    let output: CompilerOutput<SolxBytecode> = serde_json::from_str(output_json)?;
-
-    let identified_contracts =
-        extract_solx_contract_metadata("0.8.34".to_owned(), input, output.clone())?;
-
-    Ok((
-        BuildInfoConfig {
-            identified_contracts,
-            ignore_contracts: None,
-        },
-        output,
-    ))
+    assemble_build_info(
+        serde_json::from_str(input_json)?,
+        STACK_TRACE_SCENARIOS_SOURCE,
+        include_str!("../../../edr_solidity/fixtures/sources/StackTraceScenarios.sol"),
+        serde_json::from_str(output_json)?,
+    )
 }
 
 /// Builds a local provider seeded with `decoder`, with bail-on-failure set
@@ -159,48 +139,9 @@ fn selector(signature: &str) -> Selector {
     )
 }
 
-fn deploy(
-    provider: &Provider<L1ChainSpec>,
-    from: Address,
-    creation: Bytes,
-) -> anyhow::Result<Address> {
-    let response = provider.handle_request(ProviderRequest::with_single(
-        MethodInvocation::SendTransaction(TransactionRequest {
-            from,
-            data: Some(creation),
-            ..TransactionRequest::default()
-        }),
-    ))?;
-    let tx_hash: B256 = serde_json::from_value(response.result)?;
-    let receipt_response = provider.handle_request(ProviderRequest::with_single(
-        MethodInvocation::GetTransactionReceipt(tx_hash),
-    ))?;
-    let receipt: L1RpcTransactionReceipt = serde_json::from_value(receipt_response.result)?;
-    receipt
-        .contract_address
-        .context("deployment receipt must carry contract_address")
-}
-
-/// Sends a transaction and expects [`ProviderError::TransactionFailed`] to
-/// be returned — i.e. the call reverted under `bail_on_transaction_failure`.
 /// Pulls the stack trace out of the failure and returns it directly to
 /// avoid naming `TransactionFailureWithCallTraces` (its module is private).
-fn expect_failed_call_stack_trace(
-    provider: &Provider<L1ChainSpec>,
-    from: Address,
-    to: Address,
-    calldata: Bytes,
-) -> Vec<StackTraceEntry> {
-    let err = provider
-        .handle_request(ProviderRequest::with_single(
-            MethodInvocation::SendTransaction(TransactionRequest {
-                from,
-                to: Some(to),
-                data: Some(calldata),
-                ..TransactionRequest::default()
-            }),
-        ))
-        .expect_err("call must revert and bail");
+fn stack_trace_from_failure(err: ProviderErrorForChainSpec<L1ChainSpec>) -> Vec<StackTraceEntry> {
     match err {
         ProviderError::TransactionFailed(boxed) => match &boxed.failure.stack_trace_result {
             StackTraceCreationResult::Success(v) => v.clone(),
@@ -208,6 +149,38 @@ fn expect_failed_call_stack_trace(
         },
         other => panic!("expected TransactionFailed, got: {other:?}"),
     }
+}
+
+/// Sends a transaction and expects [`ProviderError::TransactionFailed`] to
+/// be returned — i.e. the call reverted under `bail_on_transaction_failure`.
+fn expect_failed_call_stack_trace(
+    provider: &Provider<L1ChainSpec>,
+    from: Address,
+    to: Address,
+    calldata: Bytes,
+) -> Vec<StackTraceEntry> {
+    expect_failed_call_with_value_stack_trace(provider, from, to, calldata, U256::ZERO)
+}
+
+fn expect_failed_call_with_value_stack_trace(
+    provider: &Provider<L1ChainSpec>,
+    from: Address,
+    to: Address,
+    calldata: Bytes,
+    value: U256,
+) -> Vec<StackTraceEntry> {
+    let err = provider
+        .handle_request(ProviderRequest::with_single(
+            MethodInvocation::SendTransaction(TransactionRequest {
+                from,
+                to: Some(to),
+                data: Some(calldata),
+                value: Some(value),
+                ..TransactionRequest::default()
+            }),
+        ))
+        .expect_err("call must revert and bail");
+    stack_trace_from_failure(err)
 }
 
 /// No-argument calldata: just the 4-byte selector.
@@ -230,56 +203,6 @@ fn encode_call_address(signature: &str, addr: Address) -> Bytes {
     Bytes::from(calldata)
 }
 
-fn source_reference_of(entry: &StackTraceEntry) -> Option<&SourceReference> {
-    match entry {
-        StackTraceEntry::CallstackEntry {
-            source_reference, ..
-        }
-        | StackTraceEntry::RevertError {
-            source_reference, ..
-        }
-        | StackTraceEntry::CheatCodeError {
-            source_reference, ..
-        }
-        | StackTraceEntry::CustomError {
-            source_reference, ..
-        }
-        | StackTraceEntry::FunctionNotPayableError {
-            source_reference, ..
-        }
-        | StackTraceEntry::InvalidParamsError { source_reference }
-        | StackTraceEntry::FallbackNotPayableError {
-            source_reference, ..
-        }
-        | StackTraceEntry::FallbackNotPayableAndNoReceiveError {
-            source_reference, ..
-        }
-        | StackTraceEntry::UnrecognizedFunctionWithoutFallbackError { source_reference }
-        | StackTraceEntry::MissingFallbackOrReceiveError { source_reference }
-        | StackTraceEntry::ReturndataSizeError { source_reference }
-        | StackTraceEntry::NoncontractAccountCalledError { source_reference }
-        | StackTraceEntry::CallFailedError { source_reference }
-        | StackTraceEntry::DirectLibraryCallError { source_reference }
-        | StackTraceEntry::InternalFunctionCallstackEntry {
-            source_reference, ..
-        } => Some(source_reference),
-        StackTraceEntry::PanicError {
-            source_reference, ..
-        }
-        | StackTraceEntry::OtherExecutionError { source_reference }
-        | StackTraceEntry::UnmappedSolc0_6_3RevertError { source_reference }
-        | StackTraceEntry::ContractTooLargeError { source_reference }
-        | StackTraceEntry::ContractCallRunOutOfGasError { source_reference } => {
-            source_reference.as_ref()
-        }
-        StackTraceEntry::UnrecognizedCreateCallstackEntry
-        | StackTraceEntry::UnrecognizedContractCallstackEntry { .. }
-        | StackTraceEntry::PrecompileError { .. }
-        | StackTraceEntry::UnrecognizedCreateError { .. }
-        | StackTraceEntry::UnrecognizedContractError { .. } => None,
-    }
-}
-
 // ---------- variance-axis tests ----------
 
 /// Counter.set(0) reverts via `require(v > 0, "must be positive")`.
@@ -292,17 +215,18 @@ async fn revert_error_variant_surfaces_for_counter() -> anyhow::Result<()> {
     let decoder = ContractDecoder::new(build_info);
     let (provider, from) = make_provider(decoder)?;
 
-    let counter = deploy(
+    let counter = deploy_contract(
         &provider,
         from,
         creation_bytes(&output, "Counter.sol", "Counter")?,
     )?;
 
-    let mut calldata = Vec::with_capacity(36);
-    calldata.extend_from_slice(selector("set(uint256)").as_slice());
-    calldata.extend_from_slice(&[0u8; 32]);
-    let stack_trace =
-        expect_failed_call_stack_trace(&provider, from, counter, Bytes::from(calldata));
+    let stack_trace = expect_failed_call_stack_trace(
+        &provider,
+        from,
+        counter,
+        encode_call_u256("set(uint256)", 0),
+    );
 
     assert!(
         stack_trace
@@ -311,7 +235,8 @@ async fn revert_error_variant_surfaces_for_counter() -> anyhow::Result<()> {
         "expected a RevertError entry, got: {stack_trace:#?}"
     );
     assert!(
-        stack_trace.iter().any(|e| source_reference_of(e)
+        stack_trace.iter().any(|e| e
+            .source_reference()
             .is_some_and(|s| s.source_name.ends_with("Counter.sol"))),
         "expected an entry referencing Counter.sol, got: {stack_trace:#?}"
     );
@@ -327,18 +252,13 @@ async fn panic_error_variant_surfaces_for_overflow_scenario() -> anyhow::Result<
     let decoder = ContractDecoder::new(build_info);
     let (provider, from) = make_provider(decoder)?;
 
-    let addr = deploy(
+    let addr = deploy_contract(
         &provider,
         from,
         creation_bytes(&output, "project/contracts/Scenarios.t.sol", "OverflowTest")?,
     )?;
 
-    let stack_trace = expect_failed_call_stack_trace(
-        &provider,
-        from,
-        addr,
-        Bytes::from(selector("testOverflow()").as_slice().to_vec()),
-    );
+    let stack_trace = expect_failed_call_stack_trace(&provider, from, addr, call("testOverflow()"));
 
     assert!(
         stack_trace
@@ -358,7 +278,7 @@ async fn custom_error_variant_surfaces_for_custom_error_scenario() -> anyhow::Re
     let decoder = ContractDecoder::new(build_info);
     let (provider, from) = make_provider(decoder)?;
 
-    let addr = deploy(
+    let addr = deploy_contract(
         &provider,
         from,
         creation_bytes(
@@ -368,12 +288,8 @@ async fn custom_error_variant_surfaces_for_custom_error_scenario() -> anyhow::Re
         )?,
     )?;
 
-    let stack_trace = expect_failed_call_stack_trace(
-        &provider,
-        from,
-        addr,
-        Bytes::from(selector("testCustomError()").as_slice().to_vec()),
-    );
+    let stack_trace =
+        expect_failed_call_stack_trace(&provider, from, addr, call("testCustomError()"));
 
     assert!(
         stack_trace
@@ -383,6 +299,8 @@ async fn custom_error_variant_surfaces_for_custom_error_scenario() -> anyhow::Re
     );
     Ok(())
 }
+
+const SCENARIOS_SOURCE: &str = "project/contracts/Scenarios.t.sol";
 
 fn contains_ascii(data: &[u8], needle: &str) -> bool {
     data.windows(needle.len()).any(|w| w == needle.as_bytes())
@@ -396,7 +314,7 @@ fn brief_trace(stack_trace: &[StackTraceEntry]) -> String {
         .map(|entry| {
             let debug = format!("{entry:?}");
             let variant = debug.split_whitespace().next().unwrap_or("?").to_string();
-            match source_reference_of(entry) {
+            match entry.source_reference() {
                 Some(source_reference) => format!(
                     "{variant} {}:{} ({}.{})",
                     source_reference.source_name,
@@ -492,7 +410,7 @@ fn deploy_stack_trace_scenario(
     output: &CompilerOutput<SolxBytecode>,
     contract: &str,
 ) -> anyhow::Result<Address> {
-    deploy(
+    deploy_contract(
         provider,
         from,
         creation_bytes(output, STACK_TRACE_SCENARIOS_SOURCE, contract)?,
@@ -527,8 +445,9 @@ fn assert_returndata_size_error_at_call_get(stack_trace: &[StackTraceEntry]) {
         |e| matches!(e, StackTraceEntry::ReturndataSizeError { .. }),
         "ReturndataSizeError",
     );
-    let source_reference =
-        source_reference_of(entry).expect("ReturndataSizeError carries a source reference");
+    let source_reference = entry
+        .source_reference()
+        .expect("ReturndataSizeError carries a source reference");
     assert_eq!(source_reference.function.as_deref(), Some("callGet"));
     assert_eq!(
         source_reference.line,
@@ -628,7 +547,9 @@ async fn bare_modifier_revert_attributes_to_the_revert_statement() -> anyhow::Re
         |e| matches!(e, StackTraceEntry::RevertError { .. }),
         "RevertError",
     );
-    let source_reference = source_reference_of(entry).expect("entry carries a source reference");
+    let source_reference = entry
+        .source_reference()
+        .expect("entry carries a source reference");
     assert_eq!(
         (source_reference.line, source_reference.function.as_deref()),
         (68, Some("guarded")),
@@ -690,7 +611,9 @@ async fn mode3_bare_modifier_revert_recovers_the_failing_function() -> anyhow::R
         |e| matches!(e, StackTraceEntry::RevertError { .. }),
         "RevertError",
     );
-    let source_reference = source_reference_of(entry).expect("entry carries a source reference");
+    let source_reference = entry
+        .source_reference()
+        .expect("entry carries a source reference");
     assert_eq!(
         (source_reference.line, source_reference.function.as_deref()),
         (67, Some("guarded")),


### PR DESCRIPTION
Adding wide test coverage for stack trace tests, along with some test refactoring for more re-use. This is a follow-up of #1572. I've tried to put tests into blocks to make it a bit easier to follow what's currently covered. I could split into files instead if that is easier.

Note that I've removed two tests as they were already covered by a more generic test, see also the test folding Claude section below.

This is the first PR of a planned few. I'm trying to do a structured expansion of stack-trace coverage. The idea here is that this functions both as increased coverage for solx/solc, and some of the pre-work for being able to migrate away from hardhat-tests. 

Planned next, roughly in order:

1. **Failing deployments**: sending ether to a non-payable constructor, or deploying with wrong or truncated constructor arguments. The error is attributed by looking at where in the bytecode execution stopped, so solx's debug info can place it differently than solc's. **This is currently untested.**
2. **Solc-specific pattern checks running on solx bytecode**: a few error classifications work by recognizing short, hard-coded instruction sequences that solc happens to emit (for example "you called an address with no contract on it"). solx compiles the same Solidity to different instructions, but these checks still run on its traces.  Nothing today verifies whether they match correctly, match wrongly, or simply never fire. Includes the plain "call an address with no contract behind it" case itself.
3. **Two rarer error kinds**: a revert with a custom error the decoder doesn't recognize, and panic `0x51` (calling a function variable that was never assigned). Both are reported through fallback code paths no test reaches today.
4. **Errors travelling between contracts**: a nested call failing because it ran out of gas, errors bubbling up through proxy contracts, calls that fail before the callee even runs, and deployments rejected for exceeding the contract size limit.
5. **`eth_call`**: the tests so far only cover failing *transactions*; failing read-only calls take a separate path that we should either cover or explicitly leave out of scope.

# Claude summary

Rebased onto `main` now that #1577 (the DWARF attribution fixes + fixture infrastructure) is merged. This PR is tests only: it broadens the provider-path (JSON-RPC) stack-trace coverage for solx artifacts from 11 tests to 36, all against fixtures already on `main` — and organizes the file so the coverage is auditable against the inference pipeline instead of reading as a blob.

The provider path is what Hardhat 3's JS-test flow (`hardhat test` + ethers/viem) hits. #1425 covers the solidity-test-runner path via the JS parity sweep, but the sweep is CI-skipped until `@nomicfoundation/hardhat-solx` is published — so these are the trace assertions that actually run in CI today.

## File layout mirrors the inference pipeline

`solx_stack_trace.rs` puts all helpers in one block up front, then one test section per `edr_solidity` inference stage, so reviewing the file is walking the pipeline:

| Section | Inference path pinned | Tests |
|---|---|---|
| Provider plumbing | end-to-end smoke on the minimal Counter fixture | 1 |
| Pre-execution guards | `infer_before_tracing_call_message`: payability, missing function/fallback/receive, direct library calls | 6 |
| Calldata decoding | `check_last_instruction`: `InvalidParamsError` for truncated calldata | 1 |
| Revert/panic/custom | `check_revert_or_invalid_opcode`: six panic codes with statement anchors, custom-error argument decoding, revert-line discrimination between requires | 8 |
| Callstack reconstruction | frame push/pop, submessage splicing, `filter_redundant_frames`: cross-contract frames, external/internal/mutual recursion, internal helpers and libraries, linked external library (`linkReferences` + DELEGATECALL decode), fallback/receive bodies | 9 |
| Modifiers | `fix_initial_modifier` + `SolxTraceStrategy` attribution: plain, nested, cross-contract, bare-revert | 4 |
| Create path | creation-code `debugInfo`: reverting constructors, plain and via internal helper | 2 |
| Submessage checks | `check_last_submessage`: returndata-size errors (real callee and EOA target) | 2 |
| `-O3` twins (the `mode3_*` tests) | three modifier scenarios recompiled at solx optimizer mode 3 (`-O3`; hardhat-solx defaults to `-O1`). Since solx 0.1.6 the `-O1` DWARF maps compiler helpers to real statement lines, so only these more aggressively optimized artifacts still reach the fallback inference paths: walking back to the last statement when a revert is attributed to a declaration line, and recovering the failing function for unmapped bare reverts | 3 |

Every test now asserts a source anchor (function/contract/statement line), not just the entry variant — e.g. each panic code pins the statement it's attributed to, and the dispatch guards pin the declaration they anchor at. The two call shapes where frame gains/losses are the point (cross-contract call, external recursion) pin the full rendered trace via `assert_trace_shape`. Line pins are goldens: a shifted anchor after a solx upgrade is expected drift (update the pin), a lost frame is a regression.

Deliberately **not** covered — location-free classification paths already pinned by the solc corpus, plus follow-up material: message-kind dispatch (precompiles, unrecognized contracts, contract-too-large), create-side guards, the solc-opcode-pattern rewrites in `mapped_inline_internal_functions_heuristics`, out-of-gas rewrites, proxy propagation, and the `eth_call` channel. `bail_on_call_failure` was dropped from the test provider config since nothing exercised it.

The external-recursion test already caught one real regression: a late refactor in #1425 dropped the per-strategy recursion carve-out in `filter_redundant_frames`, collapsing any external-recursion depth to a single frame. That fix was upstreamed separately as #1569.

## Two tests folded, one renamed (no coverage removed)

The diff deletes two tests by name; both were variant-only assertions strictly subsumed by a stronger replacement:

- `panic_error_variant_surfaces_for_overflow_scenario` asserted only that *some* `PanicError` entry appears for `OverflowTest` — a weaker duplicate of the panic-code family right next to it. It's now `panic_code_surfaces_for_arithmetic_overflow` in that family, additionally pinning the code (0x11) and the statement the panic is attributed to (`x = x + 1`, line 26).
- `custom_error_variant_surfaces_for_custom_error_scenario` asserted only that *some* `CustomError` entry appears. It's now `custom_error_decodes_name_and_args`, additionally pinning the decoded message (`reverted with custom error 'MyError(42, "custom error")'`) and the `revert` statement line — the known-selector argument-decoding path had no coverage before.
- The third test from the same old "variance-axis" block, `revert_error_variant_surfaces_for_counter`, is kept as `revert_error_surfaces_end_to_end_for_counter`: it's the only test on the minimal Counter fixture (a second, independent artifact assembly), so it stays as the plumbing smoke test.

## Accepted gaps

Two `SolxTraceStrategy` fallbacks remain untested: `unresolved_callstack_entry` and the panic-helper selector fallback. Both are last resorts for instructions whose DWARF location doesn't resolve to a known function, and no fixture produces that — not even at `-O3` (`MutualRecursionTest`, the closest candidate, reached parity without them). Auditing that solx covers every reachable PC with a `DW_TAG_subprogram` belongs in solx's own test suite, not EDR scenarios.

## Verification

- `solx_stack_trace.rs`: 36/36 against the 0.1.6 fixtures (including the `-O3` twins from #1577).
- `edr_provider` integration harness: 216/216 (fork tests require `ALCHEMY_URL`).
- `cargo +nightly fmt --check` and `cargo clippy -p edr_provider --tests --features test-utils` clean.
- Test-only change: no changeset.
