### PR TITLE
bench: add a memory benchmark for the Solidity test runner

### DIFF
--- a/js/benchmark/README.md
+++ b/js/benchmark/README.md
@@ -48,6 +48,31 @@ pnpm soltestsBenchmark --benchmark-output soltest-report.json
 
 The CI is set up to run `soltestsBenchmark` on every commit in `main`, save the measurements and then compare PRs against the latest measurements from `main`. The measurements from `main` are visualized [here.](https://nomic-foundation-automation.github.io/edr-benchmark-results/soltests/)
 
+### Memory Benchmark
+
+Measures the peak memory (resident set size) of a full Solidity test run per repository and Hardhat verbosity level. Verbosity is the input that matters: Hardhat maps it to the EDR options that control trace collection (`collectStackTraces`/`includeTraces`), and at `-vvv` and above EDR records EVM steps for every call, which is what drove the out-of-memory reports this benchmark exists to track.
+
+How it works:
+
+- Every (repo, verbosity) cell runs in a fresh child process, because a process's peak RSS is a high-water mark that never decreases. The child is wrapped in GNU `time -v` where available, so the peak is also observed from outside — including for a child that the OOM killer terminates before it can report anything.
+- A cell whose child ran out of memory is recorded as `OOM`, with the last externally observed peak as a lower bound; on an unoptimized build this is expected for the larger repos. A cell that failed for any other reason is recorded as `error`, the remaining cells still run, and the command exits unsuccessfully at the end.
+- Children run with 4 rayon threads (`RAYON_NUM_THREADS`): peak memory scales with how many test suites run concurrently, and unbounded parallelism would leave every cell of an unoptimized build reading `OOM`, with nothing to compare against. They inherit the same V8 flags as the other benchmarks (a raised `--max-old-space-size`), so the operating system rather than V8's heap limit decides when a child is out of memory.
+- Progress goes to stderr; stdout carries only the final markdown table (rows are repos, columns are verbosity levels). The full results, including the memory in use before any test ran, are written to the JSON output file after every cell.
+
+Freed memory is reflected in these numbers: EDR's Node binding uses mimalloc, which returns the large freed buffers (such as recorded EVM steps) to the operating system.
+
+#### Run
+
+```shell
+pnpm install --frozen-lockfile
+
+# All default repos at verbosity 2, 3 and 4 (the levels with distinct trace-collection behaviour)
+pnpm soltestsMemory --benchmark-output memory-report.json
+
+# One repo, one verbosity level
+pnpm soltestsMemory --repo solady --verbosity 3
+```
+
 ### Compare EDR and Forge
 
 This is the second iteration of the Solidity test benchmarks that focuses on comparing the performance of EDR and Foundry Forge.

--- a/js/benchmark/package.json
+++ b/js/benchmark/package.json
@@ -50,7 +50,9 @@
     "reportForge": "tsx src/index.ts report-forge",
     "reportProviderBenchmark": "tsx src/index.ts report-provider-benchmark",
     "soltests": "node --noconcurrent_sweeping --noconcurrent_recompilation --max-old-space-size=28000 --import tsx src/index.ts solidity-tests",
+    "presoltestsMemory": "pnpm run preproviderBenchmark",
     "soltestsBenchmark": "node --noconcurrent_sweeping --noconcurrent_recompilation --max-old-space-size=28000 --import tsx src/index.ts solidity-tests-benchmark",
+    "soltestsMemory": "node --import tsx src/index.ts solidity-tests-memory",
     "test": "node --import tsx/esm --test \"test/*.ts\"",
     "verifyProviderBenchmark": "tsx src/index.ts verify-provider-benchmark"
   },

--- a/js/benchmark/package.json
+++ b/js/benchmark/package.json
@@ -52,7 +52,7 @@
     "soltests": "node --noconcurrent_sweeping --noconcurrent_recompilation --max-old-space-size=28000 --import tsx src/index.ts solidity-tests",
     "presoltestsMemory": "pnpm run preproviderBenchmark",
     "soltestsBenchmark": "node --noconcurrent_sweeping --noconcurrent_recompilation --max-old-space-size=28000 --import tsx src/index.ts solidity-tests-benchmark",
-    "soltestsMemory": "node --import tsx src/index.ts solidity-tests-memory",
+    "soltestsMemory": "node --noconcurrent_sweeping --noconcurrent_recompilation --max-old-space-size=28000 --import tsx src/index.ts solidity-tests-memory",
     "test": "node --import tsx/esm --test \"test/*.ts\"",
     "verifyProviderBenchmark": "tsx src/index.ts verify-provider-benchmark"
   },

--- a/js/benchmark/src/index.ts
+++ b/js/benchmark/src/index.ts
@@ -26,6 +26,7 @@ import {
   setupRepo,
   REPOS,
   runSolidityTestsMemoryBenchmark,
+  MEMORY_REPOS,
   MEMORY_VERBOSITIES,
 } from "./solidity-tests.js";
 
@@ -189,10 +190,7 @@ async function main(): Promise<boolean> {
       return false;
     }
   } else if (args.command === "solidity-tests-memory") {
-    const repos =
-      args.repo !== undefined
-        ? args.repo.split(",")
-        : ["solady", "uniswap-v4-core", "morpho-blue"];
+    const repos = args.repo !== undefined ? args.repo.split(",") : MEMORY_REPOS;
     const verbosities =
       args.verbosity !== undefined ? [args.verbosity] : MEMORY_VERBOSITIES;
     const memoryResults = await runSolidityTestsMemoryBenchmark(

--- a/js/benchmark/src/index.ts
+++ b/js/benchmark/src/index.ts
@@ -195,11 +195,20 @@ async function main(): Promise<boolean> {
         : ["solady", "uniswap-v4-core", "morpho-blue"];
     const verbosities =
       args.verbosity !== undefined ? [args.verbosity] : MEMORY_VERBOSITIES;
-    await runSolidityTestsMemoryBenchmark(
+    const memoryResults = await runSolidityTestsMemoryBenchmark(
       repos,
       verbosities,
       benchmarkOutputPath
     );
+    const failed = memoryResults.filter((result) => result.kind === "error");
+    if (failed.length > 0) {
+      console.error(
+        `Error: ${failed.length} measurement(s) failed: ${failed
+          .map((result) => `${result.repo} at verbosity ${result.verbosity}`)
+          .join(", ")}`
+      );
+      return false;
+    }
   } else if (args.command === "compare-forge") {
     if (args.csv_output === undefined) {
       console.error(

--- a/js/benchmark/src/index.ts
+++ b/js/benchmark/src/index.ts
@@ -190,7 +190,13 @@ async function main(): Promise<boolean> {
       return false;
     }
   } else if (args.command === "solidity-tests-memory") {
-    const repos = args.repo !== undefined ? args.repo.split(",") : MEMORY_REPOS;
+    const repos =
+      args.repo !== undefined
+        ? args.repo
+            .split(",")
+            .map((repo) => repo.trim())
+            .filter((repo) => repo.length > 0)
+        : MEMORY_REPOS;
     const verbosities =
       args.verbosity !== undefined ? [args.verbosity] : MEMORY_VERBOSITIES;
     const memoryResults = await runSolidityTestsMemoryBenchmark(

--- a/js/benchmark/src/index.ts
+++ b/js/benchmark/src/index.ts
@@ -137,7 +137,7 @@ async function main(): Promise<boolean> {
   });
   parser.add_argument("--verbosity", {
     type: "int",
-    help: "Hardhat verbosity level for the solidity-tests-memory command. Repeat the command for each level, or omit to measure all of them.",
+    help: `Hardhat verbosity level (0-5, i.e. -v to -vvvvv) for the \`solidity-tests-memory\` command. Pass one level per run; omit to measure verbosities ${MEMORY_VERBOSITIES.join(", ")}, the ones with distinct trace-collection behaviour.`,
   });
   const args: ParsedArguments = parser.parse_args();
 

--- a/js/benchmark/src/index.ts
+++ b/js/benchmark/src/index.ts
@@ -25,6 +25,8 @@ import {
   runForgeTests,
   setupRepo,
   REPOS,
+  runSolidityTestsMemoryBenchmark,
+  MEMORY_VERBOSITIES,
 } from "./solidity-tests.js";
 
 const {
@@ -42,6 +44,7 @@ interface ParsedArguments {
     | "report-provider-benchmark"
     | "solidity-tests-benchmark"
     | "solidity-tests"
+    | "solidity-tests-memory"
     | "compare-forge"
     | "report-forge";
   grep?: string;
@@ -55,6 +58,7 @@ interface ParsedArguments {
   csv_input?: string;
   // eslint-disable-next-line @typescript-eslint/naming-convention
   forge_path?: string;
+  verbosity?: number;
 }
 
 interface BenchmarkScenarioResult {
@@ -94,6 +98,7 @@ async function main(): Promise<boolean> {
       "report-provider-benchmark",
       "solidity-tests-benchmark",
       "solidity-tests",
+      "solidity-tests-memory",
       "compare-forge",
       "report-forge",
     ],
@@ -128,6 +133,10 @@ async function main(): Promise<boolean> {
   parser.add_argument("--forge-path", {
     type: "str",
     help: "Path to forge executable (default: 'forge')",
+  });
+  parser.add_argument("--verbosity", {
+    type: "int",
+    help: "Hardhat verbosity level for the solidity-tests-memory command. Repeat the command for each level, or omit to measure all of them.",
   });
   const args: ParsedArguments = parser.parse_args();
 
@@ -179,6 +188,18 @@ async function main(): Promise<boolean> {
       console.error("Error: --repo is required for solidity-tests command");
       return false;
     }
+  } else if (args.command === "solidity-tests-memory") {
+    const repos =
+      args.repo !== undefined
+        ? args.repo.split(",")
+        : ["solady", "uniswap-v4-core", "morpho-blue"];
+    const verbosities =
+      args.verbosity !== undefined ? [args.verbosity] : MEMORY_VERBOSITIES;
+    await runSolidityTestsMemoryBenchmark(
+      repos,
+      verbosities,
+      benchmarkOutputPath
+    );
   } else if (args.command === "compare-forge") {
     if (args.csv_output === undefined) {
       console.error(

--- a/js/benchmark/src/index.ts
+++ b/js/benchmark/src/index.ts
@@ -116,7 +116,7 @@ async function main(): Promise<boolean> {
   });
   parser.add_argument("-r", "--repo", {
     type: "str",
-    help: "Path to a repo to execute for Solidity tests. For the `solidity-tests` command, defaults to `forge-std` that is checked out automatically. For the `compare-forge` command defaults to all supported repos.",
+    help: `Which repo(s) to run. For the \`solidity-tests\` command: the path to a repo. For the \`compare-forge\` command: a repo name (defaults to all supported repos). For the \`solidity-tests-memory\` command: a comma-separated list of repo names (defaults to ${MEMORY_REPOS.join(", ")}).`,
   });
   parser.add_argument("-c", "--count", {
     type: "int",

--- a/js/benchmark/src/index.ts
+++ b/js/benchmark/src/index.ts
@@ -197,6 +197,10 @@ async function main(): Promise<boolean> {
             .map((repo) => repo.trim())
             .filter((repo) => repo.length > 0)
         : MEMORY_REPOS;
+    if (repos.length === 0) {
+      console.error("Error: --repo must name at least one repo");
+      return false;
+    }
     if (
       args.verbosity !== undefined &&
       (args.verbosity < 0 || args.verbosity > 5)

--- a/js/benchmark/src/index.ts
+++ b/js/benchmark/src/index.ts
@@ -197,6 +197,15 @@ async function main(): Promise<boolean> {
             .map((repo) => repo.trim())
             .filter((repo) => repo.length > 0)
         : MEMORY_REPOS;
+    if (
+      args.verbosity !== undefined &&
+      (args.verbosity < 0 || args.verbosity > 5)
+    ) {
+      console.error(
+        `Error: --verbosity must be between 0 and 5 (like Hardhat's -v to -vvvvv), got ${args.verbosity}`
+      );
+      return false;
+    }
     const verbosities =
       args.verbosity !== undefined ? [args.verbosity] : MEMORY_VERBOSITIES;
     const memoryResults = await runSolidityTestsMemoryBenchmark(

--- a/js/benchmark/src/solidity-tests-memory-child.ts
+++ b/js/benchmark/src/solidity-tests-memory-child.ts
@@ -1,0 +1,49 @@
+/**
+ * Internal entry point for the `solidity-tests-memory` benchmark, spawned by
+ * `runSolidityTestsMemoryBenchmark` — one process per measurement, because
+ * `maxRSS` is a per-process high-water mark that never decreases.
+ *
+ * Parameters arrive as a single JSON argument, and the result leaves as a
+ * `MEMORY_RESULT`-prefixed JSON line on stdout.
+ */
+
+import {
+  EdrContext,
+  L1_CHAIN_TYPE,
+  l1SolidityTestRunnerFactory,
+} from "@nomicfoundation/edr";
+
+import {
+  compileSolidityTestsInput,
+  runSolidityTestsMemoryChild,
+  printMemoryResult,
+  MemoryChildParams,
+} from "./solidity-tests.js";
+
+const rawParams = process.argv[2];
+if (rawParams === undefined) {
+  throw new Error(
+    "Missing parameters argument. This script is spawned by the " +
+      "solidity-tests-memory benchmark driver and is not meant to be run directly."
+  );
+}
+const params: MemoryChildParams = JSON.parse(rawParams);
+
+if (params.compileOnly === true) {
+  await compileSolidityTestsInput(params.repoPath);
+} else {
+  const context = new EdrContext();
+  await context.registerSolidityTestRunnerFactory(
+    L1_CHAIN_TYPE,
+    l1SolidityTestRunnerFactory()
+  );
+
+  const result = await runSolidityTestsMemoryChild(
+    context,
+    L1_CHAIN_TYPE,
+    params.repo,
+    params.repoPath,
+    params.verbosity
+  );
+  printMemoryResult(result);
+}

--- a/js/benchmark/src/solidity-tests-memory-child.ts
+++ b/js/benchmark/src/solidity-tests-memory-child.ts
@@ -3,8 +3,10 @@
  * `runSolidityTestsMemoryBenchmark` — one process per measurement, because
  * `maxRSS` is a per-process high-water mark that never decreases.
  *
- * Parameters arrive as a single JSON argument, and the result leaves as a
- * `MEMORY_RESULT`-prefixed JSON line on stdout.
+ * The driver uses `spawn` rather than `fork` so the child can be wrapped in
+ * `/usr/bin/time`; that leaves no IPC channel, so parameters arrive as a single
+ * JSON argument and the result leaves as a `MEMORY_RESULT`-prefixed JSON line
+ * on stdout.
  */
 
 import {

--- a/js/benchmark/src/solidity-tests-memory-child.ts
+++ b/js/benchmark/src/solidity-tests-memory-child.ts
@@ -27,7 +27,14 @@ if (rawParams === undefined) {
       "solidity-tests-memory benchmark driver and is not meant to be run directly."
   );
 }
-const params: MemoryChildParams = JSON.parse(rawParams);
+const params = JSON.parse(rawParams) as Partial<MemoryChildParams>;
+if (
+  typeof params.repo !== "string" ||
+  typeof params.repoPath !== "string" ||
+  typeof params.verbosity !== "number"
+) {
+  throw new Error(`malformed memory-benchmark parameters: ${rawParams}`);
+}
 
 if (params.compileOnly === true) {
   await compileSolidityTestsInput(params.repoPath);

--- a/js/benchmark/src/solidity-tests.ts
+++ b/js/benchmark/src/solidity-tests.ts
@@ -876,6 +876,25 @@ function parseGnuTimeMaxRss(stderr: string): number | undefined {
   return match === null ? undefined : Number(match[1]) * 1024;
 }
 
+/** Whether a child process exited because it ran out of memory. */
+function isOomError(
+  code: number | null,
+  signal: NodeJS.Signals | null,
+  stderr: string
+): boolean {
+  // The Linux OOM killer terminates processes with SIGKILL.
+  if (signal === "SIGKILL") {
+    return true;
+  }
+
+  // When the child is wrapped in GNU time, the kill hits the grandchild:
+  // GNU time itself then exits with 128 + 9 and reports the signal on
+  // stderr.
+  return (
+    code === 128 + 9 || /Command terminated by signal 9\b/.test(stderr)
+  );
+}
+
 /**
  * Driver: run every (repo, verbosity) pair in a fresh child process and collect
  * peak RSS.
@@ -916,38 +935,20 @@ export async function runSolidityTestsMemoryBenchmark(
   for (const repoName of repoNames) {
     for (const verbosity of verbosities) {
       console.error(`measuring ${repoName} at verbosity ${verbosity}...`);
-      let result: MemoryRunResult;
-      try {
-        result = await runMemoryChildProcess(
-          repoName,
-          repoPaths.get(repoName)!,
-          verbosity,
-          useGnuTime
-        );
+      const result = await runMemoryChildProcess(
+        repoName,
+        repoPaths.get(repoName)!,
+        verbosity,
+        useGnuTime
+      );
+      if (result.oom) {
+        console.error(`  OOM: killed at >= ${displayMiB(result.peakRssBytes)}`);
+      } else {
         console.error(
           `  peak RSS ${displayMiB(result.peakRssBytes)}, ` +
-            `${result.elapsedMs}ms, ${result.testCount} tests ` +
+            `${displayDuration(result.elapsedMs)}, ${result.testCount} tests ` +
             `(${result.failureCount} failing)`
         );
-      } catch (e) {
-        // A killed child (usually the OOM killer) is a result, not a harness
-        // failure: it means this configuration doesn't fit in memory.
-        const stderr = e instanceof Error ? e.message : String(e);
-        const lastSeenRss = parseGnuTimeMaxRss(stderr) ?? 0;
-        console.error(
-          `  OOM: killed at >= ${displayMiB(lastSeenRss)}\n` +
-            stderr.split("\n").slice(0, 3).join("\n")
-        );
-        result = {
-          repo: repoName,
-          verbosity,
-          peakRssBytes: lastSeenRss,
-          elapsedMs: 0,
-          suiteCount: 0,
-          testCount: 0,
-          failureCount: 0,
-          oom: true,
-        };
       }
       results.push(result);
     }
@@ -1034,7 +1035,21 @@ function runMemoryChildProcess(
     child.stderr.on("data", (chunk) => (stderr += chunk));
 
     child.on("error", reject);
-    child.on("close", (code) => {
+    child.on("close", (code, signal) => {
+      if (isOomError(code, signal, stderr)) {
+        resolve({
+          repo: repoName,
+          verbosity,
+          peakRssBytes: parseGnuTimeMaxRss(stderr) ?? 0,
+          elapsedMs: 0,
+          suiteCount: 0,
+          testCount: 0,
+          failureCount: 0,
+          oom: true,
+        });
+        return;
+      }
+
       if (code !== 0) {
         reject(
           new Error(
@@ -1071,6 +1086,14 @@ function displayMiB(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MiB`;
 }
 
+/** Sub-second durations in milliseconds, longer ones in seconds. */
+function displayDuration(elapsedMs: number): string {
+  if (elapsedMs < 1000) {
+    return `${elapsedMs}ms`;
+  }
+  return `${(elapsedMs / 1000).toFixed(1)}s`;
+}
+
 /** Render results as a markdown table: rows are repos, columns are verbosities. */
 export function formatMemoryTable(results: MemoryRunResult[]): string {
   const verbosities = Array.from(new Set(results.map((r) => r.verbosity))).sort(
@@ -1094,7 +1117,7 @@ export function formatMemoryTable(results: MemoryRunResult[]): string {
       if (result.oom) {
         return peak > 0 ? `OOM (>= ${displayMiB(peak)})` : "OOM";
       }
-      return `${displayMiB(peak)} / ${result.elapsedMs}ms`;
+      return `${displayMiB(peak)} / ${displayDuration(result.elapsedMs)}`;
     }),
   ]);
 

--- a/js/benchmark/src/solidity-tests.ts
+++ b/js/benchmark/src/solidity-tests.ts
@@ -973,7 +973,7 @@ export async function compileSolidityTestsInput(repoPath: string) {
 
 /**
  * Node arguments invoking the internal child entry point with the given
- * parameters. `process.execArgv` carries the tsx loader over.
+ * parameters. `process.execArgv` carries the driver's node flags over.
  */
 function memoryChildNodeArgs(params: MemoryChildParams): string[] {
   const childEntry = path.join(

--- a/js/benchmark/src/solidity-tests.ts
+++ b/js/benchmark/src/solidity-tests.ts
@@ -782,6 +782,12 @@ export interface MemoryCell {
 export interface MemoryMeasurementPayload extends MemoryCell {
   /** Peak resident set size of the whole process, in bytes. */
   peakRssBytes: number;
+  /**
+   * Peak RSS after the repo's artifacts were loaded but before any test ran,
+   * in bytes. This part of `peakRssBytes` is a constant offset that has
+   * nothing to do with trace retention.
+   */
+  baselineRssBytes?: number;
   elapsedMs: number;
   suiteCount: number;
   testCount: number;
@@ -835,6 +841,8 @@ export async function runSolidityTestsMemoryChild(
 ): Promise<MemoryMeasurementPayload> {
   const { artifacts, testSuiteIds, tracingConfig, solidityTestsConfig } =
     await createSolidityTestsInput(repoPath, verbosity);
+  // `maxRSS` is in kilobytes on Linux.
+  const baselineRssBytes = process.resourceUsage().maxRSS * 1024;
 
   const startNs = process.hrtime.bigint();
   const [, results] = await runAllSolidityTests(
@@ -851,9 +859,10 @@ export async function runSolidityTestsMemoryChild(
     throw new Error(`Didn't run any tests for ${repoName}`);
   }
 
-  // Read the high-water mark *before* dropping the results, and keep `results`
-  // alive across the read so neither V8 nor Rust can reclaim the arenas early.
-  // `maxRSS` is in kilobytes on Linux.
+  // `runAllSolidityTests` holds every `SuiteResult` — and with it every
+  // `TestResult`'s trace arenas — alive for the whole run, so the high-water
+  // mark reflects full retention. `maxRSS` never decreases, so where it is
+  // read does not matter.
   const peakRssBytes = process.resourceUsage().maxRSS * 1024;
 
   let testCount = 0;
@@ -871,6 +880,7 @@ export async function runSolidityTestsMemoryChild(
     repo: repoName,
     verbosity,
     peakRssBytes,
+    baselineRssBytes,
     elapsedMs: Number(elapsedNs / 1_000_000n),
     suiteCount: results.length,
     testCount,
@@ -922,7 +932,9 @@ function parseMemoryMeasurement(
   ] as const;
   if (
     typeof candidate.repo !== "string" ||
-    !numbers.every((key) => typeof candidate[key] === "number")
+    !numbers.every((key) => typeof candidate[key] === "number") ||
+    (candidate.baselineRssBytes !== undefined &&
+      typeof candidate.baselineRssBytes !== "number")
   ) {
     return undefined;
   }
@@ -930,6 +942,7 @@ function parseMemoryMeasurement(
     repo: candidate.repo,
     verbosity: candidate.verbosity as number,
     peakRssBytes: candidate.peakRssBytes as number,
+    baselineRssBytes: candidate.baselineRssBytes,
     elapsedMs: candidate.elapsedMs as number,
     suiteCount: candidate.suiteCount as number,
     testCount: candidate.testCount as number,
@@ -1292,13 +1305,18 @@ function reportedPeakRssBytes(
 function logMemoryProgress(result: MemoryMeasurement | MemoryExhausted) {
   const peak = reportedPeakRssBytes(result);
   switch (result.kind) {
-    case "measured":
+    case "measured": {
+      const baseline =
+        result.baselineRssBytes !== undefined
+          ? ` (${displayMiB(result.baselineRssBytes)} before tests ran)`
+          : "";
       console.error(
-        `  peak RSS ${displayMiB(peak ?? result.peakRssBytes)}, ` +
+        `  peak RSS ${displayMiB(peak ?? result.peakRssBytes)}${baseline}, ` +
           `${displayDuration(result.elapsedMs)}, ${result.testCount} tests ` +
           `(${result.failureCount} failing)`
       );
       break;
+    }
     case "oom":
       console.error(
         peak !== undefined

--- a/js/benchmark/src/solidity-tests.ts
+++ b/js/benchmark/src/solidity-tests.ts
@@ -765,9 +765,9 @@ export const MEMORY_REPOS = ["solady", "uniswap-v4-core", "morpho-blue"];
 /**
  * Rayon thread cap for measured children. Test suites (and tests within a
  * suite) run in parallel, and each in-flight suite retains its trace arenas, so
- * peak RSS scales with parallelism. An unbounded run OOMs a 16 GiB machine on
- * the unoptimized baseline (solady at verbosity 3 exceeds 10 GiB), which would
- * leave nothing to compare optimisations against; a fixed cap keeps every
+ * peak RSS scales with parallelism. An unbounded run passes 10 GiB on solady
+ * at verbosity 3 before the kernel kills it on a 16 GiB machine, which would
+ * leave nothing to compare optimizations against; a fixed cap keeps every
  * (build × repo × verbosity) cell measurable and comparable.
  */
 const MEMORY_RAYON_THREADS = "4";
@@ -802,9 +802,10 @@ export interface MemoryMeasurement extends MemoryMeasurementPayload {
 }
 
 /**
- * The child was killed (out of memory) before completing. Only the peak GNU
- * time observed from outside is known, and only when it was available; the
- * true requirement is higher either way.
+ * The child ran out of memory before completing — either killed by the kernel,
+ * or aborted by V8 or by Rust's allocator. Only the peak GNU time observed
+ * from outside is known, and only when it was available; the true requirement
+ * is higher either way.
  */
 export interface MemoryExhausted extends MemoryCell {
   kind: "oom";
@@ -890,7 +891,7 @@ export async function runSolidityTestsMemoryChild(
 
 const MEMORY_RESULT_PREFIX = "MEMORY_RESULT ";
 
-/** Print a child result in the form the driver parses. */
+/** Prints a child result in the form the driver parses. */
 export function printMemoryResult(result: MemoryMeasurementPayload) {
   console.log(MEMORY_RESULT_PREFIX + JSON.stringify(result));
 }

--- a/js/benchmark/src/solidity-tests.ts
+++ b/js/benchmark/src/solidity-tests.ts
@@ -997,10 +997,12 @@ export async function runSolidityTestsMemoryBenchmark(
         logMemoryProgress(result);
       }
       results.push(result);
+      // Persist after every cell: a full matrix takes a long time and an
+      // interrupted run should keep what it measured.
+      fs.writeFileSync(resultsPath, JSON.stringify(results, null, 2) + "\n");
     }
   }
 
-  fs.writeFileSync(resultsPath, JSON.stringify(results, null, 2) + "\n");
   console.error(`saved results to ${resultsPath}`);
   console.log(formatMemoryTable(results));
 

--- a/js/benchmark/src/solidity-tests.ts
+++ b/js/benchmark/src/solidity-tests.ts
@@ -890,7 +890,14 @@ function isOomError(
   // When the child is wrapped in GNU time, the kill hits the grandchild:
   // GNU time itself then exits with 128 + 9 and reports the signal on
   // stderr.
-  return code === 128 + 9 || /Command terminated by signal 9\b/.test(stderr);
+  if (code === 128 + 9 || /Command terminated by signal 9\b/.test(stderr)) {
+    return true;
+  }
+
+  // V8 aborts the process when its own heap limit is exhausted. Match the
+  // fatal-error message rather than the SIGABRT it dies with, which has
+  // other causes too.
+  return /JavaScript heap out of memory/.test(stderr);
 }
 
 /**

--- a/js/benchmark/src/solidity-tests.ts
+++ b/js/benchmark/src/solidity-tests.ts
@@ -1024,6 +1024,50 @@ function memoryChildNodeArgs(params: MemoryChildParams): string[] {
   return [...process.execArgv, childEntry, JSON.stringify(params)];
 }
 
+/**
+ * A measured child that has run for this long is stuck (typically thrashing
+ * at the edge of memory instead of getting killed) and is terminated so the
+ * remaining cells still get measured.
+ */
+const MEMORY_CHILD_TIMEOUT_MS = 60 * 60 * 1000;
+
+/** Kills `child` together with everything in its process group. */
+function killChildGroup(child: child_process.ChildProcess) {
+  if (child.pid === undefined) {
+    return;
+  }
+  try {
+    process.kill(-child.pid, "SIGKILL");
+  } catch {
+    // Already gone.
+  }
+}
+
+/**
+ * Kills `child` if the driver is terminated while waiting on it. Children are
+ * spawned into their own process group: that is what lets us kill the whole
+ * `time` + `node` pair, but it also means a signal delivered to the driver (CI
+ * cancellation, `kill`, Ctrl-C) would otherwise leave the child — the process
+ * designed to consume many gigabytes — running on its own.
+ *
+ * Returns a function that uninstalls the handlers once the child has exited.
+ */
+function killChildOnTermination(child: child_process.ChildProcess): () => void {
+  const handlers = (["SIGINT", "SIGTERM"] as const).map((signal) => {
+    const handler = () => {
+      killChildGroup(child);
+      process.exit(128 + (signal === "SIGINT" ? 2 : 15));
+    };
+    process.once(signal, handler);
+    return [signal, handler] as const;
+  });
+  return () => {
+    for (const [signal, handler] of handlers) {
+      process.removeListener(signal, handler);
+    }
+  };
+}
+
 function runCompileOnlyChildProcess(
   repoName: string,
   repoPath: string
@@ -1038,13 +1082,20 @@ function runCompileOnlyChildProcess(
     const child = child_process.spawn(process.execPath, nodeArgs, {
       cwd: process.cwd(),
       stdio: ["ignore", "inherit", "inherit"],
+      detached: true,
     });
+    const stopKillingOnTermination = killChildOnTermination(child);
     child.on("error", reject);
-    child.on("close", (code) => {
+    child.on("close", (code, signal) => {
+      stopKillingOnTermination();
       if (code === 0) {
         resolve();
       } else {
-        reject(new Error(`compile child for ${repoName} exited with ${code}`));
+        reject(
+          new Error(
+            `compile child for ${repoName} exited with ${signal ?? code}`
+          )
+        );
       }
     });
   });
@@ -1073,7 +1124,18 @@ function runMemoryChildProcess(
       cwd: process.cwd(),
       stdio: ["ignore", "pipe", "pipe"],
       env: { ...process.env, RAYON_NUM_THREADS: MEMORY_RAYON_THREADS },
+      detached: true,
     });
+    const stopKillingOnTermination = killChildOnTermination(child);
+
+    // Not spawn's `timeout` option: that kills only the direct child (GNU
+    // time when wrapped, orphaning node) and would be indistinguishable from
+    // an OOM kill below.
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      killChildGroup(child);
+    }, MEMORY_CHILD_TIMEOUT_MS);
 
     let stdout = "";
     let stderr = "";
@@ -1082,6 +1144,18 @@ function runMemoryChildProcess(
 
     child.on("error", reject);
     child.on("close", (code, signal) => {
+      clearTimeout(timer);
+      stopKillingOnTermination();
+
+      if (timedOut) {
+        reject(
+          new Error(
+            `memory child for ${repoName} v${verbosity} exceeded ${displayDuration(MEMORY_CHILD_TIMEOUT_MS)} and was killed`
+          )
+        );
+        return;
+      }
+
       if (isOomError(code, signal, stderr)) {
         resolve({
           kind: "oom",

--- a/js/benchmark/src/solidity-tests.ts
+++ b/js/benchmark/src/solidity-tests.ts
@@ -890,9 +890,7 @@ function isOomError(
   // When the child is wrapped in GNU time, the kill hits the grandchild:
   // GNU time itself then exits with 128 + 9 and reports the signal on
   // stderr.
-  return (
-    code === 128 + 9 || /Command terminated by signal 9\b/.test(stderr)
-  );
+  return code === 128 + 9 || /Command terminated by signal 9\b/.test(stderr);
 }
 
 /**

--- a/js/benchmark/src/solidity-tests.ts
+++ b/js/benchmark/src/solidity-tests.ts
@@ -18,7 +18,7 @@ forge test --fuzz-seed 0x1234567890123456789012345678901234567890 --match-contra
 import fs from "fs";
 import path from "path";
 import { simpleGit } from "simple-git";
-import { exec } from "child_process";
+import child_process, { exec } from "child_process";
 import { promisify } from "util";
 import { stringify } from "csv-stringify/sync";
 
@@ -622,6 +622,16 @@ export async function setupRepo(
   await git.fetch(["--depth", "1", "origin", repoData.commit]);
   await git.checkout(repoData.commit);
 
+  // The shallow clone didn't fetch submodules, so update them.
+  await git.raw([
+    "submodule",
+    "update",
+    "--init",
+    "--recursive",
+    "--depth",
+    "1",
+  ]);
+
   if (repoData.patchFile !== undefined) {
     const patchFile = path.join(
       dirName(import.meta.url),
@@ -642,12 +652,19 @@ export async function setupRepo(
     }
   }
 
-  await execAsync("npm install", { cwd: repoPath });
+  try {
+    await execAsync("npm install", { cwd: repoPath });
+  } catch (e) {
+    console.error(
+      `npm install failed for ${repoPath}, retrying with --ignore-scripts`
+    );
+    await execAsync("npm install --ignore-scripts", { cwd: repoPath });
+  }
 
   return repoPath;
 }
 
-async function createSolidityTestsInput(repoPath: string) {
+async function createSolidityTestsInput(repoPath: string, verbosity = 0) {
   if (!path.isAbsolute(repoPath)) {
     // If repo path is not absolute, assume it's relative to the current working directory
     repoPath = path.join(process.cwd(), repoPath);
@@ -671,7 +688,7 @@ async function createSolidityTestsInput(repoPath: string) {
       chainType: "l1",
       projectRoot: repoPath,
       config: userConfig.solidityTest,
-      verbosity: 0,
+      verbosity,
       observability: undefined,
       testPattern: undefined,
       generateGasReport: false,
@@ -716,4 +733,375 @@ function assertNoFailures(results: SuiteResult[]) {
     console.error(failed);
     throw new Error(`Some tests failed`);
   }
+}
+
+// ---------------------------------------------------------------------------
+// Memory benchmark
+//
+// Call-trace arena retention is a function of Hardhat's verbosity, which maps
+// to `includeTraces`/`collectStackTraces`:
+//
+//   verbosity <= 2  ->  IncludeTraces.None    + CollectStackTraces.OnFailure
+//   verbosity == 3  ->  IncludeTraces.Failing + CollectStackTraces.Always
+//   verbosity >= 4  ->  IncludeTraces.All     + CollectStackTraces.Always
+//
+// Peak RSS is the metric because the arenas live in Rust while the napi
+// `TestResult` objects that reference them are held by JS.
+// ---------------------------------------------------------------------------
+
+/** The verbosity levels that produce distinct trace-retention behaviour. */
+export const MEMORY_VERBOSITIES = [2, 3, 4];
+
+/**
+ * Rayon thread cap for measured children. Test suites (and tests within a
+ * suite) run in parallel, and each in-flight suite retains its trace arenas, so
+ * peak RSS scales with parallelism. An unbounded run OOMs a 16 GiB machine on
+ * the unoptimized baseline (solady at verbosity 3 exceeds 10 GiB), which would
+ * leave nothing to compare optimisations against; a fixed cap keeps every
+ * (build × repo × verbosity) cell measurable and comparable.
+ */
+const MEMORY_RAYON_THREADS = "4";
+
+export interface MemoryRunResult {
+  repo: string;
+  verbosity: number;
+  /** Peak resident set size of the whole process, in bytes. */
+  peakRssBytes: number;
+  /** Peak RSS as reported by `/usr/bin/time -v`, if it was available. */
+  peakRssBytesExternal?: number;
+  elapsedMs: number;
+  suiteCount: number;
+  testCount: number;
+  failureCount: number;
+  /**
+   * The run was killed (out of memory) before completing. `peakRssBytes` then
+   * holds the last externally observed RSS: the true requirement is higher.
+   */
+  oom?: boolean;
+}
+
+/**
+ * Child-process entry point: run one repo at one verbosity and report peak RSS
+ * on stdout as a single JSON line prefixed with `MEMORY_RESULT `.
+ *
+ * This must run in its own process: `maxRSS` is a high-water mark that never
+ * decreases, so a second measurement in the same process would inherit the
+ * first one's peak.
+ */
+export async function runSolidityTestsMemoryChild(
+  context: EdrContext,
+  chainType: string,
+  repoName: string,
+  repoPath: string,
+  verbosity: number
+): Promise<MemoryRunResult> {
+  const { artifacts, testSuiteIds, tracingConfig, solidityTestsConfig } =
+    await createSolidityTestsInput(repoPath, verbosity);
+
+  const startNs = process.hrtime.bigint();
+  const [, results] = await runAllSolidityTests(
+    context,
+    chainType,
+    artifacts,
+    testSuiteIds,
+    tracingConfig,
+    solidityTestsConfig
+  );
+  const elapsedNs = process.hrtime.bigint() - startNs;
+
+  if (results.length === 0) {
+    throw new Error(`Didn't run any tests for ${repoName}`);
+  }
+
+  // Read the high-water mark *before* dropping the results, and keep `results`
+  // alive across the read so neither V8 nor Rust can reclaim the arenas early.
+  // `maxRSS` is in kilobytes on Linux.
+  const peakRssBytes = process.resourceUsage().maxRSS * 1024;
+
+  let testCount = 0;
+  let failureCount = 0;
+  for (const suite of results) {
+    for (const test of suite.testResults) {
+      testCount += 1;
+      if (test.status !== TestStatus.Success) {
+        failureCount += 1;
+      }
+    }
+  }
+
+  return {
+    repo: repoName,
+    verbosity,
+    peakRssBytes,
+    elapsedMs: Number(elapsedNs / 1_000_000n),
+    suiteCount: results.length,
+    testCount,
+    failureCount,
+  };
+}
+
+const MEMORY_RESULT_PREFIX = "MEMORY_RESULT ";
+
+/** Print a child result in the form the driver parses. */
+export function printMemoryResult(result: MemoryRunResult) {
+  console.log(MEMORY_RESULT_PREFIX + JSON.stringify(result));
+}
+
+/**
+ * Parameters the driver passes to `solidity-tests-memory-child.ts`, as a
+ * single JSON argument.
+ */
+export interface MemoryChildParams {
+  repo: string;
+  repoPath: string;
+  verbosity: number;
+  /** Only compile the repo (to warm the artifact cache); don't measure. */
+  compileOnly?: boolean;
+}
+
+function hasGnuTime(): boolean {
+  try {
+    child_process.execFileSync("/usr/bin/time", ["-v", "true"], {
+      stdio: "ignore",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Extract `Maximum resident set size (kbytes): N` from `/usr/bin/time -v`. */
+function parseGnuTimeMaxRss(stderr: string): number | undefined {
+  const match = stderr.match(/Maximum resident set size \(kbytes\): (\d+)/);
+  return match === null ? undefined : Number(match[1]) * 1024;
+}
+
+/**
+ * Driver: run every (repo, verbosity) pair in a fresh child process and collect
+ * peak RSS.
+ */
+export async function runSolidityTestsMemoryBenchmark(
+  repoNames: string[],
+  verbosities: number[],
+  resultsPath: string
+): Promise<MemoryRunResult[]> {
+  for (const repoName of repoNames) {
+    if (REPOS[repoName] === undefined) {
+      throw new Error(
+        `Unknown repo '${repoName}'. Known repos: ${Object.keys(REPOS).join(", ")}`
+      );
+    }
+  }
+
+  const repoPaths = new Map<string, string>();
+  for (const repoName of repoNames) {
+    console.error(`setting up ${repoName}...`);
+    const repoPath = await setupRepo(REPOS[repoName], "hardhat");
+    repoPaths.set(repoName, repoPath);
+
+    // Compile in a throwaway child so the first measured run doesn't pay
+    // solc costs that later runs get from the artifact cache.
+    console.error(`compiling ${repoName}...`);
+    await runCompileOnlyChildProcess(repoName, repoPath);
+  }
+
+  const useGnuTime = hasGnuTime();
+  if (!useGnuTime) {
+    console.error(
+      "note: /usr/bin/time not available, relying on process.resourceUsage() alone"
+    );
+  }
+
+  const results: MemoryRunResult[] = [];
+  for (const repoName of repoNames) {
+    for (const verbosity of verbosities) {
+      console.error(`measuring ${repoName} at verbosity ${verbosity}...`);
+      let result: MemoryRunResult;
+      try {
+        result = await runMemoryChildProcess(
+          repoName,
+          repoPaths.get(repoName)!,
+          verbosity,
+          useGnuTime
+        );
+        console.error(
+          `  peak RSS ${displayMiB(result.peakRssBytes)}, ` +
+            `${result.elapsedMs}ms, ${result.testCount} tests ` +
+            `(${result.failureCount} failing)`
+        );
+      } catch (e) {
+        // A killed child (usually the OOM killer) is a result, not a harness
+        // failure: it means this configuration doesn't fit in memory.
+        const stderr = e instanceof Error ? e.message : String(e);
+        const lastSeenRss = parseGnuTimeMaxRss(stderr) ?? 0;
+        console.error(
+          `  OOM: killed at >= ${displayMiB(lastSeenRss)}\n` +
+            stderr.split("\n").slice(0, 3).join("\n")
+        );
+        result = {
+          repo: repoName,
+          verbosity,
+          peakRssBytes: lastSeenRss,
+          elapsedMs: 0,
+          suiteCount: 0,
+          testCount: 0,
+          failureCount: 0,
+          oom: true,
+        };
+      }
+      results.push(result);
+    }
+  }
+
+  fs.writeFileSync(resultsPath, JSON.stringify(results, null, 2) + "\n");
+  console.error(`saved results to ${resultsPath}`);
+  console.log(formatMemoryTable(results));
+
+  return results;
+}
+
+/** Compile a repo's contracts + tests without running anything. */
+export async function compileSolidityTestsInput(repoPath: string) {
+  await createSolidityTestsInput(repoPath);
+}
+
+/**
+ * Node arguments invoking the internal child entry point with the given
+ * parameters. `process.execArgv` carries the tsx loader over.
+ */
+function memoryChildNodeArgs(params: MemoryChildParams): string[] {
+  const childEntry = path.join(
+    dirName(import.meta.url),
+    "solidity-tests-memory-child.ts"
+  );
+  return [...process.execArgv, childEntry, JSON.stringify(params)];
+}
+
+function runCompileOnlyChildProcess(
+  repoName: string,
+  repoPath: string
+): Promise<void> {
+  const nodeArgs = memoryChildNodeArgs({
+    repo: repoName,
+    repoPath,
+    verbosity: 0,
+    compileOnly: true,
+  });
+  return new Promise((resolve, reject) => {
+    const child = child_process.spawn(process.execPath, nodeArgs, {
+      cwd: process.cwd(),
+      stdio: ["ignore", "inherit", "inherit"],
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`compile child for ${repoName} exited with ${code}`));
+      }
+    });
+  });
+}
+
+function runMemoryChildProcess(
+  repoName: string,
+  repoPath: string,
+  verbosity: number,
+  useGnuTime: boolean
+): Promise<MemoryRunResult> {
+  const nodeArgs = memoryChildNodeArgs({
+    repo: repoName,
+    repoPath,
+    verbosity,
+  });
+
+  // Wrap in GNU time where available: it observes the peak RSS externally,
+  // which also covers a child that gets OOM-killed before it can report.
+  const [command, commandArgs] = useGnuTime
+    ? ["/usr/bin/time", ["-v", process.execPath, ...nodeArgs]]
+    : [process.execPath, nodeArgs];
+
+  return new Promise((resolve, reject) => {
+    const child = child_process.spawn(command, commandArgs, {
+      cwd: process.cwd(),
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env, RAYON_NUM_THREADS: MEMORY_RAYON_THREADS },
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => (stdout += chunk));
+    child.stderr.on("data", (chunk) => (stderr += chunk));
+
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code !== 0) {
+        reject(
+          new Error(
+            `memory child for ${repoName} v${verbosity} exited with ${code}\n${stderr}`
+          )
+        );
+        return;
+      }
+
+      const line = stdout
+        .split("\n")
+        .find((l) => l.startsWith(MEMORY_RESULT_PREFIX));
+      if (line === undefined) {
+        reject(
+          new Error(
+            `memory child for ${repoName} v${verbosity} produced no result\n${stdout}\n${stderr}`
+          )
+        );
+        return;
+      }
+
+      const result: MemoryRunResult = JSON.parse(
+        line.slice(MEMORY_RESULT_PREFIX.length)
+      );
+      if (useGnuTime) {
+        result.peakRssBytesExternal = parseGnuTimeMaxRss(stderr);
+      }
+      resolve(result);
+    });
+  });
+}
+
+function displayMiB(bytes: number): string {
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MiB`;
+}
+
+/** Render results as a markdown table: rows are repos, columns are verbosities. */
+export function formatMemoryTable(results: MemoryRunResult[]): string {
+  const verbosities = Array.from(new Set(results.map((r) => r.verbosity))).sort(
+    (a, b) => a - b
+  );
+  const repos = Array.from(new Set(results.map((r) => r.repo)));
+
+  const header = ["repo", ...verbosities.map((v) => `-${"v".repeat(v)}`)];
+  const rows = repos.map((repo) => [
+    repo,
+    ...verbosities.map((verbosity) => {
+      const result = results.find(
+        (r) => r.repo === repo && r.verbosity === verbosity
+      );
+      if (result === undefined) {
+        return "—";
+      }
+      // Prefer the externally observed peak; it also covers allocations made
+      // after the in-process read.
+      const peak = result.peakRssBytesExternal ?? result.peakRssBytes;
+      if (result.oom) {
+        return peak > 0 ? `OOM (>= ${displayMiB(peak)})` : "OOM";
+      }
+      return `${displayMiB(peak)} / ${result.elapsedMs}ms`;
+    }),
+  ]);
+
+  const lines = [
+    `| ${header.join(" | ")} |`,
+    `|${header.map(() => "---").join("|")}|`,
+    ...rows.map((row) => `| ${row.join(" | ")} |`),
+  ];
+  return lines.join("\n");
 }

--- a/js/benchmark/src/solidity-tests.ts
+++ b/js/benchmark/src/solidity-tests.ts
@@ -1150,7 +1150,9 @@ function runCompileOnlyChildProcess(
   return new Promise((resolve, reject) => {
     const child = child_process.spawn(process.execPath, nodeArgs, {
       cwd: process.cwd(),
-      stdio: ["ignore", "inherit", "inherit"],
+      // Compiler output belongs with the progress messages on stderr, not
+      // on stdout, which carries only the results table.
+      stdio: ["ignore", process.stderr, process.stderr],
       detached: true,
     });
     const stopKillingOnTermination = killChildOnTermination(child);

--- a/js/benchmark/src/solidity-tests.ts
+++ b/js/benchmark/src/solidity-tests.ts
@@ -762,23 +762,51 @@ export const MEMORY_VERBOSITIES = [2, 3, 4];
  */
 const MEMORY_RAYON_THREADS = "4";
 
-export interface MemoryRunResult {
+/** Identifies a (repo, verbosity) cell; common to every outcome. */
+export interface MemoryCell {
   repo: string;
   verbosity: number;
+}
+
+/** What the child prints: the measurement it can observe about itself. */
+export interface MemoryMeasurementPayload extends MemoryCell {
   /** Peak resident set size of the whole process, in bytes. */
   peakRssBytes: number;
-  /** Peak RSS as reported by `/usr/bin/time -v`, if it was available. */
-  peakRssBytesExternal?: number;
   elapsedMs: number;
   suiteCount: number;
   testCount: number;
   failureCount: number;
-  /**
-   * The run was killed (out of memory) before completing. `peakRssBytes` then
-   * holds the last externally observed RSS: the true requirement is higher.
-   */
-  oom?: boolean;
 }
+
+/** The child completed and reported its measurement. */
+export interface MemoryMeasurement extends MemoryMeasurementPayload {
+  kind: "measured";
+  /** Peak RSS as reported by `/usr/bin/time -v`, if it was available. */
+  peakRssBytesExternal?: number;
+}
+
+/**
+ * The child was killed (out of memory) before completing. Only the peak GNU
+ * time observed from outside is known, and only when it was available; the
+ * true requirement is higher either way.
+ */
+export interface MemoryExhausted extends MemoryCell {
+  kind: "oom";
+  peakRssBytesExternal?: number;
+}
+
+/**
+ * The child failed for a reason other than running out of memory. The other
+ * cells are still measured, but the benchmark exits unsuccessfully.
+ */
+export interface MemoryRunError extends MemoryCell {
+  kind: "error";
+  error: string;
+}
+
+/** The outcome of one (repo, verbosity) cell. */
+export type MemoryRunResult =
+  MemoryMeasurement | MemoryExhausted | MemoryRunError;
 
 /**
  * Child-process entry point: run one repo at one verbosity and report peak RSS
@@ -794,7 +822,7 @@ export async function runSolidityTestsMemoryChild(
   repoName: string,
   repoPath: string,
   verbosity: number
-): Promise<MemoryRunResult> {
+): Promise<MemoryMeasurementPayload> {
   const { artifacts, testSuiteIds, tracingConfig, solidityTestsConfig } =
     await createSolidityTestsInput(repoPath, verbosity);
 
@@ -843,7 +871,7 @@ export async function runSolidityTestsMemoryChild(
 const MEMORY_RESULT_PREFIX = "MEMORY_RESULT ";
 
 /** Print a child result in the form the driver parses. */
-export function printMemoryResult(result: MemoryRunResult) {
+export function printMemoryResult(result: MemoryMeasurementPayload) {
   console.log(MEMORY_RESULT_PREFIX + JSON.stringify(result));
 }
 
@@ -940,20 +968,23 @@ export async function runSolidityTestsMemoryBenchmark(
   for (const repoName of repoNames) {
     for (const verbosity of verbosities) {
       console.error(`measuring ${repoName} at verbosity ${verbosity}...`);
-      const result = await runMemoryChildProcess(
-        repoName,
-        repoPaths.get(repoName)!,
-        verbosity,
-        useGnuTime
-      );
-      if (result.oom === true) {
-        console.error(`  OOM: killed at >= ${displayMiB(result.peakRssBytes)}`);
-      } else {
-        console.error(
-          `  peak RSS ${displayMiB(result.peakRssBytes)}, ` +
-            `${displayDuration(result.elapsedMs)}, ${result.testCount} tests ` +
-            `(${result.failureCount} failing)`
+      let result: MemoryRunResult;
+      try {
+        result = await runMemoryChildProcess(
+          repoName,
+          repoPaths.get(repoName)!,
+          verbosity,
+          useGnuTime
         );
+      } catch (e) {
+        // Record the failure and keep measuring the other cells; the caller
+        // reports the failed ones.
+        const error = e instanceof Error ? e.message : String(e);
+        console.error(`  error: ${error}`);
+        result = { kind: "error", repo: repoName, verbosity, error };
+      }
+      if (result.kind !== "error") {
+        logMemoryProgress(result);
       }
       results.push(result);
     }
@@ -1014,7 +1045,7 @@ function runMemoryChildProcess(
   repoPath: string,
   verbosity: number,
   useGnuTime: boolean
-): Promise<MemoryRunResult> {
+): Promise<MemoryMeasurement | MemoryExhausted> {
   const nodeArgs = memoryChildNodeArgs({
     repo: repoName,
     repoPath,
@@ -1043,14 +1074,10 @@ function runMemoryChildProcess(
     child.on("close", (code, signal) => {
       if (isOomError(code, signal, stderr)) {
         resolve({
+          kind: "oom",
           repo: repoName,
           verbosity,
-          peakRssBytes: parseGnuTimeMaxRss(stderr) ?? 0,
-          elapsedMs: 0,
-          suiteCount: 0,
-          testCount: 0,
-          failureCount: 0,
-          oom: true,
+          peakRssBytesExternal: parseGnuTimeMaxRss(stderr),
         });
         return;
       }
@@ -1076,15 +1103,56 @@ function runMemoryChildProcess(
         return;
       }
 
-      const result: MemoryRunResult = JSON.parse(
+      const measurement: MemoryMeasurementPayload = JSON.parse(
         line.slice(MEMORY_RESULT_PREFIX.length)
       );
-      if (useGnuTime) {
-        result.peakRssBytesExternal = parseGnuTimeMaxRss(stderr);
-      }
-      resolve(result);
+      resolve({
+        kind: "measured",
+        ...measurement,
+        peakRssBytesExternal: useGnuTime
+          ? parseGnuTimeMaxRss(stderr)
+          : undefined,
+      });
     });
   });
+}
+
+/**
+ * The peak RSS to report for a result, or `undefined` when nothing observed
+ * one: the externally observed peak where available, since it also covers
+ * allocations made after the in-process read.
+ */
+function reportedPeakRssBytes(
+  result: MemoryMeasurement | MemoryExhausted
+): number | undefined {
+  return result.kind === "measured"
+    ? (result.peakRssBytesExternal ?? result.peakRssBytes)
+    : result.peakRssBytesExternal;
+}
+
+/** Logs one measured or out-of-memory cell to the progress stream. */
+function logMemoryProgress(result: MemoryMeasurement | MemoryExhausted) {
+  const peak = reportedPeakRssBytes(result);
+  switch (result.kind) {
+    case "measured":
+      console.error(
+        `  peak RSS ${displayMiB(peak ?? result.peakRssBytes)}, ` +
+          `${displayDuration(result.elapsedMs)}, ${result.testCount} tests ` +
+          `(${result.failureCount} failing)`
+      );
+      break;
+    case "oom":
+      console.error(
+        peak !== undefined
+          ? `  out of memory at >= ${displayMiB(peak)}`
+          : "  out of memory (peak RSS unknown)"
+      );
+      break;
+    default: {
+      const _exhaustiveCheck: never = result;
+      throw new Error(`unrecognized memory result: ${JSON.stringify(result)}`);
+    }
+  }
 }
 
 function displayMiB(bytes: number): string {
@@ -1116,13 +1184,22 @@ export function formatMemoryTable(results: MemoryRunResult[]): string {
       if (result === undefined) {
         return "—";
       }
-      // Prefer the externally observed peak; it also covers allocations made
-      // after the in-process read.
-      const peak = result.peakRssBytesExternal ?? result.peakRssBytes;
-      if (result.oom === true) {
-        return peak > 0 ? `OOM (>= ${displayMiB(peak)})` : "OOM";
+      switch (result.kind) {
+        case "measured":
+          return `${displayMiB(reportedPeakRssBytes(result) ?? result.peakRssBytes)} / ${displayDuration(result.elapsedMs)}`;
+        case "oom": {
+          const peak = reportedPeakRssBytes(result);
+          return peak !== undefined ? `OOM (>= ${displayMiB(peak)})` : "OOM";
+        }
+        case "error":
+          return "error";
+        default: {
+          const _exhaustiveCheck: never = result;
+          throw new Error(
+            `unrecognized memory result: ${JSON.stringify(result)}`
+          );
+        }
       }
-      return `${displayMiB(peak)} / ${displayDuration(result.elapsedMs)}`;
     }),
   ]);
 

--- a/js/benchmark/src/solidity-tests.ts
+++ b/js/benchmark/src/solidity-tests.ts
@@ -897,10 +897,17 @@ export interface MemoryChildParams {
   compileOnly?: boolean;
 }
 
+/**
+ * Environment for processes whose GNU time report we parse: its messages are
+ * translatable, so pin the locale.
+ */
+const GNU_TIME_ENV = { LC_ALL: "C" };
+
 function hasGnuTime(): boolean {
   try {
     child_process.execFileSync("/usr/bin/time", ["-v", "true"], {
       stdio: "ignore",
+      env: { ...process.env, ...GNU_TIME_ENV },
     });
     return true;
   } catch {
@@ -914,7 +921,11 @@ function parseGnuTimeMaxRss(stderr: string): number | undefined {
   return match === null ? undefined : Number(match[1]) * 1024;
 }
 
-/** Whether a child process exited because it ran out of memory. */
+/**
+ * Whether a child process that exited abnormally did so because it ran out of
+ * memory. Only meaningful for abnormal exits: the stderr checks would otherwise
+ * mistake a successful run that merely printed one of these messages.
+ */
 function isOomError(
   code: number | null,
   signal: NodeJS.Signals | null,
@@ -932,10 +943,14 @@ function isOomError(
     return true;
   }
 
-  // V8 aborts the process when its own heap limit is exhausted. Match the
-  // fatal-error message rather than the SIGABRT it dies with, which has
-  // other causes too.
-  return /JavaScript heap out of memory/.test(stderr);
+  // V8 aborts the process when its own heap limit is exhausted, and Rust's
+  // allocator aborts when an allocation fails. Match their fatal-error
+  // messages rather than the SIGABRT both die with, which has other causes
+  // too.
+  return (
+    /JavaScript heap out of memory/.test(stderr) ||
+    /memory allocation of \d+ bytes failed/.test(stderr)
+  );
 }
 
 /**
@@ -1125,7 +1140,11 @@ function runMemoryChildProcess(
     const child = child_process.spawn(command, commandArgs, {
       cwd: process.cwd(),
       stdio: ["ignore", "pipe", "pipe"],
-      env: { ...process.env, RAYON_NUM_THREADS: MEMORY_RAYON_THREADS },
+      env: {
+        ...process.env,
+        ...GNU_TIME_ENV,
+        RAYON_NUM_THREADS: MEMORY_RAYON_THREADS,
+      },
       detached: true,
     });
     const stopKillingOnTermination = killChildOnTermination(child);
@@ -1158,7 +1177,8 @@ function runMemoryChildProcess(
         return;
       }
 
-      if (isOomError(code, signal, stderr)) {
+      const abnormalExit = code !== 0 || signal !== null;
+      if (abnormalExit && isOomError(code, signal, stderr)) {
         resolve({
           kind: "oom",
           repo: repoName,

--- a/js/benchmark/src/solidity-tests.ts
+++ b/js/benchmark/src/solidity-tests.ts
@@ -654,9 +654,12 @@ export async function setupRepo(
 
   try {
     await execAsync("npm install", { cwd: repoPath });
-  } catch {
+  } catch (e) {
+    // Logged so that a repository left in a bad state by the fallback can be
+    // traced back to the script that failed.
     console.error(
-      `npm install failed for ${repoPath}, retrying with --ignore-scripts`
+      `npm install failed for ${repoPath}, retrying with --ignore-scripts. Error:\n` +
+        (e instanceof Error ? e.message : String(e))
     );
     await execAsync("npm install --ignore-scripts", { cwd: repoPath });
   }

--- a/js/benchmark/src/solidity-tests.ts
+++ b/js/benchmark/src/solidity-tests.ts
@@ -886,6 +886,58 @@ export function printMemoryResult(result: MemoryMeasurementPayload) {
 }
 
 /**
+ * Extracts the child's measurement from its stdout, or `undefined` if it isn't
+ * there or doesn't have the expected shape. Tolerates other output around it,
+ * and rebuilds the payload from the known fields rather than trusting it: the
+ * driver and child may be built from different revisions while bisecting.
+ */
+function parseMemoryMeasurement(
+  stdout: string
+): MemoryMeasurementPayload | undefined {
+  const start = stdout.lastIndexOf(MEMORY_RESULT_PREFIX);
+  if (start === -1) {
+    return undefined;
+  }
+  const json = stdout
+    .slice(start + MEMORY_RESULT_PREFIX.length)
+    .split("\n", 1)[0];
+
+  let value: unknown;
+  try {
+    value = JSON.parse(json);
+  } catch {
+    return undefined;
+  }
+  if (typeof value !== "object" || value === null) {
+    return undefined;
+  }
+  const candidate = value as Record<string, unknown>;
+  const numbers = [
+    "verbosity",
+    "peakRssBytes",
+    "elapsedMs",
+    "suiteCount",
+    "testCount",
+    "failureCount",
+  ] as const;
+  if (
+    typeof candidate.repo !== "string" ||
+    !numbers.every((key) => typeof candidate[key] === "number")
+  ) {
+    return undefined;
+  }
+  return {
+    repo: candidate.repo,
+    verbosity: candidate.verbosity as number,
+    peakRssBytes: candidate.peakRssBytes as number,
+    elapsedMs: candidate.elapsedMs as number,
+    suiteCount: candidate.suiteCount as number,
+    testCount: candidate.testCount as number,
+    failureCount: candidate.failureCount as number,
+  };
+}
+
+/**
  * Parameters the driver passes to `solidity-tests-memory-child.ts`, as a
  * single JSON argument.
  */
@@ -1160,8 +1212,12 @@ function runMemoryChildProcess(
 
     let stdout = "";
     let stderr = "";
-    child.stdout.on("data", (chunk) => (stdout += chunk));
-    child.stderr.on("data", (chunk) => (stderr += chunk));
+    // Decode as streams, not per chunk: a chunk boundary inside a multi-byte
+    // character would otherwise corrupt the text.
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => (stdout += chunk));
+    child.stderr.on("data", (chunk: string) => (stderr += chunk));
 
     child.on("error", reject);
     child.on("close", (code, signal) => {
@@ -1197,10 +1253,8 @@ function runMemoryChildProcess(
         return;
       }
 
-      const line = stdout
-        .split("\n")
-        .find((l) => l.startsWith(MEMORY_RESULT_PREFIX));
-      if (line === undefined) {
+      const measurement = parseMemoryMeasurement(stdout);
+      if (measurement === undefined) {
         reject(
           new Error(
             `memory child for ${repoName} v${verbosity} produced no result\n${stdout}\n${stderr}`
@@ -1208,10 +1262,6 @@ function runMemoryChildProcess(
         );
         return;
       }
-
-      const measurement: MemoryMeasurementPayload = JSON.parse(
-        line.slice(MEMORY_RESULT_PREFIX.length)
-      );
       resolve({
         kind: "measured",
         ...measurement,

--- a/js/benchmark/src/solidity-tests.ts
+++ b/js/benchmark/src/solidity-tests.ts
@@ -654,7 +654,7 @@ export async function setupRepo(
 
   try {
     await execAsync("npm install", { cwd: repoPath });
-  } catch (e) {
+  } catch {
     console.error(
       `npm install failed for ${repoPath}, retrying with --ignore-scripts`
     );
@@ -939,7 +939,7 @@ export async function runSolidityTestsMemoryBenchmark(
         verbosity,
         useGnuTime
       );
-      if (result.oom) {
+      if (result.oom === true) {
         console.error(`  OOM: killed at >= ${displayMiB(result.peakRssBytes)}`);
       } else {
         console.error(
@@ -1112,7 +1112,7 @@ export function formatMemoryTable(results: MemoryRunResult[]): string {
       // Prefer the externally observed peak; it also covers allocations made
       // after the in-process read.
       const peak = result.peakRssBytesExternal ?? result.peakRssBytes;
-      if (result.oom) {
+      if (result.oom === true) {
         return peak > 0 ? `OOM (>= ${displayMiB(peak)})` : "OOM";
       }
       return `${displayMiB(peak)} / ${displayDuration(result.elapsedMs)}`;

--- a/js/benchmark/src/solidity-tests.ts
+++ b/js/benchmark/src/solidity-tests.ts
@@ -756,6 +756,13 @@ function assertNoFailures(results: SuiteResult[]) {
 export const MEMORY_VERBOSITIES = [2, 3, 4];
 
 /**
+ * The repos measured by default, chosen to cover the different execution
+ * paths: solady is large and fuzz-heavy, uniswap-v4-core has many tests per
+ * suite, and morpho-blue exercises invariant testing.
+ */
+export const MEMORY_REPOS = ["solady", "uniswap-v4-core", "morpho-blue"];
+
+/**
  * Rayon thread cap for measured children. Test suites (and tests within a
  * suite) run in parallel, and each in-flight suite retains its trace arenas, so
  * peak RSS scales with parallelism. An unbounded run OOMs a 16 GiB machine on


### PR DESCRIPTION
Hardhat 3 users report out-of-memory crashes when running Solidity tests at verbosity `-vvv` and above. Before fixing that, we need a way to measure peak memory use reliably and compare builds. This PR adds a `solidity-tests-memory` benchmark command that does exactly that.

## What it measures

Peak resident memory (RSS) of a full test run, for each combination of repository and Hardhat verbosity level. Verbosity is the input that matters because Hardhat maps it to the EDR options that control trace collection (`includeTraces` / `collectStackTraces`): `-vv` collects nothing, `-vvv` records EVM steps for every test and keeps traces of failing tests, `-vvvv` keeps traces of all tests.

The benchmarked repositories cover the different execution paths: **solady** (1557 tests, fuzz-heavy), **uniswap-v4-core** (598 tests), and **morpho-blue** (145 tests including invariant testing).

## Design

- **One child process per measurement.** `maxRSS` is a per-process high-water mark that never goes down, so a second measurement in the same process would inherit the first one's peak. The driver therefore spawns a fresh process for every (repo, verbosity) cell.
- **A dedicated internal entry script** (`solidity-tests-memory-child.ts`) runs the measurement. The driver passes its parameters as a single JSON argument. The child reports its result as a tagged JSON line on stdout.
- **Two independent memory readings.** The child reads its own peak via `process.resourceUsage()`; the driver additionally wraps the child in `/usr/bin/time -v`, which observes the peak from outside. The external reading is the important one: it also covers a child that the OOM killer terminates before it can report anything.
- **OOM is a result, not a failure.** If a child is killed, the driver records the cell as `OOM` with the last externally observed RSS ("the true requirement is at least this much") and moves on to the next cell.
- **Warm-up compile.** Each repo is compiled in a throwaway child first, so the first measured run doesn't pay one-time solc costs that later runs would get from the artifact cache.
- **Bounded parallelism.** Children are capped at 4 rayon threads. Peak RSS scales with how many test suites run concurrently, and with unbounded parallelism the current runner OOMs a 16 GiB machine at `-vvv` on solady — every cell would just read "OOM", leaving nothing to compare fixes against. A fixed cap keeps every cell measurable and comparable across builds.
- **stdout is data, stderr is progress.** The command prints per-cell progress to stderr and exactly one artifact to stdout: a markdown table (rows = repos, columns = verbosity levels), ready to paste into a PR. Full results are also written to a JSON file.

## Usage

```bash
cd js/benchmark
pnpm soltestsMemory                          # all repos × verbosity 2, 3, 4
pnpm soltestsMemory --repo solady            # one repo
pnpm soltestsMemory --verbosity 3            # one verbosity level
```

## Example output table

| repo | -vv | -vvv | -vvvv |
|---|---|---|---|
| solady | 510 MiB / 3.1s | 4750 MiB / 17.7s | OOM (killed at ≥ 10.3 GiB) |
| uniswap-v4-core | 387 MiB / 1.6s | 2308 MiB / 1.8s | 3652 MiB / 1.9s |
| morpho-blue | 283 MiB / 2.4s | 1681 MiB / 10.9s | 1900 MiB / 10.8s |

## Also in this PR

Repo setup needed two fixes to run the new repos: submodules pinned by the benchmarked commit are now initialized after checkout (the shallow clone doesn't fetch them), and `npm install` falls back to `--ignore-scripts` for repos whose lifecycle scripts need tools we don't have (morpho-blue's `prepare` runs `forge install`, which is redundant here because the clone already checks out submodules).
