### PR TITLE
ci: add filters for HH3 regression benchmark

### DIFF
--- a/.github/scripts/resolve-regression-trigger.cjs
+++ b/.github/scripts/resolve-regression-trigger.cjs
@@ -11,6 +11,17 @@
 const CI_WAIT_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
 const CI_POLL_INTERVAL_MS = 30 * 1000; // 30 seconds
 
+// Default filters when a run doesn't specify them. The resolver always emits a
+// concrete value for both (never empty), so the workflow can pass --scenarios /
+// --benchmarks unconditionally; `*` matches everything.
+//
+// Scenarios default to all. Benchmarks default to just the test-execution
+// entries — EDR affects EVM execution, not Solidity compilation, so we skip the
+// expensive compile ones to save CI time. Override per run via the workflow
+// inputs / `scenarios=`/`benchmarks=` comment args; pass `*` for the full suite.
+const DEFAULT_SCENARIO_FILTER = "*";
+const DEFAULT_BENCHMARK_FILTER = "test solidity,mocha test";
+
 module.exports = async ({ github, context, core }) => {
   const { owner, repo } = context.repo;
   const fullName = `${owner}/${repo}`;
@@ -21,11 +32,12 @@ module.exports = async ({ github, context, core }) => {
   let edrRef = "";
   let hardhatRef = "main";
   let isBaseline = false;
-  // Glob(s) selecting which projects / benchmarks to run (forwarded to
-  // bench:regression's --scenarios / --benchmarks). Empty means all. Never set
-  // for baseline (push) runs so baselines cover the full benchmark.
-  let scenarioFilter = "";
-  let benchmarkFilter = "";
+  // Glob(s) selecting which projects / benchmarks to run (forwarded verbatim to
+  // bench:regression's --scenarios / --benchmarks). Both default to their
+  // DEFAULT_* for every trigger (including the main baseline) and are overridable
+  // on dispatch/`/bench`.
+  let scenarioFilter = DEFAULT_SCENARIO_FILTER;
+  let benchmarkFilter = DEFAULT_BENCHMARK_FILTER;
 
   // Wait for the EDR CI workflow run for `sha` to conclude. Returns true only
   // if it completed successfully. Polls until CI_WAIT_TIMEOUT_MS elapses.
@@ -88,8 +100,10 @@ module.exports = async ({ github, context, core }) => {
     shouldRun = true;
     edrRef = context.sha;
     hardhatRef = context.payload.inputs["hardhat-ref"] || "main";
-    scenarioFilter = context.payload.inputs["scenario-filter"] || "";
-    benchmarkFilter = context.payload.inputs["benchmark-filter"] || "";
+    scenarioFilter =
+      context.payload.inputs["scenario-filter"] || DEFAULT_SCENARIO_FILTER;
+    benchmarkFilter =
+      context.payload.inputs["benchmark-filter"] || DEFAULT_BENCHMARK_FILTER;
     isBaseline = false;
   } else if (eventName === "issue_comment") {
     const comment = context.payload.comment;
@@ -139,17 +153,19 @@ module.exports = async ({ github, context, core }) => {
         };
 
         hardhatRef = parseParam("hardhat-ref") || "main";
-        scenarioFilter = parseParam("scenarios");
-        benchmarkFilter = parseParam("benchmarks");
+        scenarioFilter = parseParam("scenarios") || DEFAULT_SCENARIO_FILTER;
+        benchmarkFilter = parseParam("benchmarks") || DEFAULT_BENCHMARK_FILTER;
 
         // Gate on EDR CI being green for the PR head before spending
         // ~3h on the self-hosted runner.
         const green = await waitForEdrCi(pr.head.sha);
         if (green) {
           shouldRun = true;
+          // Only mention a filter that actually narrows the run (`*` = all).
           const filterNotes = [
-            scenarioFilter && `projects matching \`${scenarioFilter}\``,
-            benchmarkFilter && `benchmarks matching \`${benchmarkFilter}\``,
+            scenarioFilter !== "*" && `projects matching \`${scenarioFilter}\``,
+            benchmarkFilter !== "*" &&
+              `benchmarks matching \`${benchmarkFilter}\``,
           ].filter(Boolean);
           const filterNote = filterNotes.length
             ? ` (${filterNotes.join(", ")})`

--- a/.github/scripts/resolve-regression-trigger.cjs
+++ b/.github/scripts/resolve-regression-trigger.cjs
@@ -21,6 +21,11 @@ module.exports = async ({ github, context, core }) => {
   let edrRef = "";
   let hardhatRef = "main";
   let isBaseline = false;
+  // Glob(s) selecting which projects / benchmarks to run (forwarded to
+  // bench:regression's --scenarios / --benchmarks). Empty means all. Never set
+  // for baseline (push) runs so baselines cover the full benchmark.
+  let scenarioFilter = "";
+  let benchmarkFilter = "";
 
   // Wait for the EDR CI workflow run for `sha` to conclude. Returns true only
   // if it completed successfully. Polls until CI_WAIT_TIMEOUT_MS elapses.
@@ -83,6 +88,8 @@ module.exports = async ({ github, context, core }) => {
     shouldRun = true;
     edrRef = context.sha;
     hardhatRef = context.payload.inputs["hardhat-ref"] || "main";
+    scenarioFilter = context.payload.inputs["scenario-filter"] || "";
+    benchmarkFilter = context.payload.inputs["benchmark-filter"] || "";
     isBaseline = false;
   } else if (eventName === "issue_comment") {
     const comment = context.payload.comment;
@@ -122,17 +129,34 @@ module.exports = async ({ github, context, core }) => {
         edrRef = pr.head.sha;
         isBaseline = false;
 
-        const match = comment.body.match(/hardhat-ref=(\S+)/);
-        hardhatRef = match ? match[1] : "main";
+        // Parse `key=value` or `key="value with spaces"` (command/step globs
+        // like "cold compile" contain spaces, so quotes are supported).
+        const parseParam = (key) => {
+          const m = comment.body.match(
+            new RegExp(`${key}=(?:"([^"]*)"|(\\S+))`)
+          );
+          return m ? (m[1] ?? m[2]) : "";
+        };
+
+        hardhatRef = parseParam("hardhat-ref") || "main";
+        scenarioFilter = parseParam("scenarios");
+        benchmarkFilter = parseParam("benchmarks");
 
         // Gate on EDR CI being green for the PR head before spending
         // ~3h on the self-hosted runner.
         const green = await waitForEdrCi(pr.head.sha);
         if (green) {
           shouldRun = true;
+          const filterNotes = [
+            scenarioFilter && `projects matching \`${scenarioFilter}\``,
+            benchmarkFilter && `benchmarks matching \`${benchmarkFilter}\``,
+          ].filter(Boolean);
+          const filterNote = filterNotes.length
+            ? ` (${filterNotes.join(", ")})`
+            : "";
           await postComment(
             `🚀 [Starting regression benchmark](${runUrl}) for ` +
-              `\`${edrRef.slice(0, 12)}\` against Hardhat \`${hardhatRef}\`.`
+              `\`${edrRef.slice(0, 12)}\` against Hardhat \`${hardhatRef}\`${filterNote}.`
           );
         } else {
           await postComment(
@@ -149,8 +173,11 @@ module.exports = async ({ github, context, core }) => {
   core.setOutput("edr_ref", edrRef);
   core.setOutput("hardhat_ref", hardhatRef);
   core.setOutput("is_baseline", String(isBaseline));
+  core.setOutput("scenario_filter", scenarioFilter);
+  core.setOutput("benchmark_filter", benchmarkFilter);
   core.info(
     `should_run=${shouldRun} edr_ref=${edrRef} ` +
-      `hardhat_ref=${hardhatRef} is_baseline=${isBaseline}`
+      `hardhat_ref=${hardhatRef} is_baseline=${isBaseline} ` +
+      `scenario_filter=${scenarioFilter} benchmark_filter=${benchmarkFilter}`
   );
 };

--- a/.github/scripts/resolve-regression-trigger.test.cjs
+++ b/.github/scripts/resolve-regression-trigger.test.cjs
@@ -54,7 +54,12 @@ function makeDeps({ eventName, sha, payload = {}, ci, pr } = {}) {
     },
   };
 
-  const context = { repo: { owner: OWNER, repo: REPO }, eventName, sha, payload };
+  const context = {
+    repo: { owner: OWNER, repo: REPO },
+    eventName,
+    sha,
+    payload,
+  };
 
   return { github, context, core, captured };
 }
@@ -62,7 +67,12 @@ function makeDeps({ eventName, sha, payload = {}, ci, pr } = {}) {
 // A `/bench` comment on a same-repo PR, by an authorized author.
 function commentPayload(body, { assoc = "MEMBER", number = 7 } = {}) {
   return {
-    comment: { author_association: assoc, user: { login: "dev" }, id: 99, body },
+    comment: {
+      author_association: assoc,
+      user: { login: "dev" },
+      id: 99,
+      body,
+    },
     issue: { number },
   };
 }
@@ -78,6 +88,9 @@ test("push → baseline run against Hardhat main", async () => {
     edr_ref: "deadbeefcafe1234",
     hardhat_ref: "main",
     is_baseline: "true",
+    // Baselines never filter — they must cover the full benchmark.
+    scenario_filter: "",
+    benchmark_filter: "",
   });
 });
 
@@ -101,6 +114,31 @@ test("workflow_dispatch → defaults hardhat-ref to main", async () => {
   });
   await resolve(deps);
   assert.equal(captured.outputs.hardhat_ref, "main");
+});
+
+test("workflow_dispatch → forwards scenario/benchmark filters, defaults to empty", async () => {
+  const withFilter = makeDeps({
+    eventName: "workflow_dispatch",
+    sha: "abc123",
+    payload: {
+      inputs: {
+        "scenario-filter": "1inch*",
+        "benchmark-filter": "test solidity",
+      },
+    },
+  });
+  await resolve(withFilter);
+  assert.equal(withFilter.captured.outputs.scenario_filter, "1inch*");
+  assert.equal(withFilter.captured.outputs.benchmark_filter, "test solidity");
+
+  const withoutFilter = makeDeps({
+    eventName: "workflow_dispatch",
+    sha: "abc123",
+    payload: { inputs: {} },
+  });
+  await resolve(withoutFilter);
+  assert.equal(withoutFilter.captured.outputs.scenario_filter, "");
+  assert.equal(withoutFilter.captured.outputs.benchmark_filter, "");
 });
 
 test("issue_comment → unauthorized author does not run", async () => {
@@ -139,8 +177,60 @@ test("issue_comment → same-repo PR with green CI runs and parses hardhat-ref",
   assert.equal(captured.outputs.edr_ref, "1234567890ab");
   assert.equal(captured.outputs.hardhat_ref, "feature/x");
   assert.equal(captured.outputs.is_baseline, "false");
+  assert.equal(captured.outputs.scenario_filter, ""); // no scenarios= in body
+  assert.equal(captured.outputs.benchmark_filter, ""); // no benchmarks= in body
   assert.equal(captured.comments.length, 1);
   assert.match(captured.comments[0], /Starting regression benchmark/);
+});
+
+test("issue_comment → parses the 1inch* / test solidity example against a hardhat ref", async () => {
+  const { captured, ...deps } = makeDeps({
+    eventName: "issue_comment",
+    payload: commentPayload(
+      '/bench hardhat-ref=edr-benchmark/command-step-filters scenarios=1inch* benchmarks="test solidity"'
+    ),
+    pr: { head: { repo: { full_name: FULL }, sha: "1234567890ab" } },
+    ci: { id: 1, status: "completed", conclusion: "success" },
+  });
+  await resolve(deps);
+  assert.equal(captured.outputs.should_run, "true");
+  assert.equal(
+    captured.outputs.hardhat_ref,
+    "edr-benchmark/command-step-filters"
+  );
+  assert.equal(captured.outputs.scenario_filter, "1inch*");
+  assert.equal(captured.outputs.benchmark_filter, "test solidity");
+  assert.match(captured.comments[0], /projects matching/);
+  assert.match(captured.comments[0], /benchmarks matching/);
+});
+
+test("issue_comment → parses a quoted benchmarks= glob (spaces + commas preserved)", async () => {
+  const { captured, ...deps } = makeDeps({
+    eventName: "issue_comment",
+    payload: commentPayload(
+      '/bench benchmarks="warm compile,test *" hardhat-ref=main'
+    ),
+    pr: { head: { repo: { full_name: FULL }, sha: "1234567890ab" } },
+    ci: { id: 1, status: "completed", conclusion: "success" },
+  });
+  await resolve(deps);
+  assert.equal(captured.outputs.should_run, "true");
+  assert.equal(captured.outputs.hardhat_ref, "main");
+  // Quoted values preserve spaces and internal commas.
+  assert.equal(captured.outputs.benchmark_filter, "warm compile,test *");
+  assert.match(captured.comments[0], /benchmarks matching/);
+});
+
+test("issue_comment → parses an unquoted single-token filter", async () => {
+  const { captured, ...deps } = makeDeps({
+    eventName: "issue_comment",
+    payload: commentPayload("/bench benchmarks=cold-compile"),
+    pr: { head: { repo: { full_name: FULL }, sha: "1234567890ab" } },
+    ci: { id: 1, status: "completed", conclusion: "success" },
+  });
+  await resolve(deps);
+  assert.equal(captured.outputs.benchmark_filter, "cold-compile");
+  assert.equal(captured.outputs.scenario_filter, "");
 });
 
 test("issue_comment → same-repo PR with failing CI does not run", async () => {

--- a/.github/scripts/resolve-regression-trigger.test.cjs
+++ b/.github/scripts/resolve-regression-trigger.test.cjs
@@ -88,9 +88,10 @@ test("push → baseline run against Hardhat main", async () => {
     edr_ref: "deadbeefcafe1234",
     hardhat_ref: "main",
     is_baseline: "true",
-    // Baselines never filter — they must cover the full benchmark.
-    scenario_filter: "",
-    benchmark_filter: "",
+    // Baseline runs all projects (`*`), but only the default test-execution
+    // benchmarks — EDR doesn't affect compilation, so compile ones are skipped.
+    scenario_filter: "*",
+    benchmark_filter: "test solidity,mocha test",
   });
 });
 
@@ -116,20 +117,21 @@ test("workflow_dispatch → defaults hardhat-ref to main", async () => {
   assert.equal(captured.outputs.hardhat_ref, "main");
 });
 
-test("workflow_dispatch → forwards scenario/benchmark filters, defaults to empty", async () => {
+test("workflow_dispatch → forwards explicit filters; benchmark uses the default when unset", async () => {
   const withFilter = makeDeps({
     eventName: "workflow_dispatch",
     sha: "abc123",
     payload: {
       inputs: {
         "scenario-filter": "1inch*",
-        "benchmark-filter": "test solidity",
+        "benchmark-filter": "cold compile",
       },
     },
   });
   await resolve(withFilter);
   assert.equal(withFilter.captured.outputs.scenario_filter, "1inch*");
-  assert.equal(withFilter.captured.outputs.benchmark_filter, "test solidity");
+  // Explicit override wins over the default.
+  assert.equal(withFilter.captured.outputs.benchmark_filter, "cold compile");
 
   const withoutFilter = makeDeps({
     eventName: "workflow_dispatch",
@@ -137,8 +139,23 @@ test("workflow_dispatch → forwards scenario/benchmark filters, defaults to emp
     payload: { inputs: {} },
   });
   await resolve(withoutFilter);
-  assert.equal(withoutFilter.captured.outputs.scenario_filter, "");
-  assert.equal(withoutFilter.captured.outputs.benchmark_filter, "");
+  // No scenario-filter given → default `*` (all projects).
+  assert.equal(withoutFilter.captured.outputs.scenario_filter, "*");
+  // No benchmark-filter given → default test-execution benchmarks.
+  assert.equal(
+    withoutFilter.captured.outputs.benchmark_filter,
+    "test solidity,mocha test"
+  );
+});
+
+test("workflow_dispatch → benchmark-filter=* runs the full suite", async () => {
+  const { captured, ...deps } = makeDeps({
+    eventName: "workflow_dispatch",
+    sha: "abc123",
+    payload: { inputs: { "benchmark-filter": "*" } },
+  });
+  await resolve(deps);
+  assert.equal(captured.outputs.benchmark_filter, "*");
 });
 
 test("issue_comment → unauthorized author does not run", async () => {
@@ -177,10 +194,14 @@ test("issue_comment → same-repo PR with green CI runs and parses hardhat-ref",
   assert.equal(captured.outputs.edr_ref, "1234567890ab");
   assert.equal(captured.outputs.hardhat_ref, "feature/x");
   assert.equal(captured.outputs.is_baseline, "false");
-  assert.equal(captured.outputs.scenario_filter, ""); // no scenarios= in body
-  assert.equal(captured.outputs.benchmark_filter, ""); // no benchmarks= in body
+  assert.equal(captured.outputs.scenario_filter, "*"); // no scenarios= → all
+  // default test-execution benchmarks (no benchmarks= in body)
+  assert.equal(captured.outputs.benchmark_filter, "test solidity,mocha test");
   assert.equal(captured.comments.length, 1);
   assert.match(captured.comments[0], /Starting regression benchmark/);
+  // A `*` (all) scenario filter is not called out; the benchmark default is.
+  assert.doesNotMatch(captured.comments[0], /projects matching/);
+  assert.match(captured.comments[0], /benchmarks matching/);
 });
 
 test("issue_comment → parses the 1inch* / test solidity example against a hardhat ref", async () => {
@@ -230,7 +251,8 @@ test("issue_comment → parses an unquoted single-token filter", async () => {
   });
   await resolve(deps);
   assert.equal(captured.outputs.benchmark_filter, "cold-compile");
-  assert.equal(captured.outputs.scenario_filter, "");
+  // No scenarios= given → default `*` (all projects).
+  assert.equal(captured.outputs.scenario_filter, "*");
 });
 
 test("issue_comment → same-repo PR with failing CI does not run", async () => {

--- a/.github/workflows/hh3-regression-benchmark.yml
+++ b/.github/workflows/hh3-regression-benchmark.yml
@@ -19,8 +19,20 @@ on:
         required: false
         type: string
         default: "main"
-  # ChatOps: comment `/bench` (optionally `/bench hardhat-ref=<branch|sha|PR>`)
-  # on a same-repo PR. Authorization + gating happens in the `setup` job.
+      scenario-filter:
+        description: "Glob(s) selecting which projects/scenarios to run, by directory name (e.g. `1inch*`). Comma-separated. Empty = all. Forwarded to `bench:regression --scenarios`."
+        required: false
+        type: string
+        default: ""
+      benchmark-filter:
+        description: "Glob(s) selecting which benchmarks to run within each project, by name — a command or step name, i.e. the part after `<project> /` in a report (e.g. `test solidity`, `cold compile`, `*compile*`). Comma-separated. Empty = all. Forwarded to `bench:regression --benchmarks`."
+        required: false
+        type: string
+        default: ""
+  # ChatOps: comment `/bench` on a same-repo PR, optionally with
+  # `hardhat-ref=<branch|sha|PR>`, `scenarios="<glob>[,<glob>...]"` and/or
+  # `benchmarks="<glob>[,<glob>...]"` to select which projects/benchmarks run
+  # (quote values containing spaces). Authorization + gating happens in `setup`.
   issue_comment:
     types: [created]
 
@@ -63,6 +75,8 @@ jobs:
       edr_ref: ${{ steps.resolve.outputs.edr_ref }}
       hardhat_ref: ${{ steps.resolve.outputs.hardhat_ref }}
       is_baseline: ${{ steps.resolve.outputs.is_baseline }}
+      scenario_filter: ${{ steps.resolve.outputs.scenario_filter }}
+      benchmark_filter: ${{ steps.resolve.outputs.benchmark_filter }}
     steps:
       # Sparse-checkout only the workflow scripts so the github-script step can
       # require the resolver module below.
@@ -125,9 +139,11 @@ jobs:
       - uses: ./.github/actions/setup-rust
 
       - name: Install system dependencies
+        # `time` is GNU /usr/bin/time — bench:regression wraps each benchmark in
+        # it to capture peak RSS (memory) alongside timing.
         run: |
           sudo apt-get update
-          sudo apt-get install -y hyperfine jq
+          sudo apt-get install -y hyperfine jq time
 
       - name: Configure E2E clone directory
         # Use the runner's temp dir for the scenario clones.
@@ -212,17 +228,34 @@ jobs:
           # See "Start Verdaccio": bypass pnpm's frozen-lockfile deps check for
           # the repoint-desynced workspace.
           PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN: "false"
+          # Scenario/benchmark glob filters (empty on baseline runs, so they
+          # always cover the full benchmark). Forwarded verbatim to
+          # bench:regression, which matches them against scenario directory /
+          # benchmark (command or step) names natively.
+          SCENARIO_FILTER: ${{ needs.setup.outputs.scenario_filter }}
+          BENCHMARK_FILTER: ${{ needs.setup.outputs.benchmark_filter }}
         # --force-publish: reuse our already-running Verdaccio (instead of
         #   erroring) and run the global sinceReleasePublish once up front.
         # --use-local: republish the (repointed) hardhat workspace packages and
         #   pin each scenario's hardhat/@nomicfoundation deps to Verdaccio.
+        # --scenarios / --benchmarks: only added when a filter was provided;
+        #   otherwise the whole benchmark runs.
         run: |
+          set -euo pipefail
+          extra_args=()
+          if [ -n "${SCENARIO_FILTER:-}" ]; then
+            extra_args+=(--scenarios "$SCENARIO_FILTER")
+          fi
+          if [ -n "${BENCHMARK_FILTER:-}" ]; then
+            extra_args+=(--benchmarks "$BENCHMARK_FILTER")
+          fi
           pnpm bench:regression \
             --use-local \
             --force-publish \
             --force-checkout \
             --e2e-clone-dir "$E2E_CLONE_DIR" \
-            --output regression-report.json
+            --output regression-report.json \
+            "${extra_args[@]}"
 
       - name: Validate scenarios used the local EDR build
         working-directory: hardhat

--- a/.github/workflows/hh3-regression-benchmark.yml
+++ b/.github/workflows/hh3-regression-benchmark.yml
@@ -20,15 +20,15 @@ on:
         type: string
         default: "main"
       scenario-filter:
-        description: "Glob(s) selecting which projects/scenarios to run, by directory name (e.g. `1inch*`). Comma-separated. Empty = all. Forwarded to `bench:regression --scenarios`."
+        description: "Glob(s) selecting which projects/scenarios to run, by directory name (e.g. `1inch*`). Comma-separated. Defaults to `*` (all projects). Forwarded to `bench:regression --scenarios`."
         required: false
         type: string
-        default: ""
+        default: "*"
       benchmark-filter:
-        description: "Glob(s) selecting which benchmarks to run within each project, by name — a command or step name, i.e. the part after `<project> /` in a report (e.g. `test solidity`, `cold compile`, `*compile*`). Comma-separated. Empty = all. Forwarded to `bench:regression --benchmarks`."
+        description: "Glob(s) selecting which benchmarks to run within each project, by name — a command or step name, i.e. the part after `<project> /` in a report (e.g. `test solidity`, `cold compile`, `*compile*`). Comma-separated. Defaults to `test solidity,mocha test` (EDR affects test execution, not compilation); pass `*` to run the full suite. Forwarded to `bench:regression --benchmarks`."
         required: false
         type: string
-        default: ""
+        default: "test solidity,mocha test"
   # ChatOps: comment `/bench` on a same-repo PR, optionally with
   # `hardhat-ref=<branch|sha|PR>`, `scenarios="<glob>[,<glob>...]"` and/or
   # `benchmarks="<glob>[,<glob>...]"` to select which projects/benchmarks run
@@ -228,34 +228,26 @@ jobs:
           # See "Start Verdaccio": bypass pnpm's frozen-lockfile deps check for
           # the repoint-desynced workspace.
           PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN: "false"
-          # Scenario/benchmark glob filters (empty on baseline runs, so they
-          # always cover the full benchmark). Forwarded verbatim to
-          # bench:regression, which matches them against scenario directory /
-          # benchmark (command or step) names natively.
+          # Scenario/benchmark glob filters, always set by the setup job (`*`
+          # matches all). Forwarded verbatim to bench:regression, which matches
+          # them against scenario directory / benchmark (command or step) names.
           SCENARIO_FILTER: ${{ needs.setup.outputs.scenario_filter }}
           BENCHMARK_FILTER: ${{ needs.setup.outputs.benchmark_filter }}
         # --force-publish: reuse our already-running Verdaccio (instead of
         #   erroring) and run the global sinceReleasePublish once up front.
         # --use-local: republish the (repointed) hardhat workspace packages and
         #   pin each scenario's hardhat/@nomicfoundation deps to Verdaccio.
-        # --scenarios / --benchmarks: only added when a filter was provided;
-        #   otherwise the whole benchmark runs.
+        # --scenarios / --benchmarks: always passed; `*` means "all".
         run: |
           set -euo pipefail
-          extra_args=()
-          if [ -n "${SCENARIO_FILTER:-}" ]; then
-            extra_args+=(--scenarios "$SCENARIO_FILTER")
-          fi
-          if [ -n "${BENCHMARK_FILTER:-}" ]; then
-            extra_args+=(--benchmarks "$BENCHMARK_FILTER")
-          fi
           pnpm bench:regression \
             --use-local \
             --force-publish \
             --force-checkout \
             --e2e-clone-dir "$E2E_CLONE_DIR" \
             --output regression-report.json \
-            "${extra_args[@]}"
+            --scenarios "$SCENARIO_FILTER" \
+            --benchmarks "$BENCHMARK_FILTER"
 
       - name: Validate scenarios used the local EDR build
         working-directory: hardhat


### PR DESCRIPTION
This PR integrates into EDR the ability to filter which commands/steps (benchmarks) and which scenarios run as part of the regression benchmark via glob patterns.

Example:

`/bench hardhat-ref=ci/regression-benchmark-filters scenarios=1inch* benchmarks="test solidity"`

Runs the `test solidity` command on all the `1inch` scenarios (1inch-aqua, 1inch-cross-chain-swap, 1inch-swap-vm).