### PR TITLE
ci: adopt cargo-cooldown-check v0.2.0, drop its cache step and config

### DIFF
--- a/.cargo/cooldown-allowlist.toml
+++ b/.cargo/cooldown-allowlist.toml
@@ -1,13 +1,2 @@
 # Allowlist for cargo-cooldown-check.
 # Add `[[allow.exact]]` entries to skip cooldown for a freshly published crate version.
-
-[[allow.exact]]
-crate = "anyhow"
-version = "1.0.103"
-# RUSTSEC-2026-0190: downcast_mut unsoundness. Security fix; bypass 7-day cooldown. See PR #1523.
-
-[[allow.exact]]
-crate = "napi"
-version = "3.10.0"
-# napi-rs#3357: custom-GC use-after-free for buffers dropped off the JS thread (V8 GlobalHandles
-# corruption -> segfaults). Memory-safety fix; bypass 7-day cooldown. See PR #1385.

--- a/.cargo/cooldown.toml
+++ b/.cargo/cooldown.toml
@@ -1,2 +1,1 @@
 cooldown_minutes = 10080 # 7 days
-cache_dir = "./edr-cache/cargo-cooldown-check"

--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -390,14 +390,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup-rust
 
-      - name: Cache cooldown data
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
-        with:
-          path: |
-            **/edr-cache/cargo-cooldown-check
-          key: cooldown-check-v1-${{ hashFiles('**/Cargo.lock') }}
-
-      - uses: NomicFoundation/cargo-cooldown-check@ac40e701f9f1155741a761ac9039987fb892af4b
+      - uses: NomicFoundation/cargo-cooldown-check@0e9231d9dc6084e8ed2e2eee2fa812f27776cab8 # v0.2.0
 
   actionlint:
     name: Lint GitHub Actions workflows

--- a/.github/workflows/edr-npm-release.yml
+++ b/.github/workflows/edr-npm-release.yml
@@ -595,7 +595,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup-rust
 
-      - uses: NomicFoundation/cargo-cooldown-check@ac40e701f9f1155741a761ac9039987fb892af4b
+      - uses: NomicFoundation/cargo-cooldown-check@0e9231d9dc6084e8ed2e2eee2fa812f27776cab8 # v0.2.0
 
   notify-deploy:
     name: Notify pre-deploy to Slack


### PR DESCRIPTION
Adapts EDR CI to use [cargo-cooldown-check v0.2.0](https://github.com/NomicFoundation/cargo-cooldown-check/releases/tag/v0.2.0). Biggest change is that we now use the cargo.io sparse index, via `cargo metadata`. In practice this means only a single retrieval call (done just by the Rust tooling) so at this point cargo-cooldown-check does not need a cache any more. 

Should fix the cooldown check job failing in CI (due to HTTP 429s). 


# Claude Summary
Adopts [cargo-cooldown-check v0.2.0](https://github.com/NomicFoundation/cargo-cooldown-check/releases/tag/v0.2.0), which resolves publish times from cargo's own sparse-index cache instead of the rate-limited crates.io API — fixing the HTTP 429 aborts our 735-crate graph kept hitting (e.g. [this run](https://github.com/NomicFoundation/edr/actions/runs/29261715856/job/86856954133?pr=1556)). Steady state performs no network I/O at all.

**Changes:**

- `edr-ci.yml` / `edr-npm-release.yml`: action pin bumped to v0.2.0. The tool is now stateless, so the `Cache cooldown data` step is deleted — there is nothing left to cache.
- `.cargo/cooldown.toml`: the retired `cache_dir` key is removed (v0.2.0 ignores it either way).
- `.cargo/cooldown-allowlist.toml`: pruned expired entries — anyhow 1.0.103 (published 2026-06-25) and napi 3.10.0 (2026-07-01) both clear the 7-day window on their own now, and the lockfile has moved past napi 3.10.0 anyway.

**Verified** by running the v0.2.0 release binary against this workspace with the new config: passes, with only `cooldown_minutes` parsed and git-sourced deps skipped as before.

Note for the CI run on this PR: it's the first to exercise v0.2.0 here, so the cooldown job's time goes into `cargo metadata` materializing sources on a fresh runner (~1.5 min) rather than API calls; the check itself is near-instant once the local index is populated.