### PR TITLE
build(npm): redefine platform packages as `optionalDependencies`

### DIFF
--- a/.changeset/ten-lines-sort.md
+++ b/.changeset/ten-lines-sort.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": minor
+---
+
+Changed the platform-specific `@nomicfoundation/edr-*` packages from `dependencies` to `optionalDependencies`, so installs only download the build for the current platform instead of all of them.

--- a/.changeset/ten-lines-sort.md
+++ b/.changeset/ten-lines-sort.md
@@ -2,4 +2,4 @@
 "@nomicfoundation/edr": minor
 ---
 
-Changed the platform-specific `@nomicfoundation/edr-*` packages from `dependencies` to `optionalDependencies`, so installs only download the build for the current platform instead of all of them.
+Changed the platform-specific `@nomicfoundation/edr-*` packages from `dependencies` to `optionalDependencies`, so installs only download the build for the current platform instead of all of them. Note: npm < 11.3.0 may skip the platform package when reusing a lockfile created on a different platform (npm/cli#4828); if affected, upgrade with `npm install -g npm@11`.

--- a/.github/workflows/edr-npm-release.yml
+++ b/.github/workflows/edr-npm-release.yml
@@ -542,10 +542,6 @@ jobs:
         uses: ./.github/actions/setup-node
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
-      - name: Install sponge # needed for prepublish script
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y moreutils
       - name: Download all artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/scripts/prepublish.sh
+++ b/scripts/prepublish.sh
@@ -12,5 +12,3 @@ set -o pipefail
 #   --skip-optional-publish  — don't run `npm publish` for the platform pkgs.
 #   --no-gh-release          — don't try to create a GitHub release.
 pnpm napi pre-publish -t npm --skip-optional-publish --no-gh-release
-
-jq 'with_entries(if .key == "optionalDependencies" then .key = "dependencies" else . end)' package.json | sponge package.json

--- a/scripts/publish_to_verdaccio.sh
+++ b/scripts/publish_to_verdaccio.sh
@@ -3,21 +3,20 @@
 # Publish a locally-built EDR NAPI package to a (Verdaccio) registry.
 #
 # It stages the prebuilt native binary into its platform package, compiles the
-# bundled TypeScript helpers, pins both the main and platform packages to the
-# requested version, wires the main package's dependency on the platform
-# package, and publishes both (platform package first).
+# bundled TypeScript helpers, pins the packages to the requested version, wires
+# the platform packages as optionalDependencies — the same package shape as a
+# real release — and publishes the main package and this platform's package
+# (platform package first).
 #
-# It deliberately does NOT run scripts/prepublish.sh: that injects all 7 platform
-# packages as hard dependencies, but a local build only produces (and publishes)
-# the current platform. We wire the single platform dependency instead — which is
-# all `crates/edr_napi/index.js` needs to load the binding on this platform.
+# Only the current platform's package exists in the local registry; npm and
+# pnpm skip optionalDependencies they can't resolve, so installs still work.
 #
 # The native binary must already be built (e.g. `pnpm build` in crates/edr_napi)
 # and EDR's dependencies installed (the TypeScript compile needs the local `tsc`).
 #
 # NOTE: This mutates tracked files in crates/edr_napi (package.json versions, the
-# wired dependency, the staged .node binary, coverage.sol and dist/). Reset them
-# with `git checkout -- crates/edr_napi` afterwards.
+# injected optionalDependencies, the staged .node binary, coverage.sol and
+# dist/). Reset them with `git checkout -- crates/edr_napi` afterwards.
 #
 # Usage:
 #   scripts/publish_to_verdaccio.sh --version <ver> [options]
@@ -96,11 +95,12 @@ echo ">> Compiling bundled TypeScript helpers"
 cp "$REPO_ROOT/data/contracts/coverage.sol" "$NAPI_DIR/coverage.sol"
 ( cd "$NAPI_DIR" && pnpm exec tsc )
 
-echo ">> Pinning versions and wiring the platform dependency"
+echo ">> Pinning versions and wiring the platform packages"
 ( cd "$NAPI_DIR"
   npm pkg set version="$VERSION"
-  npm pkg set version="$VERSION" --prefix "npm/$PLATFORM"
-  npm pkg set "dependencies.@nomicfoundation/edr-$PLATFORM=$VERSION"
+  # Syncs the platform packages' versions and wires them as optionalDependencies,
+  # mirroring the release workflow.
+  "$SCRIPT_DIR/prepublish.sh"
 )
 
 if [ -n "$NPMRC" ]; then


### PR DESCRIPTION
closes #1576

## Changes

- `scripts/prepublish.sh`: removed the `optionalDependencies` → `dependencies` rename, so the platform-specific `@nomicfoundation/edr-*` packages are published as `optionalDependencies` again and installs only
  download the build for the current platform. 
   - The rename was a workaround (#434) for npm/cli#4828
   - npm fixed it in version `11.3.0`.
- `scripts/publish_to_verdaccio.sh`: now runs `prepublish.sh` instead of hand-wiring a single platform dependency, keeping the local publish flow as close as possible to the real release. The entries for platforms not published locally are left in place: npm and pnpm skip `optionalDependencies` they can't resolve.

## Validations

Ran the publish flow end to end against a local Verdaccio 6 registry  on `linux-arm64-gnu`:

  - **Publish**: `scripts/publish_to_verdaccio.sh --version 0.15.0-local.<sha>` — runs the same `prepublish.sh` as the release workflow and published both the platform package and the root package. 
  - **Published shape**: `npm view` on the registry shows all 7 platform packages under `optionalDependencies` and no `dependencies` key.
  - **Consumer installs**: fresh projects installing from the registry with npm and pnpm each downloaded only `@nomicfoundation/edr` plus the current platform's package.
  - **TypeScript client**: a `tsc` project that at runtime constructed an `EdrContext` and  registered the generic provider factory, confirming the native binding loads through the optional platform package.
