### PR TITLE
refactor: rename the solx compiler type to slangSolx

### DIFF
--- a/.changeset/great-hornets-invite.md
+++ b/.changeset/great-hornets-invite.md
@@ -2,4 +2,4 @@
 "@nomicfoundation/edr": patch
 ---
 
-Update supported compiler types to include slangSolx.
+Changed `solx` compiler type string to `slangSolx`.

--- a/.changeset/great-hornets-invite.md
+++ b/.changeset/great-hornets-invite.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Update supported compiler types to include slangSolx.

--- a/.changeset/great-hornets-invite.md
+++ b/.changeset/great-hornets-invite.md
@@ -2,4 +2,6 @@
 "@nomicfoundation/edr": patch
 ---
 
-Changed `solx` compiler type string to `slangSolx`.
+- Added support for compilation artifacts with `slangSolx` compiler type string.
+- BREAKING CHANGE: Removed support for compilation arifacts with `solx` compiler type string. Instead, use the `slangSolx` compiler type string.
+

--- a/.changeset/great-hornets-invite.md
+++ b/.changeset/great-hornets-invite.md
@@ -4,4 +4,3 @@
 
 - Added support for compilation artifacts with `slangSolx` compiler type string.
 - BREAKING CHANGE: Removed support for compilation arifacts with `solx` compiler type string. Instead, use the `slangSolx` compiler type string.
-

--- a/crates/edr_napi/src/provider.rs
+++ b/crates/edr_napi/src/provider.rs
@@ -115,7 +115,7 @@ impl Provider {
                         })
                         .map_err(|error| napi::Error::from_reason(error.to_string()))
                     }),
-                    edr_solidity::artifacts::CompilerType::Solx => serde_json::from_value::<
+                    edr_solidity::artifacts::CompilerType::SlangSolx => serde_json::from_value::<
                         edr_solidity::artifacts::CompilerOutput<
                             edr_solidity::artifacts::SolxBytecode,
                         >,

--- a/crates/edr_solidity/src/artifacts.rs
+++ b/crates/edr_solidity/src/artifacts.rs
@@ -581,10 +581,19 @@ mod tests {
         const SLANG_SOLX_COMPILER_TYPE: &str = "slangSolx";
 
         assert_eq!(CompilerType::Solc.to_string(), SOLC_COMPILER_TYPE);
-        assert_eq!(CompilerType::SlangSolx.to_string(), SLANG_SOLX_COMPILER_TYPE);
+        assert_eq!(
+            CompilerType::SlangSolx.to_string(),
+            SLANG_SOLX_COMPILER_TYPE
+        );
 
-        assert_eq!(to_compiler_type(Some(SOLC_COMPILER_TYPE)), CompilerType::Solc);
-        assert_eq!(to_compiler_type(Some(SLANG_SOLX_COMPILER_TYPE)), CompilerType::SlangSolx);
+        assert_eq!(
+            to_compiler_type(Some(SOLC_COMPILER_TYPE)),
+            CompilerType::Solc
+        );
+        assert_eq!(
+            to_compiler_type(Some(SLANG_SOLX_COMPILER_TYPE)),
+            CompilerType::SlangSolx
+        );
 
         assert_eq!(to_compiler_type(None), CompilerType::Solc);
         assert_eq!(to_compiler_type(Some("not-a-compiler")), CompilerType::Solc);

--- a/crates/edr_solidity/src/artifacts.rs
+++ b/crates/edr_solidity/src/artifacts.rs
@@ -147,12 +147,10 @@ pub enum ContractMetadataExtractionError {
 #[serde(rename_all = "camelCase")]
 #[strum(serialize_all = "camelCase")]
 pub enum CompilerType {
-    /// Reference Solidity compiler; uses `evm.{deployed,}Bytecode.sourceMap`.
+    /// Solc compiler
     #[default]
     Solc,
-    /// solx compiler; uses `evm.{deployed,}Bytecode.debugInfo`.
-    /// Serializes as `slangSolx`, the compiler type in the `hardhat-slang-solx`
-    /// plugin's build-infos.
+    /// Slang solx compiler
     SlangSolx,
 }
 
@@ -579,11 +577,14 @@ mod tests {
 
     #[test]
     fn to_compiler_type_reads_the_build_info_sentinel() {
-        assert_eq!(CompilerType::Solc.to_string(), "solc");
-        assert_eq!(CompilerType::SlangSolx.to_string(), "slangSolx");
+        const SOLC_COMPILER_TYPE: &str = "solc";
+        const SLANG_SOLX_COMPILER_TYPE: &str = "slangSolx";
 
-        assert_eq!(to_compiler_type(Some("solc")), CompilerType::Solc);
-        assert_eq!(to_compiler_type(Some("slangSolx")), CompilerType::SlangSolx);
+        assert_eq!(CompilerType::Solc.to_string(), SOLC_COMPILER_TYPE);
+        assert_eq!(CompilerType::SlangSolx.to_string(), SLANG_SOLX_COMPILER_TYPE);
+
+        assert_eq!(to_compiler_type(Some(SOLC_COMPILER_TYPE)), CompilerType::Solc);
+        assert_eq!(to_compiler_type(Some(SLANG_SOLX_COMPILER_TYPE)), CompilerType::SlangSolx);
 
         assert_eq!(to_compiler_type(None), CompilerType::Solc);
         assert_eq!(to_compiler_type(Some("not-a-compiler")), CompilerType::Solc);

--- a/crates/edr_solidity/src/artifacts.rs
+++ b/crates/edr_solidity/src/artifacts.rs
@@ -151,7 +151,9 @@ pub enum CompilerType {
     #[default]
     Solc,
     /// solx compiler; uses `evm.{deployed,}Bytecode.debugInfo`.
-    Solx,
+    /// Serializes as `slangSolx`, the compiler type in the `hardhat-slang-solx`
+    /// plugin's build-infos.
+    SlangSolx,
 }
 
 /// Configuration for the [`crate::contract_decoder::ContractDecoder`].
@@ -237,7 +239,7 @@ impl BuildInfoBuffers<'_> {
 
                     match to_compiler_type(peek.compiler_type) {
                         CompilerType::Solc => parse_solc_compiler_metadata(*item),
-                        CompilerType::Solx => parse_solx_compiler_metadata(*item),
+                        CompilerType::SlangSolx => parse_solx_compiler_metadata(*item),
                     }
                     // Silently ignore unsupported solc versions
                     .or_else(|error| {
@@ -259,7 +261,7 @@ impl BuildInfoBuffers<'_> {
                         CompilerType::Solc => {
                             parse_split_solc_compiler_metadata(item.build_info, item.output)
                         }
-                        CompilerType::Solx => {
+                        CompilerType::SlangSolx => {
                             parse_split_solx_compiler_metadata(item.build_info, item.output)
                         }
                     }
@@ -573,5 +575,17 @@ mod tests {
             .starts_with("7f454c46"));
         assert!(contract.evm.bytecode.debug_info.len() >= 200);
         assert!(contract.evm.deployed_bytecode.debug_info.len() >= 200);
+    }
+
+    #[test]
+    fn to_compiler_type_reads_the_build_info_sentinel() {
+        assert_eq!(CompilerType::Solc.to_string(), "solc");
+        assert_eq!(CompilerType::SlangSolx.to_string(), "slangSolx");
+
+        assert_eq!(to_compiler_type(Some("solc")), CompilerType::Solc);
+        assert_eq!(to_compiler_type(Some("slangSolx")), CompilerType::SlangSolx);
+
+        assert_eq!(to_compiler_type(None), CompilerType::Solc);
+        assert_eq!(to_compiler_type(Some("not-a-compiler")), CompilerType::Solc);
     }
 }


### PR DESCRIPTION
We rename `CompilerType::Solx` to `SlangSolx` as an accepted compiler type. This is to mirror the change in the renamed `hardhat-slang-solx` plugin.

EDR reads a build info's `compilerType` field to decide how to recover source locations: `solc` means `evm.{deployed,}Bytecode.sourceMap`, and the solx variant means `evm.{deployed,}Bytecode.debugInfo`.

The Hardhat plugin that produces those build infos has been renamed to `hardhat-slang-solx`, and the compiler type it registers and writes is now `slangSolx`. That value triggered `to_compiler_type`'s unknown-value path and fell back to `Solc`, where we look for a `sourceMap` that solx does not emit. Solidity stack traces were silently lost: every failing test under a solx build profile printed `Stack Trace Warning: Instruction not found at PC 2` and no frames.

Currently `hardhat-slang-solx` does a remapping of `slangSolx` to `solx` to support EDR. When EDR changes to the new compiler type value, we will update the `hardhat-slang-solx` plugin. No backwards compatibility is required.
