### PR TITLE
fix: restore per-compiler `recursion_start_idx` in frame filtering

### DIFF
--- a/.changeset/solx-recursion-frame-filtering.md
+++ b/.changeset/solx-recursion-frame-filtering.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Fixed missing recursion frames in solx stack traces for external self-recursive calls.

--- a/crates/edr_solidity/src/error_inferrer.rs
+++ b/crates/edr_solidity/src/error_inferrer.rs
@@ -22,7 +22,7 @@ use crate::{
     },
     trace_strategy::{
         function_start_source_reference, source_location_to_source_reference, PanicHelperContext,
-        TraceStrategyError,
+        TraceStrategy, TraceStrategyError,
     },
 };
 
@@ -133,7 +133,9 @@ impl<HaltReasonT> From<TraceStrategyError> for InferrerError<HaltReasonT> {
 
 pub(crate) fn filter_redundant_frames<HaltReasonT: HaltReasonTrait>(
     stacktrace: Vec<StackTraceEntry>,
+    trace_strategy: &dyn TraceStrategy,
 ) -> Result<Vec<StackTraceEntry>, InferrerError<HaltReasonT>> {
+    let recursion_start_idx = trace_strategy.recursion_start_idx();
     // To work around the borrow checker, we'll collect the indices of the frames we
     // want to keep. We can't clone the frames, because some of them contain
     // non-Clone `ClassInstance`s`
@@ -182,7 +184,7 @@ pub(crate) fn filter_redundant_frames<HaltReasonT: HaltReasonTrait>(
             }
 
             let is_recursing = || {
-                *idx > 0
+                *idx >= recursion_start_idx
                     && mem::discriminant(*frame) == mem::discriminant(next_frame)
                     && frame_source.range == next_frame_source.range
                     && frame_source.line == next_frame_source.line

--- a/crates/edr_solidity/src/solidity_tracer.rs
+++ b/crates/edr_solidity/src/solidity_tracer.rs
@@ -298,6 +298,9 @@ fn raw_trace_evm_execution<HaltReasonT: HaltReasonTrait>(
         last_submessage_data,
     )?;
 
-    error_inferrer::filter_redundant_frames(stacktrace_with_inferred_error)
-        .map_err(SolidityTracerError::from)
+    error_inferrer::filter_redundant_frames(
+        stacktrace_with_inferred_error,
+        identified_contract.trace_strategy,
+    )
+    .map_err(SolidityTracerError::from)
 }

--- a/crates/edr_solidity/src/trace_strategy.rs
+++ b/crates/edr_solidity/src/trace_strategy.rs
@@ -37,6 +37,12 @@ pub struct PanicHelperContext<'a> {
 
 /// Compiler-specific stack-trace policy used by the error inferrer.
 pub trait TraceStrategy: std::fmt::Debug + Send + Sync + 'static {
+    /// Minimum `idx` at which same-location consecutive frames are treated
+    /// as recursion in `filter_redundant_frames`. The filter runs
+    /// per-message, so frame 0 can be a recursive call site (solx) rather
+    /// than an entry point (solc).
+    fn recursion_start_idx(&self) -> usize;
+
     /// Fallback frame when source-reference resolution returned `None` but
     /// the enclosing function is known.
     fn unresolved_callstack_entry(
@@ -80,6 +86,10 @@ pub struct SolcTraceStrategy;
 pub static SOLC_TRACE_STRATEGY: SolcTraceStrategy = SolcTraceStrategy;
 
 impl TraceStrategy for SolcTraceStrategy {
+    fn recursion_start_idx(&self) -> usize {
+        1
+    }
+
     fn unresolved_callstack_entry(
         &self,
         _contract_name: &str,
@@ -124,6 +134,10 @@ pub static SOLX_TRACE_STRATEGY: SolxTraceStrategy = SolxTraceStrategy;
 pub struct SolxTraceStrategy;
 
 impl TraceStrategy for SolxTraceStrategy {
+    fn recursion_start_idx(&self) -> usize {
+        0
+    }
+
     fn unresolved_callstack_entry(
         &self,
         contract_name: &str,


### PR DESCRIPTION
Follow-up to #1425. 

Issue: There was a regression in the javascript integration test sweep that compares solc and solx stack traces, specifically related to whether the idx recursion start strategy in error_inferrer is needed or not. 

The root cause has to do with the fact that the recursion is checked per message, not per top of the call stack, so a recursion at idx == 0 is possible within a given message. 

## Options verified

Both unified configurations were tested against the solx-parity-sweep, changing only the index condition:

1) Unified `idx > 0` (default state after #1425): `DeepRecursionTest#testDeepRecursion` fails — solc renders the correct 5 frames (three `this.recurse(depth - 1)` call sites at `:111`), solx renders only 3: two recursion frames are dropped.

2) Exemption from `idx 0` for both compilers: `DeepRecursionTest` passes, but `ModifierRevertTest` and `NestedModifierRevertTest` regress on the **solc** side (3 → 4 frames): the duplicate modifier-entry frame that solc's `idx > 0` check was removing is incorrectly kept.

No single index works with both compilers.

## Rationale 

`filter_redundant_frames` runs per message: `get_stack_trace` filters every nested CALL's sub-stack, and the parent embeds the result after pushing the call-site frame. When the parent contributed no frames of its own — common under solx, whose DWARF jump classification does not push dispatcher-entry frames the way solc's source maps do — the merged list starts with the call-site frame at `idx 0`. For external self-recursion that frame and the child's first frame resolve to the same statement, and without the exemption the enclosing-range rule drops one recursion level per nesting depth.

## Change

Restores `TraceStrategy::recursion_start_idx` (solc = 1, solx = 0) that was originally added in the draft of #1425 prior to refactoring, and thread the strategy into `filter_redundant_frames`. 

Solc behaviour is identical to upstream Hardhat.
solx now correctly passes the javascript sweep scenario tests. 
