### PR TITLE
fix(edr_solidity): resolve declaration-attributed locations in solx stack traces

### DIFF
--- a/.changeset/solx-declaration-attributed-inference.md
+++ b/.changeset/solx-declaration-attributed-inference.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Fixed solx stack traces degrading to `OtherExecutionError` at the contract declaration for returndata-size mismatches and calls to codeless accounts, and reporting modifier reverts at the function declaration line instead of the failing statement.

--- a/crates/edr_provider/tests/integration/solx_stack_trace.rs
+++ b/crates/edr_provider/tests/integration/solx_stack_trace.rs
@@ -658,18 +658,17 @@ async fn modifier_revert_points_at_modifier_require() -> anyhow::Result<()> {
 
 /// Revert inside a multi-statement modifier body (`validates`, pre-`_`).
 ///
-/// Golden divergence from solc: the failing `require` is on line 415, but
-/// solx flattens the modifier into `bumpIfValid` and attributes the revert
-/// to the function declaration (line 420) — the provider-level twin of the
-/// sweep's pinned `NestedModifierRevertTest` divergence. If this pin breaks
-/// with a future solx, check whether it now reports 415 (improvement:
-/// update the pin and the sweep golden together).
+/// solx flattens the modifier into `bumpIfValid` and attributes the shared
+/// revert helper to the function declaration line (420);
+/// `SolxTraceStrategy::revert_source_reference` walks the executed steps
+/// back to the message-building code of the `require` that actually fired
+/// (line 415), matching solc.
 #[tokio::test(flavor = "multi_thread")]
-async fn nested_modifier_revert_attributes_to_function_declaration() -> anyhow::Result<()> {
+async fn nested_modifier_revert_points_at_failing_require() -> anyhow::Result<()> {
     expect_scenario_revert(
         "NestedModifierTarget",
         encode_call_u256("bumpIfValid(uint256)", 13),
-        420,
+        415,
         "unlucky",
     )?;
     Ok(())
@@ -1012,15 +1011,29 @@ async fn invalid_params_error_surfaces_for_truncated_calldata() -> anyhow::Resul
     Ok(())
 }
 
-/// Interface promises a word; callee returns nothing.
-///
-/// Golden inference gap: the solc route infers `ReturndataSizeError` at the
-/// call site (line 47) for this shape — the DWARF route currently degrades
-/// to `OtherExecutionError` at the contract declaration (line 45). If this
-/// pin breaks with `ReturndataSizeError`, the inference improved: flip the
-/// assertion.
+#[track_caller]
+fn assert_returndata_size_error_at_call_get(stack_trace: &[StackTraceEntry]) {
+    let entry = assert_single_variant(
+        stack_trace,
+        |e| matches!(e, StackTraceEntry::ReturndataSizeError { .. }),
+        "ReturndataSizeError",
+    );
+    let source_reference =
+        source_reference_of(entry).expect("ReturndataSizeError carries a source reference");
+    assert_eq!(source_reference.function.as_deref(), Some("callGet"));
+    assert_eq!(
+        source_reference.line,
+        47,
+        "expected the call-site line, got:\n{}",
+        brief_trace(stack_trace)
+    );
+}
+
+/// Interface promises a word; callee returns nothing. Pin: the
+/// returndata-size check reverting right after the call is attributed to
+/// the call site, matching the solc route.
 #[tokio::test(flavor = "multi_thread")]
-async fn returndata_size_mismatch_degrades_to_other_execution_error() -> anyhow::Result<()> {
+async fn returndata_size_error_surfaces_at_call_site() -> anyhow::Result<()> {
     let (provider, from, output) = long_tail_provider()?;
     let callee = deploy_long_tail(&provider, from, &output, "ReturnsNothing")?;
     let caller = deploy_long_tail(&provider, from, &output, "ExpectsWord")?;
@@ -1030,32 +1043,17 @@ async fn returndata_size_mismatch_degrades_to_other_execution_error() -> anyhow:
         caller,
         encode_call_address("callGet(address)", callee),
     );
-    let entry = assert_single_variant(
-        &stack_trace,
-        |e| matches!(e, StackTraceEntry::OtherExecutionError { .. }),
-        "OtherExecutionError",
-    );
-    let source_reference =
-        source_reference_of(entry).expect("the degraded entry keeps a source reference");
-    assert_eq!(source_reference.contract.as_deref(), Some("ExpectsWord"));
-    assert_eq!(
-        source_reference.line,
-        45,
-        "expected the contract declaration line, got:\n{}",
-        brief_trace(&stack_trace)
-    );
+    assert_returndata_size_error_at_call_get(&stack_trace);
     Ok(())
 }
 
-/// Typed call to an address with no code.
-///
-/// Golden inference gap: the solc route infers
-/// `NoncontractAccountCalledError` at the call site for this shape — the
-/// DWARF route currently degrades to `OtherExecutionError` at the contract
-/// declaration. If this pin breaks with `NoncontractAccountCalledError`,
-/// the inference improved: flip the assertion.
+/// Typed call to an address with no code. Like solc (which emits no
+/// EXTCODESIZE probe for returndata-expecting calls since 0.8.10), solx
+/// surfaces this as the returndata-size check failing at the call site —
+/// a true `NoncontractAccountCalledError` would need a void-returning
+/// call scenario.
 #[tokio::test(flavor = "multi_thread")]
-async fn noncontract_account_call_degrades_to_other_execution_error() -> anyhow::Result<()> {
+async fn noncontract_account_call_surfaces_as_returndata_size_error() -> anyhow::Result<()> {
     let (provider, from, output) = long_tail_provider()?;
     let caller = deploy_long_tail(&provider, from, &output, "ExpectsWord")?;
     let eoa = Address::repeat_byte(0x42);
@@ -1065,11 +1063,7 @@ async fn noncontract_account_call_degrades_to_other_execution_error() -> anyhow:
         caller,
         encode_call_address("callGet(address)", eoa),
     );
-    assert_single_variant(
-        &stack_trace,
-        |e| matches!(e, StackTraceEntry::OtherExecutionError { .. }),
-        "OtherExecutionError",
-    );
+    assert_returndata_size_error_at_call_get(&stack_trace);
     Ok(())
 }
 

--- a/crates/edr_solidity/src/error_inferrer.rs
+++ b/crates/edr_solidity/src/error_inferrer.rs
@@ -718,10 +718,21 @@ fn check_last_instruction<HaltReasonT: HaltReasonTrait>(
     if let Some(location) = &last_instruction.location
         && let Some(failing_function) = location.get_containing_function()?
     {
+        // Thunked so only strategies that need the walk pay for it.
+        let step_pcs = || -> Vec<u32> {
+            steps
+                .iter()
+                .filter_map(|step| match step {
+                    NestedTraceStep::Evm(evm) => Some(evm.pc),
+                    _ => None,
+                })
+                .collect()
+        };
         let revert_source_reference = trace_strategy.revert_source_reference(
             contract_metadata.as_ref(),
             location,
             &failing_function,
+            &step_pcs,
         )?;
 
         let mut frames = trace_strategy.intermediate_frames(
@@ -1964,8 +1975,11 @@ fn is_last_location<HaltReasonT: HaltReasonTrait>(
     from_step: u32,
     location: &SourceLocation,
 ) -> Result<bool, InferrerError<HaltReasonT>> {
-    let contract_meta = trace
-        .contract_meta()
+    let IdentifiedContract {
+        contract_metadata,
+        trace_strategy,
+    } = trace
+        .identified_contract()
         .ok_or(InferrerError::MissingContract)?;
     let steps = trace.steps();
 
@@ -1975,10 +1989,10 @@ fn is_last_location<HaltReasonT: HaltReasonTrait>(
             _ => return Ok(false),
         };
 
-        let step_inst = contract_meta.get_instruction(step.pc)?;
+        let step_inst = contract_metadata.get_instruction(step.pc)?;
 
         if let Some(step_inst_location) = &step_inst.location
-            && step_inst_location != location
+            && !trace_strategy.locations_equivalent(step_inst_location, location)
         {
             return Ok(false);
         }

--- a/crates/edr_solidity/src/trace_strategy.rs
+++ b/crates/edr_solidity/src/trace_strategy.rs
@@ -43,6 +43,15 @@ pub trait TraceStrategy: std::fmt::Debug + Send + Sync + 'static {
     /// than an entry point (solc).
     fn recursion_start_idx(&self) -> usize;
 
+    /// Whether `step_location` counts as "execution is still at
+    /// `reference_location`" when deciding that a statement was the last
+    /// user code to run (`is_last_location`-style checks).
+    fn locations_equivalent(
+        &self,
+        step_location: &SourceLocation,
+        reference_location: &SourceLocation,
+    ) -> bool;
+
     /// Fallback frame when source-reference resolution returned `None` but
     /// the enclosing function is known.
     fn unresolved_callstack_entry(
@@ -60,12 +69,15 @@ pub trait TraceStrategy: std::fmt::Debug + Send + Sync + 'static {
     ) -> Result<Vec<StackTraceEntry>, TraceStrategyError>;
 
     /// Source anchor for a revert that happened at a specific instruction
-    /// inside a known function.
+    /// inside a known function. `step_pcs` lazily yields the trace's EVM
+    /// step PCs in execution order, for strategies that need to walk back
+    /// from the reverting instruction.
     fn revert_source_reference(
         &self,
         contract_meta: &ContractMetadata,
         inst_location: &SourceLocation,
         failing_function: &ContractFunction,
+        step_pcs: &dyn Fn() -> Vec<u32>,
     ) -> Result<SourceReference, TraceStrategyError>;
 
     /// Fallback source reference for a panic-helper PC when the primary
@@ -90,6 +102,14 @@ impl TraceStrategy for SolcTraceStrategy {
         1
     }
 
+    fn locations_equivalent(
+        &self,
+        step_location: &SourceLocation,
+        reference_location: &SourceLocation,
+    ) -> bool {
+        step_location == reference_location
+    }
+
     fn unresolved_callstack_entry(
         &self,
         _contract_name: &str,
@@ -112,6 +132,7 @@ impl TraceStrategy for SolcTraceStrategy {
         contract_meta: &ContractMetadata,
         _inst_location: &SourceLocation,
         failing_function: &ContractFunction,
+        _step_pcs: &dyn Fn() -> Vec<u32>,
     ) -> Result<SourceReference, TraceStrategyError> {
         function_start_source_reference(contract_meta, failing_function)
     }
@@ -136,6 +157,19 @@ pub struct SolxTraceStrategy;
 impl TraceStrategy for SolxTraceStrategy {
     fn recursion_start_idx(&self) -> usize {
         0
+    }
+
+    fn locations_equivalent(
+        &self,
+        step_location: &SourceLocation,
+        reference_location: &SourceLocation,
+    ) -> bool {
+        // solx attributes compiler-generated helper code (calldata decoding,
+        // revert builders) to the enclosing function or contract
+        // *declaration*, whose range contains the statement — where solc
+        // leaves such code unmapped. Treat declaration-level padding as
+        // "still at the statement".
+        step_location == reference_location || step_location.contains(reference_location)
     }
 
     fn unresolved_callstack_entry(
@@ -203,8 +237,33 @@ impl TraceStrategy for SolxTraceStrategy {
         &self,
         contract_meta: &ContractMetadata,
         inst_location: &SourceLocation,
-        _failing_function: &ContractFunction,
+        failing_function: &ContractFunction,
+        step_pcs: &dyn Fn() -> Vec<u32>,
     ) -> Result<SourceReference, TraceStrategyError> {
+        // solx attributes shared revert helpers to the *declaration line* of
+        // the function they were flattened into (e.g. a modifier's `require`
+        // reverting at the modified function's signature line). When the
+        // reverting instruction sits on the declaration line, walk the
+        // executed steps backwards to the statement that actually led here —
+        // the message-building code preceding the revert keeps its own line.
+        let declaration_line = failing_function.location.get_starting_line_number()?;
+        if inst_location.get_starting_line_number()? == declaration_line {
+            for pc in step_pcs().iter().rev() {
+                let prev_inst = contract_meta.get_instruction(*pc)?;
+                let Some(prev_location) = &prev_inst.location else {
+                    continue;
+                };
+                if prev_location.get_starting_line_number()? == declaration_line {
+                    continue;
+                }
+                if let Some(source_reference) =
+                    source_location_to_source_reference(contract_meta, Some(prev_location))?
+                {
+                    return Ok(source_reference);
+                }
+            }
+        }
+
         source_location_to_source_reference(contract_meta, Some(inst_location))?
             .ok_or(TraceStrategyError::MissingSourceReference)
     }


### PR DESCRIPTION
Note: For now these are quick AI written fixes/tests to try and validate the solx trace integration.


# Claude Summary
Fixes the two inference gaps found by #1552's provider-path tests (stacked: #1425 ← #1552 ← this).

## Root cause

solx attributes compiler-generated helper code — calldata decoding, shared revert builders — to the **declaration** of the enclosing function or contract in its DWARF line table, where solc leaves the same code **unmapped** in source maps. Two location-anchored inference paths broke on that difference:

1. **`fails_right_after_call` / `is_call_failed_error`** compare every post-CALL step location to the call site by strict equality. Under solc, unmapped helper instructions are skipped; under solx, the same instructions carry declaration-level locations (whose range merely *contains* the statement), so the heuristics bailed and the revert degraded to `OtherExecutionError` at the contract-declaration line.
2. **Shared revert helpers flattened out of a modifier** are attributed to the modified function's declaration line, so a modifier's failing `require` (line 415 in the scenarios fixture) was reported at the function signature (line 420). Diagnosis showed the statement's real line *is* present in the line table — on the message-building instructions executed just before the revert — so this is recoverable EDR-side.

## Fix

Both fixes live in the solx strategy; `SolcTraceStrategy` is behavior-identical (strict equality kept, new parameter ignored).

- New `TraceStrategy::locations_equivalent(step, reference)`: solx treats a step location that **contains** the reference (declaration-level padding) as "still at the statement"; solc keeps `==`. Used by `is_last_location`.
- `TraceStrategy::revert_source_reference` now receives a lazy `step_pcs` thunk (same pattern as `PanicHelperContext`). When the reverting instruction sits on the function's declaration line, `SolxTraceStrategy` walks the executed steps back to the last statement-level location — the `require`'s message-building code keeps its own line.

## Effect (goldens flipped in `solx_stack_trace.rs`)

- `ReturndataSizeError` now surfaces **at the call site** (`LongTail.sol:47`, `ExpectsWord.callGet`) for both the returndata-size mismatch and the typed call to a codeless account, replacing `OtherExecutionError` at the contract declaration. This is parity with the solc route: solc ≥ 0.8.10 emits no EXTCODESIZE probe for returndata-expecting calls either, so both routes classify the EOA case as a returndata failure. (A true `NoncontractAccountCalledError` would need a void-returning call scenario — future coverage.)
- The multi-statement modifier revert reports the failing `require`'s line (415) instead of the declaration line (420) — removing the provider-level twin of the sweep's pinned `NestedModifierRevertTest` divergence. **The sweep golden for that scenario will need updating** when the sweep next runs against a linked plugin (its pinned line should move accordingly).

## Verification

- `solx_stack_trace.rs`: 31/31 pass (the three flipped goldens broke in the improvement direction before the assertions were updated, everything else unchanged).
- `edr_solidity` unit tests: 77/77; full `edr_provider` integration harness: 198/198.
- solc behavior is guarded code-structurally (solc strategy unchanged) and by the hardhat-tests stack-trace corpus in CI.

No changeset: this is a pre-release fix to the solx DWARF feature introduced in #1425, covered by its changeset.

## Also: the hardhat-tests CI failure on the feature branch

Second commit fixes the `Error: missing field 'remainder'` failures in the "Run Hardhat tests" job (seen on both #1425's and #1552's CI): the solx routing in `add_compilation_result` deserialized the compiler output into a struct with a literal `remainder` field, so every existing caller — HH2/HH3 pass a bare standard-JSON output — crashed on `hardhat_addCompilationResult`. Replaced with `edr_solidity::artifacts::parse_compiler_output`, which peeks an optional top-level `compilerType` field on the same value (mirroring the build-info path's `PeekableCompilerType`) and deserializes the whole output accordingly; absent/unknown → solc. Unit-tested against both fixture outputs. This commit is self-contained if it's preferred cherry-picked into #1425 directly, since it fixes that branch's red CI.
