### PR TITLE
Bump Rust toolchain to 1.97.1

### DIFF
--- a/crates/decoder/revert/src/lib.rs
+++ b/crates/decoder/revert/src/lib.rs
@@ -208,8 +208,8 @@ fn trimmed_hex(s: &[u8]) -> String {
             .expect("slice end index should be valid");
         format!(
             "{}…{} ({} bytes)",
-            &hex::encode(start),
-            &hex::encode(end),
+            hex::encode(start),
+            hex::encode(end),
             s.len(),
         )
     }

--- a/crates/edr_chain_l1/src/rpc/transaction.rs
+++ b/crates/edr_chain_l1/src/rpc/transaction.rs
@@ -123,14 +123,10 @@ impl L1RpcTransaction {
             *transaction.gas_price()
         };
 
-        let chain_id = transaction.chain_id().and_then(|chain_id| {
+        let chain_id = transaction.chain_id().filter(|_| {
             // Following Hardhat in not returning `chain_id` for `PostEip155Legacy` legacy
             // transactions even though the chain id would be recoverable.
-            if transaction.is_legacy() {
-                None
-            } else {
-                Some(chain_id)
-            }
+            !transaction.is_legacy()
         });
 
         let show_transaction_type = hardfork >= EvmSpecId::BERLIN;

--- a/crates/foundry/cheatcodes/src/test/assert.rs
+++ b/crates/foundry/cheatcodes/src/test/assert.rs
@@ -154,7 +154,7 @@ impl EqRelAssertionError<U256> {
                 format_units_uint(&f.left, decimals),
                 format_units_uint(&f.right, decimals),
                 format_delta_percent(&f.max_delta),
-                &f.real_delta,
+                f.real_delta,
             ),
             Self::Overflow => self.to_string(),
         }
@@ -169,7 +169,7 @@ impl EqRelAssertionError<I256> {
                 format_units_int(&f.left, decimals),
                 format_units_int(&f.right, decimals),
                 format_delta_percent(&f.max_delta),
-                &f.real_delta,
+                f.real_delta,
             ),
             Self::Overflow => self.to_string(),
         }

--- a/crates/foundry/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/foundry/evm/evm/src/executors/invariant/mod.rs
@@ -633,7 +633,7 @@ impl<
         // Throw an error to abort test run if the invariant function accepts input
         // params
         if !invariant_contract.invariant_function.inputs.is_empty() {
-            return Err(eyre!("Invariant test function should have no inputs"))?;
+            Err(eyre!("Invariant test function should have no inputs"))?;
         }
 
         let (invariant_test, mut corpus_manager) =
@@ -673,7 +673,7 @@ impl<
 
             // We stop the run immediately if we have reverted, and `fail_on_revert` is set.
             if self.config.fail_on_revert && invariant_test.reverts() > 0 {
-                return Err(eyre!("call reverted"))?;
+                Err(eyre!("call reverted"))?;
             }
 
             while current_run.depth < self.config.depth {

--- a/crates/foundry/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/foundry/evm/evm/src/executors/invariant/mod.rs
@@ -633,7 +633,7 @@ impl<
         // Throw an error to abort test run if the invariant function accepts input
         // params
         if !invariant_contract.invariant_function.inputs.is_empty() {
-            Err(eyre!("Invariant test function should have no inputs"))?;
+            return Err(eyre!("Invariant test function should have no inputs").into());
         }
 
         let (invariant_test, mut corpus_manager) =
@@ -673,7 +673,7 @@ impl<
 
             // We stop the run immediately if we have reverted, and `fail_on_revert` is set.
             if self.config.fail_on_revert && invariant_test.reverts() > 0 {
-                Err(eyre!("call reverted"))?;
+                return Err(eyre!("call reverted").into());
             }
 
             while current_run.depth < self.config.depth {

--- a/crates/foundry/evm/fuzz/src/lib.rs
+++ b/crates/foundry/evm/fuzz/src/lib.rs
@@ -178,7 +178,7 @@ impl fmt::Display for BaseCounterExample {
         if let Some(sig) = &self.signature {
             write!(f, "calldata={sig}")?;
         } else {
-            write!(f, "calldata={}", &self.calldata)?;
+            write!(f, "calldata={}", self.calldata)?;
         }
 
         if let Some(args) = &self.args {

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.96.1"
+channel = "1.97.1"


### PR DESCRIPTION
Bumps the pinned Rust toolchain from 1.96.1 to 1.97.1 to pick up the LLVM fix for the enum-niche miscompilation ([rust-lang/rust#159035](https://github.com/rust-lang/rust/issues/159035)) that crashed macOS x86-64 builds in solx.

With the bump to 1.97 I had to apply a few more formatting fixes.

# Claude summary

The only pin in the repo is the `rust-toolchain` file; CI's `setup-rust` action reads it by default, so all jobs pick up the new version automatically. The explicit `stable`/`nightly` references in other workflows are intentional and unaffected. No `rust-version` MSRV field exists to update.

See NomicFoundation/solx#547 for the full reasoning.