### PR TITLE
fix(edr_solidity_tests): include failing call's trace in invariant setup failures

### DIFF
--- a/.changeset/shiny-planets-behave.md
+++ b/.changeset/shiny-planets-behave.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Fixed missing Solidity test stack trace when an invariant is already broken at the campaign's initial check and stack traces are collected with `CollectStackTraces::Always`.

--- a/crates/edr_solidity_tests/src/result.rs
+++ b/crates/edr_solidity_tests/src/result.rs
@@ -679,7 +679,7 @@ impl<HaltReasonT: HaltReasonTrait> TestResult<HaltReasonT> {
     }
 
     /// Returns the fail result for invariant test setup.
-    pub fn invariant_setup_fail(&mut self, e: InvariantFuzzError, duration: Duration) {
+    pub fn invariant_setup_fail(&mut self, mut e: InvariantFuzzError, duration: Duration) {
         self.kind = TestKind::Invariant {
             runs: 0,
             calls: 0,
@@ -687,6 +687,7 @@ impl<HaltReasonT: HaltReasonTrait> TestResult<HaltReasonT> {
             metrics: HashMap::default(),
             failed_corpus_replays: 0,
         };
+        self.execution_traces.extend(e.take_traces());
         self.status = TestStatus::Failure;
         self.reason = Some(format!(
             "failed to set up invariant testing environment: {e}"

--- a/crates/edr_solidity_tests/src/runner.rs
+++ b/crates/edr_solidity_tests/src/runner.rs
@@ -1291,11 +1291,6 @@ impl<
 
                 let stack_trace_result: SolidityTestStackTraceResult<HaltReasonT> =
                     if self.executor.tracer_records_steps() {
-                        // The `InvariantFuzzTestResult` doesn't include the failing call's trace,
-                        // so rely on the recorded traces.
-                        //
-                        // TODO: We should be able to get the failing call's trace from
-                        // `invariant_fuzz` on failure
                         collect_stack_trace(
                             &*self.cr.contract_decoder,
                             self.setup,

--- a/crates/edr_solidity_tests/tests/it/repros.rs
+++ b/crates/edr_solidity_tests/tests/it/repros.rs
@@ -645,13 +645,55 @@ async fn issue_1482() {
     );
 }
 
+// Asserts that a failing test produced a decoded stack trace that reaches the
+// failing call's execution error, and returns the result for further checks.
+fn assert_execution_error_stack_trace<'suite, HaltReasonT: HaltReasonTrait>(
+    suite: &'suite edr_solidity_tests::result::SuiteResult<HaltReasonT>,
+    test_name: &str,
+) -> &'suite edr_solidity_tests::result::TestResult<HaltReasonT> {
+    let result = suite
+        .test_results
+        .get(test_name)
+        .unwrap_or_else(|| panic!("{test_name} should have run"));
+
+    assert_eq!(result.status, TestStatus::Failure, "{test_name}");
+
+    let stack_trace = match result
+        .stack_trace_result
+        .as_ref()
+        .unwrap_or_else(|| panic!("{test_name}: stack trace should be computed"))
+    {
+        SolidityTestStackTraceResult::Success(entries) => entries,
+        other => panic!("{test_name}: expected a stack trace, got {other:?}"),
+    };
+
+    // A non-empty trace that reaches the failing call's execution error
+    // (exact variant depends on the compilation mode).
+    assert!(
+        stack_trace.iter().any(|entry| matches!(
+            entry,
+            StackTraceEntry::RevertError { .. }
+                | StackTraceEntry::PanicError { .. }
+                | StackTraceEntry::CustomError { .. }
+                | StackTraceEntry::OtherExecutionError { .. }
+        )),
+        "{test_name}: expected an execution-error stack trace, got:\n{stack_trace:#?}"
+    );
+
+    result
+}
+
 // A failing test in `CollectStackTraces::Always` mode must produce a
-// source-level stack trace, not `HeuristicFailed`. Covers the unit-test and
-// table-test paths.
+// source-level stack trace, not `HeuristicFailed`. Covers the unit-test,
+// table-test, fuzz and invariant paths.
 #[tokio::test(flavor = "multi_thread")]
 async fn always_mode_produces_stack_trace_for_failing_test() {
     let mut config = runner_config(None, &TEST_DATA_VIA_IR, false).await;
     config.collect_stack_traces = CollectStackTraces::Always;
+    // The invariant fixture fails on the first call of the first run; keep the
+    // campaign bounded in case a regression makes it pass instead.
+    config.invariant.runs = 10;
+    config.invariant.depth = 10;
 
     // Real decoder so the stack-trace inferrer runs (mirrors `issue_1482`).
     let contract_decoder = contract_decoder(TEST_DATA_VIA_IR.build_info_path());
@@ -665,39 +707,62 @@ async fn always_mode_produces_stack_trace_for_failing_test() {
         .get("via-ir/repros/StackTraceAlwaysMode.t.sol:AlwaysStackTraceTest")
         .expect("the AlwaysStackTrace suite should have run");
 
-    // Both the unit-test and table-test paths must produce a decoded stack
-    // trace for the failing call, not `HeuristicFailed`.
-    let assert_stack_trace = |test_name: &str| {
-        let result = suite
-            .test_results
-            .get(test_name)
-            .unwrap_or_else(|| panic!("{test_name} should have run"));
+    assert_execution_error_stack_trace(suite, "testRevertHasStackTrace()");
+    assert_execution_error_stack_trace(suite, "tableRevertHasStackTrace(uint256)");
 
-        assert_eq!(result.status, TestStatus::Failure, "{test_name}");
+    let fuzz_result =
+        assert_execution_error_stack_trace(suite, "testFuzzRevertHasStackTrace(uint256)");
+    assert!(
+        matches!(fuzz_result.kind, TestKind::Fuzz { .. }),
+        "expected a fuzz test kind, got {:?}",
+        fuzz_result.kind
+    );
 
-        let stack_trace = match result
-            .stack_trace_result
-            .as_ref()
-            .unwrap_or_else(|| panic!("{test_name}: stack trace should be computed"))
-        {
-            SolidityTestStackTraceResult::Success(entries) => entries,
-            other => panic!("{test_name}: expected a stack trace, got {other:?}"),
-        };
+    let invariant_suite = suite_results
+        .get("via-ir/repros/StackTraceAlwaysMode.t.sol:AlwaysStackTraceInvariantTest")
+        .expect("the AlwaysStackTraceInvariant suite should have run");
 
-        // A non-empty trace that reaches the failing call's execution error
-        // (exact variant depends on the compilation mode).
-        assert!(
-            stack_trace.iter().any(|entry| matches!(
-                entry,
-                StackTraceEntry::RevertError { .. }
-                    | StackTraceEntry::PanicError { .. }
-                    | StackTraceEntry::CustomError { .. }
-                    | StackTraceEntry::OtherExecutionError { .. }
-            )),
-            "{test_name}: expected an execution-error stack trace, got:\n{stack_trace:#?}"
-        );
-    };
+    let invariant_result =
+        assert_execution_error_stack_trace(invariant_suite, "invariantCountIsZero()");
+    assert!(
+        matches!(invariant_result.kind, TestKind::Invariant { .. }),
+        "expected an invariant test kind, got {:?}",
+        invariant_result.kind
+    );
+    // A counterexample proves the invariant was broken by fuzzed calls (and
+    // replayed), rather than failing the campaign's initial check.
+    assert!(
+        invariant_result.counterexample.is_some(),
+        "expected a counterexample call sequence"
+    );
 
-    assert_stack_trace("testRevertHasStackTrace()");
-    assert_stack_trace("tableRevertHasStackTrace(uint256)");
+    // An invariant that is already broken in the initial state fails the
+    // campaign's initial check (`invariant_fuzz` returns an error before any
+    // fuzzed calls); that path must produce a stack trace too.
+    let invariant_initial_suite = suite_results
+        .get("via-ir/repros/StackTraceAlwaysMode.t.sol:AlwaysStackTraceInvariantInitialTest")
+        .expect("the AlwaysStackTraceInvariantInitial suite should have run");
+
+    let invariant_initial_result =
+        assert_execution_error_stack_trace(invariant_initial_suite, "invariantAlwaysBroken()");
+    // Only the `invariant_fuzz` error path (`TestResult::invariant_setup_fail`)
+    // produces this reason and a zero-runs invariant kind.
+    assert!(
+        matches!(
+            invariant_initial_result.kind,
+            TestKind::Invariant { runs: 0, .. }
+        ),
+        "expected a zero-runs invariant test kind, got {:?}",
+        invariant_initial_result.kind
+    );
+    assert!(
+        invariant_initial_result
+            .reason
+            .as_deref()
+            .is_some_and(|reason| {
+                reason.starts_with("failed to set up invariant testing environment")
+            }),
+        "expected an invariant setup failure, got {:?}",
+        invariant_initial_result.reason
+    );
 }

--- a/crates/edr_solidity_tests/tests/testdata/via-ir/repros/StackTraceAlwaysMode.t.sol
+++ b/crates/edr_solidity_tests/tests/testdata/via-ir/repros/StackTraceAlwaysMode.t.sol
@@ -24,10 +24,59 @@ contract AlwaysStackTraceTest is DSTest {
         require(amount == 1, "amount");
         reverter.boom();
     }
+
+    // `test`-prefixed with a param => runs as a fuzz test. Reverts for every
+    // input, so the first run yields a counterexample, covering the fuzz
+    // stack-trace path. The param is unnamed so it doesn't pick up
+    // `fixtureAmount`.
+    function testFuzzRevertHasStackTrace(uint256) public {
+        reverter.boom();
+    }
 }
 
 contract Reverter {
     function boom() public pure {
         require(false, "boom");
+    }
+}
+
+// Covers the invariant stack-trace path: `increment` is the only fuzzable
+// function on `Counter` (the getter is view, so it's excluded), so the first
+// fuzzed call breaks the invariant deterministically.
+contract AlwaysStackTraceInvariantTest is DSTest {
+    Counter counter;
+
+    function setUp() public {
+        counter = new Counter();
+    }
+
+    function invariantCountIsZero() public view {
+        require(counter.count() == 0, "count is not zero");
+    }
+}
+
+contract Counter {
+    uint256 public count;
+
+    function increment() public {
+        count += 1;
+    }
+}
+
+// Covers the invariant setup-failure stack-trace path: the invariant is
+// already broken in the initial state, so the campaign fails during the
+// initial invariant check, before any fuzzed calls. `Counter` is deployed so
+// there is a fuzzable target and target selection doesn't fail first.
+contract AlwaysStackTraceInvariantInitialTest is DSTest {
+    Counter counter;
+    Reverter reverter;
+
+    function setUp() public {
+        counter = new Counter();
+        reverter = new Reverter();
+    }
+
+    function invariantAlwaysBroken() public view {
+        reverter.boom();
     }
 }

--- a/crates/foundry/evm/evm/src/executors/invariant/error.rs
+++ b/crates/foundry/evm/evm/src/executors/invariant/error.rs
@@ -14,6 +14,7 @@ use foundry_evm_fuzz::{
     invariant::{FuzzRunIdentifiedContracts, InvariantConfig},
     Reason,
 };
+use foundry_evm_traces::SparsedTraceArena;
 use proptest::test_runner::TestError;
 use revm::context::result::HaltReasonTr;
 
@@ -85,6 +86,14 @@ impl InvariantFuzzError {
         }
     }
 
+    /// Removes and returns the traces of the offending call, if recorded.
+    pub fn take_traces(&mut self) -> Option<SparsedTraceArena> {
+        match self {
+            Self::BrokenInvariant(case_data) | Self::Revert(case_data) => case_data.traces.take(),
+            Self::Abi(_) | Self::Other(_) | Self::MaxAssumeRejects(_) => None,
+        }
+    }
+
     pub fn revert_reason(&self) -> Option<String> {
         match self {
             Self::BrokenInvariant(case_data) | Self::Revert(case_data) => {
@@ -118,6 +127,8 @@ pub struct FailedInvariantCaseData {
     pub fail_on_revert: bool,
     /// Indeterminism from cheatcodes if any.
     pub indeterminism_reasons: Option<IndeterminismReasons>,
+    /// The traces of the offending call, if recorded.
+    pub traces: Option<SparsedTraceArena>,
 }
 
 impl FailedInvariantCaseData {
@@ -167,6 +178,7 @@ impl FailedInvariantCaseData {
             shrink_run_limit: invariant_config.shrink_run_limit,
             fail_on_revert: invariant_config.fail_on_revert,
             indeterminism_reasons: call_result.indeterminism_reasons,
+            traces: call_result.traces,
         }
     }
 }


### PR DESCRIPTION
This PR is a follow-up to #1575.

When an invariant is already broken in the initial state, `invariant_fuzz` fails during its initial `assert_invariants` check and returns an error before any fuzzed calls run. There is no counterexample sequence to replay in that case, and the only copy of the failing call's trace was inside the `RawCallResult` that `FailedInvariantCaseData::new` consumed and discarded. In `Always` mode the stack trace was then built from the setup traces alone — whose last entry succeeded — producing an empty stack trace.

Fixed by carrying the trace through the error:

- `FailedInvariantCaseData` keeps the offending call's traces, exposed via `InvariantFuzzError::take_traces()`.
- `TestResult::invariant_setup_fail` merges those traces into `execution_traces`, mirroring `single_result`/`fuzz_result`, so the subsequent `collect_stack_trace` sees the failing call as the last trace.

The other invariant failure scenarios were already covered: invariants broken during fuzzing (including `fail_on_revert` and `afterInvariant` failures) replay the counterexample with step tracing via `replay_error`/`replay_run`, which regenerates the failing trace itself.