### PR TITLE
perf: off-load Response deallocation to background thread

### DIFF
--- a/crates/edr_napi/src/async_deallocator.rs
+++ b/crates/edr_napi/src/async_deallocator.rs
@@ -22,27 +22,24 @@ pub struct AsyncDeallocator<T: Send + 'static> {
 
 impl<T: Send + 'static> AsyncDeallocator<T> {
     /// Constructs a new instance.
-    pub fn new(runtime: runtime::Handle) -> io::Result<Self> {
+    pub fn new(thread_name: String, runtime: runtime::Handle) -> io::Result<Self> {
         let (sender, receiver) = unbounded::<T>();
 
-        let thread = CancellableThread::spawn(
-            "async-deallocator".to_owned(),
-            move |cancellation_receiver| {
-                loop {
-                    // `select_biased!` picks the first listed branch when multiple
-                    // arms are ready, so cancellation always wins over pending work.
-                    select_biased! {
-                        // Cancellation channel was disconnected by dropping the CancellableThread.
-                        recv(cancellation_receiver) -> _ => break,
-                        recv(receiver) -> msg => match msg {
-                            Ok(value) => drop(value),
-                            // All senders dropped; no more work can arrive.
-                            Err(_) => break,
-                        },
-                    }
+        let thread = CancellableThread::spawn(thread_name, move |cancellation_receiver| {
+            loop {
+                // `select_biased!` picks the first listed branch when multiple
+                // arms are ready, so cancellation always wins over pending work.
+                select_biased! {
+                    // Cancellation channel was disconnected by dropping the CancellableThread.
+                    recv(cancellation_receiver) -> _ => break,
+                    recv(receiver) -> msg => match msg {
+                        Ok(value) => drop(value),
+                        // All senders dropped; no more work can arrive.
+                        Err(_) => break,
+                    },
                 }
-            },
-        )?;
+            }
+        })?;
 
         Ok(Self {
             sender,

--- a/crates/edr_napi/src/async_deallocator.rs
+++ b/crates/edr_napi/src/async_deallocator.rs
@@ -1,7 +1,8 @@
-use std::io;
+use std::{io, sync::Arc};
 
 use crossbeam_channel::{select_biased, unbounded, SendError, Sender};
 use derive_where::derive_where;
+use edr_napi_core::provider::SyncProvider;
 use edr_utils_sync::{CancellableThread, MAX_THREAD_NAME_LEN};
 use napi::tokio::runtime;
 
@@ -15,6 +16,18 @@ const _: () = {
     assert!(PROVIDER_THREAD_NAME.len() <= MAX_THREAD_NAME_LEN);
     assert!(RESPONSE_THREAD_NAME.len() <= MAX_THREAD_NAME_LEN);
 };
+
+/// Senders for off-loading dropped values to their deallocator threads.
+///
+/// Dropping the last handle to a provider joins that provider's event-loop
+/// thread. Providers therefore need a deallocator thread separate from the
+/// responses'.
+pub struct Deallocators {
+    /// Accepts dropped providers.
+    pub provider: AsyncDeallocatorSender<Arc<dyn SyncProvider>>,
+    /// Accepts dropped responses.
+    pub response: AsyncDeallocatorSender<edr_napi_core::spec::Response>,
+}
 
 /// Owns a dedicated OS thread that drops values of type `T` outside of the
 /// calling thread. Producers obtain cloneable senders via [`Self::sender`] and

--- a/crates/edr_napi/src/async_deallocator.rs
+++ b/crates/edr_napi/src/async_deallocator.rs
@@ -2,8 +2,19 @@ use std::io;
 
 use crossbeam_channel::{select_biased, unbounded, SendError, Sender};
 use derive_where::derive_where;
-use edr_utils_sync::CancellableThread;
+use edr_utils_sync::{CancellableThread, MAX_THREAD_NAME_LEN};
 use napi::tokio::runtime;
+
+/// Name of the thread that drops providers.
+pub const PROVIDER_THREAD_NAME: &str = "edr-drop-prov";
+
+/// Name of the thread that drops responses.
+pub const RESPONSE_THREAD_NAME: &str = "edr-drop-resp";
+
+const _: () = {
+    assert!(PROVIDER_THREAD_NAME.len() <= MAX_THREAD_NAME_LEN);
+    assert!(RESPONSE_THREAD_NAME.len() <= MAX_THREAD_NAME_LEN);
+};
 
 /// Owns a dedicated OS thread that drops values of type `T` outside of the
 /// calling thread. Producers obtain cloneable senders via [`Self::sender`] and
@@ -22,6 +33,9 @@ pub struct AsyncDeallocator<T: Send + 'static> {
 
 impl<T: Send + 'static> AsyncDeallocator<T> {
     /// Constructs a new instance.
+    ///
+    /// `thread_name` must be at most [`MAX_THREAD_NAME_LEN`] bytes long, or the
+    /// OS receives it truncated.
     pub fn new(thread_name: String, runtime: runtime::Handle) -> io::Result<Self> {
         let (sender, receiver) = unbounded::<T>();
 

--- a/crates/edr_napi/src/context.rs
+++ b/crates/edr_napi/src/context.rs
@@ -17,7 +17,7 @@ use napi_derive::napi;
 use tracing_subscriber::{prelude::*, EnvFilter, Registry};
 
 use crate::{
-    async_deallocator::AsyncDeallocator,
+    async_deallocator::{AsyncDeallocator, AsyncDeallocatorSender},
     config::{resolve_configs, ConfigResolution, ProviderConfig, TracingConfigWithBuffers},
     contract_decoder::ContractDecoder,
     logger::LoggerConfig,
@@ -74,6 +74,12 @@ impl EdrContext {
         subscription_config: SubscriptionConfig<'env>,
         contract_decoder: &ContractDecoder,
     ) -> napi::Result<Object<'env>> {
+        struct ContextualParameters {
+            factory: Arc<dyn SyncProviderFactory>,
+            dropped_provider_sender: AsyncDeallocatorSender<Arc<dyn SyncProvider>>,
+            dropped_response_sender: AsyncDeallocatorSender<edr_napi_core::spec::Response>,
+        }
+
         let (deferred, promise) = env.create_deferred()?;
 
         let runtime = runtime::Handle::current();
@@ -104,7 +110,11 @@ impl EdrContext {
             ))
         );
 
-        let (factory, dropped_provider_sender) = {
+        let ContextualParameters {
+            factory,
+            dropped_provider_sender,
+            dropped_response_sender,
+        } = {
             // TODO: https://github.com/NomicFoundation/edr/issues/760
             // TODO: Don't block the JS event loop
             let context = runtime.block_on(async { self.inner.lock().await });
@@ -115,8 +125,13 @@ impl EdrContext {
                 context.get_provider_factory(&chain_type)
             );
             let dropped_provider_sender = context.provider_deallocator.sender();
+            let dropped_response_sender = context.response_deallocator.sender();
 
-            (factory, dropped_provider_sender)
+            ContextualParameters {
+                factory,
+                dropped_provider_sender,
+                dropped_response_sender,
+            }
         };
 
         let contract_decoder = Arc::clone(contract_decoder.as_inner());
@@ -135,6 +150,7 @@ impl EdrContext {
                         runtime,
                         contract_decoder,
                         dropped_provider_sender,
+                        dropped_response_sender,
                         #[cfg(feature = "scenarios")]
                         scenario_file,
                     )
@@ -363,11 +379,23 @@ impl EdrContext {
     ) -> napi::Result<Provider> {
         use crate::mock::MockProvider;
 
+        struct ContextualParameters {
+            dropped_provider_sender: AsyncDeallocatorSender<Arc<dyn SyncProvider>>,
+            dropped_response_sender: AsyncDeallocatorSender<edr_napi_core::spec::Response>,
+        }
+
         let runtime = runtime::Handle::current();
 
-        let dropped_provider_sender = {
+        let ContextualParameters {
+            dropped_provider_sender,
+            dropped_response_sender,
+        } = {
             let context = runtime.block_on(async { self.inner.lock().await });
-            context.provider_deallocator.sender()
+
+            ContextualParameters {
+                dropped_provider_sender: context.provider_deallocator.sender(),
+                dropped_response_sender: context.response_deallocator.sender(),
+            }
         };
 
         let provider = Provider::new(
@@ -375,6 +403,7 @@ impl EdrContext {
             runtime,
             Arc::default(),
             dropped_provider_sender,
+            dropped_response_sender,
             #[cfg(feature = "scenarios")]
             None,
         );
@@ -396,6 +425,11 @@ impl EdrContext {
     ) -> napi::Result<Object<'env>> {
         use edr_generic::GenericChainSpec;
         use edr_napi_core::logger::Logger;
+
+        struct ContextualParameters {
+            dropped_provider_sender: AsyncDeallocatorSender<Arc<dyn SyncProvider>>,
+            dropped_response_sender: AsyncDeallocatorSender<edr_napi_core::spec::Response>,
+        }
 
         let (deferred, promise) = env.create_deferred()?;
 
@@ -419,9 +453,16 @@ impl EdrContext {
         let contract_decoder = Arc::clone(contract_decoder.as_inner());
         let timer = Arc::clone(time.as_inner());
 
-        let dropped_provider_sender = {
+        let ContextualParameters {
+            dropped_provider_sender,
+            dropped_response_sender,
+        } = {
             let context = runtime.block_on(async { self.inner.lock().await });
-            context.provider_deallocator.sender()
+
+            ContextualParameters {
+                dropped_provider_sender: context.provider_deallocator.sender(),
+                dropped_response_sender: context.response_deallocator.sender(),
+            }
         };
 
         runtime.clone().spawn_blocking(move || {
@@ -462,6 +503,7 @@ impl EdrContext {
                     runtime,
                     contract_decoder,
                     dropped_provider_sender,
+                    dropped_response_sender,
                     #[cfg(feature = "scenarios")]
                     None,
                 ))
@@ -479,6 +521,7 @@ pub struct Context {
     provider_factories: HashMap<String, Arc<dyn SyncProviderFactory>>,
     solidity_test_runner_factories: HashMap<String, Arc<dyn solidity::SyncTestRunnerFactory>>,
     provider_deallocator: AsyncDeallocator<Arc<dyn SyncProvider>>,
+    response_deallocator: AsyncDeallocator<edr_napi_core::spec::Response>,
     #[cfg(feature = "tracing")]
     _tracing_write_guard: tracing_flame::FlushGuard<std::io::BufWriter<std::fs::File>>,
 }
@@ -523,10 +566,24 @@ impl Context {
         Ok(Self {
             provider_factories: HashMap::default(),
             solidity_test_runner_factories: HashMap::default(),
-            provider_deallocator: AsyncDeallocator::new(runtime).map_err(|error| {
+            provider_deallocator: AsyncDeallocator::new(
+                "async-deallocator-provider".to_owned(),
+                runtime.clone(),
+            )
+            .map_err(|error| {
                 napi::Error::new(
                     napi::Status::GenericFailure,
                     format!("Failed to spawn the provider deallocator thread: {error}"),
+                )
+            })?,
+            response_deallocator: AsyncDeallocator::new(
+                "async-deallocator-response".to_owned(),
+                runtime,
+            )
+            .map_err(|error| {
+                napi::Error::new(
+                    napi::Status::GenericFailure,
+                    format!("Failed to spawn the response deallocator thread: {error}"),
                 )
             })?,
             #[cfg(feature = "tracing")]

--- a/crates/edr_napi/src/context.rs
+++ b/crates/edr_napi/src/context.rs
@@ -17,7 +17,7 @@ use napi_derive::napi;
 use tracing_subscriber::{prelude::*, EnvFilter, Registry};
 
 use crate::{
-    async_deallocator::AsyncDeallocator,
+    async_deallocator::{AsyncDeallocator, AsyncDeallocatorSender},
     config::{resolve_configs, ConfigResolution, ProviderConfig, TracingConfigWithBuffers},
     contract_decoder::ContractDecoder,
     logger::LoggerConfig,
@@ -83,6 +83,12 @@ impl EdrContext {
         subscription_config: SubscriptionConfig<'env>,
         contract_decoder: &ContractDecoder,
     ) -> napi::Result<Object<'env>> {
+        struct ContextualParameters {
+            factory: Arc<dyn SyncProviderFactory>,
+            dropped_provider_sender: AsyncDeallocatorSender<Arc<dyn SyncProvider>>,
+            dropped_response_sender: AsyncDeallocatorSender<edr_napi_core::spec::Response>,
+        }
+
         let (deferred, promise) = env.create_deferred()?;
 
         let runtime = runtime::Handle::current();
@@ -113,7 +119,11 @@ impl EdrContext {
             ))
         );
 
-        let (factory, dropped_provider_sender) = {
+        let ContextualParameters {
+            factory,
+            dropped_provider_sender,
+            dropped_response_sender,
+        } = {
             // TODO: https://github.com/NomicFoundation/edr/issues/760
             // TODO: Don't block the JS event loop
             let context = runtime.block_on(async { self.inner.lock().await });
@@ -124,8 +134,13 @@ impl EdrContext {
                 context.get_provider_factory(&chain_type)
             );
             let dropped_provider_sender = context.provider_deallocator.sender();
+            let dropped_response_sender = context.response_deallocator.sender();
 
-            (factory, dropped_provider_sender)
+            ContextualParameters {
+                factory,
+                dropped_provider_sender,
+                dropped_response_sender,
+            }
         };
 
         let contract_decoder = Arc::clone(contract_decoder.as_inner());
@@ -144,6 +159,7 @@ impl EdrContext {
                         runtime,
                         contract_decoder,
                         dropped_provider_sender,
+                        dropped_response_sender,
                         #[cfg(feature = "scenarios")]
                         scenario_file,
                     )
@@ -397,11 +413,23 @@ impl EdrContext {
     ) -> napi::Result<Provider> {
         use crate::mock::MockProvider;
 
+        struct ContextualParameters {
+            dropped_provider_sender: AsyncDeallocatorSender<Arc<dyn SyncProvider>>,
+            dropped_response_sender: AsyncDeallocatorSender<edr_napi_core::spec::Response>,
+        }
+
         let runtime = runtime::Handle::current();
 
-        let dropped_provider_sender = {
+        let ContextualParameters {
+            dropped_provider_sender,
+            dropped_response_sender,
+        } = {
             let context = runtime.block_on(async { self.inner.lock().await });
-            context.provider_deallocator.sender()
+
+            ContextualParameters {
+                dropped_provider_sender: context.provider_deallocator.sender(),
+                dropped_response_sender: context.response_deallocator.sender(),
+            }
         };
 
         let provider = Provider::new(
@@ -409,6 +437,7 @@ impl EdrContext {
             runtime,
             Arc::default(),
             dropped_provider_sender,
+            dropped_response_sender,
             #[cfg(feature = "scenarios")]
             None,
         );
@@ -430,6 +459,11 @@ impl EdrContext {
     ) -> napi::Result<Object<'env>> {
         use edr_generic::GenericChainSpec;
         use edr_napi_core::logger::Logger;
+
+        struct ContextualParameters {
+            dropped_provider_sender: AsyncDeallocatorSender<Arc<dyn SyncProvider>>,
+            dropped_response_sender: AsyncDeallocatorSender<edr_napi_core::spec::Response>,
+        }
 
         let (deferred, promise) = env.create_deferred()?;
 
@@ -453,9 +487,16 @@ impl EdrContext {
         let contract_decoder = Arc::clone(contract_decoder.as_inner());
         let timer = Arc::clone(time.as_inner());
 
-        let dropped_provider_sender = {
+        let ContextualParameters {
+            dropped_provider_sender,
+            dropped_response_sender,
+        } = {
             let context = runtime.block_on(async { self.inner.lock().await });
-            context.provider_deallocator.sender()
+
+            ContextualParameters {
+                dropped_provider_sender: context.provider_deallocator.sender(),
+                dropped_response_sender: context.response_deallocator.sender(),
+            }
         };
 
         runtime.clone().spawn_blocking(move || {
@@ -496,6 +537,7 @@ impl EdrContext {
                     runtime,
                     contract_decoder,
                     dropped_provider_sender,
+                    dropped_response_sender,
                     #[cfg(feature = "scenarios")]
                     None,
                 ))
@@ -513,6 +555,7 @@ pub struct Context {
     provider_factories: HashMap<String, Arc<dyn SyncProviderFactory>>,
     solidity_test_runner_factories: HashMap<String, Arc<dyn solidity::SyncTestRunnerFactory>>,
     provider_deallocator: AsyncDeallocator<Arc<dyn SyncProvider>>,
+    response_deallocator: AsyncDeallocator<edr_napi_core::spec::Response>,
     #[cfg(feature = "tracing")]
     _tracing_write_guard: tracing_flame::FlushGuard<std::io::BufWriter<std::fs::File>>,
 }
@@ -557,10 +600,24 @@ impl Context {
         Ok(Self {
             provider_factories: HashMap::default(),
             solidity_test_runner_factories: HashMap::default(),
-            provider_deallocator: AsyncDeallocator::new(runtime).map_err(|error| {
+            provider_deallocator: AsyncDeallocator::new(
+                "async-deallocator-provider".to_owned(),
+                runtime.clone(),
+            )
+            .map_err(|error| {
                 napi::Error::new(
                     napi::Status::GenericFailure,
                     format!("Failed to spawn the provider deallocator thread: {error}"),
+                )
+            })?,
+            response_deallocator: AsyncDeallocator::new(
+                "async-deallocator-response".to_owned(),
+                runtime,
+            )
+            .map_err(|error| {
+                napi::Error::new(
+                    napi::Status::GenericFailure,
+                    format!("Failed to spawn the response deallocator thread: {error}"),
                 )
             })?,
             #[cfg(feature = "tracing")]

--- a/crates/edr_napi/src/context.rs
+++ b/crates/edr_napi/src/context.rs
@@ -18,7 +18,7 @@ use tracing_subscriber::{prelude::*, EnvFilter, Registry};
 
 use crate::{
     async_deallocator::{
-        AsyncDeallocator, AsyncDeallocatorSender, PROVIDER_THREAD_NAME, RESPONSE_THREAD_NAME,
+        AsyncDeallocator, Deallocators, PROVIDER_THREAD_NAME, RESPONSE_THREAD_NAME,
     },
     config::{resolve_configs, ConfigResolution, ProviderConfig, TracingConfigWithBuffers},
     contract_decoder::ContractDecoder,
@@ -85,12 +85,6 @@ impl EdrContext {
         subscription_config: SubscriptionConfig<'env>,
         contract_decoder: &ContractDecoder,
     ) -> napi::Result<Object<'env>> {
-        struct ContextualParameters {
-            factory: Arc<dyn SyncProviderFactory>,
-            dropped_provider_sender: AsyncDeallocatorSender<Arc<dyn SyncProvider>>,
-            dropped_response_sender: AsyncDeallocatorSender<edr_napi_core::spec::Response>,
-        }
-
         let (deferred, promise) = env.create_deferred()?;
 
         let runtime = runtime::Handle::current();
@@ -121,11 +115,7 @@ impl EdrContext {
             ))
         );
 
-        let ContextualParameters {
-            factory,
-            dropped_provider_sender,
-            dropped_response_sender,
-        } = {
+        let (factory, deallocators) = {
             // TODO: https://github.com/NomicFoundation/edr/issues/760
             // TODO: Don't block the JS event loop
             let context = runtime.block_on(async { self.inner.lock().await });
@@ -135,14 +125,8 @@ impl EdrContext {
                 promise,
                 context.get_provider_factory(&chain_type)
             );
-            let dropped_provider_sender = context.provider_deallocator.sender();
-            let dropped_response_sender = context.response_deallocator.sender();
 
-            ContextualParameters {
-                factory,
-                dropped_provider_sender,
-                dropped_response_sender,
-            }
+            (factory, context.deallocators())
         };
 
         let contract_decoder = Arc::clone(contract_decoder.as_inner());
@@ -160,8 +144,7 @@ impl EdrContext {
                         provider,
                         runtime,
                         contract_decoder,
-                        dropped_provider_sender,
-                        dropped_response_sender,
+                        deallocators,
                         #[cfg(feature = "scenarios")]
                         scenario_file,
                     )
@@ -415,31 +398,18 @@ impl EdrContext {
     ) -> napi::Result<Provider> {
         use crate::mock::MockProvider;
 
-        struct ContextualParameters {
-            dropped_provider_sender: AsyncDeallocatorSender<Arc<dyn SyncProvider>>,
-            dropped_response_sender: AsyncDeallocatorSender<edr_napi_core::spec::Response>,
-        }
-
         let runtime = runtime::Handle::current();
 
-        let ContextualParameters {
-            dropped_provider_sender,
-            dropped_response_sender,
-        } = {
+        let deallocators = {
             let context = runtime.block_on(async { self.inner.lock().await });
-
-            ContextualParameters {
-                dropped_provider_sender: context.provider_deallocator.sender(),
-                dropped_response_sender: context.response_deallocator.sender(),
-            }
+            context.deallocators()
         };
 
         let provider = Provider::new(
             Arc::new(MockProvider::new(mocked_response)),
             runtime,
             Arc::default(),
-            dropped_provider_sender,
-            dropped_response_sender,
+            deallocators,
             #[cfg(feature = "scenarios")]
             None,
         );
@@ -461,11 +431,6 @@ impl EdrContext {
     ) -> napi::Result<Object<'env>> {
         use edr_generic::GenericChainSpec;
         use edr_napi_core::logger::Logger;
-
-        struct ContextualParameters {
-            dropped_provider_sender: AsyncDeallocatorSender<Arc<dyn SyncProvider>>,
-            dropped_response_sender: AsyncDeallocatorSender<edr_napi_core::spec::Response>,
-        }
 
         let (deferred, promise) = env.create_deferred()?;
 
@@ -489,16 +454,9 @@ impl EdrContext {
         let contract_decoder = Arc::clone(contract_decoder.as_inner());
         let timer = Arc::clone(time.as_inner());
 
-        let ContextualParameters {
-            dropped_provider_sender,
-            dropped_response_sender,
-        } = {
+        let deallocators = {
             let context = runtime.block_on(async { self.inner.lock().await });
-
-            ContextualParameters {
-                dropped_provider_sender: context.provider_deallocator.sender(),
-                dropped_response_sender: context.response_deallocator.sender(),
-            }
+            context.deallocators()
         };
 
         runtime.clone().spawn_blocking(move || {
@@ -538,8 +496,7 @@ impl EdrContext {
                     Arc::new(provider),
                     runtime,
                     contract_decoder,
-                    dropped_provider_sender,
-                    dropped_response_sender,
+                    deallocators,
                     #[cfg(feature = "scenarios")]
                     None,
                 ))
@@ -551,6 +508,19 @@ impl EdrContext {
 
         Ok(promise)
     }
+}
+
+/// Spawns a deallocator thread named `thread_name`.
+fn spawn_deallocator<T: Send + 'static>(
+    thread_name: &str,
+    runtime: runtime::Handle,
+) -> napi::Result<AsyncDeallocator<T>> {
+    AsyncDeallocator::new(thread_name.to_owned(), runtime).map_err(|error| {
+        napi::Error::new(
+            napi::Status::GenericFailure,
+            format!("Failed to spawn the '{thread_name}' deallocator thread: {error}"),
+        )
+    })
 }
 
 pub struct Context {
@@ -602,26 +572,20 @@ impl Context {
         Ok(Self {
             provider_factories: HashMap::default(),
             solidity_test_runner_factories: HashMap::default(),
-            provider_deallocator: AsyncDeallocator::new(
-                PROVIDER_THREAD_NAME.to_owned(),
-                runtime.clone(),
-            )
-            .map_err(|error| {
-                napi::Error::new(
-                    napi::Status::GenericFailure,
-                    format!("Failed to spawn the provider deallocator thread: {error}"),
-                )
-            })?,
-            response_deallocator: AsyncDeallocator::new(RESPONSE_THREAD_NAME.to_owned(), runtime)
-                .map_err(|error| {
-                napi::Error::new(
-                    napi::Status::GenericFailure,
-                    format!("Failed to spawn the response deallocator thread: {error}"),
-                )
-            })?,
+            provider_deallocator: spawn_deallocator(PROVIDER_THREAD_NAME, runtime.clone())?,
+            response_deallocator: spawn_deallocator(RESPONSE_THREAD_NAME, runtime)?,
             #[cfg(feature = "tracing")]
             _tracing_write_guard: guard,
         })
+    }
+
+    /// Returns senders for off-loading dropped values to the deallocator
+    /// threads.
+    fn deallocators(&self) -> Deallocators {
+        Deallocators {
+            provider: self.provider_deallocator.sender(),
+            response: self.response_deallocator.sender(),
+        }
     }
 
     /// Registers a new provider factory for the provided chain type.

--- a/crates/edr_napi/src/context.rs
+++ b/crates/edr_napi/src/context.rs
@@ -17,7 +17,9 @@ use napi_derive::napi;
 use tracing_subscriber::{prelude::*, EnvFilter, Registry};
 
 use crate::{
-    async_deallocator::{AsyncDeallocator, AsyncDeallocatorSender},
+    async_deallocator::{
+        AsyncDeallocator, AsyncDeallocatorSender, PROVIDER_THREAD_NAME, RESPONSE_THREAD_NAME,
+    },
     config::{resolve_configs, ConfigResolution, ProviderConfig, TracingConfigWithBuffers},
     contract_decoder::ContractDecoder,
     logger::LoggerConfig,
@@ -601,7 +603,7 @@ impl Context {
             provider_factories: HashMap::default(),
             solidity_test_runner_factories: HashMap::default(),
             provider_deallocator: AsyncDeallocator::new(
-                "async-deallocator-provider".to_owned(),
+                PROVIDER_THREAD_NAME.to_owned(),
                 runtime.clone(),
             )
             .map_err(|error| {
@@ -610,11 +612,8 @@ impl Context {
                     format!("Failed to spawn the provider deallocator thread: {error}"),
                 )
             })?,
-            response_deallocator: AsyncDeallocator::new(
-                "async-deallocator-response".to_owned(),
-                runtime,
-            )
-            .map_err(|error| {
+            response_deallocator: AsyncDeallocator::new(RESPONSE_THREAD_NAME.to_owned(), runtime)
+                .map_err(|error| {
                 napi::Error::new(
                     napi::Status::GenericFailure,
                     format!("Failed to spawn the response deallocator thread: {error}"),

--- a/crates/edr_napi/src/provider.rs
+++ b/crates/edr_napi/src/provider.rs
@@ -30,6 +30,7 @@ pub struct Provider {
     provider: Arc<dyn SyncProvider>,
     runtime: runtime::Handle,
     dropped_provider_sender: AsyncDeallocatorSender<Arc<dyn SyncProvider>>,
+    dropped_response_sender: AsyncDeallocatorSender<edr_napi_core::spec::Response>,
     #[cfg(feature = "scenarios")]
     scenario_file: Option<napi::tokio::sync::Mutex<napi::tokio::fs::File>>,
 }
@@ -41,6 +42,7 @@ impl Provider {
         runtime: runtime::Handle,
         contract_decoder: Arc<RwLock<edr_solidity::contract_decoder::ContractDecoder>>,
         dropped_provider_sender: AsyncDeallocatorSender<Arc<dyn SyncProvider>>,
+        dropped_response_sender: AsyncDeallocatorSender<edr_napi_core::spec::Response>,
         #[cfg(feature = "scenarios")] scenario_file: Option<
             napi::tokio::sync::Mutex<napi::tokio::fs::File>,
         >,
@@ -50,6 +52,7 @@ impl Provider {
             provider,
             runtime,
             dropped_provider_sender,
+            dropped_response_sender,
             #[cfg(feature = "scenarios")]
             scenario_file,
         }
@@ -158,6 +161,7 @@ impl Provider {
     #[napi(catch_unwind)]
     pub async fn handle_request(&self, request: String) -> napi::Result<Response> {
         let provider = self.provider.clone();
+        let dropped_response_sender = self.dropped_response_sender.clone();
 
         #[cfg(feature = "scenarios")]
         if let Some(scenario_file) = &self.scenario_file {
@@ -168,7 +172,7 @@ impl Provider {
             .spawn_blocking(move || provider.handle_request(request))
             .await
             .map_err(|error| napi::Error::new(Status::GenericFailure, error.to_string()))?
-            .map(Response::from)
+            .map(|response| Response::new(response, dropped_response_sender))
     }
 
     #[napi(catch_unwind, ts_return_type = "Promise<void>")]

--- a/crates/edr_napi/src/provider.rs
+++ b/crates/edr_napi/src/provider.rs
@@ -30,6 +30,7 @@ pub struct Provider {
     provider: Arc<dyn SyncProvider>,
     runtime: runtime::Handle,
     dropped_provider_sender: AsyncDeallocatorSender<Arc<dyn SyncProvider>>,
+    dropped_response_sender: AsyncDeallocatorSender<edr_napi_core::spec::Response>,
     #[cfg(feature = "scenarios")]
     scenario_file: Option<Arc<napi::tokio::sync::Mutex<napi::tokio::fs::File>>>,
 }
@@ -41,6 +42,7 @@ impl Provider {
         runtime: runtime::Handle,
         contract_decoder: Arc<RwLock<edr_solidity::contract_decoder::ContractDecoder>>,
         dropped_provider_sender: AsyncDeallocatorSender<Arc<dyn SyncProvider>>,
+        dropped_response_sender: AsyncDeallocatorSender<edr_napi_core::spec::Response>,
         #[cfg(feature = "scenarios")] scenario_file: Option<
             napi::tokio::sync::Mutex<napi::tokio::fs::File>,
         >,
@@ -50,6 +52,7 @@ impl Provider {
             provider,
             runtime,
             dropped_provider_sender,
+            dropped_response_sender,
             #[cfg(feature = "scenarios")]
             scenario_file: scenario_file.map(Arc::new),
         }
@@ -163,12 +166,16 @@ impl Provider {
     ) -> napi::Result<Object<'env>> {
         let (deferred, promise) = env.create_deferred()?;
 
+        let dropped_response_sender = self.dropped_response_sender.clone();
+
         let enqueue_request =
             move |provider: &dyn SyncProvider, request: napi::Result<String>| match request {
                 Ok(request) => provider.enqueue_request(
                     request,
                     Box::new(move |result| match result {
-                        Ok(response) => deferred.resolve(move |_env| Ok(Response::from(response))),
+                        Ok(response) => deferred.resolve(move |_env| {
+                            Ok(Response::new(response, dropped_response_sender))
+                        }),
                         Err(error) => deferred.reject(error),
                     }),
                 ),

--- a/crates/edr_napi/src/provider.rs
+++ b/crates/edr_napi/src/provider.rs
@@ -19,7 +19,7 @@ use parking_lot::RwLock;
 pub use self::factory::ProviderFactory;
 use self::response::Response;
 use crate::{
-    async_deallocator::AsyncDeallocatorSender, call_override::CallOverrideCallback,
+    async_deallocator::Deallocators, call_override::CallOverrideCallback,
     contract_decoder::ContractDecoder,
 };
 
@@ -29,8 +29,7 @@ pub struct Provider {
     contract_decoder: Arc<RwLock<edr_solidity::contract_decoder::ContractDecoder>>,
     provider: Arc<dyn SyncProvider>,
     runtime: runtime::Handle,
-    dropped_provider_sender: AsyncDeallocatorSender<Arc<dyn SyncProvider>>,
-    dropped_response_sender: AsyncDeallocatorSender<edr_napi_core::spec::Response>,
+    deallocators: Deallocators,
     #[cfg(feature = "scenarios")]
     scenario_file: Option<Arc<napi::tokio::sync::Mutex<napi::tokio::fs::File>>>,
 }
@@ -41,8 +40,7 @@ impl Provider {
         provider: Arc<dyn SyncProvider>,
         runtime: runtime::Handle,
         contract_decoder: Arc<RwLock<edr_solidity::contract_decoder::ContractDecoder>>,
-        dropped_provider_sender: AsyncDeallocatorSender<Arc<dyn SyncProvider>>,
-        dropped_response_sender: AsyncDeallocatorSender<edr_napi_core::spec::Response>,
+        deallocators: Deallocators,
         #[cfg(feature = "scenarios")] scenario_file: Option<
             napi::tokio::sync::Mutex<napi::tokio::fs::File>,
         >,
@@ -51,8 +49,7 @@ impl Provider {
             contract_decoder,
             provider,
             runtime,
-            dropped_provider_sender,
-            dropped_response_sender,
+            deallocators,
             #[cfg(feature = "scenarios")]
             scenario_file: scenario_file.map(Arc::new),
         }
@@ -166,7 +163,7 @@ impl Provider {
     ) -> napi::Result<Object<'env>> {
         let (deferred, promise) = env.create_deferred()?;
 
-        let dropped_response_sender = self.dropped_response_sender.clone();
+        let dropped_response_sender = self.deallocators.response.clone();
 
         let enqueue_request =
             move |provider: &dyn SyncProvider, request: napi::Result<String>| match request {
@@ -276,14 +273,14 @@ impl ObjectFinalize for Provider {
     fn finalize(self, _env: Env) -> napi::Result<()> {
         let Self {
             provider,
-            dropped_provider_sender,
+            deallocators,
             ..
         } = self;
 
         // Off-loads deallocation to a background thread to avoid blocking the
         // JS thread (the provider may be running thread-safe functions on a
         // background thread; dropping it here would deadlock).
-        dropped_provider_sender.deallocate(provider);
+        deallocators.provider.deallocate(provider);
 
         Ok(())
     }

--- a/crates/edr_napi/src/provider/response.rs
+++ b/crates/edr_napi/src/provider/response.rs
@@ -1,8 +1,12 @@
 use edr_solidity::solidity_stack_trace::StackTraceCreationResult;
-use napi::{bindgen_prelude::Either3, Either};
+use napi::{
+    bindgen_prelude::{Either3, ObjectFinalize},
+    Either,
+};
 use napi_derive::napi;
 
 use crate::{
+    async_deallocator::AsyncDeallocatorSender,
     solidity_tests::test_results::{CallTrace, HeuristicFailed, StackTrace, UnexpectedError},
     trace::solidity_stack_trace::{
         solidity_stack_trace_error_to_napi, solidity_stack_trace_heuristic_failed_to_napi,
@@ -10,14 +14,22 @@ use crate::{
     },
 };
 
-#[napi]
+#[napi(custom_finalize)]
 pub struct Response {
+    dropped_response_sender: AsyncDeallocatorSender<edr_napi_core::spec::Response>,
     inner: edr_napi_core::spec::Response,
 }
 
-impl From<edr_napi_core::spec::Response> for Response {
-    fn from(value: edr_napi_core::spec::Response) -> Self {
-        Self { inner: value }
+impl Response {
+    /// Constructs a new instance.
+    pub fn new(
+        response: edr_napi_core::spec::Response,
+        dropped_response_sender: AsyncDeallocatorSender<edr_napi_core::spec::Response>,
+    ) -> Self {
+        Self {
+            dropped_response_sender,
+            inner: response,
+        }
     }
 }
 
@@ -72,4 +84,19 @@ impl Response {
     //         .map(|trace| RawTrace::from(trace.clone()))
     //         .collect()
     // }
+}
+
+impl ObjectFinalize for Response {
+    fn finalize(self, _env: napi::Env) -> napi::Result<()> {
+        let Self {
+            dropped_response_sender,
+            inner,
+        } = self;
+
+        // Off-loads deallocation of memory-heavy `call_trace_arenas` to a background
+        // thread to avoid blocking the JS thread; wasting valuable time.
+        dropped_response_sender.deallocate(inner);
+
+        Ok(())
+    }
 }

--- a/crates/edr_napi/src/provider/response.rs
+++ b/crates/edr_napi/src/provider/response.rs
@@ -93,8 +93,8 @@ impl ObjectFinalize for Response {
             inner,
         } = self;
 
-        // Off-loads deallocation of memory-heavy `call_trace_arenas` to a background
-        // thread to avoid blocking the JS thread; wasting valuable time.
+        // Finalizers run on the JS thread, where freeing the response's
+        // `call_trace_arenas` would hold up request dispatch.
         dropped_response_sender.deallocate(inner);
 
         Ok(())

--- a/crates/edr_provider/src/provider.rs
+++ b/crates/edr_provider/src/provider.rs
@@ -4,7 +4,7 @@ use crossbeam_channel::{bounded, unbounded, RecvError, Sender};
 use edr_chain_spec::{ProtocolHardforkChainSpec, TransactionValidation};
 use edr_solidity::contract_decoder::ContractDecoder;
 use edr_transaction::{IsEip155, IsEip4844, TransactionMut, TransactionType};
-use edr_utils_sync::CancellableThread;
+use edr_utils_sync::{CancellableThread, MAX_THREAD_NAME_LEN};
 use parking_lot::RwLock;
 use tokio::runtime;
 
@@ -20,6 +20,11 @@ use crate::{
     time::{CurrentTime, TimeSinceEpoch},
     ResponseWithCallTraces, SyncSubscriberCallback,
 };
+
+/// Name of the thread that owns the [`ProviderData`] and serves requests.
+const THREAD_NAME: &str = "edr-provider";
+
+const _: () = assert!(THREAD_NAME.len() <= MAX_THREAD_NAME_LEN);
 
 /// A JSON-RPC provider for Ethereum.
 ///
@@ -145,7 +150,7 @@ impl<
         let (request_sender, request_receiver) = unbounded();
 
         let thread =
-            CancellableThread::spawn("edr-provider".to_owned(), move |cancellation_receiver| {
+            CancellableThread::spawn(THREAD_NAME.to_owned(), move |cancellation_receiver| {
                 event_loop::run(data, request_receiver, cancellation_receiver);
             })
             .expect("failed to spawn the provider thread");

--- a/crates/utils/sync/src/cancellable_thread.rs
+++ b/crates/utils/sync/src/cancellable_thread.rs
@@ -2,6 +2,11 @@ use std::{convert::Infallible, io, thread::JoinHandle};
 
 use crossbeam_channel::{bounded, Receiver, Sender};
 
+/// The longest thread name that survives on every supported platform. Linux
+/// truncates to 15 bytes, silently collapsing longer names into a shared
+/// prefix.
+pub const MAX_THREAD_NAME_LEN: usize = 15;
+
 /// Owns a dedicated OS thread together with a cancellation channel used to
 /// shut it down. The closure passed to [`Self::spawn`] receives the receiving
 /// end of that channel and should treat its disconnection as the signal to
@@ -40,6 +45,9 @@ impl CancellableThread {
     /// See the "Shutdown via channel disconnection" section of
     /// [`CancellableThread`]'s docs for why this channel is parameterized
     /// with `Infallible` and signalled by sender-drop.
+    ///
+    /// A `name` longer than [`MAX_THREAD_NAME_LEN`] reaches the OS truncated,
+    /// so it collides with any other name sharing its first bytes.
     pub fn spawn<F>(name: String, f: F) -> io::Result<Self>
     where
         F: FnOnce(Receiver<Infallible>) + Send + 'static,

--- a/crates/utils/sync/src/lib.rs
+++ b/crates/utils/sync/src/lib.rs
@@ -4,4 +4,4 @@
 
 mod cancellable_thread;
 
-pub use self::cancellable_thread::CancellableThread;
+pub use self::cancellable_thread::{CancellableThread, MAX_THREAD_NAME_LEN};


### PR DESCRIPTION
Backports a performance improvement from https://github.com/NomicFoundation/edr/pull/1301 to `main`. This change off-loads the deallocation of large memory chunk from the JS main thread to a dedicated background thread.

See [this analysis](https://github.com/NomicFoundation/edr/pull/1301#issuecomment-4915995062) for more details.