### PR TITLE
docs: clarify Hardhat Network vs EDR issue ownership

### DIFF
--- a/spec-compliance/README.md
+++ b/spec-compliance/README.md
@@ -2,6 +2,10 @@
 
 This directory documents EIPs and chain specifications that EDR does not support or only partially supports. Each entry links to a detailed document describing what the spec requires, how EDR deviates, and any available workarounds.
 
+## Relation to Hardhat Network
+
+Hardhat Network uses EDR as its execution substrate for local EVM simulation. Spec compliance gaps and EVM behavior issues documented here are owned by EDR; please open issues against this repository when the problem is about execution semantics or EIP/support status. Hardhat plugin and developer-experience issues (tasks, hooks, config, tooling) belong in [Hardhat](https://github.com/NomicFoundation/hardhat) instead.
+
 ## Status definitions
 
 | Status | Meaning |


### PR DESCRIPTION
﻿## Summary
- Add a short Relation to Hardhat Network section to `spec-compliance/README.md`.
- States that Hardhat Network uses EDR as its execution substrate, and directs EVM/spec issues here vs DX/plugin issues to Hardhat.

## Test plan
- [ ] Read the new section for accuracy and tone
