### PR TITLE
fix: clean yarn berry persistent cache

### DIFF
--- a/.github/workflows/hh3-regression-benchmark.yml
+++ b/.github/workflows/hh3-regression-benchmark.yml
@@ -149,9 +149,23 @@ jobs:
         # Use the runner's temp dir for the scenario clones.
         run: echo "E2E_CLONE_DIR=${RUNNER_TEMP:?}/edr-e2e-clones" >> "$GITHUB_ENV"
 
-      - name: Configure per-run bun cache
-        # Set the bun cache directory to a temp dir that is cleaned up at the end of the job.
-        run: echo "BUN_INSTALL_CACHE_DIR=${RUNNER_TEMP:?}/bun-install-cache" >> "$GITHUB_ENV"
+      - name: Configure per-run package-manager caches
+        # The benchmark republishes deterministic versions (e.g. hardhat@3.12.1)
+        # whose content changes each run (new @nomicfoundation/edr pin), so any
+        # package-manager cache that persists on the self-hosted runner can
+        # resolve a prior run's stale republish. Point these caches at temp dirs
+        # that are cleaned up at the end of the job (see "Clean up temp dir").
+        #
+        # Yarn berry: the global folder holds both the zip cache and the npm
+        # packument metadata cache. YARN_* env vars override any .yarnrc.yml.
+        #
+        # Yarn classic: no override is needed. It doesn't have a persistent
+        # metadata cache, and its tarball cache slug includes the tarball's
+        # sha1.
+        run: |
+          set -euo pipefail
+          echo "BUN_INSTALL_CACHE_DIR=${RUNNER_TEMP:?}/bun-install-cache" >> "$GITHUB_ENV"
+          echo "YARN_GLOBAL_FOLDER=${RUNNER_TEMP:?}/yarn-global" >> "$GITHUB_ENV"
 
       - name: Compute sentinel versions
         # Writes EDR_VER and HH_VER to $GITHUB_ENV
@@ -392,7 +406,7 @@ jobs:
         # Self-hosted runners don't automatically wipe RUNNER_TEMP between jobs, so we do
         # this manually to avoid polluting future runs.
         if: always()
-        run: rm -rf "$E2E_CLONE_DIR" "$BUN_INSTALL_CACHE_DIR"
+        run: rm -rf "$E2E_CLONE_DIR" "$BUN_INSTALL_CACHE_DIR" "$YARN_GLOBAL_FOLDER"
 
   report:
     name: Report result to PR

--- a/.github/workflows/hh3-regression-benchmark.yml
+++ b/.github/workflows/hh3-regression-benchmark.yml
@@ -162,10 +162,18 @@ jobs:
         # Yarn classic: no override is needed. It doesn't have a persistent
         # metadata cache, and its tarball cache slug includes the tarball's
         # sha1.
+        #
+        # All caches live under PACKAGE_MANAGER_CACHES so the cleanup step can
+        # remove that single directory without being updated for every cache
+        # added here.
         run: |
           set -euo pipefail
-          echo "BUN_INSTALL_CACHE_DIR=${RUNNER_TEMP:?}/bun-install-cache" >> "$GITHUB_ENV"
-          echo "YARN_GLOBAL_FOLDER=${RUNNER_TEMP:?}/yarn-global" >> "$GITHUB_ENV"
+          PACKAGE_MANAGER_CACHES="${RUNNER_TEMP:?}/package-manager-caches"
+          {
+            echo "PACKAGE_MANAGER_CACHES=$PACKAGE_MANAGER_CACHES"
+            echo "BUN_INSTALL_CACHE_DIR=$PACKAGE_MANAGER_CACHES/bun-install"
+            echo "YARN_GLOBAL_FOLDER=$PACKAGE_MANAGER_CACHES/yarn-global"
+          } >> "$GITHUB_ENV"
 
       - name: Compute sentinel versions
         # Writes EDR_VER and HH_VER to $GITHUB_ENV
@@ -406,7 +414,7 @@ jobs:
         # Self-hosted runners don't automatically wipe RUNNER_TEMP between jobs, so we do
         # this manually to avoid polluting future runs.
         if: always()
-        run: rm -rf "$E2E_CLONE_DIR" "$BUN_INSTALL_CACHE_DIR" "$YARN_GLOBAL_FOLDER"
+        run: rm -rf "$E2E_CLONE_DIR" "$PACKAGE_MANAGER_CACHES"
 
   report:
     name: Report result to PR


### PR DESCRIPTION
## Problem

The HH3 regression benchmark's baseline run for `01e3c8df1` failed the "Validate scenarios used the local EDR build" step: the **lidofinance-core** scenario resolved `@nomicfoundation/edr@0.15.0-local.b0267ca7e2a7` (the build from a `/bench` run of `fix/call-trace-memory` two days earlier) instead of the expected `0.15.0-local.01e3c8df1f33`.

This is the same class of bug as the bun cache fix (#1588) — a package-manager cache persisting across runs on the self-hosted runner — but for **Yarn 4 (berry)**, which lidofinance-core alone uses.

## Root cause

The benchmark republishes a deterministic hardhat version (npm latest + 1, e.g. `3.12.1`) each run, with per-run content: the `@nomicfoundation/edr` dependency pin.

Yarn berry keeps a persistent per-user global folder (`~/.yarn/berry`) containing both its zip cache and an on-disk npm packument (metadata) cache. Berry's [`getPackageMetadata`](https://github.com/yarnpkg/berry/blob/master/packages/plugin-npm/sources/npmHttpUtils.ts) short-circuits: when the exact version being resolved already exists in the cached packument, it returns the cached metadata without any network request. Since the registry host (`127.0.0.1`) and the hardhat sentinel version were identical to the earlier run, yarn never asked this run's Verdaccio: it resolved the stale hardhat manifest, whose stale EDR pin (packument and zips also cached) installed as a fully self-consistent stale graph.

This also explains the validation split (Check A curls Verdaccio directly → fresh → pass; Check B inspects the installed `node_modules` → stale → fail) and why the yarn scenarios 1inch-aqua, 1inch-cross-chain-swap and aave-v4 passed: they use yarn **1.22.22** (Yarn Classic), which fetches packuments fresh on every install and keys its tarball cache by the tarball's sha1, so a same-version republish can never match a stale entry.

## Fix

Point yarn berry's global folder at a per-run temp dir, mirroring the bun fix.

## Verification

This fix cannot be validated until we've merged in into `main`. Once merged, I'll re-run the failing scenario to validate the fix.