### PR TITLE
feat: expose mimalloc memory stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2131,6 +2131,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cty"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3173,6 +3179,7 @@ dependencies = [
  "edr_utils_sync",
  "foundry-cheatcodes",
  "foundry-compilers",
+ "libmimalloc-sys",
  "mimalloc",
  "napi",
  "napi-build",
@@ -5563,6 +5570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
 dependencies = [
  "cc",
+ "cty",
 ]
 
 [[package]]

--- a/crates/edr_napi/Cargo.toml
+++ b/crates/edr_napi/Cargo.toml
@@ -42,6 +42,7 @@ edr_signer.workspace = true
 edr_solidity.workspace = true
 edr_tracing.workspace = true
 edr_utils_sync.workspace = true
+libmimalloc-sys = { version = "0.1.49", features = ["extended"], optional = true }
 mimalloc = { version = "0.1.39", default-features = false, features = [
     "local_dynamic_tls",
 ] }
@@ -99,6 +100,7 @@ napi-build = "2.3"
 napi = { version = "3", default-features = false, features = ["dyn-symbols"] }
 
 [features]
+memory-stats = ["dep:libmimalloc-sys"]
 op = ["dep:edr_op"]
 scenarios = ["dep:edr_scenarios", "dep:rand"]
 test-mock = ["edr_provider/test-utils"]

--- a/crates/edr_napi/package.json
+++ b/crates/edr_napi/package.json
@@ -59,6 +59,7 @@
     "build": "pnpm run build:publish",
     "build:debug": "bash ../../scripts/build_edr_napi.sh --features op",
     "build:dev": "bash ../../scripts/build_edr_napi.sh --release --features op",
+    "build:memory-stats": "bash ../../scripts/build_edr_napi.sh --release --features op,memory-stats",
     "build:perf-js": "RUSTFLAGS='-Cforce-frame-pointers=yes' bash ../../scripts/build_edr_napi.sh --profile napi-publish --features op",
     "build:publish": "bash ../../scripts/build_edr_napi.sh --profile napi-publish --features op",
     "build:scenarios": "bash ../../scripts/build_edr_napi.sh --release --features op,scenarios",

--- a/crates/edr_napi/src/cast.rs
+++ b/crates/edr_napi/src/cast.rs
@@ -148,6 +148,21 @@ impl TryCast<U256> for BigInt {
     }
 }
 
+impl TryCast<BigInt> for usize {
+    type Error = napi::Error;
+
+    fn try_cast(self) -> std::result::Result<BigInt, Self::Error> {
+        let value = u64::try_from(self).map_err(|_error| {
+            napi::Error::new(
+                Status::GenericFailure,
+                "usize was expected to fit within 64 bits.".to_string(),
+            )
+        })?;
+
+        Ok(BigInt::from(value))
+    }
+}
+
 impl<T> TryCast<T> for T {
     type Error = napi::Error;
 

--- a/crates/edr_napi/src/lib.rs
+++ b/crates/edr_napi/src/lib.rs
@@ -28,6 +28,7 @@ pub mod instrument;
 pub mod log;
 /// Types for an RPC request logger.
 pub mod logger;
+pub mod memory_stats;
 /// Types for mocking provider behavior.
 #[cfg(feature = "test-mock")]
 pub mod mock;

--- a/crates/edr_napi/src/lib.rs
+++ b/crates/edr_napi/src/lib.rs
@@ -10,7 +10,7 @@ mod async_deallocator;
 mod block;
 /// Types for overriding a call.
 pub mod call_override;
-/// Types for casting N-API types to Rust types.
+/// Types for casting between N-API types and Rust types.
 pub mod cast;
 /// Supported chain types.
 pub mod chains;

--- a/crates/edr_napi/src/memory_stats.rs
+++ b/crates/edr_napi/src/memory_stats.rs
@@ -142,13 +142,6 @@ unsafe extern "C" fn append_to_buffer(msg: *const c_char, arg: *mut c_void) {
 mod tests {
     use super::*;
 
-    /// Helper function to convert a `BigInt` to a `u64` for testing purposes.
-    /// `TryCast::try_cast` cannot be used directly, as the error type cannot be
-    /// inferred in the test context.
-    fn to_u64(value: BigInt) -> napi::Result<u64> {
-        value.try_cast()
-    }
-
     #[test]
     fn memory_stats_reports_process_memory() {
         // Ensure the allocator has something to report.
@@ -156,8 +149,49 @@ mod tests {
 
         let stats = memory_stats().expect("memory statistics should be available");
 
+        let peak_rss: u64 = stats.peak_rss.try_cast().unwrap();
+        let current_commit: u64 = stats.current_commit.try_cast().unwrap();
+        let peak_commit: u64 = stats.peak_commit.try_cast().unwrap();
+
         // The peak RSS is an OS process-level measurement, so it is non-zero.
-        assert!(to_u64(stats.peak_rss).unwrap() > 0);
+        assert!(peak_rss > 0);
+
+        // Invariant that holds across all platforms and constrains the
+        // mapping of `mi_process_info`'s out-parameters to struct fields: the
+        // peak commit is the high-water mark of the current commit. Note that
+        // `peak_rss >= current_commit` does NOT hold in general: zeroed
+        // allocations commit pages without touching them, so the commit can
+        // exceed the RSS.
+        assert!(peak_commit >= current_commit);
+    }
+
+    #[test]
+    fn memory_stats_commit_tracks_allocation() {
+        fn current_commit() -> u64 {
+            memory_stats()
+                .expect("memory statistics should be available")
+                .current_commit
+                .try_cast()
+                .unwrap()
+        }
+
+        let before = current_commit();
+
+        // Non-zero contents, so that all pages are touched and the allocation
+        // drives the RSS in addition to the commit.
+        let big = vec![1u8; 256 * 1024 * 1024];
+        std::hint::black_box(&big);
+
+        let stats = memory_stats().expect("memory statistics should be available");
+        let after: u64 = stats.current_commit.try_cast().unwrap();
+        let peak_rss: u64 = stats.peak_rss.try_cast().unwrap();
+
+        // The live 256 MiB allocation must show up in the committed memory,
+        // with slack for concurrent deallocations by other tests.
+        assert!(after >= before + 200 * 1024 * 1024);
+        // The touched 256 MiB must have driven the OS peak RSS at least this
+        // high, pinning `peak_rss` to an RSS out-parameter.
+        assert!(peak_rss >= 200 * 1024 * 1024);
     }
 
     #[test]

--- a/crates/edr_napi/src/memory_stats.rs
+++ b/crates/edr_napi/src/memory_stats.rs
@@ -105,7 +105,14 @@ pub fn memory_stats() -> napi::Result<MiMemoryStats> {
 /// internal assertions and is expensive.
 #[napi(catch_unwind)]
 pub fn memory_report() -> String {
-    let mut buffer = Vec::<u8>::new();
+    // Pre-allocate so that `append_to_buffer` doesn't reallocate through the
+    // global allocator (mimalloc) while `mimalloc` is printing.
+    //
+    // 2 KiB covers the ~1.3 KiB report that `MI_STAT=0` builds produce.
+    //
+    // If `MI_STAT > 1`, a variable part is added, which is capped at `MI_BIN_HUGE +
+    // 1`; i.e. 74 bin lines. Extrapolating to all 74 bins gives ~7.7 KB.
+    let mut buffer = Vec::<u8>::with_capacity(2048);
 
     // SAFETY: `append_to_buffer` does not unwind and only accesses `arg` as
     // the `Vec<u8>` it points to. `buffer` outlives the call and is not
@@ -116,6 +123,8 @@ pub fn memory_report() -> String {
             ptr::from_mut(&mut buffer).cast::<c_void>(),
         );
     }
+
+    buffer.shrink_to_fit();
 
     String::from_utf8_lossy(&buffer).into_owned()
 }

--- a/crates/edr_napi/src/memory_stats.rs
+++ b/crates/edr_napi/src/memory_stats.rs
@@ -18,7 +18,7 @@ use crate::cast::TryCast as _;
 /// Memory statistics for the process, as reported by `mimalloc`'s
 /// `mi_process_info`.
 #[napi(object)]
-pub struct MiMemoryStats {
+pub struct MemoryStats {
     /// Elapsed wall-clock time of the process, in milliseconds.
     pub elapsed_ms: BigInt,
     /// User time, in milliseconds, as the sum over all threads.
@@ -46,7 +46,7 @@ pub struct MiMemoryStats {
 /// Returns memory statistics for the process, as reported by `mimalloc`'s
 /// `mi_process_info`.
 #[napi(catch_unwind)]
-pub fn memory_stats() -> napi::Result<MiMemoryStats> {
+pub fn memory_stats() -> napi::Result<MemoryStats> {
     let mut elapsed_msecs = 0usize;
     let mut user_msecs = 0usize;
     let mut system_msecs = 0usize;
@@ -80,7 +80,7 @@ pub fn memory_stats() -> napi::Result<MiMemoryStats> {
     let peak_commit = peak_commit.try_cast()?;
     let page_faults = page_faults.try_cast()?;
 
-    Ok(MiMemoryStats {
+    Ok(MemoryStats {
         elapsed_ms,
         user_ms,
         system_ms,

--- a/crates/edr_napi/src/memory_stats.rs
+++ b/crates/edr_napi/src/memory_stats.rs
@@ -1,0 +1,186 @@
+#![cfg(feature = "memory-stats")]
+
+//! Types and functions for inspecting memory usage.
+//!
+//! Exposes the statistics collected by the `mimalloc` allocator that is used
+//! as the global allocator of this addon.
+
+use std::{
+    ffi::{c_char, c_void, CStr},
+    ptr,
+};
+
+use napi::bindgen_prelude::BigInt;
+use napi_derive::napi;
+
+use crate::cast::TryCast as _;
+
+/// Memory statistics for the process, as reported by `mimalloc`'s
+/// `mi_process_info`.
+#[napi(object)]
+pub struct MiMemoryStats {
+    /// Elapsed wall-clock time of the process, in milliseconds.
+    pub elapsed_ms: BigInt,
+    /// User time, in milliseconds, as the sum over all threads.
+    pub user_ms: BigInt,
+    /// System time, in milliseconds.
+    pub system_ms: BigInt,
+    /// Current resident set size (touched pages), in bytes. This is an OS
+    /// process-level measurement. It is precise on Windows and macOS; on
+    /// other systems it is estimated using the current committed memory.
+    pub current_rss: BigInt,
+    /// Peak resident set size, in bytes. This is an OS process-level
+    /// measurement.
+    pub peak_rss: BigInt,
+    /// Current committed memory, in bytes. This is a `mimalloc`-internal
+    /// measurement: the amount of read/write accessible memory reserved by
+    /// the allocator (precise on Windows, estimated elsewhere).
+    pub current_commit: BigInt,
+    /// Peak committed memory, in bytes. This is a `mimalloc`-internal
+    /// measurement.
+    pub peak_commit: BigInt,
+    /// Count of hard page faults.
+    pub page_faults: BigInt,
+}
+
+/// Returns memory statistics for the process, as reported by `mimalloc`'s
+/// `mi_process_info`.
+#[napi(catch_unwind)]
+pub fn memory_stats() -> napi::Result<MiMemoryStats> {
+    let mut elapsed_msecs = 0usize;
+    let mut user_msecs = 0usize;
+    let mut system_msecs = 0usize;
+    let mut current_rss = 0usize;
+    let mut peak_rss = 0usize;
+    let mut current_commit = 0usize;
+    let mut peak_commit = 0usize;
+    let mut page_faults = 0usize;
+
+    // SAFETY: All out-parameters point to live `usize` values that outlive
+    // the call.
+    unsafe {
+        libmimalloc_sys::mi_process_info(
+            &mut elapsed_msecs,
+            &mut user_msecs,
+            &mut system_msecs,
+            &mut current_rss,
+            &mut peak_rss,
+            &mut current_commit,
+            &mut peak_commit,
+            &mut page_faults,
+        );
+    }
+
+    let elapsed_ms = elapsed_msecs.try_cast()?;
+    let user_ms = user_msecs.try_cast()?;
+    let system_ms = system_msecs.try_cast()?;
+    let current_rss = current_rss.try_cast()?;
+    let peak_rss = peak_rss.try_cast()?;
+    let current_commit = current_commit.try_cast()?;
+    let peak_commit = peak_commit.try_cast()?;
+    let page_faults = page_faults.try_cast()?;
+
+    Ok(MiMemoryStats {
+        elapsed_ms,
+        user_ms,
+        system_ms,
+        current_rss,
+        peak_rss,
+        current_commit,
+        peak_commit,
+        page_faults,
+    })
+}
+
+/// Returns a human-readable report of `mimalloc`'s main statistics, i.e. the
+/// output of `mi_stats_print_out`.
+///
+/// The level of detail depends on how `mimalloc` was compiled (`MI_STAT`);
+/// release builds report summary-level statistics.
+#[napi(catch_unwind)]
+pub fn memory_report() -> String {
+    let mut buffer = Vec::<u8>::new();
+
+    // SAFETY: `append_to_buffer` does not unwind and only accesses `arg` as
+    // the `Vec<u8>` it points to. `buffer` outlives the call and is not
+    // accessed otherwise while `mi_stats_print_out` runs.
+    unsafe {
+        libmimalloc_sys::mi_stats_print_out(
+            Some(append_to_buffer),
+            ptr::from_mut(&mut buffer).cast::<c_void>(),
+        );
+    }
+
+    String::from_utf8_lossy(&buffer).into_owned()
+}
+
+/// Resets `mimalloc`'s statistics, e.g. for per-phase measurements. OS
+/// process-level values such as the resident set size are unaffected.
+#[napi(catch_unwind)]
+pub fn reset_memory_stats() {
+    // SAFETY: `mi_stats_reset` has no preconditions and is thread-safe.
+    unsafe { libmimalloc_sys::mi_stats_reset() };
+}
+
+/// Output callback for `mi_stats_print_out` that appends the message to the
+/// `Vec<u8>` passed through `arg`.
+///
+/// As it is called from C code, this function must not unwind. It only
+/// performs operations that abort rather than unwind on failure: allocation
+/// failure in `extend_from_slice` aborts via the global allocation error
+/// handler. In addition, the `extern "C"` ABI converts any unexpected panic
+/// into an abort instead of undefined behavior.
+unsafe extern "C" fn append_to_buffer(msg: *const c_char, arg: *mut c_void) {
+    if msg.is_null() || arg.is_null() {
+        return;
+    }
+
+    // SAFETY: `mimalloc` passes a valid nul-terminated C string that is live
+    // for the duration of the callback.
+    let message = unsafe { CStr::from_ptr(msg) };
+    // SAFETY: `arg` is the pointer to the `Vec<u8>` created in
+    // `memory_report`, which is live and not accessed by anything else while
+    // `mi_stats_print_out` runs.
+    let buffer = unsafe { &mut *arg.cast::<Vec<u8>>() };
+
+    buffer.extend_from_slice(message.to_bytes());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper function to convert a `BigInt` to a `u64` for testing purposes.
+    /// `TryCast::try_cast` cannot be used directly, as the error type cannot be
+    /// inferred in the test context.
+    fn to_u64(value: BigInt) -> napi::Result<u64> {
+        value.try_cast()
+    }
+
+    #[test]
+    fn memory_stats_reports_process_memory() {
+        // Ensure the allocator has something to report.
+        let _allocation = vec![0u8; 1024 * 1024];
+
+        let stats = memory_stats().expect("memory statistics should be available");
+
+        // The peak RSS is an OS process-level measurement, so it is non-zero
+        // and unaffected by concurrent `reset_memory_stats` calls.
+        assert!(to_u64(stats.peak_rss).unwrap() > 0);
+    }
+
+    #[test]
+    fn memory_report_is_non_empty() {
+        let report = memory_report();
+
+        assert!(!report.is_empty());
+    }
+
+    #[test]
+    fn reset_memory_stats_keeps_reporting_working() {
+        reset_memory_stats();
+
+        let stats = memory_stats().expect("memory statistics should be available");
+        assert!(to_u64(stats.peak_rss).unwrap() > 0);
+    }
+}

--- a/crates/edr_napi/src/memory_stats.rs
+++ b/crates/edr_napi/src/memory_stats.rs
@@ -95,8 +95,14 @@ pub fn memory_stats() -> napi::Result<MiMemoryStats> {
 /// Returns a human-readable report of `mimalloc`'s main statistics, i.e. the
 /// output of `mi_stats_print_out`.
 ///
-/// The level of detail depends on how `mimalloc` was compiled (`MI_STAT`);
-/// release builds report summary-level statistics.
+/// The level of detail is fixed at compile time (`MI_STAT`). In EDR's
+/// configuration `mimalloc` is compiled with `MI_STAT=0` ("only essential"),
+/// regardless of the cargo profile: the report contains arena-level
+/// accounting (reserved, committed, purged), page statistics, and process
+/// information, but the per-allocation breakdown (block totals and
+/// per-size-class bins) is compiled out. Reaching `MI_STAT=2` would require
+/// building `libmimalloc-sys` with its `debug` feature, which also enables
+/// internal assertions and is expensive.
 #[napi(catch_unwind)]
 pub fn memory_report() -> String {
     let mut buffer = Vec::<u8>::new();

--- a/crates/edr_napi/src/memory_stats.rs
+++ b/crates/edr_napi/src/memory_stats.rs
@@ -114,14 +114,6 @@ pub fn memory_report() -> String {
     String::from_utf8_lossy(&buffer).into_owned()
 }
 
-/// Resets `mimalloc`'s statistics, e.g. for per-phase measurements. OS
-/// process-level values such as the resident set size are unaffected.
-#[napi(catch_unwind)]
-pub fn reset_memory_stats() {
-    // SAFETY: `mi_stats_reset` has no preconditions and is thread-safe.
-    unsafe { libmimalloc_sys::mi_stats_reset() };
-}
-
 /// Output callback for `mi_stats_print_out` that appends the message to the
 /// `Vec<u8>` passed through `arg`.
 ///
@@ -164,8 +156,7 @@ mod tests {
 
         let stats = memory_stats().expect("memory statistics should be available");
 
-        // The peak RSS is an OS process-level measurement, so it is non-zero
-        // and unaffected by concurrent `reset_memory_stats` calls.
+        // The peak RSS is an OS process-level measurement, so it is non-zero.
         assert!(to_u64(stats.peak_rss).unwrap() > 0);
     }
 
@@ -174,13 +165,5 @@ mod tests {
         let report = memory_report();
 
         assert!(!report.is_empty());
-    }
-
-    #[test]
-    fn reset_memory_stats_keeps_reporting_working() {
-        reset_memory_stats();
-
-        let stats = memory_stats().expect("memory statistics should be available");
-        assert!(to_u64(stats.peak_rss).unwrap() > 0);
     }
 }


### PR DESCRIPTION
## Expose mimalloc memory statistics behind a `memory-stats` feature flag

### Purpose

EDR uses mimalloc as the global allocator of the N-API addon, which makes its native memory invisible to standard profiling tools: a heaptrack run against Hardhat 3's end-to-end benchmarks saw only 1.87 GB of malloc-attributed memory while the process RSS was 15.25 GB. Consumers currently have to approximate EDR's memory as `rss − v8HeapTotal − external − arrayBuffers`.

This PR exposes mimalloc's own statistics API through N-API, behind a new opt-in cargo feature `memory-stats`:

- `memoryStats(): MiMemoryStats` — wraps `mi_process_info`; returns elapsed/user/system time (ms), current/peak RSS, current/peak commit, and hard page faults as `BigInt`s. The doc comments distinguish OS process-level values (RSS) from mimalloc-internal ones (commit), so consumers don't conflate them.
- `memoryReport(): string` — wraps `mi_stats_print_out`; returns mimalloc's human-readable stats report.

A `resetMemoryStats()` wrapper was considered and dropped: `mi_stats_reset` is deprecated and effectively a no-op in the vendored mimalloc v3 (it merges thread-local stats instead of resetting, so peaks survive), which would silently break per-phase measurements. Per-phase deltas for the current values can be computed by diffing two `memoryStats()` snapshots; peaks genuinely cannot be reset in v3.

The bindings come from a direct optional dependency on `libmimalloc-sys` (with its `extended` feature), pinned to the version already locked via the `mimalloc` crate — cargo unifies the two, so this adds bindings only, not a second allocator build. The existing `mimalloc` dependency and `#[global_allocator]` are unchanged.

### Packaging

Published npm packages deliberately do **not** ship this feature: `build:publish` and `build:typingFile` remain `--features op`, so the released binaries and the committed `index.d.ts` are unchanged. The APIs are only available in local builds via the new `pnpm build:memory-stats` script (mirroring `build:scenarios`/`build:tracing`).

### Stats detail

The depth of `memoryReport()` is fixed at compile time by mimalloc's `MI_STAT` level. EDR's builds get `MI_STAT=0` ("only essential") in **every** cargo profile — libmimalloc-sys only raises it via its `debug` feature (which also enables mimalloc's internal assertions), and we don't enable it; a dev-profile report is byte-identical to a release one.

| `MI_STAT` | What the report exposes | Cost |
|---|---|---|
| `0` (what EDR builds, all profiles) | Arena stats (`reserved`, `committed` current+peak, purge/mmap/commit counters), page stats (`touched`, `pages`, `abandoned`, reclaim/retire counters), process info (threads, times, peak RSS/commit, page faults) | none |
| `1` | Adds per-heap block allocation totals (`binned`/`huge`/`total` bytes of live blocks), tracked on every alloc/free | small |
| `2` (requires libmimalloc-sys `debug` feature) | Adds per-size-class bin table, allocation counts, and `malloc req` (exact requested bytes) | measurable, plus internal assertions |

Note the practical consequence: the report attributes memory at the arena/commit level — which is the number that explains the RSS gap motivating this PR — but the per-size-class malloc breakdown readers might expect from mimalloc stats is compiled out in EDR's configuration. Everything `memoryStats()` returns is `MI_STAT=0` data, so it is fully accurate in our builds.


### Testing

- New Rust unit tests constrain the out-param→field mapping of the `mi_process_info` wrapper: `peak_commit >= current_commit` must hold, a touched 256 MiB allocation must raise `current_commit` by ≥200 MiB and drive `peak_rss` ≥200 MiB, and `memoryReport()` must be non-empty. They pass under `--features memory-stats` and `--all-features`, so CI's `llvm-cov --all-features` job runs them automatically. (Note: `peak_rss >= current_commit` is deliberately *not* asserted — zeroed allocations commit pages without touching them, so commit can legitimately exceed RSS.)
  - This is the first Rust test in `edr_napi`, linking via the existing `dyn-symbols` dev-dependency. Before the introduction of `dyn-symbols` having Rust tests was not possible.
- `cargo check --no-default-features --all-targets` and `cargo clippy --all-targets --all-features -- -D warnings` are clean; `cargo tree` confirms a single `libmimalloc-sys` in the graph.
- Manual smoke test: built the addon with `pnpm build:memory-stats` and loaded it in Node — `memoryStats()` returns `BigInt` values and `currentCommit` moved from 4.65 MB to 9.04 MB when allocating through an EDR API; `memoryReport()` returns a real mimalloc stats report. Notably, `Buffer.alloc` does *not* move the commit figures (Node's heap isn't mimalloc), which is exactly the RSS-vs-commit distinction the API documents.
- Committed `index.d.ts`/`index.js` are untouched (generated with `--features op` as before), keeping the typings-check CI job green.
