### PR TITLE
ci: update HH3 regression benchmark default filter

### DIFF
--- a/.github/scripts/resolve-regression-trigger.cjs
+++ b/.github/scripts/resolve-regression-trigger.cjs
@@ -20,7 +20,7 @@ const CI_POLL_INTERVAL_MS = 30 * 1000; // 30 seconds
 // expensive compile ones to save CI time. Override per run via the workflow
 // inputs / `scenarios=`/`benchmarks=` comment args; pass `*` for the full suite.
 const DEFAULT_SCENARIO_FILTER = "*";
-const DEFAULT_BENCHMARK_FILTER = "test solidity,mocha test";
+const DEFAULT_BENCHMARK_FILTER = "test solidity,test mocha,test vitest";
 
 module.exports = async ({ github, context, core }) => {
   const { owner, repo } = context.repo;

--- a/.github/scripts/resolve-regression-trigger.test.cjs
+++ b/.github/scripts/resolve-regression-trigger.test.cjs
@@ -91,7 +91,7 @@ test("push → baseline run against Hardhat main", async () => {
     // Baseline runs all projects (`*`), but only the default test-execution
     // benchmarks — EDR doesn't affect compilation, so compile ones are skipped.
     scenario_filter: "*",
-    benchmark_filter: "test solidity,mocha test",
+    benchmark_filter: "test solidity,test mocha,test vitest",
   });
 });
 
@@ -144,7 +144,7 @@ test("workflow_dispatch → forwards explicit filters; benchmark uses the defaul
   // No benchmark-filter given → default test-execution benchmarks.
   assert.equal(
     withoutFilter.captured.outputs.benchmark_filter,
-    "test solidity,mocha test"
+    "test solidity,test mocha,test vitest"
   );
 });
 
@@ -196,7 +196,10 @@ test("issue_comment → same-repo PR with green CI runs and parses hardhat-ref",
   assert.equal(captured.outputs.is_baseline, "false");
   assert.equal(captured.outputs.scenario_filter, "*"); // no scenarios= → all
   // default test-execution benchmarks (no benchmarks= in body)
-  assert.equal(captured.outputs.benchmark_filter, "test solidity,mocha test");
+  assert.equal(
+    captured.outputs.benchmark_filter,
+    "test solidity,test mocha,test vitest"
+  );
   assert.equal(captured.comments.length, 1);
   assert.match(captured.comments[0], /Starting regression benchmark/);
   // A `*` (all) scenario filter is not called out; the benchmark default is.

--- a/.github/workflows/hh3-regression-benchmark.yml
+++ b/.github/workflows/hh3-regression-benchmark.yml
@@ -25,10 +25,10 @@ on:
         type: string
         default: "*"
       benchmark-filter:
-        description: "Glob(s) selecting which benchmarks to run within each project, by name — a command or step name, i.e. the part after `<project> /` in a report (e.g. `test solidity`, `cold compile`, `*compile*`). Comma-separated. Defaults to `test solidity,mocha test` (EDR affects test execution, not compilation); pass `*` to run the full suite. Forwarded to `bench:regression --benchmarks`."
+        description: "Glob(s) selecting which benchmarks to run within each project, by name — a command or step name, i.e. the part after `<project> /` in a report (e.g. `test solidity`, `cold compile`, `*compile*`). Comma-separated. Defaults to `test solidity,test mocha,test vitest` (EDR affects test execution, not compilation); pass `*` to run the full suite. Forwarded to `bench:regression --benchmarks`."
         required: false
         type: string
-        default: "test solidity,mocha test"
+        default: "test solidity,test mocha,test vitest"
   # ChatOps: comment `/bench` on a same-repo PR, optionally with
   # `hardhat-ref=<branch|sha|PR>`, `scenarios="<glob>[,<glob>...]"` and/or
   # `benchmarks="<glob>[,<glob>...]"` to select which projects/benchmarks run


### PR DESCRIPTION
https://github.com/NomicFoundation/hardhat/pull/8467 adds new benchmark scenarios.

This PR updates our default benchmarks filter to include these:
- renamed `mocha test` to `test mocha` to match naming pattern
- added `test vitest` to include new type of test runner