### PR TITLE
ci: pull node images from a GHCR mirror instead of Docker Hub

### DIFF
--- a/.github/actions/select-node-image/action.yml
+++ b/.github/actions/select-node-image/action.yml
@@ -1,9 +1,5 @@
 name: Select node image
-description:
-  Resolves the node Docker image for a job. Normal runs use the GHCR mirror
-  (see mirror-docker-images.yml); release runs pull the official Docker Hub
-  image directly, keeping the mirror out of the supply chain of published
-  binaries.
+description: Resolves the node Docker image for a job. Normal runs use the GHCR mirror (see mirror-docker-images.yml); release runs pull the official Docker Hub image directly, keeping the mirror out of the supply chain of published binaries.
 
 inputs:
   tag:

--- a/.github/actions/select-node-image/action.yml
+++ b/.github/actions/select-node-image/action.yml
@@ -1,0 +1,34 @@
+name: Select node image
+description:
+  Resolves the node Docker image for a job. Normal runs use the GHCR mirror
+  (see mirror-docker-images.yml); release runs pull the official Docker Hub
+  image directly, keeping the mirror out of the supply chain of published
+  binaries.
+
+inputs:
+  tag:
+    description: node image tag, e.g. 24-bullseye-slim or 22-alpine
+    required: true
+  release-tag:
+    description: check_commit's release tag; non-empty marks a release run
+    required: true
+
+outputs:
+  ref:
+    description: Image reference to pull
+    value: ${{ steps.select.outputs.ref }}
+
+runs:
+  using: composite
+  steps:
+    - id: select
+      shell: bash
+      env:
+        TAG: ${{ inputs.tag }}
+        RELEASE_TAG: ${{ inputs.release-tag }}
+      run: |
+        if [ -n "$RELEASE_TAG" ]; then
+          echo "ref=node:${TAG}" >> "$GITHUB_OUTPUT"
+        else
+          echo "ref=ghcr.io/nomicfoundation/edr/mirror/node:${TAG}" >> "$GITHUB_OUTPUT"
+        fi

--- a/.github/workflows/edr-npm-release.yml
+++ b/.github/workflows/edr-npm-release.yml
@@ -55,9 +55,10 @@ jobs:
             cache_extra_paths: ~/.cargo/registry/src/
 
           # Container images come from our GHCR mirror (mirror-docker-images.yml),
-          # not Docker Hub, whose pull rate limits made these jobs flaky.
-          # The mirror packages are private, so every pull authenticates with
-          # GITHUB_TOKEN (registry inputs / docker login below).
+          # not Docker Hub, whose pull rate limits made these jobs flaky. New or
+          # changed tags must be added to the mirror workflow's tag list in the
+          # same PR. Release runs pull the official Docker Hub image directly
+          # (see the "Select image source" steps).
           - host: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             docker: ghcr.io/nomicfoundation/edr/mirror/node:24-bullseye-slim
@@ -152,11 +153,28 @@ jobs:
         run: ${{ matrix.settings.build }}
         shell: bash
 
+      # Release runs build on the official Docker Hub image so the mirror is
+      # never in the supply chain of published binaries; at 1-2 releases a week
+      # its rate limits don't bite there. Everything else uses the mirror.
+      - name: Select image source
+        id: select-image
+        if: ${{ matrix.settings.docker }}
+        shell: bash
+        env:
+          MIRROR_REF: ${{ matrix.settings.docker }}
+          RELEASE_TAG: ${{ needs.check_commit.outputs.tag }}
+        run: |
+          if [ -n "$RELEASE_TAG" ]; then
+            echo "ref=node:${MIRROR_REF##*:}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=$MIRROR_REF" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build in docker (gnu)
         uses: NomicFoundation/docker-run-action@63f044457cfb71a5c63fa589218c89a418565d9c # Fork of v3 with updated Docker (https://github.com/addnab/docker-run-action/issues/62)
         if: ${{ matrix.settings.docker && matrix.settings.flavor == 'gnu'}}
         with:
-          image: ${{ matrix.settings.docker }}
+          image: ${{ steps.select-image.outputs.ref }}
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
@@ -185,7 +203,7 @@ jobs:
         uses: NomicFoundation/docker-run-action@63f044457cfb71a5c63fa589218c89a418565d9c # Fork of v3 with updated Docker (https://github.com/addnab/docker-run-action/issues/62)
         if: ${{ matrix.settings.docker && matrix.settings.flavor == 'musl' }}
         with:
-          image: ${{ matrix.settings.docker }}
+          image: ${{ steps.select-image.outputs.ref }}
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
@@ -265,6 +283,7 @@ jobs:
     name: Test bindings on Linux-x64-gnu - node@${{ matrix.node }}
     needs:
       - build
+      - check_commit
     permissions:
       contents: read
       packages: read
@@ -303,11 +322,18 @@ jobs:
       - name: Test bindings
         # Setting CI=1 is important to make PNPM install non-interactive
         # https://github.com/pnpm/pnpm/issues/6615#issuecomment-1656945689
-        run: docker run --rm  -e CI=1 -v "$(pwd)":/build -w /build/crates/edr_napi ghcr.io/nomicfoundation/edr/mirror/node:${{ matrix.node }} bash -c "npm install -g pnpm@11.15.1; pnpm testNoBuild"
+        env:
+          RELEASE_TAG: ${{ needs.check_commit.outputs.tag }}
+        run: |
+          # Releases pull Docker Hub directly; see the build job's "Select image source".
+          IMAGE="ghcr.io/nomicfoundation/edr/mirror/node:${{ matrix.node }}"
+          if [ -n "$RELEASE_TAG" ]; then IMAGE="node:${{ matrix.node }}"; fi
+          docker run --rm -e CI=1 -v "$(pwd)":/build -w /build/crates/edr_napi "$IMAGE" bash -c "npm install -g pnpm@11.15.1; pnpm testNoBuild"
   test-linux-x64-musl-binding:
     name: Test bindings on x86_64-unknown-linux-musl - node@${{ matrix.node }}
     needs:
       - build
+      - check_commit
     permissions:
       contents: read
       packages: read
@@ -344,11 +370,18 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Test bindings
-        run: docker run --rm  -e CI=1 -v "$(pwd)":/build -w /build/crates/edr_napi ghcr.io/nomicfoundation/edr/mirror/node:${{ matrix.node }}-alpine sh -c "npm install -g pnpm@11.15.1; pnpm testNoBuild"
+        env:
+          RELEASE_TAG: ${{ needs.check_commit.outputs.tag }}
+        run: |
+          # Releases pull Docker Hub directly; see the build job's "Select image source".
+          IMAGE="ghcr.io/nomicfoundation/edr/mirror/node:${{ matrix.node }}-alpine"
+          if [ -n "$RELEASE_TAG" ]; then IMAGE="node:${{ matrix.node }}-alpine"; fi
+          docker run --rm -e CI=1 -v "$(pwd)":/build -w /build/crates/edr_napi "$IMAGE" sh -c "npm install -g pnpm@11.15.1; pnpm testNoBuild"
   test-linux-aarch64-gnu-binding:
     name: Test bindings on aarch64-unknown-linux-gnu - node@${{ matrix.node }}
     needs:
       - build
+      - check_commit
     permissions:
       contents: read
       packages: read
@@ -379,10 +412,21 @@ jobs:
       - name: Install dependencies
         run: |
           pnpm install --frozen-lockfile --prefer-offline --cpu=arm64 --libc=glibc
+      - name: Select image source # releases pull Docker Hub directly; see the build job
+        id: select-image
+        env:
+          MIRROR_REF: ghcr.io/nomicfoundation/edr/mirror/node:${{ matrix.node }}
+          RELEASE_TAG: ${{ needs.check_commit.outputs.tag }}
+        run: |
+          if [ -n "$RELEASE_TAG" ]; then
+            echo "ref=node:${MIRROR_REF##*:}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=$MIRROR_REF" >> "$GITHUB_OUTPUT"
+          fi
       - name: Setup and run tests # zizmor: ignore[superfluous-actions] deliberate cross-arch (arm64) test runner
         uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 #v3
         with:
-          image: ghcr.io/nomicfoundation/edr/mirror/node:${{ matrix.node }}
+          image: ${{ steps.select-image.outputs.ref }}
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
@@ -396,6 +440,7 @@ jobs:
     name: Test bindings on aarch64-unknown-linux-musl - node@${{ matrix.node }}
     needs:
       - build
+      - check_commit
     permissions:
       contents: read
       packages: read
@@ -425,10 +470,21 @@ jobs:
         shell: bash
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline --cpu=arm64 --libc=musl
+      - name: Select image source # releases pull Docker Hub directly; see the build job
+        id: select-image
+        env:
+          MIRROR_REF: ghcr.io/nomicfoundation/edr/mirror/node:${{ matrix.node }}-alpine
+          RELEASE_TAG: ${{ needs.check_commit.outputs.tag }}
+        run: |
+          if [ -n "$RELEASE_TAG" ]; then
+            echo "ref=node:${MIRROR_REF##*:}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=$MIRROR_REF" >> "$GITHUB_OUTPUT"
+          fi
       - name: Setup and run tests # zizmor: ignore[superfluous-actions] deliberate cross-arch (arm64/musl) test runner
         uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # v3
         with:
-          image: ghcr.io/nomicfoundation/edr/mirror/node:${{ matrix.node }}-alpine
+          image: ${{ steps.select-image.outputs.ref }}
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/edr-npm-release.yml
+++ b/.github/workflows/edr-npm-release.yml
@@ -165,6 +165,7 @@ jobs:
         if: ${{ matrix.settings.docker_tag && matrix.settings.flavor == 'gnu'}}
         with:
           image: ${{ steps.select-image.outputs.ref }}
+          # GHCR auth for mirror pulls; unused when a release run selects the Docker Hub image.
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
@@ -194,6 +195,7 @@ jobs:
         if: ${{ matrix.settings.docker_tag && matrix.settings.flavor == 'musl' }}
         with:
           image: ${{ steps.select-image.outputs.ref }}
+          # GHCR auth for mirror pulls; unused when a release run selects the Docker Hub image.
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
@@ -303,7 +305,7 @@ jobs:
       - name: List packages
         run: ls -R .
         shell: bash
-      - name: Log in to GHCR
+      - name: Log in to GHCR # for mirror pulls; unused when a release run selects the Docker Hub image
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
@@ -355,7 +357,7 @@ jobs:
       - name: List packages
         run: ls -R .
         shell: bash
-      - name: Log in to GHCR
+      - name: Log in to GHCR # for mirror pulls; unused when a release run selects the Docker Hub image
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
@@ -416,6 +418,7 @@ jobs:
         uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 #v3
         with:
           image: ${{ steps.select-image.outputs.ref }}
+          # GHCR auth for mirror pulls; unused when a release run selects the Docker Hub image.
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
@@ -469,6 +472,7 @@ jobs:
         uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # v3
         with:
           image: ${{ steps.select-image.outputs.ref }}
+          # GHCR auth for mirror pulls; unused when a release run selects the Docker Hub image.
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/edr-npm-release.yml
+++ b/.github/workflows/edr-npm-release.yml
@@ -53,24 +53,26 @@ jobs:
             # that caching it isn't worth the size hit.
             cache_extra_paths: ~/.cargo/registry/src/
 
+          # Container images come from our GHCR mirror (mirror-docker-images.yml),
+          # not Docker Hub, whose anonymous per-IP pull limits made these jobs flaky.
           - host: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
-            docker: node:24-bullseye-slim
+            docker: ghcr.io/nomicfoundation/edr/mirror/node:24-bullseye-slim
             flavor: gnu
 
           - host: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
-            docker: node:24-bullseye-slim
+            docker: ghcr.io/nomicfoundation/edr/mirror/node:24-bullseye-slim
             flavor: gnu
 
           - host: ubuntu-24.04
             target: x86_64-unknown-linux-musl
-            docker: node:24-alpine
+            docker: ghcr.io/nomicfoundation/edr/mirror/node:24-alpine
             flavor: musl
 
           - host: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
-            docker: node:24-alpine
+            docker: ghcr.io/nomicfoundation/edr/mirror/node:24-alpine
             flavor: musl
     outputs:
       commit_sha: ${{ steps.save-commit.outputs.commit_sha}}
@@ -285,7 +287,7 @@ jobs:
       - name: Test bindings
         # Setting CI=1 is important to make PNPM install non-interactive
         # https://github.com/pnpm/pnpm/issues/6615#issuecomment-1656945689
-        run: docker run --rm  -e CI=1 -v "$(pwd)":/build -w /build/crates/edr_napi node:${{ matrix.node }} bash -c "npm install -g pnpm@11.15.1; pnpm testNoBuild"
+        run: docker run --rm  -e CI=1 -v "$(pwd)":/build -w /build/crates/edr_napi ghcr.io/nomicfoundation/edr/mirror/node:${{ matrix.node }} bash -c "npm install -g pnpm@11.15.1; pnpm testNoBuild"
   test-linux-x64-musl-binding:
     name: Test bindings on x86_64-unknown-linux-musl - node@${{ matrix.node }}
     needs:
@@ -319,7 +321,7 @@ jobs:
         run: ls -R .
         shell: bash
       - name: Test bindings
-        run: docker run --rm  -e CI=1 -v "$(pwd)":/build -w /build/crates/edr_napi node:${{ matrix.node }}-alpine sh -c "npm install -g pnpm@11.15.1; pnpm testNoBuild"
+        run: docker run --rm  -e CI=1 -v "$(pwd)":/build -w /build/crates/edr_napi ghcr.io/nomicfoundation/edr/mirror/node:${{ matrix.node }}-alpine sh -c "npm install -g pnpm@11.15.1; pnpm testNoBuild"
   test-linux-aarch64-gnu-binding:
     name: Test bindings on aarch64-unknown-linux-gnu - node@${{ matrix.node }}
     needs:
@@ -356,7 +358,7 @@ jobs:
       - name: Setup and run tests # zizmor: ignore[superfluous-actions] deliberate cross-arch (arm64) test runner
         uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 #v3
         with:
-          image: node:${{ matrix.node }}
+          image: ghcr.io/nomicfoundation/edr/mirror/node:${{ matrix.node }}
           options: "--platform linux/arm64 -v ${{ github.workspace }}:/build -w /build/crates/edr_napi -e CI=1"
           run: |
             npm install -g pnpm@11.15.1
@@ -398,7 +400,7 @@ jobs:
       - name: Setup and run tests # zizmor: ignore[superfluous-actions] deliberate cross-arch (arm64/musl) test runner
         uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # v3
         with:
-          image: node:${{ matrix.node }}-alpine
+          image: ghcr.io/nomicfoundation/edr/mirror/node:${{ matrix.node }}-alpine
           options: "--platform linux/arm64 -v ${{ github.workspace }}:/build -w /build/crates/edr_napi -e CI=1"
           run: |
             npm install -g pnpm@11.15.1

--- a/.github/workflows/edr-npm-release.yml
+++ b/.github/workflows/edr-npm-release.yml
@@ -55,7 +55,7 @@ jobs:
             cache_extra_paths: ~/.cargo/registry/src/
 
           # Container images come from our GHCR mirror (mirror-docker-images.yml),
-          # not Docker Hub, whose anonymous per-IP pull limits made these jobs flaky.
+          # not Docker Hub, whose pull rate limits made these jobs flaky.
           # The mirror packages are private, so every pull authenticates with
           # GITHUB_TOKEN (registry inputs / docker login below).
           - host: ubuntu-24.04

--- a/.github/workflows/edr-npm-release.yml
+++ b/.github/workflows/edr-npm-release.yml
@@ -54,29 +54,28 @@ jobs:
             # that caching it isn't worth the size hit.
             cache_extra_paths: ~/.cargo/registry/src/
 
-          # Container images come from our GHCR mirror (mirror-docker-images.yml),
-          # not Docker Hub, whose pull rate limits made these jobs flaky. New or
-          # changed tags must be added to the mirror workflow's tag list in the
-          # same PR. Release runs pull the official Docker Hub image directly
-          # (see the "Select image source" steps).
+          # docker_tag legs build in a node container resolved by the
+          # select-node-image action (GHCR mirror normally, Docker Hub on
+          # releases). New or changed tags must be added to the mirror
+          # workflow's tag list in the same PR.
           - host: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
-            docker: ghcr.io/nomicfoundation/edr/mirror/node:24-bullseye-slim
+            docker_tag: 24-bullseye-slim
             flavor: gnu
 
           - host: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
-            docker: ghcr.io/nomicfoundation/edr/mirror/node:24-bullseye-slim
+            docker_tag: 24-bullseye-slim
             flavor: gnu
 
           - host: ubuntu-24.04
             target: x86_64-unknown-linux-musl
-            docker: ghcr.io/nomicfoundation/edr/mirror/node:24-alpine
+            docker_tag: 24-alpine
             flavor: musl
 
           - host: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
-            docker: ghcr.io/nomicfoundation/edr/mirror/node:24-alpine
+            docker_tag: 24-alpine
             flavor: musl
     outputs:
       commit_sha: ${{ steps.save-commit.outputs.commit_sha}}
@@ -109,14 +108,14 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # latest main commit (2025-11-17)
-        if: ${{ !matrix.settings.docker }}
+        if: ${{ !matrix.settings.docker_tag }}
         with:
           toolchain: stable
           targets: ${{ matrix.settings.target }}
           components: rust-src
 
       - name: Setup node and pnpm
-        if: ${{ !matrix.settings.docker }}
+        if: ${{ !matrix.settings.docker_tag }}
         uses: ./.github/actions/setup-node
         with:
           node-version: 24
@@ -139,40 +138,31 @@ jobs:
             ${{ matrix.settings.target }}-cargo-v5-${{ matrix.settings.host }}-
 
       - name: Install dependencies (non-Windows)
-        if: ${{ !matrix.settings.docker && runner.os != 'Windows' }}
+        if: ${{ !matrix.settings.docker_tag && runner.os != 'Windows' }}
         run: sfw pnpm install --frozen-lockfile --prefer-offline
 
       # SFW doesn't install dependencies correctly on Windows
       # https://github.com/NomicFoundation/edr/issues/1199
       - name: Install dependencies (Windows)
-        if: ${{ !matrix.settings.docker && runner.os == 'Windows' }}
+        if: ${{ !matrix.settings.docker_tag && runner.os == 'Windows' }}
         run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Build (non-docker)
-        if: ${{ !matrix.settings.docker }}
+        if: ${{ !matrix.settings.docker_tag }}
         run: ${{ matrix.settings.build }}
         shell: bash
 
-      # Release runs build on the official Docker Hub image so the mirror is
-      # never in the supply chain of published binaries; at 1-2 releases a week
-      # its rate limits don't bite there. Everything else uses the mirror.
       - name: Select image source
         id: select-image
-        if: ${{ matrix.settings.docker }}
-        shell: bash
-        env:
-          MIRROR_REF: ${{ matrix.settings.docker }}
-          RELEASE_TAG: ${{ needs.check_commit.outputs.tag }}
-        run: |
-          if [ -n "$RELEASE_TAG" ]; then
-            echo "ref=node:${MIRROR_REF##*:}" >> "$GITHUB_OUTPUT"
-          else
-            echo "ref=$MIRROR_REF" >> "$GITHUB_OUTPUT"
-          fi
+        if: ${{ matrix.settings.docker_tag }}
+        uses: ./.github/actions/select-node-image
+        with:
+          tag: ${{ matrix.settings.docker_tag }}
+          release-tag: ${{ needs.check_commit.outputs.tag }}
 
       - name: Build in docker (gnu)
         uses: NomicFoundation/docker-run-action@63f044457cfb71a5c63fa589218c89a418565d9c # Fork of v3 with updated Docker (https://github.com/addnab/docker-run-action/issues/62)
-        if: ${{ matrix.settings.docker && matrix.settings.flavor == 'gnu'}}
+        if: ${{ matrix.settings.docker_tag && matrix.settings.flavor == 'gnu'}}
         with:
           image: ${{ steps.select-image.outputs.ref }}
           registry: ghcr.io
@@ -201,7 +191,7 @@ jobs:
       # https://github.com/NomicFoundation/edr/issues/1198
       - name: Build in docker (musl)
         uses: NomicFoundation/docker-run-action@63f044457cfb71a5c63fa589218c89a418565d9c # Fork of v3 with updated Docker (https://github.com/addnab/docker-run-action/issues/62)
-        if: ${{ matrix.settings.docker && matrix.settings.flavor == 'musl' }}
+        if: ${{ matrix.settings.docker_tag && matrix.settings.flavor == 'musl' }}
         with:
           image: ${{ steps.select-image.outputs.ref }}
           registry: ghcr.io
@@ -319,16 +309,18 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Select image source
+        id: select-image
+        uses: ./.github/actions/select-node-image
+        with:
+          tag: ${{ matrix.node }}
+          release-tag: ${{ needs.check_commit.outputs.tag }}
       - name: Test bindings
         # Setting CI=1 is important to make PNPM install non-interactive
         # https://github.com/pnpm/pnpm/issues/6615#issuecomment-1656945689
         env:
-          RELEASE_TAG: ${{ needs.check_commit.outputs.tag }}
-        run: |
-          # Releases pull Docker Hub directly; see the build job's "Select image source".
-          IMAGE="ghcr.io/nomicfoundation/edr/mirror/node:${{ matrix.node }}"
-          if [ -n "$RELEASE_TAG" ]; then IMAGE="node:${{ matrix.node }}"; fi
-          docker run --rm -e CI=1 -v "$(pwd)":/build -w /build/crates/edr_napi "$IMAGE" bash -c "npm install -g pnpm@11.15.1; pnpm testNoBuild"
+          IMAGE: ${{ steps.select-image.outputs.ref }}
+        run: docker run --rm -e CI=1 -v "$(pwd)":/build -w /build/crates/edr_napi "$IMAGE" bash -c "npm install -g pnpm@11.15.1; pnpm testNoBuild"
   test-linux-x64-musl-binding:
     name: Test bindings on x86_64-unknown-linux-musl - node@${{ matrix.node }}
     needs:
@@ -369,14 +361,16 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Select image source
+        id: select-image
+        uses: ./.github/actions/select-node-image
+        with:
+          tag: ${{ matrix.node }}-alpine
+          release-tag: ${{ needs.check_commit.outputs.tag }}
       - name: Test bindings
         env:
-          RELEASE_TAG: ${{ needs.check_commit.outputs.tag }}
-        run: |
-          # Releases pull Docker Hub directly; see the build job's "Select image source".
-          IMAGE="ghcr.io/nomicfoundation/edr/mirror/node:${{ matrix.node }}-alpine"
-          if [ -n "$RELEASE_TAG" ]; then IMAGE="node:${{ matrix.node }}-alpine"; fi
-          docker run --rm -e CI=1 -v "$(pwd)":/build -w /build/crates/edr_napi "$IMAGE" sh -c "npm install -g pnpm@11.15.1; pnpm testNoBuild"
+          IMAGE: ${{ steps.select-image.outputs.ref }}
+        run: docker run --rm -e CI=1 -v "$(pwd)":/build -w /build/crates/edr_napi "$IMAGE" sh -c "npm install -g pnpm@11.15.1; pnpm testNoBuild"
   test-linux-aarch64-gnu-binding:
     name: Test bindings on aarch64-unknown-linux-gnu - node@${{ matrix.node }}
     needs:
@@ -412,17 +406,12 @@ jobs:
       - name: Install dependencies
         run: |
           pnpm install --frozen-lockfile --prefer-offline --cpu=arm64 --libc=glibc
-      - name: Select image source # releases pull Docker Hub directly; see the build job
+      - name: Select image source
         id: select-image
-        env:
-          MIRROR_REF: ghcr.io/nomicfoundation/edr/mirror/node:${{ matrix.node }}
-          RELEASE_TAG: ${{ needs.check_commit.outputs.tag }}
-        run: |
-          if [ -n "$RELEASE_TAG" ]; then
-            echo "ref=node:${MIRROR_REF##*:}" >> "$GITHUB_OUTPUT"
-          else
-            echo "ref=$MIRROR_REF" >> "$GITHUB_OUTPUT"
-          fi
+        uses: ./.github/actions/select-node-image
+        with:
+          tag: ${{ matrix.node }}
+          release-tag: ${{ needs.check_commit.outputs.tag }}
       - name: Setup and run tests # zizmor: ignore[superfluous-actions] deliberate cross-arch (arm64) test runner
         uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 #v3
         with:
@@ -470,17 +459,12 @@ jobs:
         shell: bash
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline --cpu=arm64 --libc=musl
-      - name: Select image source # releases pull Docker Hub directly; see the build job
+      - name: Select image source
         id: select-image
-        env:
-          MIRROR_REF: ghcr.io/nomicfoundation/edr/mirror/node:${{ matrix.node }}-alpine
-          RELEASE_TAG: ${{ needs.check_commit.outputs.tag }}
-        run: |
-          if [ -n "$RELEASE_TAG" ]; then
-            echo "ref=node:${MIRROR_REF##*:}" >> "$GITHUB_OUTPUT"
-          else
-            echo "ref=$MIRROR_REF" >> "$GITHUB_OUTPUT"
-          fi
+        uses: ./.github/actions/select-node-image
+        with:
+          tag: ${{ matrix.node }}-alpine
+          release-tag: ${{ needs.check_commit.outputs.tag }}
       - name: Setup and run tests # zizmor: ignore[superfluous-actions] deliberate cross-arch (arm64/musl) test runner
         uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # v3
         with:

--- a/.github/workflows/edr-npm-release.yml
+++ b/.github/workflows/edr-npm-release.yml
@@ -31,6 +31,7 @@ jobs:
     needs: check_commit
     permissions:
       contents: read
+      packages: read
     strategy:
       fail-fast: false
       matrix:
@@ -55,6 +56,8 @@ jobs:
 
           # Container images come from our GHCR mirror (mirror-docker-images.yml),
           # not Docker Hub, whose anonymous per-IP pull limits made these jobs flaky.
+          # The mirror packages are private, so every pull authenticates with
+          # GITHUB_TOKEN (registry inputs / docker login below).
           - host: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             docker: ghcr.io/nomicfoundation/edr/mirror/node:24-bullseye-slim
@@ -154,6 +157,9 @@ jobs:
         if: ${{ matrix.settings.docker && matrix.settings.flavor == 'gnu'}}
         with:
           image: ${{ matrix.settings.docker }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
           # /home/runner/.cargo matches where the host's `Cache cargo` step writes
           # (`~/.cargo` on GH-hosted Linux runners); docker -v doesn't expand `~` and
           # GHA has no `runner.home` context, so the path is hardcoded.
@@ -180,6 +186,9 @@ jobs:
         if: ${{ matrix.settings.docker && matrix.settings.flavor == 'musl' }}
         with:
           image: ${{ matrix.settings.docker }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
           # See gnu step above for why /home/runner/.cargo is hardcoded.
           options: "--user 0:0 -v /home/runner/.cargo/git:/usr/local/cargo/git -v /home/runner/.cargo/registry:/usr/local/cargo/registry -v ${{ github.workspace }}:/build -w /build/crates/edr_napi"
           run: |
@@ -258,6 +267,7 @@ jobs:
       - build
     permissions:
       contents: read
+      packages: read
     strategy:
       fail-fast: false
       matrix:
@@ -284,6 +294,12 @@ jobs:
       - name: List packages
         run: ls -R .
         shell: bash
+      - name: Log in to GHCR
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Test bindings
         # Setting CI=1 is important to make PNPM install non-interactive
         # https://github.com/pnpm/pnpm/issues/6615#issuecomment-1656945689
@@ -294,6 +310,7 @@ jobs:
       - build
     permissions:
       contents: read
+      packages: read
     strategy:
       fail-fast: false
       matrix:
@@ -320,6 +337,12 @@ jobs:
       - name: List packages
         run: ls -R .
         shell: bash
+      - name: Log in to GHCR
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Test bindings
         run: docker run --rm  -e CI=1 -v "$(pwd)":/build -w /build/crates/edr_napi ghcr.io/nomicfoundation/edr/mirror/node:${{ matrix.node }}-alpine sh -c "npm install -g pnpm@11.15.1; pnpm testNoBuild"
   test-linux-aarch64-gnu-binding:
@@ -328,6 +351,7 @@ jobs:
       - build
     permissions:
       contents: read
+      packages: read
     strategy:
       fail-fast: false
       matrix:
@@ -359,6 +383,9 @@ jobs:
         uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 #v3
         with:
           image: ghcr.io/nomicfoundation/edr/mirror/node:${{ matrix.node }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
           options: "--platform linux/arm64 -v ${{ github.workspace }}:/build -w /build/crates/edr_napi -e CI=1"
           run: |
             npm install -g pnpm@11.15.1
@@ -371,6 +398,7 @@ jobs:
       - build
     permissions:
       contents: read
+      packages: read
     strategy:
       fail-fast: false
       matrix:
@@ -401,6 +429,9 @@ jobs:
         uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # v3
         with:
           image: ghcr.io/nomicfoundation/edr/mirror/node:${{ matrix.node }}-alpine
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
           options: "--platform linux/arm64 -v ${{ github.workspace }}:/build -w /build/crates/edr_napi -e CI=1"
           run: |
             npm install -g pnpm@11.15.1

--- a/.github/workflows/mirror-docker-images.yml
+++ b/.github/workflows/mirror-docker-images.yml
@@ -46,6 +46,7 @@ jobs:
 
       - name: Copy images to GHCR
         run: |
+          set -euo pipefail
           # Keep in sync with the node versions and container images in
           # edr-npm-release.yml; a tag missing here fails CI with "manifest
           # unknown" on the mirror pull.

--- a/.github/workflows/mirror-docker-images.yml
+++ b/.github/workflows/mirror-docker-images.yml
@@ -2,8 +2,8 @@ name: Mirror Docker images
 
 # Copies the Docker Hub images used by CI into GHCR
 # (ghcr.io/nomicfoundation/edr/mirror/*). CI pulls the mirror instead of
-# Docker Hub: anonymous Docker Hub pulls share per-IP rate limits across all
-# GitHub-hosted runners and fail intermittently, while GHCR sits on the same
+# Docker Hub: Docker Hub rate-limits pulls, which fail intermittently on
+# GitHub-hosted runners as a result, while GHCR sits on the same
 # infrastructure as the runners.
 #
 # The mirror packages stay private; consumers authenticate with GITHUB_TOKEN.

--- a/.github/workflows/mirror-docker-images.yml
+++ b/.github/workflows/mirror-docker-images.yml
@@ -1,0 +1,65 @@
+name: Mirror Docker images
+
+# Copies the Docker Hub images used by CI into GHCR
+# (ghcr.io/nomicfoundation/edr/mirror/*). CI pulls the mirror instead of
+# Docker Hub: anonymous Docker Hub pulls share per-IP rate limits across all
+# GitHub-hosted runners and fail intermittently, while GHCR sits on the same
+# infrastructure as the runners.
+
+permissions: {}
+
+on:
+  schedule:
+    # Weekly: upstream refreshes these tags in place with security patches.
+    - cron: "0 3 * * 1"
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/mirror-docker-images.yml
+
+jobs:
+  mirror:
+    name: Mirror node images to GHCR
+    runs-on: ubuntu-24.04
+    permissions:
+      packages: write
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Copy images to GHCR
+        run: |
+          # Keep in sync with the node versions and container images in
+          # edr-npm-release.yml; a tag missing here fails CI with "manifest
+          # unknown" on the mirror pull.
+          TAGS=(22 22-alpine 24 24-alpine 24-bullseye-slim 26 26-alpine)
+
+          OWNER=${GITHUB_REPOSITORY_OWNER,,} # ghcr.io requires lowercase
+          for tag in "${TAGS[@]}"; do
+            SOURCE="docker.io/library/node:${tag}"
+            DEST="ghcr.io/${OWNER}/edr/mirror/node:${tag}"
+            for attempt in 1 2 3; do
+              if docker buildx imagetools create --tag "$DEST" "$SOURCE"; then
+                break
+              fi
+              if [ "$attempt" = 3 ]; then
+                echo "Failed to mirror $SOURCE after 3 attempts" >&2
+                exit 1
+              fi
+              sleep $((attempt * 30))
+            done
+            # A faithful copy preserves the manifest digest; a mismatch means
+            # imagetools rewrote the manifest (or upstream moved the tag mid-copy).
+            SRC_DIGEST=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "$SOURCE")
+            DEST_DIGEST=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "$DEST")
+            if [ "$SRC_DIGEST" != "$DEST_DIGEST" ]; then
+              echo "Digest mismatch for $DEST: $SRC_DIGEST (source) != $DEST_DIGEST (mirror)" >&2
+              exit 1
+            fi
+          done

--- a/.github/workflows/mirror-docker-images.yml
+++ b/.github/workflows/mirror-docker-images.yml
@@ -5,6 +5,10 @@ name: Mirror Docker images
 # Docker Hub: anonymous Docker Hub pulls share per-IP rate limits across all
 # GitHub-hosted runners and fail intermittently, while GHCR sits on the same
 # infrastructure as the runners.
+#
+# The mirror packages stay private; consumers authenticate with GITHUB_TOKEN.
+# Publishing via GITHUB_TOKEN links the packages to this repo automatically,
+# which is what grants that access — don't seed them from a personal token.
 
 permissions: {}
 
@@ -18,11 +22,18 @@ on:
       - main
     paths:
       - .github/workflows/mirror-docker-images.yml
+  # Same-repo PRs touching this file mirror immediately, so a PR that adds a
+  # tag below (e.g. a new node version) can be tested before merge.
+  pull_request:
+    paths:
+      - .github/workflows/mirror-docker-images.yml
 
 jobs:
   mirror:
     name: Mirror node images to GHCR
     runs-on: ubuntu-24.04
+    # Fork PRs get a read-only GITHUB_TOKEN and can't push to GHCR.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       packages: write
     steps:

--- a/book/src/02_development/11_ci_docker_mirror.md
+++ b/book/src/02_development/11_ci_docker_mirror.md
@@ -1,10 +1,14 @@
 # CI Docker image mirror
 
-CI pulls its Docker images from a GHCR mirror (`ghcr.io/nomicfoundation/edr/mirror/*`) instead of Docker Hub: Docker Hub rate-limits pulls, which fail intermittently on GitHub-hosted runners as a result. The mirror is maintained by `.github/workflows/mirror-docker-images.yml`, which re-copies the images weekly and can be run on demand via `workflow_dispatch`.
+CI pulls its Docker images from a GHCR mirror (`ghcr.io/nomicfoundation/edr/mirror/*`) instead of Docker Hub: Docker Hub rate-limits pulls, which fail intermittently on GitHub-hosted runners as a result. The mirror is maintained by `.github/workflows/mirror-docker-images.yml`, which re-copies the images weekly, on pushes to `main` and same-repo PRs that change the workflow itself, and on demand via `workflow_dispatch`.
+
+Release runs are the exception: when `check_commit` resolves a release tag, the docker jobs in `edr-npm-release.yml` pull the official image straight from Docker Hub (the "Select image source" steps), so the mirror is never in the supply chain of published binaries — a tampered mirror tag can at most affect PR/branch CI, which publishes nothing. At one or two releases a week, Docker Hub's rate limits are not a concern for those runs.
 
 ## Adding a Node.js version (or any new tag)
 
 Add the tag to the `TAGS` list in `mirror-docker-images.yml` in the same PR that changes the matrix in `edr-npm-release.yml`. The mirror workflow runs on same-repo PRs that touch it, so the new tag is mirrored — and the release matrix testable against it — before merge. A tag referenced in CI but missing from the mirror fails loudly with `manifest unknown`.
+
+On such a PR the mirror job and the release-workflow jobs start in parallel, so on the first run the release jobs can race ahead and fail their pulls with `manifest unknown`. That's benign: re-run the failed jobs once the mirror job is green.
 
 ## Access
 

--- a/book/src/02_development/11_ci_docker_mirror.md
+++ b/book/src/02_development/11_ci_docker_mirror.md
@@ -1,0 +1,13 @@
+# CI Docker image mirror
+
+CI pulls its Docker images from a GHCR mirror (`ghcr.io/nomicfoundation/edr/mirror/*`) instead of Docker Hub: Docker Hub rate-limits pulls, which fail intermittently on GitHub-hosted runners as a result. The mirror is maintained by `.github/workflows/mirror-docker-images.yml`, which re-copies the images weekly and can be run on demand via `workflow_dispatch`.
+
+## Adding a Node.js version (or any new tag)
+
+Add the tag to the `TAGS` list in `mirror-docker-images.yml` in the same PR that changes the matrix in `edr-npm-release.yml`. The mirror workflow runs on same-repo PRs that touch it, so the new tag is mirrored — and the release matrix testable against it — before merge. A tag referenced in CI but missing from the mirror fails loudly with `manifest unknown`.
+
+## Access
+
+The mirror packages are private. Jobs that pull from the mirror need `packages: read` in their permissions and authenticate with `GITHUB_TOKEN`: a `docker login` step before raw `docker run` commands, or the `registry`/`username`/`password` inputs on `docker-run-action` (a container action, which can't see a host `docker login`).
+
+Access works because GHCR automatically links a package to the repository whose workflow published it. Never seed or push the mirror packages from a personal token — that breaks the repository link and CI loses access. Fork PRs can pull (their read-only `GITHUB_TOKEN` still carries `packages: read`) but can't publish, so the mirror job skips itself on fork PRs; a fork PR that needs a new tag has to wait for the post-merge mirror run on `main`.

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -20,6 +20,7 @@
   - [`pnpm patch` a dependency](./02_development/07_pnpm_patch.md)
   - [Solidity test cheatcodes](./02_development/08_cheatcodes)
   - [Predeploys](./02_development/09_predeploys.md)
+  - [CI Docker image mirror](./02_development/11_ci_docker_mirror.md)
 
 - [Release](./03_release.md)
 

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -18,8 +18,9 @@
   - [Using pnpm link](./02_development/05_pnpm_link.md)
   - [Style Guide](./02_development/06_style_guide.md)
   - [`pnpm patch` a dependency](./02_development/07_pnpm_patch.md)
-  - [Solidity test cheatcodes](./02_development/08_cheatcodes)
+  - [Solidity test cheatcodes](./02_development/08_cheatcodes.md)
   - [Predeploys](./02_development/09_predeploys.md)
+  - [Dynamic Base Fee Parameters](./02_development/10_dynamic_base_fee_params.md)
   - [CI Docker image mirror](./02_development/11_ci_docker_mirror.md)
 
 - [Release](./03_release.md)


### PR DESCRIPTION
I've seen the docker image flake for a while, particularly when creating more PRs. I've now taken the step of mirroring the images into ghcr.io, for EDR, privately. This is possible by using the GITHUB_TOKEN.

Mirrored docker images are already working in this PR! 

Documented the process of adding further node images. Did a couple of small quick fixes to the book to fix up a chapter link and an extension. 

Note: the Docker login warning is not a problem as it's a short-lived GITHUB_TOKEN (not a PAT) and is aimed at local dev. 

# Claude summary
## Problem

`edr-npm-release.yml` runs on every PR and makes ~16 Docker Hub pulls per run (`node:24-bullseye-slim` / `node:{22,24,26}[-alpine]` across the build matrix and the four Linux test-binding jobs). Docker Hub rate-limits pulls, which is the source of the intermittent pull failures we see in CI.

## Change

- New `mirror-docker-images.yml`: copies the node tags CI needs into `ghcr.io/nomicfoundation/edr/mirror/node:<tag>` using the runner's preinstalled `docker buildx imagetools create` (no new third-party actions). Runs weekly (upstream refreshes these tags in place with security patches), on `workflow_dispatch`, on pushes to `main` that touch the workflow itself, and on same-repo PRs that touch it — so a PR adding a tag (e.g. a new node version) mirrors and tests it before merge. Each copy retries with backoff and verifies the mirrored manifest digest matches upstream, so an unfaithful copy fails loudly.
- `edr-npm-release.yml`: all six image references now point at the mirror. GHCR sits on the same infrastructure as the runners, so these pulls are both faster and not subject to Docker Hub's limits.
- New book chapter (`Development → CI Docker image mirror`) documenting the add-a-node-version flow — add the tag to the mirror list in the same PR that changes the release matrix, and the PR trigger mirrors it before merge — plus the `GITHUB_TOKEN` access model. Someone editing the release matrix has no reason to open the mirror workflow and see its comments, hence a findable chapter.
- Drive-by (separate commit): two pre-existing book `SUMMARY.md` gaps — `10_dynamic_base_fee_params.md` was never listed, and the `08_cheatcodes` entry was missing its `.md` extension.

The mirror packages stay **private** (making org packages public needs an org admin), so every pull authenticates with `GITHUB_TOKEN`: `docker/login-action` before the raw `docker run` steps, and `registry`/`username`/`password` inputs on the `docker-run-action` legs (it's a container action, so a host `docker login` wouldn't reach it). Access works because publishing via `GITHUB_TOKEN` from the mirror workflow links the packages to this repo automatically — including for fork PRs, whose read-only token still carries `packages: read`. For that reason the packages must never be seeded from a personal token.

Deliberately excluded: the `docker://rhysd/actionlint` image in `edr-ci.yml` also comes from Docker Hub, but it's a single digest-pinned pull per run and Renovate tracks its tag+digest — mirroring it would break that bump flow for marginal gain.

## Rollout

No manual steps. This PR touches `mirror-docker-images.yml`, so the mirror job runs on the PR itself and creates the packages; the release-workflow jobs that raced ahead of it on the first run will fail their pulls — re-run failed jobs once the mirror job is green.

## Notes

- Private GHCR storage counts against the org Packages quota (a few GB for these multi-arch images; Actions-download bandwidth is free). If an org admin later flips the packages public, storage becomes free — nothing in this PR depends on visibility either way.
- Adding a node version to the release matrix requires adding the tag to the mirror list first; a missing tag fails loudly with "manifest unknown".

## Verification

- `actionlint` (with `SHELLCHECK_OPTS=--severity=warning`, matching CI): clean on both files.
- `zizmor` 1.26.1 (CI's version, online audits enabled): no findings.
