### PR TITLE
refactor: name the failing arena explicitly in `get_stack_trace`

### DIFF
--- a/crates/edr_provider/src/error.rs
+++ b/crates/edr_provider/src/error.rs
@@ -25,7 +25,7 @@ use edr_runtime::{overrides::AccountOverrideConversionError, transaction};
 use edr_signer::SignatureError;
 use edr_solidity::{
     contract_decoder::{ContractDecoder, ContractDecoderError},
-    solidity_stack_trace::{get_stack_trace, StackTraceCreationResult},
+    solidity_stack_trace::{get_stack_trace, DeployedCode, StackTraceCreationResult},
 };
 use edr_state_api::StateError;
 use foundry_evm_traces::CallTraceArena;
@@ -659,11 +659,13 @@ impl<HaltReasonT: HaltReasonTrait> TransactionFailure<HaltReasonT> {
     ) -> Self {
         let stack_trace_result = get_stack_trace(
             contract_decoder,
-            std::iter::once(call_trace_arena),
-            Some(address_to_executed_code),
+            call_trace_arena,
+            std::iter::empty(),
+            DeployedCode {
+                creation: None,
+                runtime: Some(address_to_executed_code),
+            },
         )
-        .transpose()
-        .expect("Contains a single call trace arena")
         .into();
 
         Self {
@@ -684,11 +686,13 @@ impl<HaltReasonT: HaltReasonTrait> TransactionFailure<HaltReasonT> {
         let data = format!("0x{}", hex::encode(output.as_ref()));
         let stack_trace_result = get_stack_trace(
             contract_decoder,
-            std::iter::once(call_trace_arena),
-            Some(address_to_executed_code),
+            call_trace_arena,
+            std::iter::empty(),
+            DeployedCode {
+                creation: None,
+                runtime: Some(address_to_executed_code),
+            },
         )
-        .transpose()
-        .expect("Contains a single call trace arena")
         .into();
 
         Self {

--- a/crates/edr_solidity/src/solidity_stack_trace.rs
+++ b/crates/edr_solidity/src/solidity_stack_trace.rs
@@ -259,35 +259,51 @@ impl<HaltReasonT> StackTraceCreationError<HaltReasonT> {
     }
 }
 
-/// Compute stack trace based on execution traces.
+/// Code known to have been deployed to an address. A `None` field contributes
+/// no entries — the same as an empty map.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct DeployedCode<'a> {
+    /// Mapping from contract address to creation (init) code.
+    pub creation: Option<&'a HashMap<Address, Bytes>>,
+    /// Mapping from contract address to runtime (deployed) code.
+    pub runtime: Option<&'a HashMap<Address, Bytes>>,
+}
+
+/// Computes the stack trace of `failing_trace`.
 ///
-/// Assumes last trace is the error one. This is important for invariant tests
-/// where there might be multiple errors traces. Returns `None` if `traces` is
-/// empty.
+/// Decoding requires knowing the creation and runtime code of every contract
+/// involved. That knowledge comes from three places, applied in order (later
+/// entries override earlier ones for the same address):
 ///
-/// A mapping from contract address to executed code can be provided to help
-/// with decoding.
+/// 1. `deployed_code`: pre-computed mappings.
+/// 2. `code_sources`: arenas walked only for their CREATE nodes. They are never
+///    converted, so they need no recorded EVM steps.
+/// 3. `failing_trace` itself, since execution may deploy a contract and then
+///    fail inside it.
 pub fn get_stack_trace<
     'arena,
     HaltReasonT: HaltReasonTrait,
     NestedTraceDecoderT: NestedTraceDecoder<HaltReasonT>,
 >(
     contract_decoder: &NestedTraceDecoderT,
-    traces: impl IntoIterator<Item = &'arena CallTraceArena>,
-    address_to_executed_code: Option<&'arena HashMap<Address, Bytes>>,
-) -> Result<Option<Vec<StackTraceEntry>>, StackTraceCreationError<HaltReasonT>> {
-    let mut address_to_creation_code = HashMap::default();
-    let mut address_to_runtime_code =
-        if let Some(address_to_executed_code) = address_to_executed_code {
-            address_to_executed_code
-                .iter()
-                .map(|(k, v)| (*k, v))
-                .collect()
-        } else {
-            HashMap::default()
-        };
+    failing_trace: &'arena CallTraceArena,
+    code_sources: impl IntoIterator<Item = &'arena CallTraceArena>,
+    deployed_code: DeployedCode<'arena>,
+) -> Result<Vec<StackTraceEntry>, StackTraceCreationError<HaltReasonT>> {
+    let mut address_to_creation_code: HashMap<Address, &Bytes> = deployed_code
+        .creation
+        .map(|map| map.iter().map(|(k, v)| (*k, v)).collect())
+        .unwrap_or_default();
 
-    let last_trace = traces.into_iter().fold(None, |_, trace| {
+    let mut address_to_runtime_code: HashMap<Address, &Bytes> = deployed_code
+        .runtime
+        .map(|map| map.iter().map(|(k, v)| (*k, v)).collect())
+        .unwrap_or_default();
+
+    for trace in code_sources
+        .into_iter()
+        .chain(std::iter::once(failing_trace))
+    {
         for node in trace.nodes() {
             let address = node.trace.address;
             if node.trace.kind.is_any_create() {
@@ -295,21 +311,16 @@ pub fn get_stack_trace<
                 address_to_runtime_code.insert(address, &node.trace.output);
             }
         }
-        Some(trace)
-    });
-
-    if let Some(last_trace) = last_trace {
-        let trace = NestedTrace::from_call_trace_arena(
-            &address_to_creation_code,
-            &address_to_runtime_code,
-            last_trace,
-        )?;
-        let trace = contract_decoder.try_to_decode_nested_trace(trace)?;
-        let stack_trace = solidity_tracer::get_stack_trace(trace)?;
-        Ok(Some(stack_trace))
-    } else {
-        Ok(None)
     }
+
+    let trace = NestedTrace::from_call_trace_arena(
+        &address_to_creation_code,
+        &address_to_runtime_code,
+        failing_trace,
+    )?;
+    let trace = contract_decoder.try_to_decode_nested_trace(trace)?;
+    let stack_trace = solidity_tracer::get_stack_trace(trace)?;
+    Ok(stack_trace)
 }
 
 /// The possible outcomes from computing stack traces.

--- a/crates/edr_solidity_tests/src/runner.rs
+++ b/crates/edr_solidity_tests/src/runner.rs
@@ -18,7 +18,7 @@ use edr_chain_spec::{EvmHaltReason, HaltReasonTrait};
 use edr_decoder_revert::RevertDecoder;
 use edr_solidity::{
     contract_decoder::SyncNestedTraceDecoder,
-    solidity_stack_trace::{get_stack_trace, StackTraceEntry},
+    solidity_stack_trace::{get_stack_trace, DeployedCode, StackTraceEntry},
 };
 use eyre::Result;
 use foundry_cheatcodes::TestFunctionIdentifier;
@@ -44,7 +44,7 @@ use foundry_evm::{
         invariant::{CallDetails, InvariantContract},
         CounterExample, FuzzFixtures,
     },
-    traces::{load_contracts, SetupTraceKind, SparsedTraceArena, TracingMode},
+    traces::{load_contracts, SetupTraceKind, SetupTraces, SparsedTraceArena, TracingMode},
 };
 use itertools::Itertools;
 use proptest::test_runner::{FailurePersistence, RngAlgorithm, TestError, TestRng, TestRunner};
@@ -653,14 +653,7 @@ impl<
 
             setup.stack_trace_result = if setup_recorded_steps {
                 // We collected steps during setup, so we can generate the stack trace
-                get_stack_trace(
-                    &*self.contract_decoder,
-                    setup.traces.iter().map(|(_, arena)| &arena.arena),
-                    None,
-                )
-                .map_err(SolidityTestStackTraceError::from)
-                .transpose()
-                .map(SolidityTestStackTraceResult::from)
+                get_setup_stack_trace(&*self.contract_decoder, &setup.traces)
             } else if let Some(indeterminism_reasons) = setup.indeterminism_reasons.as_ref() {
                 // We cannot re-run the setup due to indeterminism, so we return the
                 // indeterminism reasons
@@ -671,17 +664,7 @@ impl<
                 executor.set_tracing(TracingMode::WithSteps);
                 let setup_for_stack_traces = self.setup(&mut executor, call_setup);
 
-                get_stack_trace(
-                    &*self.contract_decoder,
-                    setup_for_stack_traces
-                        .traces
-                        .iter()
-                        .map(|(_, arena)| &arena.arena),
-                    None,
-                )
-                .map_err(SolidityTestStackTraceError::from)
-                .transpose()
-                .map(SolidityTestStackTraceResult::from)
+                get_setup_stack_trace(&*self.contract_decoder, &setup_for_stack_traces.traces)
             };
 
             // The setup failed, so we return a single test result for `setUp`
@@ -953,10 +936,17 @@ impl<
         self.result.stack_trace_result = if !success {
             let stack_trace_result: SolidityTestStackTraceResult<HaltReasonT> =
                 if self.executor.tracer_records_steps() {
+                    let (failing_trace, prior_traces) = self
+                        .result
+                        .execution_traces
+                        .split_last()
+                        .expect("the traced test call recorded an arena");
+
                     collect_stack_trace(
                         &*self.cr.contract_decoder,
                         self.setup,
-                        &self.result.execution_traces,
+                        failing_trace,
+                        prior_traces,
                     )
                 } else if let Some(indeterminism_reasons) = indeterminism_reasons {
                     indeterminism_reasons.into()
@@ -1104,10 +1094,17 @@ impl<
 
                 let stack_trace_result: SolidityTestStackTraceResult<HaltReasonT> =
                     if self.executor.tracer_records_steps() {
+                        let (failing_trace, prior_traces) = self
+                            .result
+                            .execution_traces
+                            .split_last()
+                            .expect("the traced table-test call recorded an arena");
+
                         collect_stack_trace(
                             &*self.cr.contract_decoder,
                             self.setup,
-                            &self.result.execution_traces,
+                            failing_trace,
+                            prior_traces,
                         )
                     } else if let Some(indeterminism_reasons) = indeterminism_reasons {
                         indeterminism_reasons.into()
@@ -1293,20 +1290,35 @@ impl<
 
                 self.result.invariant_setup_fail(error, elapsed);
 
-                let stack_trace_result: SolidityTestStackTraceResult<HaltReasonT> =
-                    if self.executor.tracer_records_steps() {
-                        collect_stack_trace(
+                let stack_trace_result: Option<SolidityTestStackTraceResult<HaltReasonT>> = if self
+                    .executor
+                    .tracer_records_steps()
+                {
+                    if let Some((failing_trace, prior_traces)) =
+                        self.result.execution_traces.split_last()
+                    {
+                        Some(collect_stack_trace(
                             &*self.cr.contract_decoder,
                             self.setup,
-                            &self.result.execution_traces,
-                        )
-                    } else if let Some(indeterminism_reasons) = indeterminism_reasons {
-                        indeterminism_reasons.into()
+                            failing_trace,
+                            prior_traces,
+                        ))
                     } else {
+                        // The campaign failed without recording any EVM call
+                        // (e.g. an ABI error or too many `vm.assume`
+                        // rejects), so no arena describes the failure; the
+                        // result's `reason` carries the explanation.
+                        None
+                    }
+                } else if let Some(indeterminism_reasons) = indeterminism_reasons {
+                    Some(indeterminism_reasons.into())
+                } else {
+                    Some(
                         self.re_run_test_for_stack_traces(func, &[], self.setup.has_setup_method)
-                            .into()
-                    };
-                self.result.stack_trace_result = Some(stack_trace_result);
+                            .into(),
+                    )
+                };
+                self.result.stack_trace_result = stack_trace_result;
 
                 return self.result;
             }
@@ -1510,10 +1522,17 @@ impl<
         {
             let stack_trace_result: SolidityTestStackTraceResult<_> =
                 if fuzzed_executor.tracer_records_steps() {
+                    let (failing_trace, prior_traces) = self
+                        .result
+                        .execution_traces
+                        .split_last()
+                        .expect("the traced counterexample call recorded an arena");
+
                     collect_stack_trace(
                         &*self.cr.contract_decoder,
                         self.setup,
-                        &self.result.execution_traces,
+                        failing_trace,
+                        prior_traces,
                     )
                 } else if let Some(indeterminism_reasons) =
                     counter_example.indeterminism_reasons.clone()
@@ -1643,20 +1662,37 @@ impl<
 
         get_stack_trace(
             &*self.cr.contract_decoder,
-            setup
-                .traces
-                .iter()
-                .map(|(_, arena)| &arena.arena)
-                .chain(std::iter::once(&new_trace_arena.arena)),
-            None,
+            &new_trace_arena.arena,
+            setup.traces.iter().map(|(_, arena)| &arena.arena),
+            DeployedCode::default(),
         )
-        .transpose()
-        .expect("traces are not empty")
         .map_err(SolidityTestStackTraceError::Creation)
     }
 }
 
-/// Builds a stack trace from the traces recorded during this run.
+/// Builds the stack trace of a failed `setUp()` (or constructor) from the
+/// recorded setup traces. Returns `None` if no traces were recorded.
+fn get_setup_stack_trace<
+    HaltReasonT: 'static + HaltReasonTrait + TryInto<HaltReason>,
+    NestedTraceDecoderT: SyncNestedTraceDecoder<HaltReasonT>,
+>(
+    contract_decoder: &NestedTraceDecoderT,
+    setup_traces: &SetupTraces,
+) -> Option<SolidityTestStackTraceResult<HaltReasonT>> {
+    let ((_, failing_trace), code_sources) = setup_traces.split_last()?;
+    Some(
+        get_stack_trace(
+            contract_decoder,
+            &failing_trace.arena,
+            code_sources.iter().map(|(_, arena)| &arena.arena),
+            DeployedCode::default(),
+        )
+        .map_err(SolidityTestStackTraceError::from)
+        .into(),
+    )
+}
+
+/// Builds the stack trace of `failing_trace`.
 ///
 /// Taken as an associated function of explicit fields rather than `&self`
 /// so it can be called from the fuzz path, where `self.executor` has
@@ -1667,20 +1703,17 @@ fn collect_stack_trace<
 >(
     contract_decoder: &NestedTraceDecoderT,
     setup: &TestSetup<HaltReasonT>,
-    execution_traces: &[SparsedTraceArena],
+    failing_trace: &SparsedTraceArena,
+    prior_execution_traces: &[SparsedTraceArena],
 ) -> SolidityTestStackTraceResult<HaltReasonT> {
+    let setup_arenas = setup.traces.iter().map(|(_, arena)| &arena.arena);
     get_stack_trace(
         contract_decoder,
-        setup
-            .traces
-            .iter()
-            .map(|(_, arena)| &arena.arena)
-            .chain(execution_traces.iter().map(|arena| &arena.arena)),
-        None,
+        &failing_trace.arena,
+        setup_arenas.chain(prior_execution_traces.iter().map(|arena| &arena.arena)),
+        DeployedCode::default(),
     )
     .map_err(SolidityTestStackTraceError::from)
-    .transpose()
-    .expect("traces are not empty")
     .into()
 }
 
@@ -1747,15 +1780,10 @@ fn re_run_fuzz_counterexample_for_stack_traces<
 
     get_stack_trace(
         &*contract_runner.contract_decoder,
-        setup
-            .traces
-            .iter()
-            .map(|(_, arena)| &arena.arena)
-            .chain(std::iter::once(&new_trace_arena.arena)),
-        None,
+        &new_trace_arena.arena,
+        setup.traces.iter().map(|(_, arena)| &arena.arena),
+        DeployedCode::default(),
     )
-    .transpose()
-    .expect("traces are not empty")
     .map_err(SolidityTestStackTraceError::Creation)
 }
 

--- a/crates/foundry/evm/evm/src/executors/invariant/replay.rs
+++ b/crates/foundry/evm/evm/src/executors/invariant/replay.rs
@@ -4,7 +4,10 @@ use alloy_dyn_abi::JsonAbiExt;
 use alloy_primitives::Log;
 use derive_where::derive_where;
 use edr_decoder_revert::RevertDecoder;
-use edr_solidity::{contract_decoder::NestedTraceDecoder, solidity_stack_trace::get_stack_trace};
+use edr_solidity::{
+    contract_decoder::NestedTraceDecoder,
+    solidity_stack_trace::{get_stack_trace, DeployedCode},
+};
 use eyre::Result;
 use foundry_evm_core::{
     contracts::{ContractsByAddress, ContractsByArtifact},
@@ -174,20 +177,23 @@ pub fn replay_run<
                 if let Some(indeterminism_reasons) = call_result.indeterminism_reasons {
                     Some(indeterminism_reasons.into())
                 } else {
-                    contract_decoder
-                        .and_then(|decoder| {
-                            get_stack_trace(
-                                decoder,
-                                setup_traces
-                                    .iter()
-                                    .map(|(_, arena)| &arena.arena)
-                                    .chain(execution_traces.iter().map(|arena| &arena.arena)),
-                                None,
-                            )
-                            .map_err(SolidityTestStackTraceError::from)
-                            .transpose()
-                        })
-                        .map(SolidityTestStackTraceResult::from)
+                    contract_decoder.map(|decoder| {
+                        let (failing_trace, prior_traces) = execution_traces
+                            .split_last()
+                            .expect("an arena was pushed for this call above");
+
+                        get_stack_trace(
+                            decoder,
+                            &failing_trace.arena,
+                            setup_traces
+                                .iter()
+                                .map(|(_, arena)| &arena.arena)
+                                .chain(prior_traces.iter().map(|arena| &arena.arena)),
+                            DeployedCode::default(),
+                        )
+                        .map_err(SolidityTestStackTraceError::from)
+                        .into()
+                    })
                 };
             let revert_reason =
                 revert_decoder.maybe_decode(call_result.result.as_ref(), call_result.exit_reason);
@@ -242,18 +248,22 @@ pub fn replay_run<
                     .indeterminism_reasons
                     .map(SolidityTestStackTraceResult::from)
                     .or_else(|| {
-                        contract_decoder.and_then(|decoder| {
+                        contract_decoder.map(|decoder| {
+                            let (failing_trace, prior_traces) = execution_traces
+                                .split_last()
+                                .expect("the invariant call arena was pushed above");
+
                             get_stack_trace(
                                 decoder,
+                                &failing_trace.arena,
                                 setup_traces
                                     .iter()
                                     .map(|(_, arena)| &arena.arena)
-                                    .chain(execution_traces.iter().map(|arena| &arena.arena)),
-                                None,
+                                    .chain(prior_traces.iter().map(|arena| &arena.arena)),
+                                DeployedCode::default(),
                             )
                             .map_err(SolidityTestStackTraceError::from)
-                            .transpose()
-                            .map(SolidityTestStackTraceResult::from)
+                            .into()
                         })
                     })
             })


### PR DESCRIPTION
`get_stack_trace` used to take one flat iterator of trace arenas and convert whichever came last, relying on a doc comment — "assumes last trace is the error one" — to carry the whole contract. Every arena before the last was only ever walked to collect the creation/runtime bytecode of deployed contracts, needed to decode the failing trace.

This PR makes that split explicit in the signature:

- `failing_trace` — the arena that is converted and analysed;
- `code_sources` — arenas walked only for their CREATE nodes, to map contract addresses to code;
- `deployed_code` — pre-computed address→code mappings, seeded before the arenas are walked. This replaces the previous third parameter, which could only seed runtime code; the provider now passes `DeployedCode { runtime: Some(..) }` with unchanged behaviour.

The test runner's `collect_stack_trace` helper requires the failing arena the same way. Its callers split it off `execution_traces` themselves, so the reasoning about whether a failing arena was recorded now lives at each call site, where it can actually be justified: the unit, table and fuzz sites run right after the failing call's arena was recorded under an active tracer; the one site where no arena may exist — an invariant campaign that failed before recording any EVM call — handles that case explicitly.

## Why

Two reasons:

1. **Correctness by construction.** The "last arena is the failing one" assumption was easy to break silently: any caller appending an arena after the failing one would change which trace gets analysed, with no compiler help. Now the failing arena is named at every call site.
2. **It unlocks the memory work.** This establishes the invariant that only the failing arena's recorded EVM steps are ever read — every other arena contributes just its CREATE nodes. The follow-up PRs (fixing the OOM at Hardhat verbosity `-vvv`+) rely on exactly that to strip steps from every retained arena.

## Behaviour change (one, deliberate)

An invariant campaign that fails without recording any EVM call (e.g. an ABI error, or too many `vm.assume` rejects) now reports no stack trace. Previously the "last arena" fallback silently pointed the stack-trace heuristics at the last setup arena — a call that necessarily succeeded, since a failed `setUp()` never reaches invariant execution — producing a heuristic failure at best. No arena describes such a failure; the test result's `reason` string already explains it ("failed to set up invariant testing environment: …").

Everything else is a pure refactor: same arenas walked in the same order, same seeding precedence (pre-computed code → code sources → failing trace, later wins).

## Testing

- `cargo test -p edr_solidity_tests --test it` (123 passing) — including `always_mode_produces_stack_trace_for_failing_test`, which exercises stack-trace generation through the unit, table, fuzz, invariant and invariant-campaign-failure paths.
- Benchmarked runtime-neutral against the memory benchmark from #1621 (that harness was built to measure this PR's follow-ups; this refactor sits within run-to-run noise on every cell).
