### PR TITLE
feat:  EIP-7778 block gas accounting without refunds (Amsterdam)

### DIFF
--- a/.changeset/public-friends-arrive.md
+++ b/.changeset/public-friends-arrive.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Added experimental EIP-7778 support: from the Amsterdam hardfork, a block's `gasUsed` excludes gas refunds. Transaction receipts are unchanged.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3403,8 +3403,8 @@ dependencies = [
 name = "edr_receipt_builder_api"
 version = "0.3.8"
 dependencies = [
- "edr_block_header",
  "edr_chain_spec_evm",
+ "edr_primitives",
  "edr_state_api",
 ]
 

--- a/crates/edr_chain_l1/src/block.rs
+++ b/crates/edr_chain_l1/src/block.rs
@@ -502,10 +502,8 @@ impl<
         self.state.commit(state_diff);
 
         self.cumulative_gas_used += transaction_result.tx_gas_used();
-        self.header.gas_used += transaction_block_gas_contribution::<ChainSpecT>(
-            self.blockchain.hardfork(),
-            &transaction_result,
-        );
+        self.header.gas_used +=
+            transaction_block_gas_contribution::<ChainSpecT>(self.cfg.spec, &transaction_result);
 
         if let Some(BlobGas { gas_used, .. }) = self.header.blob_gas.as_mut() {
             let blob_gas_used = transaction.total_blob_gas().unwrap_or_default();

--- a/crates/edr_chain_l1/src/block.rs
+++ b/crates/edr_chain_l1/src/block.rs
@@ -15,8 +15,8 @@ use edr_block_header::{
 };
 use edr_block_local::EthLocalBlock;
 use edr_chain_spec::{
-    BlockEnvChainSpec, BlockEnvConstructor as _, EvmSpecId, ExecutableTransaction,
-    TransactionValidation,
+    BlockEnvChainSpec, BlockEnvConstructor as _, ChainSpec, EvmSpecId, ExecutableTransaction,
+    HardforkChainSpec, TransactionValidation,
 };
 use edr_chain_spec_block::BlockChainSpec;
 use edr_chain_spec_evm::{
@@ -83,6 +83,9 @@ pub struct EthBlockBuilder<
     // creation should be deterministic.
     precompile_addresses: HashSet<Address>,
     _phantom: PhantomData<fn() -> (EvmChainSpecT, ExecutionReceiptBuilderT)>,
+    // Net cumulative gas used (after refunds), tracked separately because from Amsterdam
+    // (EIP-7778) the header's `gas_used` is gross (before refunds).
+    cumulative_gas_used: u64,
 }
 
 impl<
@@ -363,6 +366,7 @@ impl<
             custom_precompiles,
             precompile_addresses,
             _phantom: PhantomData,
+            cumulative_gas_used: 0,
         })
     }
 
@@ -497,7 +501,11 @@ impl<
 
         self.state.commit(state_diff);
 
-        self.header.gas_used += transaction_result.tx_gas_used();
+        self.cumulative_gas_used += transaction_result.tx_gas_used();
+        self.header.gas_used += transaction_block_gas_contribution::<ChainSpecT>(
+            self.blockchain.hardfork(),
+            &transaction_result,
+        );
 
         if let Some(BlobGas { gas_used, .. }) = self.header.blob_gas.as_mut() {
             let blob_gas_used = transaction.total_blob_gas().unwrap_or_default();
@@ -505,10 +513,11 @@ impl<
         }
 
         let receipt = receipt_builder.build_receipt(
-            &self.header,
             &transaction,
             &transaction_result,
             self.cfg.spec,
+            self.cumulative_gas_used,
+            self.header.state_root,
         );
         let receipt = TransactionReceipt::new(
             receipt,
@@ -522,6 +531,22 @@ impl<
 
         self.transactions.push(transaction);
         self.transaction_results.push(transaction_result);
+    }
+}
+
+/// Gas a transaction contributes to the block's `gas_used`: from Amsterdam
+/// (EIP-7778) the gross gas before refunds, otherwise its net gas used.
+fn transaction_block_gas_contribution<ChainSpecT: ChainSpec + HardforkChainSpec>(
+    hardfork: ChainSpecT::Hardfork,
+    execution_result: &ExecutionResult<ChainSpecT::HaltReason>,
+) -> u64 {
+    if hardfork.into() >= EvmSpecId::AMSTERDAM {
+        let execution_gas = execution_result.gas();
+        execution_gas
+            .total_gas_spent()
+            .max(execution_gas.floor_gas())
+    } else {
+        execution_result.tx_gas_used()
     }
 }
 
@@ -929,6 +954,71 @@ mod tests {
                     &non_empty_state_diff(),
                     B256::repeat_byte(3)
                 ),
+            );
+        }
+    }
+
+    mod transaction_block_gas_contribution {
+        use edr_chain_spec_evm::result::{Output, ResultGas, SuccessReason};
+        use edr_primitives::Bytes;
+
+        use super::*;
+        use crate::{HaltReason, Hardfork, L1ChainSpec};
+
+        // A successful result carrying the given raw gas figures.
+        fn execution_result(
+            total_gas_spent: u64,
+            refunded: u64,
+            floor_gas: u64,
+        ) -> ExecutionResult<HaltReason> {
+            ExecutionResult::Success {
+                reason: SuccessReason::Stop,
+                gas: ResultGas::default()
+                    .with_total_gas_spent(total_gas_spent)
+                    .with_refunded(refunded)
+                    .with_floor_gas(floor_gas),
+                logs: Vec::new(),
+                output: Output::Call(Bytes::new()),
+            }
+        }
+
+        #[test]
+        fn before_amsterdam_uses_gas_after_refunds() {
+            // Net gas: total - refund = 40_000, above the (30_000) floor.
+            let result = execution_result(50_000, 10_000, 30_000);
+            assert_eq!(
+                transaction_block_gas_contribution::<L1ChainSpec>(Hardfork::OSAKA, &result),
+                40_000
+            );
+        }
+
+        #[test]
+        fn from_amsterdam_uses_gas_before_refunds() {
+            // EIP-7778: the refund is not subtracted from the block gas.
+            let result = execution_result(50_000, 10_000, 0);
+            assert_eq!(
+                transaction_block_gas_contribution::<L1ChainSpec>(Hardfork::AMSTERDAM, &result),
+                50_000
+            );
+        }
+
+        #[test]
+        fn from_amsterdam_applies_calldata_floor() {
+            // The EIP-7623 floor still applies when it exceeds the gas spent.
+            let result = execution_result(20_000, 0, 25_000);
+            assert_eq!(
+                transaction_block_gas_contribution::<L1ChainSpec>(Hardfork::AMSTERDAM, &result),
+                25_000
+            );
+        }
+
+        #[test]
+        fn before_amsterdam_applies_calldata_floor() {
+            // Net gas is floored too: max(total - refund, floor).
+            let result = execution_result(50_000, 10_000, 45_000);
+            assert_eq!(
+                transaction_block_gas_contribution::<L1ChainSpec>(Hardfork::OSAKA, &result),
+                45_000
             );
         }
     }

--- a/crates/edr_chain_l1/src/receipt/builder.rs
+++ b/crates/edr_chain_l1/src/receipt/builder.rs
@@ -1,7 +1,7 @@
 //! Ethereum L1 receipt builder
 
-use edr_block_header::PartialHeader;
 use edr_chain_spec::EvmSpecId;
+use edr_primitives::B256;
 use edr_receipt::{
     log::{logs_to_bloom, ExecutionLog},
     ExecutionResult,
@@ -29,10 +29,11 @@ impl ExecutionReceiptBuilder<HaltReason, Hardfork, L1SignedTransaction>
 
     fn build_receipt(
         self,
-        header: &PartialHeader,
         transaction: &L1SignedTransaction,
         result: &ExecutionResult<HaltReason>,
         hardfork: Hardfork,
+        cumulative_gas_used: u64,
+        state_root: B256,
     ) -> Self::Receipt {
         let logs = result.logs().to_vec();
         let logs_bloom = logs_to_bloom(&logs);
@@ -40,15 +41,15 @@ impl ExecutionReceiptBuilder<HaltReason, Hardfork, L1SignedTransaction>
         let receipt = if hardfork >= EvmSpecId::BYZANTIUM {
             edr_receipt::execution::Eip658 {
                 status: result.is_success(),
-                cumulative_gas_used: header.gas_used,
+                cumulative_gas_used,
                 logs_bloom,
                 logs,
             }
             .into()
         } else {
             edr_receipt::execution::Legacy {
-                root: header.state_root,
-                cumulative_gas_used: header.gas_used,
+                root: state_root,
+                cumulative_gas_used,
                 logs_bloom,
                 logs,
             }

--- a/crates/edr_generic/src/receipt.rs
+++ b/crates/edr_generic/src/receipt.rs
@@ -1,6 +1,6 @@
-use edr_block_header::PartialHeader;
 use edr_chain_spec::EvmSpecId;
 use edr_chain_spec_evm::result::ExecutionResult;
+use edr_primitives::B256;
 use edr_receipt::log::{logs_to_bloom, ExecutionLog};
 use edr_receipt_builder_api::ExecutionReceiptBuilder;
 use edr_state_api::State;
@@ -28,10 +28,11 @@ impl
 
     fn build_receipt(
         self,
-        header: &PartialHeader,
         transaction: &crate::transaction::SignedTransactionWithFallbackToPostEip155,
         result: &ExecutionResult<edr_chain_l1::HaltReason>,
         hardfork: edr_chain_l1::Hardfork,
+        cumulative_gas_used: u64,
+        state_root: B256,
     ) -> Self::Receipt {
         let logs = result.logs().to_vec();
         let logs_bloom = logs_to_bloom(&logs);
@@ -39,15 +40,15 @@ impl
         let receipt = if hardfork >= EvmSpecId::BYZANTIUM {
             edr_receipt::execution::Eip658 {
                 status: result.is_success(),
-                cumulative_gas_used: header.gas_used,
+                cumulative_gas_used,
                 logs_bloom,
                 logs,
             }
             .into()
         } else {
             edr_receipt::execution::Legacy {
-                root: header.state_root,
-                cumulative_gas_used: header.gas_used,
+                root: state_root,
+                cumulative_gas_used,
                 logs_bloom,
                 logs,
             }

--- a/crates/edr_op/src/receipt/execution.rs
+++ b/crates/edr_op/src/receipt/execution.rs
@@ -2,9 +2,8 @@
 
 mod deposit;
 
-use edr_block_header::PartialHeader;
 use edr_chain_spec_evm::result::ExecutionResult;
-use edr_primitives::Bloom;
+use edr_primitives::{Bloom, B256};
 pub use edr_receipt::execution::{Eip658, Legacy};
 use edr_receipt::{
     log::{logs_to_bloom, ExecutionLog},
@@ -117,10 +116,11 @@ impl ExecutionReceiptBuilder<HaltReason, Hardfork, OpSignedTransaction>
 
     fn build_receipt(
         self,
-        header: &PartialHeader,
         transaction: &OpSignedTransaction,
         result: &ExecutionResult<HaltReason>,
         hardfork: Hardfork,
+        cumulative_gas_used: u64,
+        _state_root: B256,
     ) -> Self::Receipt {
         let logs = result.logs().to_vec();
         let logs_bloom = logs_to_bloom(&logs);
@@ -128,7 +128,7 @@ impl ExecutionReceiptBuilder<HaltReason, Hardfork, OpSignedTransaction>
         let receipt = if transaction.transaction_type() == OpTransactionType::Deposit {
             OpExecutionReceipt::Deposit(Deposit {
                 status: result.is_success(),
-                cumulative_gas_used: header.gas_used,
+                cumulative_gas_used,
                 logs_bloom,
                 logs,
                 deposit_nonce: self.deposit_nonce,
@@ -141,7 +141,7 @@ impl ExecutionReceiptBuilder<HaltReason, Hardfork, OpSignedTransaction>
         } else {
             OpExecutionReceipt::Eip658(Eip658 {
                 status: result.is_success(),
-                cumulative_gas_used: header.gas_used,
+                cumulative_gas_used,
                 logs_bloom,
                 logs,
             })

--- a/crates/edr_provider/tests/integration/eip7778.rs
+++ b/crates/edr_provider/tests/integration/eip7778.rs
@@ -1,0 +1,188 @@
+#![cfg(feature = "test-utils")]
+
+//! EIP-7778: Block Gas Accounting without Refunds.
+//! see <https://eips.ethereum.org/EIPS/eip-7778>
+//
+//! From Amsterdam onward, a block's `gas_used` counts gas before refunds, while
+//! transaction receipts keep counting gas after refunds (unchanged). So the
+//! block header's `gas_used` no longer matches the last receipt's
+//! `cumulative_gas_used`: it is greater whenever the block contains refunds.
+
+use std::sync::Arc;
+
+use edr_chain_l1::{
+    rpc::{block::L1RpcBlock, receipt::L1RpcTransactionReceipt, TransactionRequest},
+    L1ChainSpec,
+};
+use edr_eth::PreEip1898BlockSpec;
+use edr_primitives::{address, bytes, Address, Bytecode, Bytes, B256, U256};
+use edr_provider::{
+    test_utils::{create_test_config, one_ether, set_genesis_state_with_owned_accounts},
+    time::CurrentTime,
+    AccountOverride, MethodInvocation, NoopLogger, Provider, ProviderRequest,
+};
+use edr_solidity::contract_decoder::ContractDecoder;
+use edr_state_api::{EvmStorage, EvmStorageSlot};
+use edr_test_utils::secret_key::secret_key_from_str;
+use parking_lot::RwLock;
+use tokio::runtime;
+
+const CHAIN_ID: u64 = 0x7a69;
+
+/// The first Hardhat account (owner of `SECRET_KEYS[0]`).
+const CALLER: Address = address!("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+
+/// Address of the storage-writer contract seeded into the genesis state.
+const CONTRACT: Address = address!("0x000000000000000000000000000000000000c0de");
+
+/// Deployed code `SSTORE(calldataload(0), calldataload(32))`: calling it with
+/// `[slot(32) || value(32)]` writes `value` to storage `slot`.
+const STORAGE_WRITER_CODE: Bytes = bytes!("0x6020356000355500");
+
+/// Storage slot seeded into [`CONTRACT`] and cleared by the refunding
+/// transaction.
+const SLOT: u64 = 1;
+
+/// Genesis storage for [`CONTRACT`]: [`SLOT`] set to a non-zero value, so that
+/// clearing it to zero qualifies for a refund.
+fn seeded_storage() -> EvmStorage {
+    std::iter::once((U256::from(SLOT), EvmStorageSlot::new(U256::from(1), 0))).collect()
+}
+
+fn new_provider(hardfork: edr_chain_l1::Hardfork) -> anyhow::Result<Provider<L1ChainSpec>> {
+    let secret_key = secret_key_from_str(edr_defaults::SECRET_KEYS[0])?;
+
+    let logger = Box::new(NoopLogger::<L1ChainSpec>::default());
+    let subscriber = Box::new(|_event| {});
+
+    let mut config = create_test_config();
+    set_genesis_state_with_owned_accounts(&mut config, vec![secret_key], one_ether());
+    config.chain_id = CHAIN_ID;
+    config.hardfork = hardfork;
+
+    // Seed the storage-writer contract with a non-zero slot to clear.
+    config.genesis_state.insert(
+        CONTRACT,
+        AccountOverride {
+            code: Some(Bytecode::new_raw(STORAGE_WRITER_CODE)),
+            storage: Some(seeded_storage()),
+            ..AccountOverride::default()
+        },
+    );
+
+    let provider = Provider::new(
+        runtime::Handle::current(),
+        logger,
+        subscriber,
+        config,
+        Arc::new(RwLock::<ContractDecoder>::default()),
+        CurrentTime,
+    )?;
+
+    Ok(provider)
+}
+
+/// Transaction clearing [`SLOT`] to zero. The storage-writer contract takes
+/// `[slot(32) || value(32)]` calldata; a zero value clears the slot.
+fn clear_slot() -> TransactionRequest {
+    let mut data = Vec::with_capacity(64);
+    data.extend_from_slice(&U256::from(SLOT).to_be_bytes::<32>());
+    data.extend_from_slice(&U256::ZERO.to_be_bytes::<32>());
+
+    TransactionRequest {
+        from: CALLER,
+        to: Some(CONTRACT),
+        data: Some(data.into()),
+        ..TransactionRequest::default()
+    }
+}
+
+fn send_transaction(
+    provider: &Provider<L1ChainSpec>,
+    request: TransactionRequest,
+) -> anyhow::Result<B256> {
+    let response = provider.handle_request(ProviderRequest::with_single(
+        MethodInvocation::SendTransaction(request),
+    ))?;
+
+    Ok(serde_json::from_value(response.result)?)
+}
+
+fn transaction_receipt(
+    provider: &Provider<L1ChainSpec>,
+    transaction_hash: B256,
+) -> anyhow::Result<L1RpcTransactionReceipt> {
+    let response = provider.handle_request(ProviderRequest::with_single(
+        MethodInvocation::GetTransactionReceipt(transaction_hash),
+    ))?;
+
+    let receipt: Option<L1RpcTransactionReceipt> = serde_json::from_value(response.result)?;
+    receipt.ok_or_else(|| anyhow::anyhow!("receipt should exist"))
+}
+
+fn latest_block(provider: &Provider<L1ChainSpec>) -> anyhow::Result<L1RpcBlock<B256>> {
+    let response = provider.handle_request(ProviderRequest::with_single(
+        MethodInvocation::GetBlockByNumber(PreEip1898BlockSpec::latest(), false),
+    ))?;
+
+    Ok(serde_json::from_value(response.result)?)
+}
+
+/// Clears the seeded slot, generating an SSTORE refund. With automining the
+/// transaction is mined into its own block, which becomes the latest block.
+fn send_refund_transaction(provider: &Provider<L1ChainSpec>) -> anyhow::Result<()> {
+    send_transaction(provider, clear_slot())?;
+    Ok(())
+}
+
+/// Before Amsterdam, a block's `gas_used` equals the last transaction receipt's
+/// `cumulative_gas_used` even when the block's transactions clear storage slots
+/// to zero: both track gas after refunds.
+#[tokio::test(flavor = "multi_thread")]
+async fn block_gas_used_matches_last_tx_cumulative_before_amsterdam() -> anyhow::Result<()> {
+    let provider = new_provider(edr_chain_l1::Hardfork::OSAKA)?;
+
+    send_refund_transaction(&provider)?;
+
+    let block = latest_block(&provider)?;
+    let last_transaction = *block
+        .transactions
+        .last()
+        .expect("block should contain transactions");
+    let last_cumulative_gas_used =
+        transaction_receipt(&provider, last_transaction)?.cumulative_gas_used;
+
+    assert_eq!(
+        block.gas_used, last_cumulative_gas_used,
+        "before Amsterdam the block gas_used must equal the last receipt's cumulative_gas_used"
+    );
+
+    Ok(())
+}
+
+/// On Amsterdam (EIP-7778), the block's `gas_used` counts gas before refunds
+/// while the receipt's `cumulative_gas_used` stays after refunds, so the block
+/// `gas_used` is greater than the last receipt's `cumulative_gas_used`.
+#[tokio::test(flavor = "multi_thread")]
+async fn block_gas_used_excludes_refunds_on_amsterdam() -> anyhow::Result<()> {
+    let provider = new_provider(edr_chain_l1::Hardfork::AMSTERDAM)?;
+
+    send_refund_transaction(&provider)?;
+
+    let block = latest_block(&provider)?;
+    let last_transaction = *block
+        .transactions
+        .last()
+        .expect("block should contain transactions");
+    let last_cumulative_gas_used =
+        transaction_receipt(&provider, last_transaction)?.cumulative_gas_used;
+
+    assert!(
+        block.gas_used > last_cumulative_gas_used,
+        "on Amsterdam the block gas_used (before refunds) must exceed the last receipt's \
+         cumulative_gas_used (after refunds): {} vs {last_cumulative_gas_used}",
+        block.gas_used
+    );
+
+    Ok(())
+}

--- a/crates/edr_provider/tests/integration/mod.rs
+++ b/crates/edr_provider/tests/integration/mod.rs
@@ -8,6 +8,7 @@ mod eip7623;
 mod eip7691;
 mod eip7702;
 mod eip7708;
+mod eip7778;
 mod eip7825;
 mod eip7928;
 mod estimate_gas;

--- a/crates/receipt/builder/api/Cargo.toml
+++ b/crates/receipt/builder/api/Cargo.toml
@@ -4,8 +4,8 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
-edr_block_header.workspace = true
 edr_chain_spec_evm.workspace = true
+edr_primitives.workspace = true
 edr_state_api.workspace = true
 
 [features]

--- a/crates/receipt/builder/api/src/lib.rs
+++ b/crates/receipt/builder/api/src/lib.rs
@@ -1,7 +1,7 @@
 //! Types needed to implement a builder pattern for execution receipts.
 
-use edr_block_header::PartialHeader;
 use edr_chain_spec_evm::result::ExecutionResult;
+use edr_primitives::B256;
 use edr_state_api::State;
 
 /// Trait for a builder that constructs an execution receipt.
@@ -18,9 +18,12 @@ pub trait ExecutionReceiptBuilder<HaltReasonT, HardforkT, SignedTransactionT>: S
     /// Builds a receipt using the provided information.
     fn build_receipt(
         self,
-        header: &PartialHeader,
         transaction: &SignedTransactionT,
         result: &ExecutionResult<HaltReasonT>,
         hardfork: HardforkT,
+        // Net cumulative gas used; distinct from the block's `gas_used` from Amsterdam
+        // (EIP-7778)
+        cumulative_gas_used: u64,
+        state_root: B256,
     ) -> Self::Receipt;
 }

--- a/crates/test/blockchain/src/lib.rs
+++ b/crates/test/blockchain/src/lib.rs
@@ -196,10 +196,11 @@ pub fn insert_dummy_block_with_transaction<
     };
 
     let execution_receipt = receipt_builder.build_receipt(
-        &header,
         &transaction,
         &execution_result,
         blockchain.hardfork(),
+        header.gas_used,
+        header.state_root,
     );
 
     let transaction_receipt = TransactionReceipt::new(


### PR DESCRIPTION

## Summary

Implements [EIP-7778: Block Gas Accounting without Refunds](https://eips.ethereum.org/EIPS/eip-7778) for the Amsterdam hardfork. From Amsterdam, a block's `gasUsed` is accounted **before** gas refunds (gross), so the block gas limit bounds actual computational work and refunds can no longer be used to fit more work into a block than the limit allows.

Transaction receipts are unchanged: both `cumulativeGasUsed` and per-transaction `gasUsed` still count gas **after** refunds, so user transaction costs are unaffected.

## EIP consequences
### The broken invariant 👀 ❕ 

Before Amsterdam, a block's `gasUsed` equals the sum of its transactions' gas, equivalently, the last receipt's `cumulativeGasUsed` (the running total of per-transaction gas). EIP-7778 breaks this: the header goes gross while receipts stay net, so `block.gasUsed >= last receipt.cumulativeGasUsed`, greater whenever the block contains refunds.

**This broken invariant is not stated explicitly in the EIP text**: the spec only defines block-level gas accounting and notes that individual-transaction behavior is unchanged. It is nonetheless the clear intent, evidenced by:

- The EIP's own history: An earlier revision of the spec *did* change receipts (making `cumulative_gas_used` gross and adding a `gas_spent` field), but that was deliberately reverted in [ethereum/EIPs@3929b1a — "Revert back to not having a receipt field"](https://github.com/ethereum/EIPs/commit/3929b1aab57b493417eccec7457d1485eccb9768), leaving receipts as-is while the block header goes gross necessarily makes the two diverge.
- Reference client implementations: As of their current `main`, both geth ([go-ethereum#33593](https://github.com/ethereum/go-ethereum/pull/33593)) and reth ([reth#21821](https://github.com/paradigmxyz/reth/pull/21821)) make the block header's gas refund-free while receipts stay net

### Another implicit consequence: base fee

Also not spelled out in the EIP: EIP-1559's base-fee update reads the parent block's `gasUsed` against the gas target, so with `gasUsed` now gross the base fee responds to pre-refund gas. This is consistent with the reference clients (which make the header gross too) and arguably the intent, the base fee should price actual computational load, but it is a behavioral change beyond receipts.

I think in practice the effect is small, but noting it for completeness.

## Changes

- Decoupled the block header's `gas_used` from the receipt's `cumulative_gas_used` in `EthBlockBuilder`: the header accumulates the gross per-transaction contribution, while a new `cumulative_gas_used` field accumulates the net value used for receipts (mirroring geth's separate counters).
- Added `transaction_block_gas_contribution` function
- `ExecutionReceiptBuilder::build_receipt` no longer takes `&PartialHeader`; it receives `cumulative_gas_used` and `state_root` directly, so the receipt's cumulative can differ from the header. Updated the L1, OP, and generic implementations.
- The block gas limit check continues to use the (now gross) header value, so the limit bounds gross work as the EIP intends.