### PR TITLE
feat: experimental EIP-7843 support (Amsterdam)

### DIFF
--- a/.changeset/solid-cases-return.md
+++ b/.changeset/solid-cases-return.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Added experimental EIP-7843 support: blocks on Amsterdam+ now include the `slotNumber` header field, and the `SLOTNUM` (`0x4b`) opcode returns it. EDR has no consensus layer, so the value is simulated: increments by one per mined block, starting at 0 on local blockchains.

--- a/crates/block/header/src/lib.rs
+++ b/crates/block/header/src/lib.rs
@@ -1078,6 +1078,14 @@ mod tests {
         hardfork: EvmSpecId,
         overrides: HeaderOverrides<EvmSpecId>,
     ) -> PartialHeader {
+        partial_header_with_parent(hardfork, overrides, None)
+    }
+
+    fn partial_header_with_parent(
+        hardfork: EvmSpecId,
+        overrides: HeaderOverrides<EvmSpecId>,
+        parent: Option<&BlockHeader>,
+    ) -> PartialHeader {
         let block_config = BlockConfig {
             base_fee_params: BaseFeeParams::Constant(edr_eip1559::ConstantBaseFeeParams {
                 max_change_denominator: 8,
@@ -1088,7 +1096,7 @@ mod tests {
             scheduled_blob_params: None,
         };
 
-        PartialHeader::new(&block_config, overrides, None, &Vec::new(), None)
+        PartialHeader::new(&block_config, overrides, parent, &Vec::new(), None)
     }
 
     // `PartialHeader::new` owns the EIP-7928 hardfork gate: whether a header
@@ -1127,5 +1135,46 @@ mod tests {
         );
 
         assert_eq!(header.block_access_list_hash, Some(supplied));
+    }
+
+    // `PartialHeader::new` owns the EIP-7843 hardfork gate and simulates one slot
+    // per mined block, since EDR has no consensus layer.
+    #[test]
+    fn slot_number_absent_before_amsterdam() {
+        let header = partial_header_with_hardfork(EvmSpecId::PRAGUE, HeaderOverrides::default());
+
+        assert_eq!(header.slot_number, None);
+    }
+
+    #[test]
+    fn slot_number_increments_from_the_parent() {
+        let parent = BlockHeader {
+            slot_number: Some(41),
+            ..BlockHeader::default()
+        };
+
+        let header = partial_header_with_parent(
+            EvmSpecId::AMSTERDAM,
+            HeaderOverrides::default(),
+            Some(&parent),
+        );
+
+        assert_eq!(header.slot_number, Some(42));
+    }
+
+    #[test]
+    fn slot_number_anchors_at_zero_when_parent_has_no_slot_number() {
+        // A pre-Amsterdam parent carries no slot number, so its Amsterdam child
+        // anchors at 0 rather than incrementing.
+        let parent = BlockHeader::default();
+        assert_eq!(parent.slot_number, None);
+
+        let header = partial_header_with_parent(
+            EvmSpecId::AMSTERDAM,
+            HeaderOverrides::default(),
+            Some(&parent),
+        );
+
+        assert_eq!(header.slot_number, Some(0));
     }
 }

--- a/crates/block/header/src/lib.rs
+++ b/crates/block/header/src/lib.rs
@@ -524,15 +524,16 @@ impl PartialHeader {
                 None
             },
             // The slot number exists only from Amsterdam onwards (EIP-7843); earlier hardforks
-            // must not carry it. EDR has no consensus layer, so within Amsterdam we simulate one
-            // slot per mined block by incrementing the parent's slot number (anchoring at 0 for
-            // genesis or a pre-Amsterdam parent that carries no slot number).
+            // must not carry it, so an override is ignored there. EDR has no consensus layer, so
+            // within Amsterdam we honor an override, otherwise simulate one slot per mined block
+            // by incrementing the parent's slot number (anchoring at 0 for genesis or a
+            // pre-Amsterdam parent that carries no slot number).
             slot_number: if evm_spec_id >= EvmSpecId::AMSTERDAM {
-                Some(
+                Some(overrides.slot_number.unwrap_or_else(|| {
                     parent
                         .and_then(|parent| parent.slot_number)
-                        .map_or(0, |slot_number| slot_number + 1),
-                )
+                        .map_or(0, |slot_number| slot_number + 1)
+                }))
             } else {
                 None
             },
@@ -1140,10 +1141,38 @@ mod tests {
     // `PartialHeader::new` owns the EIP-7843 hardfork gate and simulates one slot
     // per mined block, since EDR has no consensus layer.
     #[test]
-    fn slot_number_absent_before_amsterdam() {
-        let header = partial_header_with_hardfork(EvmSpecId::PRAGUE, HeaderOverrides::default());
+    fn slot_number_absent_before_amsterdam_even_with_override() {
+        // An override on an earlier hardfork is ignored, so no spec-invalid header can
+        // be built.
+        let header = partial_header_with_hardfork(
+            EvmSpecId::PRAGUE,
+            HeaderOverrides {
+                slot_number: Some(1),
+                ..HeaderOverrides::default()
+            },
+        );
 
         assert_eq!(header.slot_number, None);
+    }
+
+    #[test]
+    fn slot_number_honors_override_on_amsterdam() {
+        // The override must win over the parent-increment path (which would be 42).
+        let parent = BlockHeader {
+            slot_number: Some(41),
+            ..BlockHeader::default()
+        };
+
+        let header = partial_header_with_parent(
+            EvmSpecId::AMSTERDAM,
+            HeaderOverrides {
+                slot_number: Some(7843),
+                ..HeaderOverrides::default()
+            },
+            Some(&parent),
+        );
+
+        assert_eq!(header.slot_number, Some(7843));
     }
 
     #[test]

--- a/crates/block/header/src/lib.rs
+++ b/crates/block/header/src/lib.rs
@@ -216,6 +216,10 @@ impl<HardforkT: Into<EvmSpecId>> BlockEnvForHardfork<HardforkT> for BlockHeader 
             )
         })
     }
+
+    fn slot_number_for_hardfork(&self, _hardfork: HardforkT) -> u64 {
+        self.slot_number.unwrap_or(0)
+    }
 }
 
 /// Wrapper type combining a header with its associated hardfork.
@@ -278,6 +282,10 @@ impl<HardforkT: Copy + Into<EvmSpecId>, BlockHeaderT: BlockEnvForHardfork<Hardfo
     fn blob_excess_gas_and_price(&self) -> Option<BlobExcessGasAndPrice> {
         self.header
             .blob_excess_gas_and_price_for_hardfork(self.hardfork, self.scheduled_blob_params)
+    }
+
+    fn slot_num(&self) -> u64 {
+        self.header.slot_number_for_hardfork(self.hardfork)
     }
 }
 
@@ -608,6 +616,10 @@ impl<HardforkT: Into<EvmSpecId>> BlockEnvForHardfork<HardforkT> for PartialHeade
                 scheduled_blob_params,
             )
         })
+    }
+
+    fn slot_number_for_hardfork(&self, _hardfork: HardforkT) -> u64 {
+        self.slot_number.unwrap_or(0)
     }
 }
 

--- a/crates/block/header/src/lib.rs
+++ b/crates/block/header/src/lib.rs
@@ -523,11 +523,8 @@ impl PartialHeader {
             } else {
                 None
             },
-            // The slot number exists only from Amsterdam onwards (EIP-7843); earlier hardforks
-            // must not carry it, so an override is ignored there. EDR has no consensus layer, so
-            // within Amsterdam we honor an override, otherwise simulate one slot per mined block
-            // by incrementing the parent's slot number (anchoring at 0 for genesis or a
-            // pre-Amsterdam parent that carries no slot number).
+            // EIP-7843 (Amsterdam+): honor an override, else the parent's slot number + 1
+            // (anchoring at 0 for genesis or a pre-Amsterdam parent).
             slot_number: if evm_spec_id >= EvmSpecId::AMSTERDAM {
                 Some(overrides.slot_number.unwrap_or_else(|| {
                     parent
@@ -1138,8 +1135,6 @@ mod tests {
         assert_eq!(header.block_access_list_hash, Some(supplied));
     }
 
-    // `PartialHeader::new` owns the EIP-7843 hardfork gate and simulates one slot
-    // per mined block, since EDR has no consensus layer.
     #[test]
     fn slot_number_absent_before_amsterdam_even_with_override() {
         // An override on an earlier hardfork is ignored, so no spec-invalid header can

--- a/crates/block/header/src/lib.rs
+++ b/crates/block/header/src/lib.rs
@@ -84,6 +84,12 @@ pub struct BlockHeader {
     ///
     /// [EIP-7928](https://eips.ethereum.org/EIPS/eip-7928)
     pub block_access_list_hash: Option<B256>,
+    /// The slot number corresponding to this block. Was added by [EIP-7843] and
+    /// is ignored in legacy headers.
+    ///
+    /// [EIP-7843](https://eips.ethereum.org/EIPS/eip-7843)
+    #[serde(default, with = "alloy_serde::quantity::opt")]
+    pub slot_number: Option<u64>,
 }
 
 impl BlockHeader {
@@ -112,6 +118,7 @@ impl BlockHeader {
             parent_beacon_block_root: partial_header.parent_beacon_block_root,
             requests_hash: partial_header.requests_hash,
             block_access_list_hash: partial_header.block_access_list_hash,
+            slot_number: partial_header.slot_number,
         }
     }
 
@@ -323,6 +330,10 @@ pub struct PartialHeader {
     ///
     /// [EIP-7928](https://eips.ethereum.org/EIPS/eip-7928)
     pub block_access_list_hash: Option<B256>,
+    /// The slot number corresponding to this block ([EIP-7843])
+    ///
+    /// [EIP-7843](https://eips.ethereum.org/EIPS/eip-7843)
+    pub slot_number: Option<u64>,
 }
 
 impl PartialHeader {
@@ -504,6 +515,19 @@ impl PartialHeader {
             } else {
                 None
             },
+            // The slot number exists only from Amsterdam onwards (EIP-7843); earlier hardforks
+            // must not carry it. EDR has no consensus layer, so within Amsterdam we simulate one
+            // slot per mined block by incrementing the parent's slot number (anchoring at 0 for
+            // genesis or a pre-Amsterdam parent that carries no slot number).
+            slot_number: if evm_spec_id >= EvmSpecId::AMSTERDAM {
+                Some(
+                    parent
+                        .and_then(|parent| parent.slot_number)
+                        .map_or(0, |slot_number| slot_number + 1),
+                )
+            } else {
+                None
+            },
         }
     }
 }
@@ -531,6 +555,7 @@ impl From<BlockHeader> for PartialHeader {
             parent_beacon_block_root: header.parent_beacon_block_root,
             requests_hash: header.requests_hash,
             block_access_list_hash: header.block_access_list_hash,
+            slot_number: header.slot_number,
         }
     }
 }
@@ -740,6 +765,7 @@ mod tests {
             parent_beacon_block_root: None,
             requests_hash: Some(B256::random()),
             block_access_list_hash: Some(B256::random()),
+            slot_number: Some(1337),
         };
 
         let encoded = alloy_rlp::encode(&header);
@@ -780,6 +806,7 @@ mod tests {
             parent_beacon_block_root: None,
             requests_hash: None,
             block_access_list_hash: None,
+            slot_number: None,
         };
         let encoded = alloy_rlp::encode(&header);
         assert_eq!(encoded, expected);
@@ -828,6 +855,7 @@ mod tests {
             parent_beacon_block_root: None,
             requests_hash: None,
             block_access_list_hash: None,
+            slot_number: None,
         };
         assert_eq!(header.hash(), expected_hash);
     }
@@ -859,6 +887,7 @@ mod tests {
             parent_beacon_block_root: None,
             requests_hash: None,
             block_access_list_hash: None,
+            slot_number: None,
         };
         let decoded = BlockHeader::decode(&mut data.as_slice()).unwrap();
         assert_eq!(decoded, expected);
@@ -909,6 +938,7 @@ mod tests {
             withdrawals_root: Some(KECCAK_NULL_RLP),
             requests_hash: None,
             block_access_list_hash: None,
+            slot_number: None,
         };
 
         let encoded = alloy_rlp::encode(&header);
@@ -969,6 +999,7 @@ mod tests {
             ommers_hash: KECCAK_RLP_EMPTY_ARRAY,
             withdrawals_root: Some(KECCAK_NULL_RLP),
             block_access_list_hash: None,
+            slot_number: None,
         };
 
         let encoded = alloy_rlp::encode(&header);

--- a/crates/block/header/src/overrides.rs
+++ b/crates/block/header/src/overrides.rs
@@ -56,4 +56,10 @@ pub struct HeaderOverrides<HardforkT> {
     ///
     /// [EIP-7928]: https://eips.ethereum.org/EIPS/eip-7928
     pub block_access_list_hash: Option<B256>,
+    /// The slot number corresponding to this block ([EIP-7843]).
+    ///
+    /// Lets callers supply the exact value instead of the simulated one.
+    ///
+    /// [EIP-7843]: https://eips.ethereum.org/EIPS/eip-7843
+    pub slot_number: Option<u64>,
 }

--- a/crates/block/storage/src/reservable.rs
+++ b/crates/block/storage/src/reservable.rs
@@ -358,6 +358,9 @@ impl<
                     block_number,
                 );
 
+                let slot_number =
+                    calculate_slot_number_for_reserved_block(&storage, &reservation, block_number);
+
                 let block = BlockT::empty(
                     reservation.block_config.hardfork.clone(),
                     PartialHeader::new(
@@ -367,6 +370,7 @@ impl<
                             state_root: Some(reservation.previous_state_root),
                             base_fee: reservation.previous_base_fee_per_gas,
                             timestamp: Some(timestamp),
+                            slot_number,
                             ..HeaderOverrides::default()
                         },
                         None,
@@ -416,6 +420,42 @@ fn calculate_timestamp_for_reserved_block<
         };
 
     previous_timestamp + reservation.interval * (block_number - reservation.first_number + 1)
+}
+
+/// Calculates the slot number for a reserved block ([EIP-7843]).
+///
+/// EDR simulates one slot per block, so the slot number continues from the
+/// block preceding the reservation instead of resetting. That block
+/// (`first_number - 1`) is always stored and, on an Amsterdam reservation,
+/// always carries a slot number, so no reservation walk is needed.
+///
+/// [EIP-7843]: https://eips.ethereum.org/EIPS/eip-7843
+#[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
+fn calculate_slot_number_for_reserved_block<
+    BlockReceiptT: ReceiptTrait,
+    BlockT: Block<SignedTransactionT>,
+    HardforkT: Clone + Into<EvmSpecId>,
+    SignedTransactionT,
+>(
+    storage: &SparseBlockStorage<BlockReceiptT, BlockT, SignedTransactionT>,
+    reservation: &Reservation<HardforkT>,
+    block_number: u64,
+) -> Option<u64> {
+    // The slot number exists only from Amsterdam onwards.
+    if reservation.block_config.hardfork.clone().into() < EvmSpecId::AMSTERDAM {
+        return None;
+    }
+
+    let previous_block_number = reservation.first_number - 1;
+    let previous_slot_number = storage
+        .block_by_number(previous_block_number)
+        .expect("Block must exist")
+        .block_header()
+        .slot_number
+        .expect("Amsterdam block must have a slot number");
+
+    // One slot per block, continuing from the block before the reservation.
+    Some(previous_slot_number + (block_number - previous_block_number))
 }
 
 fn find_reservation<HardforkT>(

--- a/crates/block/storage/src/reservable.rs
+++ b/crates/block/storage/src/reservable.rs
@@ -358,8 +358,12 @@ impl<
                     block_number,
                 );
 
-                let slot_number =
-                    calculate_slot_number_for_reserved_block(&storage, &reservation, block_number);
+                let slot_number = calculate_slot_number_for_reserved_block(
+                    &storage,
+                    &reservations,
+                    &reservation,
+                    block_number,
+                );
 
                 let block = BlockT::empty(
                     reservation.block_config.hardfork.clone(),
@@ -425,9 +429,8 @@ fn calculate_timestamp_for_reserved_block<
 /// Calculates the slot number for a reserved block ([EIP-7843]).
 ///
 /// EDR simulates one slot per block, so the slot number continues from the
-/// block preceding the reservation instead of resetting. That block
-/// (`first_number - 1`) is always stored and, on an Amsterdam reservation,
-/// always carries a slot number, so no reservation walk is needed.
+/// block preceding the reservation instead of resetting, anchoring at 0 when
+/// that block carries no slot number (a pre-Amsterdam parent).
 ///
 /// [EIP-7843]: https://eips.ethereum.org/EIPS/eip-7843
 #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
@@ -438,6 +441,7 @@ fn calculate_slot_number_for_reserved_block<
     SignedTransactionT,
 >(
     storage: &SparseBlockStorage<BlockReceiptT, BlockT, SignedTransactionT>,
+    reservations: &Vec<Reservation<HardforkT>>,
     reservation: &Reservation<HardforkT>,
     block_number: u64,
 ) -> Option<u64> {
@@ -447,15 +451,29 @@ fn calculate_slot_number_for_reserved_block<
     }
 
     let previous_block_number = reservation.first_number - 1;
-    let previous_slot_number = storage
-        .block_by_number(previous_block_number)
-        .expect("Block must exist")
-        .block_header()
-        .slot_number
-        .expect("Amsterdam block must have a slot number");
+    let previous_slot_number =
+        if let Some(previous_reservation) = find_reservation(reservations, previous_block_number) {
+            calculate_slot_number_for_reserved_block(
+                storage,
+                reservations,
+                previous_reservation,
+                previous_block_number,
+            )
+        } else {
+            storage
+                .block_by_number(previous_block_number)
+                .expect("Block must exist")
+                .block_header()
+                .slot_number
+        };
 
-    // One slot per block, continuing from the block before the reservation.
-    Some(previous_slot_number + (block_number - previous_block_number))
+    // One slot per block, anchoring at 0 when the preceding block has no slot
+    // number.
+    Some(
+        previous_slot_number.map_or(block_number - reservation.first_number, |slot_number| {
+            slot_number + (block_number - previous_block_number)
+        }),
+    )
 }
 
 fn find_reservation<HardforkT>(

--- a/crates/block/storage/src/reservable.rs
+++ b/crates/block/storage/src/reservable.rs
@@ -402,7 +402,7 @@ fn calculate_timestamp_for_reserved_block<
     SignedTransactionT,
 >(
     storage: &SparseBlockStorage<BlockReceiptT, BlockT, SignedTransactionT>,
-    reservations: &Vec<Reservation<HardforkT>>,
+    reservations: &[Reservation<HardforkT>],
     reservation: &Reservation<HardforkT>,
     block_number: u64,
 ) -> u64 {
@@ -441,7 +441,7 @@ fn calculate_slot_number_for_reserved_block<
     SignedTransactionT,
 >(
     storage: &SparseBlockStorage<BlockReceiptT, BlockT, SignedTransactionT>,
-    reservations: &Vec<Reservation<HardforkT>>,
+    reservations: &[Reservation<HardforkT>],
     reservation: &Reservation<HardforkT>,
     block_number: u64,
 ) -> Option<u64> {

--- a/crates/edr_chain_l1/src/rpc/block.rs
+++ b/crates/edr_chain_l1/src/rpc/block.rs
@@ -107,6 +107,15 @@ pub struct L1RpcBlock<TransactionT> {
     /// [EIP-7928](https://eips.ethereum.org/EIPS/eip-7928)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub block_access_list_hash: Option<B256>,
+    /// The slot number corresponding to this block
+    ///
+    /// [EIP-7843](https://eips.ethereum.org/EIPS/eip-7843)
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "alloy_serde::quantity::opt"
+    )]
+    pub slot_number: Option<u64>,
 }
 
 impl<TransactionT> GetBlockNumber for L1RpcBlock<TransactionT> {
@@ -172,6 +181,7 @@ where
             parent_beacon_block_root: header.parent_beacon_block_root,
             requests_hash: header.requests_hash,
             block_access_list_hash: header.block_access_list_hash,
+            slot_number: header.slot_number,
         }
     }
 }
@@ -227,6 +237,7 @@ impl<RpcTransactionT> TryFrom<&L1RpcBlock<RpcTransactionT>> for BlockHeader {
             parent_beacon_block_root: value.parent_beacon_block_root,
             requests_hash: value.requests_hash,
             block_access_list_hash: value.block_access_list_hash,
+            slot_number: value.slot_number,
         };
 
         Ok(header)
@@ -268,6 +279,7 @@ impl<RpcTransactionT, SignedTransactionT: TryFrom<RpcTransactionT>>
             parent_beacon_block_root: value.parent_beacon_block_root,
             requests_hash: value.requests_hash,
             block_access_list_hash: value.block_access_list_hash,
+            slot_number: value.slot_number,
         };
 
         let transactions = value

--- a/crates/edr_chain_spec/src/lib.rs
+++ b/crates/edr_chain_spec/src/lib.rs
@@ -91,6 +91,12 @@ pub trait BlockEnvForHardfork<HardforkT> {
         hardfork: HardforkT,
         scheduled_blob_params: Option<&ScheduledBlobParams>,
     ) -> Option<BlobExcessGasAndPrice>;
+
+    /// The slot number of the block, added in the Amsterdam upgrade with
+    /// [EIP-7843]. Zero on hardforks that predate it.
+    ///
+    /// [EIP-7843]: https://eips.ethereum.org/EIPS/eip-7843
+    fn slot_number_for_hardfork(&self, hardfork: HardforkT) -> u64;
 }
 
 /// Trait for specifying the contextual information type of a chain.

--- a/crates/edr_generic/src/rpc/block.rs
+++ b/crates/edr_generic/src/rpc/block.rs
@@ -103,6 +103,15 @@ pub struct GenericRpcBlock<TransactionT> {
     /// [EIP-7928](https://eips.ethereum.org/EIPS/eip-7928)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub block_access_list_hash: Option<B256>,
+    /// The slot number corresponding to this block
+    ///
+    /// [EIP-7843](https://eips.ethereum.org/EIPS/eip-7843)
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "alloy_serde::quantity::opt"
+    )]
+    pub slot_number: Option<u64>,
 }
 
 impl<T> GetBlockNumber for GenericRpcBlock<T> {
@@ -183,6 +192,7 @@ where
             parent_beacon_block_root: value.parent_beacon_block_root,
             requests_hash: value.requests_hash,
             block_access_list_hash: value.block_access_list_hash,
+            slot_number: value.slot_number,
         };
 
         let transactions = value
@@ -249,6 +259,7 @@ impl<BlockT: Block<SignedTransactionT>, SignedTransactionT: ExecutableTransactio
             parent_beacon_block_root: header.parent_beacon_block_root,
             requests_hash: header.requests_hash,
             block_access_list_hash: header.block_access_list_hash,
+            slot_number: header.slot_number,
         }
     }
 }

--- a/crates/edr_generic/src/spec.rs
+++ b/crates/edr_generic/src/spec.rs
@@ -375,6 +375,7 @@ mod tests {
             parent_beacon_block_root: None,
             requests_hash: Some(B256::random()),
             block_access_list_hash: None,
+            slot_number: None,
         }
     }
 

--- a/crates/edr_generic/src/spec.rs
+++ b/crates/edr_generic/src/spec.rs
@@ -92,6 +92,10 @@ impl<'header, BlockHeaderT: BlockEnvForHardfork<EvmSpecId>> BlockEnvTrait
         self.inner.prevrandao()
     }
 
+    fn slot_num(&self) -> u64 {
+        self.inner.slot_num()
+    }
+
     fn blob_excess_gas_and_price(&self) -> Option<BlobExcessGasAndPrice> {
         self.inner.blob_excess_gas_and_price().or_else(|| {
             // If the hardfork requires it, set ExcessGasAndPrice default value

--- a/crates/edr_op/src/spec.rs
+++ b/crates/edr_op/src/spec.rs
@@ -439,6 +439,7 @@ mod tests {
             parent_beacon_block_root: None,
             requests_hash: Some(B256::random()),
             block_access_list_hash: None,
+            slot_number: None,
         }
     }
 

--- a/crates/edr_provider/src/data/call.rs
+++ b/crates/edr_provider/src/data/call.rs
@@ -59,6 +59,10 @@ impl<BlockEnvT: BlockEnvTrait> BlockEnvTrait for BlockEnvWithZeroBaseFee<BlockEn
     fn blob_excess_gas_and_price(&self) -> Option<BlobExcessGasAndPrice> {
         self.inner.blob_excess_gas_and_price()
     }
+
+    fn slot_num(&self) -> u64 {
+        self.inner.slot_num()
+    }
 }
 
 /// Execute a transaction as a call. Returns the gas used and the output.

--- a/crates/edr_provider/src/requests/eth/blocks.rs
+++ b/crates/edr_provider/src/requests/eth/blocks.rs
@@ -264,5 +264,6 @@ fn block_to_rpc_output<ChainSpecT: ProviderChainSpec>(
         parent_beacon_block_root: header.parent_beacon_block_root,
         requests_hash: header.requests_hash,
         block_access_list_hash: header.block_access_list_hash,
+        slot_number: header.slot_number,
     })
 }

--- a/crates/edr_provider/src/test_utils.rs
+++ b/crates/edr_provider/src/test_utils.rs
@@ -9,6 +9,7 @@ use edr_chain_l1::{
     L1ChainSpec,
 };
 use edr_chain_spec::TransactionValidation;
+use edr_eth::PreEip1898BlockSpec;
 use edr_primitives::{Address, Bytes, HashMap, B256, KECCAK_NULL_RLP, U160, U256};
 use edr_signer::{public_key_to_address, secret_key_from_str, SignatureWithYParity};
 use edr_solidity::contract_decoder::ContractDecoder;
@@ -286,6 +287,31 @@ where
     let contract_address = receipt.contract_address.expect("Call must create contract");
 
     Ok(contract_address)
+}
+
+/// Mines an empty block.
+pub fn mine_block<TimerT>(provider: &Provider<L1ChainSpec, TimerT>)
+where
+    TimerT: Clone + TimeSinceEpoch,
+{
+    provider
+        .handle_request(ProviderRequest::with_single(MethodInvocation::EvmMine(
+            None,
+        )))
+        .expect("evm_mine should succeed");
+}
+
+/// Returns the raw JSON of the latest block.
+pub fn get_latest_block<TimerT>(provider: &Provider<L1ChainSpec, TimerT>) -> serde_json::Value
+where
+    TimerT: Clone + TimeSinceEpoch,
+{
+    provider
+        .handle_request(ProviderRequest::with_single(
+            MethodInvocation::GetBlockByNumber(PreEip1898BlockSpec::latest(), false),
+        ))
+        .expect("eth_getBlockByNumber should succeed")
+        .result
 }
 
 /// Fixture for testing `ProviderData`.

--- a/crates/edr_provider/src/test_utils.rs
+++ b/crates/edr_provider/src/test_utils.rs
@@ -82,6 +82,9 @@ pub fn amsterdam_header_overrides(
         // EDR does not compute the real block access list (EIP-7928), only a simulated hash, so
         // replay the value from the block being replayed.
         block_access_list_hash: replay_header.block_access_list_hash,
+        // EDR only simulates the slot number (EIP-7843), so replay the value from the block being
+        // replayed.
+        slot_number: replay_header.slot_number,
         ..prague_header_overrides(replay_header)
     }
 }

--- a/crates/edr_provider/tests/integration/eip7843.rs
+++ b/crates/edr_provider/tests/integration/eip7843.rs
@@ -1,0 +1,167 @@
+#![cfg(feature = "test-utils")]
+
+//! EIP-7843: SLOTNUM opcode.
+//! see <https://eips.ethereum.org/EIPS/eip-7843>
+//
+//! From Amsterdam onward, the block header carries a `slotNumber` field and the
+//! `SLOTNUM` (`0x4b`) opcode returns it. On earlier hardforks the field is
+//! omitted from the RPC response. EDR has no consensus layer, so it simulates
+//! one slot per mined block.
+
+use std::{str::FromStr as _, sync::Arc};
+
+use edr_chain_l1::{
+    rpc::{block::L1RpcBlock, call::L1CallRequest},
+    L1ChainSpec,
+};
+use edr_eth::BlockSpec;
+use edr_primitives::{address, bytes, Address, Bytes, B256, U256};
+use edr_provider::{
+    test_utils::{create_test_config, deploy_contract, get_latest_block, mine_block},
+    time::CurrentTime,
+    MethodInvocation, NoopLogger, Provider, ProviderRequest,
+};
+use edr_solidity::contract_decoder::ContractDecoder;
+use parking_lot::RwLock;
+use tokio::runtime;
+
+const SLOT_NUMBER_JSON_KEY: &str = "slotNumber";
+
+const SENDER: Address = address!("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+
+/// Init bytecode for a contract that returns the current block's slot number.
+///
+/// `SLOTNUM` (`0x4b`) has no Solidity/Yul builtin, so this is hand-assembled
+/// instead of compiled. The deployed runtime is `4b60005260206000f3`
+/// (`SLOTNUM; PUSH1 0; MSTORE; PUSH1 0x20; PUSH1 0; RETURN`): it writes the
+/// slot number to memory and returns it as a 32-byte word. The `6009600c…f3`
+/// prefix is the standard constructor that copies that runtime out as the
+/// deployed code.
+// TODO: once Solidity exposes SLOTNUM, replace this hand-assembled bytecode
+// with a compiled Solidity source for readability.
+const SLOT_NUMBER_CONTRACT: Bytes = bytes!("0x6009600c60003960096000f34b60005260206000f3");
+
+fn new_provider(hardfork: edr_chain_l1::Hardfork) -> anyhow::Result<Provider<L1ChainSpec>> {
+    let logger = Box::new(NoopLogger::<L1ChainSpec>::default());
+    let subscriber = Box::new(|_event| {});
+
+    let mut config = create_test_config();
+    config.hardfork = hardfork;
+
+    let provider = Provider::new(
+        runtime::Handle::current(),
+        logger,
+        subscriber,
+        config,
+        Arc::new(RwLock::<ContractDecoder>::default()),
+        CurrentTime,
+    )?;
+
+    Ok(provider)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn block_header_includes_slot_number_on_amsterdam() -> anyhow::Result<()> {
+    let provider = new_provider(edr_chain_l1::Hardfork::AMSTERDAM)?;
+
+    mine_block(&provider);
+    let block_json = get_latest_block(&provider);
+
+    assert!(
+        block_json.get(SLOT_NUMBER_JSON_KEY).is_some(),
+        "Amsterdam block header should include {SLOT_NUMBER_JSON_KEY}, block: {block_json}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn block_header_omits_slot_number_before_amsterdam() -> anyhow::Result<()> {
+    let provider = new_provider(edr_chain_l1::Hardfork::OSAKA)?;
+
+    mine_block(&provider);
+    let block_json = get_latest_block(&provider);
+
+    assert!(
+        block_json.get(SLOT_NUMBER_JSON_KEY).is_none(),
+        "pre-Amsterdam block header should not include {SLOT_NUMBER_JSON_KEY}. block: {block_json}"
+    );
+
+    let block: L1RpcBlock<B256> = serde_json::from_value(block_json)?;
+    assert_eq!(
+        block.slot_number, None,
+        "pre-Amsterdam slot_number should be absent"
+    );
+
+    Ok(())
+}
+
+// EDR has no consensus layer, so in local mode it anchors the slot number at 0
+// for the initial block and simulates one slot per mined block afterwards.
+#[tokio::test(flavor = "multi_thread")]
+async fn slot_number_increments_per_block() -> anyhow::Result<()> {
+    const MINED_BLOCKS: u64 = 5;
+
+    let provider = new_provider(edr_chain_l1::Hardfork::AMSTERDAM)?;
+
+    // Before mining anything, the latest block is the genesis block.
+    let genesis: L1RpcBlock<B256> = serde_json::from_value(get_latest_block(&provider))?;
+    assert_eq!(
+        genesis.slot_number,
+        Some(0),
+        "the initial block should have slot number 0 in local mode"
+    );
+
+    for _ in 0..MINED_BLOCKS {
+        mine_block(&provider);
+    }
+
+    let latest: L1RpcBlock<B256> = serde_json::from_value(get_latest_block(&provider))?;
+    assert_eq!(
+        latest.slot_number,
+        Some(MINED_BLOCKS),
+        "after mining {MINED_BLOCKS} blocks the slot number should be {MINED_BLOCKS}"
+    );
+
+    Ok(())
+}
+
+// The SLOTNUM opcode (0x4b) must return the executing block's slot number.
+#[tokio::test(flavor = "multi_thread")]
+async fn slotnum_opcode_returns_block_slot_number() -> anyhow::Result<()> {
+    let provider = new_provider(edr_chain_l1::Hardfork::AMSTERDAM)?;
+
+    let contract_address = deploy_contract(&provider, SENDER, SLOT_NUMBER_CONTRACT.clone())?;
+
+    // Mine a few more blocks so the call executes in a block well after deployment.
+    mine_block(&provider);
+    mine_block(&provider);
+
+    let block: L1RpcBlock<B256> = serde_json::from_value(get_latest_block(&provider))?;
+    let block_number = block.number.expect("mined block should have a number");
+    let slot_number = block
+        .slot_number
+        .expect("Amsterdam block should include a slot number");
+
+    let response =
+        provider.handle_request(ProviderRequest::with_single(MethodInvocation::Call(
+            L1CallRequest {
+                from: Some(SENDER),
+                to: Some(contract_address),
+                ..L1CallRequest::default()
+            },
+            Some(BlockSpec::Number(block_number)),
+            None,
+        )))?;
+
+    let call_result: String = serde_json::from_value(response.result)?;
+    let slotnum_opcode_returned_value = U256::from_str(&call_result)?;
+
+    assert_eq!(
+        slotnum_opcode_returned_value,
+        U256::from(slot_number),
+        "SLOTNUM should return the executing block's slot number"
+    );
+
+    Ok(())
+}

--- a/crates/edr_provider/tests/integration/eip7843.rs
+++ b/crates/edr_provider/tests/integration/eip7843.rs
@@ -126,6 +126,46 @@ async fn slot_number_increments_per_block() -> anyhow::Result<()> {
     Ok(())
 }
 
+// `hardhat_mine` fast-forwards by reserving a run of gap-fill blocks. A user
+// who then mines another block must see the slot number continue rather than
+// reset: each block in between advances it by exactly one.
+#[tokio::test(flavor = "multi_thread")]
+async fn slot_number_continues_after_reserved_blocks() -> anyhow::Result<()> {
+    const FORWARDED_BLOCKS: u64 = 10;
+    let provider = new_provider(edr_chain_l1::Hardfork::AMSTERDAM)?;
+
+    // Mine a couple of blocks, then record the last block before reserving.
+    mine_block(&provider);
+    mine_block(&provider);
+    let before: L1RpcBlock<B256> = serde_json::from_value(get_latest_block(&provider))?;
+    let before_slot = before
+        .slot_number
+        .expect("Amsterdam block should include a slot number");
+
+    // Reserve a run of gap-fill blocks (see `MINIMUM_RESERVABLE_BLOCKS`).
+    provider.handle_request(ProviderRequest::with_single(MethodInvocation::Mine(
+        Some(FORWARDED_BLOCKS),
+        None,
+    )))?;
+
+    // Explicitly mine a block on top of the reservation.
+    mine_block(&provider);
+
+    let after: L1RpcBlock<B256> = serde_json::from_value(get_latest_block(&provider))?;
+    let after_slot = after
+        .slot_number
+        .expect("Amsterdam block should include a slot number");
+
+    // Every block since (reserved or not) advances the slot number by one.
+    assert_eq!(
+        after_slot,
+        before_slot + FORWARDED_BLOCKS + 1,
+        "slot number must continue across reserved blocks, not reset"
+    );
+
+    Ok(())
+}
+
 // The SLOTNUM opcode (0x4b) must return the executing block's slot number.
 #[tokio::test(flavor = "multi_thread")]
 async fn slotnum_opcode_returns_block_slot_number() -> anyhow::Result<()> {

--- a/crates/edr_provider/tests/integration/eip7843.rs
+++ b/crates/edr_provider/tests/integration/eip7843.rs
@@ -19,7 +19,8 @@ use edr_primitives::{address, bytes, Address, Bytes, B256, U256};
 use edr_provider::{
     test_utils::{create_test_config, deploy_contract, get_latest_block, mine_block},
     time::CurrentTime,
-    MethodInvocation, NoopLogger, Provider, ProviderRequest,
+    MethodInvocation, NoopLogger, Provider, ProviderError, ProviderRequest,
+    TransactionFailureReason,
 };
 use edr_solidity::contract_decoder::ContractDecoder;
 use parking_lot::RwLock;
@@ -201,6 +202,58 @@ async fn slotnum_opcode_returns_block_slot_number() -> anyhow::Result<()> {
         slotnum_opcode_returned_value,
         U256::from(slot_number),
         "SLOTNUM should return the executing block's slot number"
+    );
+
+    Ok(())
+}
+
+// Before Amsterdam the SLOTNUM opcode (0x4b) is undefined, so executing it must
+// fail rather than return a value.
+#[tokio::test(flavor = "multi_thread")]
+async fn slotnum_opcode_unavailable_before_amsterdam() -> anyhow::Result<()> {
+    let logger = Box::new(NoopLogger::<L1ChainSpec>::default());
+    let subscriber = Box::new(|_event| {});
+
+    let mut config = create_test_config();
+    config.hardfork = edr_chain_l1::Hardfork::OSAKA;
+    // Surface the resulting halt as an error instead of empty output.
+    config.bail_on_call_failure = true;
+
+    let provider = Provider::new(
+        runtime::Handle::current(),
+        logger,
+        subscriber,
+        config,
+        Arc::new(RwLock::<ContractDecoder>::default()),
+        CurrentTime,
+    )?;
+
+    // The init bytecode never executes 0x4b (it only copies the runtime out), so
+    // deployment succeeds even pre-Amsterdam.
+    let contract_address = deploy_contract(&provider, SENDER, SLOT_NUMBER_CONTRACT.clone())?;
+
+    let result = provider.handle_request(ProviderRequest::with_single(MethodInvocation::Call(
+        L1CallRequest {
+            from: Some(SENDER),
+            to: Some(contract_address),
+            ..L1CallRequest::default()
+        },
+        None,
+        None,
+    )));
+
+    // The opcode is recognized by revm but gated on the hardfork, so it halts with
+    // `NotActivated` rather than a generic failure.
+    assert!(
+        matches!(
+            &result,
+            Err(ProviderError::TransactionFailed(failure))
+                if matches!(
+                    failure.failure.reason,
+                    TransactionFailureReason::Inner(edr_chain_l1::HaltReason::NotActivated)
+                )
+        ),
+        "SLOTNUM should be inactive before Amsterdam, got {result:?}"
     );
 
     Ok(())

--- a/crates/edr_provider/tests/integration/eip7928.rs
+++ b/crates/edr_provider/tests/integration/eip7928.rs
@@ -9,12 +9,11 @@
 use std::sync::Arc;
 
 use edr_chain_l1::{rpc::block::L1RpcBlock, L1ChainSpec};
-use edr_eth::PreEip1898BlockSpec;
 use edr_primitives::{address, Address, B256, KECCAK_RLP_EMPTY_ARRAY, U256};
 use edr_provider::{
-    test_utils::{create_test_config, transfer_value},
+    test_utils::{create_test_config, get_latest_block, mine_block, transfer_value},
     time::CurrentTime,
-    MethodInvocation, NoopLogger, Provider, ProviderRequest,
+    NoopLogger, Provider,
 };
 use edr_solidity::contract_decoder::ContractDecoder;
 use parking_lot::RwLock;
@@ -42,25 +41,6 @@ fn new_provider(hardfork: edr_chain_l1::Hardfork) -> anyhow::Result<Provider<L1C
     )?;
 
     Ok(provider)
-}
-
-/// Mines an empty block.
-fn mine_block(provider: &Provider<L1ChainSpec>) {
-    provider
-        .handle_request(ProviderRequest::with_single(MethodInvocation::EvmMine(
-            None,
-        )))
-        .expect("evm_mine should succeed");
-}
-
-/// Returns the raw JSON of the latest block.
-fn get_latest_block(provider: &Provider<L1ChainSpec>) -> serde_json::Value {
-    provider
-        .handle_request(ProviderRequest::with_single(
-            MethodInvocation::GetBlockByNumber(PreEip1898BlockSpec::latest(), false),
-        ))
-        .expect("eth_getBlockByNumber should succeed")
-        .result
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/edr_provider/tests/integration/mod.rs
+++ b/crates/edr_provider/tests/integration/mod.rs
@@ -10,6 +10,7 @@ mod eip7702;
 mod eip7708;
 mod eip7778;
 mod eip7825;
+mod eip7843;
 mod eip7928;
 mod estimate_gas;
 mod eth_get_proof;


### PR DESCRIPTION
## Summary

Adds experimental support for [EIP-7843](https://eips.ethereum.org/EIPS/eip-7843) on the Amsterdam hardfork:

- Blocks on Amsterdam+ carry a new `slotNumber` (`uint64`) header field, exposed over JSON-RPC.
- The `SLOTNUM` opcode (`0x4b`) returns the executing block's slot number.

### ⚠️ EIP still in Draft

EIP-7843 is a **Draft** at the time of writing. This implementation targets the spec as of commit
[`c3bfd4b`](https://github.com/ethereum/EIPs/blob/c3bfd4ba41cf0fcbfe8c404f33ba89f5174971e0/EIPS/eip-7843.md).

The spec may still change. **We must follow up and reconcile if the EIP is modified before finalization.**


## How the value is simulated

EDR has no consensus layer, so `slotNumber` is simulated rather than sourced from one. The [product design decision](https://app.notion.com/p/nomicfoundation/Glamsterdam-Support-2f4578cdeaf58097ad26e975b9936f37?source=copy_link#36c578cdeaf580aea1dfd5d463720ad0) is to increment it by one per mined block.

- **Local mining:** starts at `0` for the initial block.
- **Forking:** the forked base block preserves (mirrors) its real on-chain `slotNumber`.
- **Replay / exact control:** overridable via `HeaderOverrides.slot_number` (used by `amsterdam_header_overrides`), because the field is part of the block hash and real slot numbers are not derivable (missed slots decouple them from block numbers).
- **Reserved blocks:** should stay monotonic across `hardhat_mine` fast-forwards: reserved/gap-fill blocks continue the count.


## Changes Overview

- **Header**: added `slot_number: Option<u64>` to the header structs and `HeaderOverrides`.
- **Block env**: overrode revm's default `slot_num` method (from the `Block` trait, re-exported as `BlockEnvTrait` in EDR) to return the header's `slot_number` on Amsterdam+, so the `SLOTNUM` opcode reads the value in both mining and call paths.
- **RPC**: `slotNumber` on the L1 and generic RPC block types.
- **Reserved blocks**: new `calculate_slot_number_for_reserved_block` keeps the slot number monotonic across gap-fill blocks.