### PR TITLE
fix: collect stack traces for `setUp()` failures in `CollectStackTraces::Always`

### DIFF
--- a/.changeset/stack-trace-failing-setup-always-mode.md
+++ b/.changeset/stack-trace-failing-setup-always-mode.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Fixed missing Solidity test stack trace when `setUp()` fails and stack traces are collected with `CollectStackTraces::Always`.

--- a/crates/edr_solidity_tests/src/runner.rs
+++ b/crates/edr_solidity_tests/src/runner.rs
@@ -640,6 +640,10 @@ impl<
         let mut setup: TestSetup<HaltReasonT> = self.setup(&mut executor, call_setup);
         debug!("finished setting up in {:?}", setup_time.elapsed());
 
+        // Whether steps were actually recorded while `setUp()` ran; must be
+        // captured before the original tracer (whose mode may differ) is
+        // restored.
+        let setup_recorded_steps = executor.tracer_records_steps();
         executor.inspector_mut().tracer = prev_tracer;
 
         if setup.reason.is_some() {
@@ -647,7 +651,7 @@ impl<
             // these numbers to reason about the performance of their code.
             let elapsed = start.elapsed();
 
-            setup.stack_trace_result = if executor.tracer_records_steps() {
+            setup.stack_trace_result = if setup_recorded_steps {
                 // We collected steps during setup, so we can generate the stack trace
                 get_stack_trace(
                     &*self.contract_decoder,

--- a/crates/edr_solidity_tests/tests/it/repros.rs
+++ b/crates/edr_solidity_tests/tests/it/repros.rs
@@ -668,16 +668,20 @@ fn assert_execution_error_stack_trace<'suite, HaltReasonT: HaltReasonTrait>(
     };
 
     // A non-empty trace that reaches the failing call's execution error
-    // (exact variant depends on the compilation mode).
+    // (exact variant depends on the compilation mode). The entry must be
+    // source-mapped: a trace inferred from step-less arenas degrades to a
+    // bare `OtherExecutionError { source_reference: None }` (issue #1605).
     assert!(
-        stack_trace.iter().any(|entry| matches!(
-            entry,
-            StackTraceEntry::RevertError { .. }
-                | StackTraceEntry::PanicError { .. }
-                | StackTraceEntry::CustomError { .. }
-                | StackTraceEntry::OtherExecutionError { .. }
-        )),
-        "{test_name}: expected an execution-error stack trace, got:\n{stack_trace:#?}"
+        stack_trace.iter().any(|entry| {
+            matches!(
+                entry,
+                StackTraceEntry::RevertError { .. }
+                    | StackTraceEntry::PanicError { .. }
+                    | StackTraceEntry::CustomError { .. }
+                    | StackTraceEntry::OtherExecutionError { .. }
+            ) && entry.source_reference().is_some()
+        }),
+        "{test_name}: expected a source-mapped execution-error stack trace, got:\n{stack_trace:#?}"
     );
 
     result
@@ -717,6 +721,11 @@ async fn always_mode_produces_stack_trace_for_failing_test() {
         "expected a fuzz test kind, got {:?}",
         fuzz_result.kind
     );
+
+    let failing_setup_suite = suite_results
+        .get("via-ir/repros/StackTraceAlwaysMode.t.sol:AlwaysStackTraceFailingSetupTest")
+        .expect("the AlwaysStackTraceFailingSetup suite should have run");
+    assert_execution_error_stack_trace(failing_setup_suite, "setUp()");
 
     let invariant_suite = suite_results
         .get("via-ir/repros/StackTraceAlwaysMode.t.sol:AlwaysStackTraceInvariantTest")
@@ -765,4 +774,30 @@ async fn always_mode_produces_stack_trace_for_failing_test() {
         "expected an invariant setup failure, got {:?}",
         invariant_initial_result.reason
     );
+}
+
+// A failing `setUp()` must produce a stack trace via the re-execution
+// fallback in the default `CollectStackTraces::OnFailure` mode too, matching
+// the `Always` mode behavior.
+#[tokio::test(flavor = "multi_thread")]
+async fn on_failure_mode_produces_stack_trace_for_failing_setup() {
+    let config = runner_config(None, &TEST_DATA_VIA_IR, false).await;
+    assert_eq!(
+        config.collect_stack_traces,
+        CollectStackTraces::OnFailure,
+        "this test relies on the default mode being `OnFailure`"
+    );
+
+    let contract_decoder = contract_decoder(TEST_DATA_VIA_IR.build_info_path());
+    let runner = TEST_DATA_VIA_IR
+        .runner_with_contract_decoder(config, contract_decoder)
+        .await;
+    let filter = SolidityTestFilter::contract("AlwaysStackTraceFailingSetupTest");
+    let suite_results = runner.test_collect(filter).await.suite_results;
+
+    let suite = suite_results
+        .get("via-ir/repros/StackTraceAlwaysMode.t.sol:AlwaysStackTraceFailingSetupTest")
+        .expect("the AlwaysStackTraceFailingSetup suite should have run");
+
+    assert_execution_error_stack_trace(suite, "setUp()");
 }

--- a/crates/edr_solidity_tests/tests/testdata/via-ir/repros/StackTraceAlwaysMode.t.sol
+++ b/crates/edr_solidity_tests/tests/testdata/via-ir/repros/StackTraceAlwaysMode.t.sol
@@ -63,6 +63,16 @@ contract Counter {
     }
 }
 
+// Covers the failing-`setUp()` stack-trace path (issue #1605). The suite
+// needs at least one test function, or `run_tests` skips setup entirely.
+contract AlwaysStackTraceFailingSetupTest is DSTest {
+    function setUp() public {
+        new Reverter().boom();
+    }
+
+    function testNeverRuns() public {}
+}
+
 // Covers the invariant setup-failure stack-trace path: the invariant is
 // already broken in the initial state, so the campaign fails during the
 // initial invariant check, before any fuzzed calls. `Counter` is deployed so


### PR DESCRIPTION
This PR fixes missing Solidity test stack trace when `setUp()` fails and stack traces are collected with `CollectStackTraces::Always`.

## Problem

In `CollectStackTraces::Always` mode, a failing `setUp()` produced a useless stack trace (`OtherExecutionError` with no source reference) instead of a source-mapped one.

`ContractRunner::run_tests` downgrades tracing to `TracingMode::WithoutSteps` during `setUp()` as an optimization, but restored the original tracer *before* the setup-failure branch consulted `executor.tracer_records_steps()`. In `Always` mode the restored tracer is `WithSteps`, so the check wrongly reported that steps had been collected during setup, and stack traces were inferred from step-less trace arenas instead of taking the re-execution fallback. `OnFailure` mode was unaffected because its tracer never records steps.

## Fix

Capture whether steps were actually recorded during `setUp()` before restoring the original tracer, and use that in the setup-failure branch. A failing `setUp()` under `Always` now takes the same re-execution fallback as `OnFailure` and yields the same source-mapped stack trace.

## Tests

- New fixture contract with a reverting `setUp()` in `StackTraceAlwaysMode.t.sol`, asserted in both `Always` mode (extends `always_mode_produces_stack_trace_for_failing_test`) and `OnFailure` mode (new test) — the latter path was previously untested too.
- Strengthened `assert_execution_error_stack_trace` to require a source-mapped error entry: the degraded trace surfaces as a nominally successful `OtherExecutionError { source_reference: None }`, which the previous assertion would have accepted. Verified red before the fix, green after.

closes #1605 