### PR TITLE
test(hardhat-tests): remove Infura from forked-provider matrix

### DIFF
--- a/.github/workflows/hardhat-tests.yml
+++ b/.github/workflows/hardhat-tests.yml
@@ -64,7 +64,6 @@ jobs:
 
       - name: Run tests
         env:
-          INFURA_URL: ${{ secrets.INFURA_URL }}
           ALCHEMY_URL: ${{ secrets.ALCHEMY_URL }}
           DO_NOT_SET_THIS_ENV_VAR____IS_HARDHAT_CI: true
           FORCE_COLOR: 3

--- a/book/src/01_getting_started/03_test.md
+++ b/book/src/01_getting_started/03_test.md
@@ -32,7 +32,7 @@ cd hardhat-tests &&
 pnpm test
 ```
 
-Similar to EDR, Hardhat can be configured to run remote tests. This can be accomplished by setting environment variables for the API URL (including token) of Alchemy or Infura, respectively: `ALCHEMY_URL` and `INFURA_URL`.
+Similar to EDR, Hardhat can be configured to run remote tests. This can be accomplished by setting the `ALCHEMY_URL` environment variable to an Alchemy API URL (including token).
 
 ### Filtering Tests
 

--- a/hardhat-tests/test/internal/hardhat-network/helpers/providers.ts
+++ b/hardhat-tests/test/internal/hardhat-network/helpers/providers.ts
@@ -8,7 +8,7 @@ import {
   HardhatNetworkMempoolConfig,
   HardhatNetworkMiningConfig,
 } from "hardhat/types";
-import { ALCHEMY_URL, INFURA_URL } from "../../../setup";
+import { ALCHEMY_URL } from "../../../setup";
 
 import { useProvider, UseProviderOptions } from "./useProvider";
 
@@ -170,23 +170,6 @@ if (ALCHEMY_URL !== undefined) {
 
   FORKED_PROVIDERS.push({
     rpcProvider: "Alchemy",
-    jsonRpcUrl: url,
-    useProvider: (options: UseProviderOptions = {}) => {
-      useProvider({
-        useJsonRpc: false,
-        loggerEnabled: true,
-        forkConfig: { jsonRpcUrl: url, blockNumber: options.forkBlockNumber },
-        ...options,
-      });
-    },
-  });
-}
-
-if (INFURA_URL !== undefined) {
-  const url = INFURA_URL;
-
-  FORKED_PROVIDERS.push({
-    rpcProvider: "Infura",
     jsonRpcUrl: url,
     useProvider: (options: UseProviderOptions = {}) => {
       useProvider({

--- a/hardhat-tests/test/internal/hardhat-network/provider/http-headers.ts
+++ b/hardhat-tests/test/internal/hardhat-network/provider/http-headers.ts
@@ -21,11 +21,6 @@ describe("Forking with HTTP headers", function () {
       setCWD();
 
       this.beforeAll(function () {
-        // Skip infura because it doesn't support an API key-based bearer token
-        if (rpcProvider === "Infura") {
-          this.skip();
-        }
-
         // Skip invalid URLs
         if (url === undefined || bearerToken === undefined) {
           this.skip();

--- a/hardhat-tests/test/setup.ts
+++ b/hardhat-tests/test/setup.ts
@@ -15,7 +15,6 @@ function getEnv(key: string): string | undefined {
   return trimmed.length === 0 ? undefined : trimmed;
 }
 
-export const INFURA_URL = getEnv("INFURA_URL");
 export const ALCHEMY_URL = getEnv("ALCHEMY_URL");
 
 function printForkingLogicNotBeingTestedWarning(varName: string) {
@@ -24,10 +23,6 @@ function printForkingLogicNotBeingTestedWarning(varName: string) {
       `TEST RUN INCOMPLETE: You need to define the env variable ${varName}`
     )
   );
-}
-
-if (INFURA_URL === undefined) {
-  printForkingLogicNotBeingTestedWarning("INFURA_URL");
 }
 
 if (ALCHEMY_URL === undefined) {


### PR DESCRIPTION
We were using two providers for retrieving historical blocks. I think we're not really catching real issues for Alchemy/Infura, but instead largely catching their availability/error codes. 

Given how flaky Infura has been for the last weeks, and how Hardhat has long moved on from Infura as well, I think we should just remove it. 

Note: Alchemy also has proper RPC caching set up (this was not done for Infura) so I consider this more future proof as well. 

I think we could consider supporting Infura as a canary, but this should be as a non-hardhat-tests, separate EDR RPC test suite. 

# Claude summary

## Why

Infura has become increasingly flaky on historical blocks. Example: in
[this run on #1579](https://github.com/NomicFoundation/edr/actions/runs/30268579508/job/90023016750?pr=1579)
all nine failures are `Forking a block with a different hardfork → Using Infura`, each an
Infura-side `-32603: precondition failure` on `eth_getBlockByNumber` for the merge/shanghai/cancun
fork-point blocks — the provider never even finishes initializing, so no EDR behavior is exercised.

## What Infura covered

`INFURA_URL` only added a second entry to `FORKED_PROVIDERS`, which is consumed by three files:

- `forked-provider.ts` and `forking-different-hardfork.ts` ran their identical suites once per
  provider — the Infura leg was a duplicate of the Alchemy run, with no Infura-specific assertions
  anywhere.
- `http-headers.ts` explicitly skipped Infura (no bearer-token auth support).

So the only coverage lost is a same-tests-different-vendor rerun. Provider-specific logic in EDR
(retries, error mapping, the URL→chain-id cache heuristic in `edr_rpc_client`) is unit-tested with
hardcoded URLs or exercised via Alchemy; the Rust remote tests already standardize on
`ALCHEMY_URL`. Hardhat 3 itself no longer carries this coverage either — its only `INFURA_URL` use
is one skippable `hardhat-ethers` signer test.

Retiring `INFURA_URL` was already agreed as part of the hardhat-tests migration end state
(ported fork tests standardize on Alchemy); this just pulls that forward to stop the flake now.

## Changes

- `hardhat-tests/test/setup.ts` — drop the `INFURA_URL` export and its missing-var warning.
- `helpers/providers.ts` — drop the Infura `FORKED_PROVIDERS` entry.
- `http-headers.ts` — remove the now-dead Infura skip branch.
- `.github/workflows/hardhat-tests.yml` — stop passing the `INFURA_URL` secret.
- `book/src/01_getting_started/03_test.md` — document `ALCHEMY_URL` only.

The `INFURA_URL` repo secret can be deleted once this merges.

## Verification

- `pnpm build:dev` (tsc) and `pnpm eslint` clean in `hardhat-tests/`.
- actionlint clean on the edited workflow.
- mocha dry-run of the three affected files loads them cleanly; the setup warning now only
  mentions `ALCHEMY_URL`.
- `grep -rn INFURA` over the repo: no references remain outside generated `build-test/` output.
