### PR TITLE
feat: add Hardhat v3 artifact & build-info loading from disk

### DIFF
--- a/.changeset/wise-crews-carry.md
+++ b/.changeset/wise-crews-carry.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": minor
+---
+
+Added `EdrContext.runSolidityTestsFromPaths` and `ContractDecoder.fromProject`, which load Hardhat v3 artifacts and build infos from disk in Rust instead of receiving them over N-API.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3608,7 +3608,9 @@ dependencies = [
  "serde",
  "serde_json",
  "strum 0.28.0",
+ "tempfile",
  "thiserror 2.0.20",
+ "walkdir",
 ]
 
 [[package]]

--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -13,6 +13,8 @@ export declare class ContractDecoder {
   constructor()
   /** Creates a new instance with the provided configuration. */
   static withContracts(config: TracingConfigWithBuffers): ContractDecoder
+  /** Creates a new instance by reading the project's build infos from disk. */
+  static fromProject(config: ProjectArtifactsConfig): ContractDecoder
 }
 
 export declare class EdrContext {
@@ -47,6 +49,28 @@ export declare class EdrContext {
    *   with the results of each test suite as soon as it finished executing.
    */
   runSolidityTests(chainType: string, artifacts: Array<Artifact>, testSuites: Array<ArtifactId>, configArgs: SolidityTestRunnerConfigArgs, tracingConfig: TracingConfigWithBuffers, onTestSuiteCompletedCallback: (arg: SuiteResult) => void): Promise<SolidityTestResult>
+  /**
+   * Executes Solidity tests, loading artifacts and build infos from the
+   * provided artifact directories.
+   *
+   * The function will return a promise that resolves to a
+   * [`SolidityTestResult`].
+   *
+   * Arguments:
+   * - `chainType`: the same chain type that was passed to
+   *   `registerProviderFactory`.
+   * - `artifactsDirectories`: the paths of the project's artifact
+   *   directories, in the Hardhat v3 format. All artifacts are loaded, so
+   *   that cheatcodes that access artifacts and other functionality (e.g.
+   *   auto-linking, gas reports) work.
+   * - `testSuites`: references to the test suite contracts to execute. The
+   *   referenced artifacts must be present in the artifact directories.
+   * - `configArgs`: solidity test runner configuration. See the struct docs
+   *   for details.
+   * - `onTestSuiteCompletedCallback`: The progress callback will be called
+   *   with the results of each test suite as soon as it finished executing.
+   */
+  runSolidityTestsFromPaths(chainType: string, artifactsDirectories: Array<string>, testSuites: Array<TestSuiteReference>, configArgs: SolidityTestRunnerConfigArgs, onTestSuiteCompletedCallback: (arg: SuiteResult) => void): Promise<SolidityTestResult>
 }
 
 export declare class Exit {
@@ -1408,6 +1432,19 @@ export declare function precompileP256Verify(): Precompile
 
 export declare function printStackTrace(trace: SolidityStackTrace): void
 
+/** Configuration for loading a project's compilation output from disk. */
+export interface ProjectArtifactsConfig {
+  /** The path of the project's artifacts directory. */
+  artifactsDir: string
+  /**
+   * The path of the directory containing the project's build info files.
+   * Defaults to the `build-info` subdirectory of `artifactsDir`.
+   */
+  buildInfoDir?: string
+  /** Whether to ignore contracts whose name starts with "Ignored". */
+  ignoreContracts?: boolean
+}
+
 /** Configuration for a provider. */
 export interface ProviderConfig {
   /** Whether to allow blocks with the same timestamp */
@@ -1967,6 +2004,33 @@ export declare enum TestStatus {
   Failure = 'Failure',
   /** Test skipped */
   Skipped = 'Skipped'
+}
+
+/**
+ * A reference to a test suite contract within an artifacts directory.
+ *
+ * Unlike [`ArtifactId`], it doesn't require knowing the solc version that
+ * produced the contract; the version is resolved from the artifacts on disk.
+ */
+export interface TestSuiteReference {
+  /**
+   * The source name of the Solidity file containing the test suite, e.g.
+   * `contracts/Counter.t.sol`. Both the user-facing source name and the
+   * compiler input source name (e.g. `project/contracts/Counter.t.sol`)
+   * are accepted.
+   */
+  source: string
+  /** The name of the test suite contract, e.g. `CounterTest`. */
+  name: string
+}
+
+/**
+ * Timeout configuration.
+ * Note: This wrapper is needed to avoid ambiguity with NAPI conversion.
+ */
+export interface TimeoutConfig {
+  /** Optional timeout (in seconds). */
+  time?: number
 }
 
 /** Tracing config for Solidity stack trace generation. */

--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -2024,15 +2024,6 @@ export interface TestSuiteReference {
   name: string
 }
 
-/**
- * Timeout configuration.
- * Note: This wrapper is needed to avoid ambiguity with NAPI conversion.
- */
-export interface TimeoutConfig {
-  /** Optional timeout (in seconds). */
-  time?: number
-}
-
 /** Tracing config for Solidity stack trace generation. */
 export interface TracingConfigWithBuffers {
   /**

--- a/crates/edr_napi/src/context.rs
+++ b/crates/edr_napi/src/context.rs
@@ -349,6 +349,8 @@ impl EdrContext {
 
                 let tracing_config = edr_napi_core::solidity::config::TracingConfigWithBuffers {
                     build_infos: Some(napi::Either::B(build_infos)),
+                    // Skipping `Ignored*`-named contracts is only used by EDR's own test harnesses;
+                    // production Hardhat always passes `false`.
                     ignore_contracts: Some(false),
                 };
 

--- a/crates/edr_napi/src/context.rs
+++ b/crates/edr_napi/src/context.rs
@@ -23,12 +23,13 @@ use crate::{
     logger::LoggerConfig,
     provider::{factory::SyncProviderFactory, Provider, ProviderFactory},
     solidity_tests::{
-        artifact::{Artifact, ArtifactId},
+        artifact::{Artifact, ArtifactId, TestSuiteReference},
+        artifact_contracts_from_napi,
         config::SolidityTestRunnerConfigArgs,
         factory::SolidityTestRunnerFactory,
-        inline_config,
+        inline_config, load_project_inputs,
         test_results::{SolidityTestResult, SuiteResult},
-        LinkingOutput,
+        ArtifactContracts, LinkingOutput, ProjectInputs,
     },
     subscription::SubscriptionConfig,
 };
@@ -217,12 +218,10 @@ impl EdrContext {
     ) -> napi::Result<Object<'env>> {
         let (deferred, promise) = env.create_deferred()?;
 
-        let on_test_suite_completed_callback = try_or_reject_promise!(
+        let on_test_suite_completed = try_or_reject_promise!(
             deferred,
             promise,
-            on_test_suite_completed_callback
-                .build_threadsafe_function::<SuiteResult>()
-                .build_callback(|ctx: ThreadsafeCallContext<SuiteResult>| Ok(ctx.value))
+            build_on_test_suite_completed(on_test_suite_completed_callback)
         );
 
         let test_filter: Arc<TestFilterConfig> = Arc::new(try_or_reject_promise!(
@@ -237,152 +236,290 @@ impl EdrContext {
 
         let context = self.inner.clone();
         runtime.clone().spawn(async move {
-            macro_rules! try_or_reject_deferred {
-                ($expr:expr) => {
-                    match $expr {
-                        Ok(value) => value,
-                        Err(error) => {
-                            deferred.reject(error);
-                            return;
-                        }
-                    }
+            let result = async {
+                let factory = {
+                    let context = context.lock().await;
+                    context.solidity_test_runner_factory(&chain_type).await?
                 };
-            }
-            let factory = {
-                let context = context.lock().await;
-                try_or_reject_deferred!(context.solidity_test_runner_factory(&chain_type).await)
-            };
 
-            let linking_output =
-                try_or_reject_deferred!(LinkingOutput::link(&config.project_root, artifacts));
+                let artifact_contracts = artifact_contracts_from_napi(artifacts)?;
 
-            // Build revert decoder from ABIs of all artifacts.
-            let abis = linking_output
-                .known_contracts
-                .iter()
-                .map(|(_, contract)| &contract.abi);
+                let test_suites = test_suites
+                    .into_iter()
+                    .map(edr_artifact::ArtifactId::try_from)
+                    .collect::<Result<Vec<_>, _>>()?;
 
-            let revert_decoder = RevertDecoder::new().with_abis(abis);
-
-            let test_suites = try_or_reject_deferred!(test_suites
-                .into_iter()
-                .map(edr_artifact::ArtifactId::try_from)
-                .collect::<Result<Vec<_>, _>>());
-
-            let contracts = try_or_reject_deferred!(test_suites
-                .iter()
-                .map(|artifact_id| {
-                    let contract_data = linking_output
-                        .known_contracts
-                        .get(artifact_id)
-                        .ok_or_else(|| {
-                            napi::Error::new(
-                                napi::Status::GenericFailure,
-                                format!("Unknown contract: {}", artifact_id.identifier()),
-                            )
-                        })?;
-
-                    let bytecode = contract_data.bytecode.clone().ok_or_else(|| {
-                        napi::Error::new(
-                            napi::Status::GenericFailure,
-                            format!(
-                                "No bytecode for test suite contract: {}",
-                                artifact_id.identifier()
-                            ),
-                        )
-                    })?;
-
-                    let test_contract = TestContract {
-                        abi: contract_data.abi.clone(),
-                        bytecode,
-                    };
-
-                    Ok((artifact_id.clone(), test_contract))
-                })
-                .collect::<napi::Result<TestContracts>>());
-
-            let include_traces = config.include_traces.into();
-
-            let runtime_for_factory = runtime.clone();
-            let create_result = runtime
-                .clone()
-                .spawn_blocking(move || {
-                    factory.create_test_runner(
-                        runtime_for_factory,
-                        config,
-                        contracts,
-                        linking_output.known_contracts,
-                        linking_output.libs_to_deploy,
-                        revert_decoder,
-                        tracing_config.into(),
-                    )
-                })
+                run_test_suites(
+                    runtime,
+                    factory,
+                    config,
+                    artifact_contracts,
+                    test_suites,
+                    edr_napi_core::solidity::config::TracingConfigWithBuffers::from(tracing_config),
+                    test_filter,
+                    on_test_suite_completed,
+                )
                 .await
-                .expect("Failed to join test runner factory thread");
+            }
+            .await;
 
-            let outcome = match create_result {
-                // An inline-config failure carries structured, located problems
-                // that we surface on the rejected promise's error as
-                // `inlineConfigErrors`. Building that JS object requires the JS
-                // thread, so route it through the deferred's resolver (which
-                // runs there) rather than `deferred.reject`, which only carries
-                // a message.
-                Err(solidity::CreateTestRunnerError::InvalidInlineConfig(errors)) => {
-                    RunOutcome::InvalidInlineConfig(errors)
-                }
-                Err(solidity::CreateTestRunnerError::Failed(error)) => {
-                    deferred.reject(error);
-                    return;
-                }
-                Ok(test_runner) => {
-                    let runtime_for_runner = runtime.clone();
-                    let test_result = try_or_reject_deferred!(runtime
-                        .clone()
-                        .spawn_blocking(move || {
-                            test_runner.run_tests(
-                                runtime_for_runner,
-                                test_filter,
-                                Arc::new(
-                                    move |SuiteResultAndArtifactId {
-                                              artifact_id,
-                                              result,
-                                          }| {
-                                        let suite_result =
-                                            SuiteResult::new(artifact_id, result, include_traces);
-
-                                        let status = on_test_suite_completed_callback.call(
-                                            suite_result,
-                                            ThreadsafeFunctionCallMode::Blocking,
-                                        );
-
-                                        // This should always succeed since we're using an
-                                        // unbounded queue. We add an assertion for completeness.
-                                        assert_eq!(
-                                            status,
-                                            napi::Status::Ok,
-                                            "Failed to call on_test_suite_completed_callback with status: {status}"
-                                        );
-                                    },
-                                ),
-                            )
-                        })
-                        .await
-                        .expect("Failed to join test runner thread"));
-
-                    RunOutcome::Completed(test_result)
-                }
-            };
-
-            deferred.resolve(move |env| match outcome {
-                RunOutcome::Completed(test_result) => Ok(SolidityTestResult::from(test_result)),
-                RunOutcome::InvalidInlineConfig(errors) => {
-                    Err(inline_config::to_napi_error(&env, &errors))
-                }
-            });
+            match result {
+                Ok(outcome) => deferred.resolve(move |env| match outcome {
+                    RunOutcome::Completed(test_result) => Ok(SolidityTestResult::from(test_result)),
+                    RunOutcome::InvalidInlineConfig(errors) => {
+                        Err(inline_config::to_napi_error(&env, &errors))
+                    }
+                }),
+                Err(error) => deferred.reject(error),
+            }
         });
 
         Ok(promise)
     }
+
+    /// Executes Solidity tests, loading artifacts and build infos from the
+    /// provided artifact directories.
+    ///
+    /// The function will return a promise that resolves to a
+    /// [`SolidityTestResult`].
+    ///
+    /// Arguments:
+    /// - `chainType`: the same chain type that was passed to
+    ///   `registerProviderFactory`.
+    /// - `artifactsDirectories`: the paths of the project's artifact
+    ///   directories, in the Hardhat v3 format. All artifacts are loaded, so
+    ///   that cheatcodes that access artifacts and other functionality (e.g.
+    ///   auto-linking, gas reports) work.
+    /// - `testSuites`: references to the test suite contracts to execute. The
+    ///   referenced artifacts must be present in the artifact directories.
+    /// - `configArgs`: solidity test runner configuration. See the struct docs
+    ///   for details.
+    /// - `onTestSuiteCompletedCallback`: The progress callback will be called
+    ///   with the results of each test suite as soon as it finished executing.
+    #[napi(
+        catch_unwind,
+        async_runtime,
+        ts_return_type = "Promise<SolidityTestResult>"
+    )]
+    pub fn run_solidity_tests_from_paths<'env>(
+        &self,
+        env: &'env Env,
+        chain_type: String,
+        artifacts_directories: Vec<String>,
+        test_suites: Vec<TestSuiteReference>,
+        config_args: SolidityTestRunnerConfigArgs<'env>,
+        on_test_suite_completed_callback: Function<'env, SuiteResult, ()>,
+    ) -> napi::Result<Object<'env>> {
+        let (deferred, promise) = env.create_deferred()?;
+
+        let on_test_suite_completed = try_or_reject_promise!(
+            deferred,
+            promise,
+            build_on_test_suite_completed(on_test_suite_completed_callback)
+        );
+
+        let test_filter: Arc<TestFilterConfig> = Arc::new(try_or_reject_promise!(
+            deferred,
+            promise,
+            config_args.try_get_test_filter()
+        ));
+
+        let runtime = runtime::Handle::current();
+        let config =
+            try_or_reject_promise!(deferred, promise, config_args.resolve(runtime.clone()));
+
+        let context = self.inner.clone();
+        runtime.clone().spawn(async move {
+            let result = async {
+                let factory = {
+                    let context = context.lock().await;
+                    context.solidity_test_runner_factory(&chain_type).await?
+                };
+
+                let ProjectInputs {
+                    artifact_contracts,
+                    test_suites,
+                    build_infos,
+                } = runtime
+                    .spawn_blocking(move || {
+                        load_project_inputs(&artifacts_directories, test_suites)
+                    })
+                    .await
+                    .expect("Failed to join artifact loading thread")?;
+
+                let tracing_config = edr_napi_core::solidity::config::TracingConfigWithBuffers {
+                    build_infos: Some(napi::Either::B(build_infos)),
+                    ignore_contracts: Some(false),
+                };
+
+                run_test_suites(
+                    runtime,
+                    factory,
+                    config,
+                    artifact_contracts,
+                    test_suites,
+                    tracing_config,
+                    test_filter,
+                    on_test_suite_completed,
+                )
+                .await
+            }
+            .await;
+
+            match result {
+                Ok(outcome) => deferred.resolve(move |env| match outcome {
+                    RunOutcome::Completed(test_result) => Ok(SolidityTestResult::from(test_result)),
+                    RunOutcome::InvalidInlineConfig(errors) => {
+                        Err(inline_config::to_napi_error(&env, &errors))
+                    }
+                }),
+                Err(error) => deferred.reject(error),
+            }
+        });
+
+        Ok(promise)
+    }
+}
+
+/// Builds a callback that forwards each completed test suite's results to the
+/// provided JS function.
+fn build_on_test_suite_completed(
+    on_test_suite_completed_callback: Function<'_, SuiteResult, ()>,
+) -> napi::Result<impl Fn(SuiteResult) + Send + Sync + 'static> {
+    let on_test_suite_completed_callback = on_test_suite_completed_callback
+        .build_threadsafe_function::<SuiteResult>()
+        .build_callback(|ctx: ThreadsafeCallContext<SuiteResult>| Ok(ctx.value))?;
+
+    Ok(move |suite_result: SuiteResult| {
+        let status = on_test_suite_completed_callback
+            .call(suite_result, ThreadsafeFunctionCallMode::Blocking);
+
+        // This should always succeed since we're using an unbounded queue.
+        // We add an assertion for completeness.
+        assert_eq!(
+            status,
+            napi::Status::Ok,
+            "Failed to call on_test_suite_completed_callback with status: {status}"
+        );
+    })
+}
+
+/// Links the provided artifacts and runs the provided test suites,
+/// forwarding each suite's results to `on_test_suite_completed` as soon as it
+/// finished executing.
+///
+/// Returns a [`RunOutcome`] so that inline-config failures can be converted
+/// into a structured JS error by the caller on the JS thread.
+#[allow(clippy::too_many_arguments)]
+async fn run_test_suites(
+    runtime: runtime::Handle,
+    factory: Arc<dyn solidity::SyncTestRunnerFactory>,
+    config: edr_napi_core::solidity::config::TestRunnerConfig,
+    artifact_contracts: ArtifactContracts,
+    test_suites: Vec<edr_artifact::ArtifactId>,
+    tracing_config: edr_napi_core::solidity::config::TracingConfigWithBuffers,
+    test_filter: Arc<TestFilterConfig>,
+    on_test_suite_completed: impl Fn(SuiteResult) + Send + Sync + 'static,
+) -> napi::Result<RunOutcome> {
+    let linking_output = LinkingOutput::link(&config.project_root, artifact_contracts)?;
+
+    // Build revert decoder from ABIs of all artifacts.
+    let abis = linking_output
+        .known_contracts
+        .iter()
+        .map(|(_, contract)| &contract.abi);
+
+    let revert_decoder = RevertDecoder::new().with_abis(abis);
+
+    let contracts = test_suites
+        .iter()
+        .map(|artifact_id| {
+            let contract_data =
+                linking_output
+                    .known_contracts
+                    .get(artifact_id)
+                    .ok_or_else(|| {
+                        napi::Error::new(
+                            napi::Status::GenericFailure,
+                            format!("Unknown contract: {}", artifact_id.identifier()),
+                        )
+                    })?;
+
+            let bytecode = contract_data.bytecode.clone().ok_or_else(|| {
+                napi::Error::new(
+                    napi::Status::GenericFailure,
+                    format!(
+                        "No bytecode for test suite contract: {}",
+                        artifact_id.identifier()
+                    ),
+                )
+            })?;
+
+            let test_contract = TestContract {
+                abi: contract_data.abi.clone(),
+                bytecode,
+            };
+
+            Ok((artifact_id.clone(), test_contract))
+        })
+        .collect::<napi::Result<TestContracts>>()?;
+
+    let include_traces = config.include_traces.into();
+
+    let runtime_for_factory = runtime.clone();
+    let create_result = runtime
+        .clone()
+        .spawn_blocking(move || {
+            factory.create_test_runner(
+                runtime_for_factory,
+                config,
+                contracts,
+                linking_output.known_contracts,
+                linking_output.libs_to_deploy,
+                revert_decoder,
+                tracing_config,
+            )
+        })
+        .await
+        .expect("Failed to join test runner factory thread");
+
+    let test_runner = match create_result {
+        // An inline-config failure carries structured, located problems that
+        // are surfaced on the rejected promise's error as `inlineConfigErrors`.
+        // Building that JS object requires the JS thread, so it's routed to
+        // the caller's deferred resolver (which runs there) rather than being
+        // rejected here, which would only carry a message.
+        Err(solidity::CreateTestRunnerError::InvalidInlineConfig(errors)) => {
+            return Ok(RunOutcome::InvalidInlineConfig(errors));
+        }
+        Err(solidity::CreateTestRunnerError::Failed(error)) => {
+            return Err(error);
+        }
+        Ok(test_runner) => test_runner,
+    };
+
+    let runtime_for_runner = runtime.clone();
+    let test_result = runtime
+        .spawn_blocking(move || {
+            test_runner.run_tests(
+                runtime_for_runner,
+                test_filter,
+                Arc::new(
+                    move |SuiteResultAndArtifactId {
+                              artifact_id,
+                              result,
+                          }| {
+                        let suite_result = SuiteResult::new(artifact_id, result, include_traces);
+
+                        on_test_suite_completed(suite_result);
+                    },
+                ),
+            )
+        })
+        .await
+        .expect("Failed to join test runner thread")?;
+
+    Ok(RunOutcome::Completed(test_result))
 }
 
 #[cfg(feature = "test-mock")]

--- a/crates/edr_napi/src/contract_decoder.rs
+++ b/crates/edr_napi/src/contract_decoder.rs
@@ -1,9 +1,24 @@
-use std::sync::Arc;
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use napi_derive::napi;
 use parking_lot::RwLock;
 
 use crate::config::TracingConfigWithBuffers;
+
+/// Configuration for loading a project's compilation output from disk.
+#[napi(object)]
+pub struct ProjectArtifactsConfig {
+    /// The path of the project's artifacts directory.
+    pub artifacts_dir: String,
+    /// The path of the directory containing the project's build info files.
+    /// Defaults to the `build-info` subdirectory of `artifactsDir`.
+    pub build_info_dir: Option<String>,
+    /// Whether to ignore contracts whose name starts with "Ignored".
+    pub ignore_contracts: Option<bool>,
+}
 
 #[napi]
 pub struct ContractDecoder {
@@ -29,6 +44,26 @@ impl ContractDecoder {
             (&edr_napi_core::solidity::config::TracingConfigWithBuffers::from(config)).into(),
         )
         .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+
+        let contract_decoder =
+            edr_solidity::contract_decoder::ContractDecoder::new(build_info_config);
+
+        Ok(Self {
+            inner: Arc::new(RwLock::new(contract_decoder)),
+        })
+    }
+
+    #[doc = "Creates a new instance by reading the project's build infos from disk."]
+    #[napi(factory, catch_unwind)]
+    pub fn from_project(config: ProjectArtifactsConfig) -> napi::Result<Self> {
+        let build_info_dir = config.build_info_dir.map_or_else(
+            || edr_solidity::project::default_build_info_dir(Path::new(&config.artifacts_dir)),
+            PathBuf::from,
+        );
+
+        let build_info_config =
+            edr_solidity::project::load_build_info_config(&build_info_dir, config.ignore_contracts)
+                .map_err(|error| napi::Error::from_reason(error.to_string()))?;
 
         let contract_decoder =
             edr_solidity::contract_decoder::ContractDecoder::new(build_info_config);

--- a/crates/edr_napi/src/solidity_tests.rs
+++ b/crates/edr_napi/src/solidity_tests.rs
@@ -9,14 +9,23 @@ pub mod op;
 pub mod runner;
 pub mod test_results;
 
-use std::path::Path;
+use std::{borrow::Cow, path::Path};
 
 use edr_primitives::Bytes;
-use edr_solidity::linker::{LinkOutput, Linker};
+use edr_solidity::{
+    linker::{LinkOutput, Linker},
+    project::{default_build_info_dir, find_build_info_files, load_artifacts, LoadedArtifact},
+};
 use edr_solidity_tests::{constants::LIBRARY_DEPLOYER, contracts::ContractsByArtifact};
-use foundry_compilers::artifacts::Libraries;
+use foundry_compilers::artifacts::{CompactContractBytecodeCow, Libraries};
 
-use crate::solidity_tests::artifact::Artifact;
+use crate::solidity_tests::artifact::{Artifact, TestSuiteReference};
+
+/// Compilation artifacts as consumed by the linker, keyed by artifact id.
+pub(crate) type ArtifactContracts = Vec<(
+    edr_artifact::ArtifactId,
+    CompactContractBytecodeCow<'static>,
+)>;
 
 pub(crate) struct LinkingOutput {
     pub libs_to_deploy: Vec<Bytes>,
@@ -24,12 +33,7 @@ pub(crate) struct LinkingOutput {
 }
 
 impl LinkingOutput {
-    pub fn link(project_root: &Path, artifacts: Vec<Artifact>) -> napi::Result<Self> {
-        let artifact_contracts = artifacts
-            .into_iter()
-            .map(|artifact| Ok((artifact.id.try_into()?, artifact.contract.try_into()?)))
-            .collect::<napi::Result<Vec<_>>>()?;
-
+    pub fn link(project_root: &Path, artifact_contracts: ArtifactContracts) -> napi::Result<Self> {
         let linker = Linker::new(project_root, artifact_contracts);
 
         let LinkOutput {
@@ -55,4 +59,127 @@ impl LinkingOutput {
             known_contracts,
         })
     }
+}
+
+/// Converts NAPI artifacts into linker inputs.
+pub(crate) fn artifact_contracts_from_napi(
+    artifacts: Vec<Artifact>,
+) -> napi::Result<ArtifactContracts> {
+    artifacts
+        .into_iter()
+        .map(|artifact| Ok((artifact.id.try_into()?, artifact.contract.try_into()?)))
+        .collect()
+}
+
+/// The test runner inputs loaded from artifact directories on disk.
+pub(crate) struct ProjectInputs {
+    /// All of the project's compilation artifacts.
+    pub artifact_contracts: ArtifactContracts,
+    /// The resolved ids of the test suites to execute.
+    pub test_suites: Vec<edr_artifact::ArtifactId>,
+    /// The build infos used for stack trace generation.
+    pub build_infos: Vec<edr_napi_core::solidity::config::BuildInfoAndOutput>,
+}
+
+/// Loads all artifacts and build infos from the provided artifact directories
+/// and resolves the test suite references against them.
+pub(crate) fn load_project_inputs(
+    artifacts_directories: &[String],
+    test_suites: Vec<TestSuiteReference>,
+) -> napi::Result<ProjectInputs> {
+    let mut artifacts: Vec<LoadedArtifact> = Vec::new();
+    let mut build_infos = Vec::new();
+
+    for artifacts_directory in artifacts_directories {
+        let artifacts_directory = Path::new(artifacts_directory);
+
+        artifacts.extend(
+            load_artifacts(artifacts_directory)
+                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
+        );
+
+        let build_info_dir = default_build_info_dir(artifacts_directory);
+        for build_info in find_build_info_files(&build_info_dir)
+            .map_err(|error| napi::Error::from_reason(error.to_string()))?
+        {
+            let output_path = build_info.output_path.ok_or_else(|| {
+                napi::Error::from_reason(format!(
+                    "Missing output file for build info '{}' in '{}'",
+                    build_info.id,
+                    build_info_dir.display()
+                ))
+            })?;
+
+            let build_info_buffer =
+                std::fs::read(&build_info.build_info_path).map_err(|error| {
+                    napi::Error::from_reason(format!(
+                        "Failed to read '{}': {error}",
+                        build_info.build_info_path.display()
+                    ))
+                })?;
+            let output_buffer = std::fs::read(&output_path).map_err(|error| {
+                napi::Error::from_reason(format!(
+                    "Failed to read '{}': {error}",
+                    output_path.display()
+                ))
+            })?;
+
+            build_infos.push(edr_napi_core::solidity::config::BuildInfoAndOutput {
+                build_info: build_info_buffer.into(),
+                output: output_buffer.into(),
+            });
+        }
+    }
+
+    let test_suites = resolve_test_suites(&artifacts, test_suites)?;
+
+    let artifact_contracts = artifacts
+        .into_iter()
+        .map(|artifact| {
+            let contract = CompactContractBytecodeCow {
+                abi: artifact.contract.abi.map(Cow::Owned),
+                bytecode: artifact.contract.bytecode.map(Cow::Owned),
+                deployed_bytecode: artifact.contract.deployed_bytecode.map(Cow::Owned),
+            };
+
+            (artifact.id, contract)
+        })
+        .collect();
+
+    Ok(ProjectInputs {
+        artifact_contracts,
+        test_suites,
+        build_infos,
+    })
+}
+
+/// Resolves test suite references to the ids of the loaded artifacts. The
+/// reference's source may be either the user-facing source name or the
+/// compiler input source name.
+fn resolve_test_suites(
+    artifacts: &[LoadedArtifact],
+    test_suites: Vec<TestSuiteReference>,
+) -> napi::Result<Vec<edr_artifact::ArtifactId>> {
+    test_suites
+        .into_iter()
+        .map(|test_suite| {
+            artifacts
+                .iter()
+                .find(|artifact| {
+                    artifact.id.name == test_suite.name
+                        && (artifact.user_source_name == test_suite.source
+                            || artifact.id.source == Path::new(&test_suite.source))
+                })
+                .map(|artifact| artifact.id.clone())
+                .ok_or_else(|| {
+                    napi::Error::new(
+                        napi::Status::GenericFailure,
+                        format!(
+                            "Unknown test suite contract: {}:{}",
+                            test_suite.source, test_suite.name
+                        ),
+                    )
+                })
+        })
+        .collect()
 }

--- a/crates/edr_napi/src/solidity_tests.rs
+++ b/crates/edr_napi/src/solidity_tests.rs
@@ -11,6 +11,7 @@ pub mod test_results;
 
 use std::{borrow::Cow, path::Path};
 
+use edr_napi_core::solidity::config::BuildInfoAndOutput;
 use edr_primitives::Bytes;
 use edr_solidity::{
     linker::{LinkOutput, Linker},
@@ -78,7 +79,7 @@ pub(crate) struct ProjectInputs {
     /// The resolved ids of the test suites to execute.
     pub test_suites: Vec<edr_artifact::ArtifactId>,
     /// The build infos used for stack trace generation.
-    pub build_infos: Vec<edr_napi_core::solidity::config::BuildInfoAndOutput>,
+    pub build_infos: Vec<BuildInfoAndOutput>,
 }
 
 /// Loads all artifacts and build infos from the provided artifact directories
@@ -124,7 +125,7 @@ pub(crate) fn load_project_inputs(
                 ))
             })?;
 
-            build_infos.push(edr_napi_core::solidity::config::BuildInfoAndOutput {
+            build_infos.push(BuildInfoAndOutput {
                 build_info: build_info_buffer.into(),
                 output: output_buffer.into(),
             });

--- a/crates/edr_napi/src/solidity_tests/artifact.rs
+++ b/crates/edr_napi/src/solidity_tests/artifact.rs
@@ -53,6 +53,22 @@ impl TryFrom<ArtifactId> for edr_artifact::ArtifactId {
     }
 }
 
+/// A reference to a test suite contract within an artifacts directory.
+///
+/// Unlike [`ArtifactId`], it doesn't require knowing the solc version that
+/// produced the contract; the version is resolved from the artifacts on disk.
+#[derive(Clone, Debug)]
+#[napi(object)]
+pub struct TestSuiteReference {
+    /// The source name of the Solidity file containing the test suite, e.g.
+    /// `contracts/Counter.t.sol`. Both the user-facing source name and the
+    /// compiler input source name (e.g. `project/contracts/Counter.t.sol`)
+    /// are accepted.
+    pub source: String,
+    /// The name of the test suite contract, e.g. `CounterTest`.
+    pub name: String,
+}
+
 /// A test contract to execute.
 #[derive(Clone, Debug)]
 #[napi(object)]

--- a/crates/edr_napi/test/contractDecoder.ts
+++ b/crates/edr_napi/test/contractDecoder.ts
@@ -1,0 +1,67 @@
+import { assert } from "chai";
+import * as path from "path";
+import * as fs from "fs";
+import * as os from "os";
+
+import { ContractDecoder } from "..";
+
+describe("ContractDecoder", () => {
+  describe("fromProject", () => {
+    // A real-world Hardhat v3 artifacts directory with build infos.
+    const artifactsDir = path.join(
+      __dirname,
+      "../../../js/integration-tests/solidity-tests/artifacts"
+    );
+
+    it("loads build infos from an artifacts directory", function () {
+      if (!fs.existsSync(path.join(artifactsDir, "build-info"))) {
+        this.skip();
+      }
+
+      const decoder = ContractDecoder.fromProject({ artifactsDir });
+      assert.instanceOf(decoder, ContractDecoder);
+    });
+
+    it("accepts an explicit build info directory", function () {
+      const buildInfoDir = path.join(artifactsDir, "build-info");
+      if (!fs.existsSync(buildInfoDir)) {
+        this.skip();
+      }
+
+      const decoder = ContractDecoder.fromProject({
+        artifactsDir,
+        buildInfoDir,
+        ignoreContracts: false,
+      });
+      assert.instanceOf(decoder, ContractDecoder);
+    });
+
+    it("creates an empty decoder for a project without build infos", function () {
+      const decoder = ContractDecoder.fromProject({
+        artifactsDir: path.join(__dirname, "does-not-exist"),
+      });
+      assert.instanceOf(decoder, ContractDecoder);
+    });
+
+    it("throws on invalid build info files", function () {
+      const brokenDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "edr-broken-build-info-")
+      );
+      try {
+        const buildInfoDir = path.join(brokenDir, "build-info");
+        fs.mkdirSync(buildInfoDir);
+        fs.writeFileSync(path.join(buildInfoDir, "solc-0_8_24-aa.json"), "");
+        fs.writeFileSync(
+          path.join(buildInfoDir, "solc-0_8_24-aa.output.json"),
+          ""
+        );
+
+        assert.throws(() => {
+          ContractDecoder.fromProject({ artifactsDir: brokenDir });
+        }, /Failed to parse build info/);
+      } finally {
+        fs.rmSync(brokenDir, { recursive: true, force: true });
+      }
+    });
+  });
+});

--- a/crates/edr_solidity/Cargo.toml
+++ b/crates/edr_solidity/Cargo.toml
@@ -37,9 +37,11 @@ strum = { version = "0.28.0", features = ["derive"] }
 semver = { workspace = true, features = ["std"] }
 thiserror.workspace = true
 itertools = "0.15.0"
+walkdir.workspace = true
 
 [dev-dependencies]
 criterion = "0.8"
+tempfile.workspace = true
 
 [features]
 tracing = ["edr_chain_spec_evm/tracing"]

--- a/crates/edr_solidity/src/lib.rs
+++ b/crates/edr_solidity/src/lib.rs
@@ -14,6 +14,7 @@ pub mod library_utils;
 pub mod linker;
 pub mod nested_trace;
 pub mod nested_tracer;
+pub mod project;
 pub mod proxy_detection;
 pub mod solidity_stack_trace;
 pub mod solidity_tracer;

--- a/crates/edr_solidity/src/project.rs
+++ b/crates/edr_solidity/src/project.rs
@@ -254,17 +254,20 @@ pub fn solc_version_from_build_info_id(build_info_id: &str) -> Option<Version> {
     let rest = build_info_id.strip_prefix("solc-")?;
 
     let parts: Vec<&str> = rest.split('-').collect();
-    let (version, compiler_type, hash) = match parts.as_slice() {
-        [version, hash] => (version, None, hash),
-        [version, compiler_type, hash] => (version, Some(compiler_type), hash),
-        _ => return None,
+    let [version, compiler_type @ .., hash] = parts.as_slice() else {
+        return None;
     };
 
-    // The compiler type must be alphanumeric and start with a letter.
-    if let Some(compiler_type) = compiler_type {
-        let mut chars = compiler_type.chars();
+    // The compiler type spans the segments between the version and the hash.
+    // It must start with a letter; the rest is alphanumeric, with the hyphens
+    // that separated the segments.
+    if let Some((first, rest)) = compiler_type.split_first() {
+        let mut chars = first.chars();
         if !chars.next().is_some_and(|c| c.is_ascii_alphabetic())
             || !chars.all(|c| c.is_ascii_alphanumeric())
+            || !rest
+                .iter()
+                .all(|segment| segment.chars().all(|c| c.is_ascii_alphanumeric()))
         {
             return None;
         }
@@ -535,6 +538,11 @@ mod tests {
             solc_version_from_build_info_id("solc-0_8_28-solx-ABC123"),
             Some(Version::new(0, 8, 28))
         );
+        // The compiler type may contain hyphens.
+        assert_eq!(
+            solc_version_from_build_info_id("solc-0_8_28-zk-solx-ABC123"),
+            Some(Version::new(0, 8, 28))
+        );
         // The hash may be empty.
         assert_eq!(
             solc_version_from_build_info_id("solc-1_2_3-"),
@@ -557,9 +565,13 @@ mod tests {
             solc_version_from_build_info_id("solc-0_8_24-1solx-abc123"),
             None
         );
-        // Too many segments.
         assert_eq!(
-            solc_version_from_build_info_id("solc-0_8_24-solx-extra-abc123"),
+            solc_version_from_build_info_id("solc-0_8_24--solx-abc123"),
+            None
+        );
+        // Non-hexadecimal trailing segment isn't a valid hash.
+        assert_eq!(
+            solc_version_from_build_info_id("solc-0_8_24-zk-solx-xyz"),
             None
         );
     }

--- a/crates/edr_solidity/src/project.rs
+++ b/crates/edr_solidity/src/project.rs
@@ -1,0 +1,819 @@
+//! Loading Hardhat v3 compilation artifacts and build infos from an
+//! artifacts directory on disk.
+//!
+//! This mirrors the file layout maintained by Hardhat v3's artifact manager:
+//!
+//! - `artifacts/<source name>/<ContractName>.json` — one artifact per contract
+//!   in the `hh3-artifact-1` format
+//! - `artifacts/build-info/<build info id>.json` — compiler input
+//! - `artifacts/build-info/<build info id>.output.json` — compiler output
+
+use std::{
+    collections::{BTreeMap, HashMap},
+    path::{Path, PathBuf},
+};
+
+use alloy_json_abi::JsonAbi;
+use alloy_primitives::hex::FromHexError;
+use edr_artifact::ArtifactId;
+use foundry_compilers::artifacts::{
+    BytecodeObject, CompactBytecode, CompactContractBytecode, CompactDeployedBytecode, Offsets,
+};
+use semver::Version;
+use serde::Deserialize;
+
+use crate::artifacts::{
+    BuildInfoBufferSeparateOutput, BuildInfoBuffers, BuildInfoConfig, BuildInfoConfigWithBuffers,
+    SplitCompilerMetadataParseError,
+};
+
+/// Name of the build info directory inside an artifacts directory.
+pub const BUILD_INFO_DIR_NAME: &str = "build-info";
+
+/// The `_format` value of Hardhat v3 artifact files.
+pub const HH3_ARTIFACT_FORMAT: &str = "hh3-artifact-1";
+
+/// Error that occurs when loading artifacts or build infos from disk.
+#[derive(Debug, thiserror::Error)]
+pub enum ArtifactLoadError {
+    /// A file or directory could not be read.
+    #[error("Failed to read '{path}': {error}")]
+    Io {
+        /// The path that failed to be read.
+        path: PathBuf,
+        /// The underlying IO error.
+        error: std::io::Error,
+    },
+    /// An artifact file could not be parsed as JSON.
+    #[error("Failed to parse artifact '{path}': {error}")]
+    InvalidJson {
+        /// The path of the artifact file.
+        path: PathBuf,
+        /// The underlying JSON error.
+        error: serde_json::Error,
+    },
+    /// An artifact file has an unsupported `_format` value.
+    #[error(
+        "Unsupported artifact format '{format}' for artifact '{path}'. Expected '{HH3_ARTIFACT_FORMAT}'."
+    )]
+    UnsupportedFormat {
+        /// The path of the artifact file.
+        path: PathBuf,
+        /// The `_format` value found in the artifact file.
+        format: String,
+    },
+    /// An artifact file is missing the `buildInfoId` field.
+    #[error("Artifact '{path}' is missing the 'buildInfoId' field")]
+    MissingBuildInfoId {
+        /// The path of the artifact file.
+        path: PathBuf,
+    },
+    /// An artifact references a build info id from which no solc version can
+    /// be derived.
+    #[error(
+        "Artifact '{path}' references build info id '{build_info_id}' which doesn't match the expected format 'solc-<major>_<minor>_<patch>[-<compilerType>]-<hex>'"
+    )]
+    InvalidBuildInfoId {
+        /// The path of the artifact file.
+        path: PathBuf,
+        /// The build info id that could not be parsed.
+        build_info_id: String,
+    },
+    /// A bytecode field of an artifact could not be hex-decoded.
+    #[error("Hex decoding error while parsing bytecode of artifact '{path}': '{error}'.")]
+    InvalidBytecode {
+        /// The path of the artifact file.
+        path: PathBuf,
+        /// The underlying hex decoding error.
+        error: FromHexError,
+    },
+}
+
+/// Library link references as stored in Hardhat v3 artifact files: source
+/// name → library name → byte offsets.
+///
+/// Uses ordered maps because the order can matter downstream for
+/// deterministic library address generation.
+pub type LinkReferences = BTreeMap<String, BTreeMap<String, Vec<Offsets>>>;
+
+/// An artifact file in the `hh3-artifact-1` format.
+///
+/// The source of truth for this format is the `Artifact` interface in
+/// Hardhat's `types/artifacts.ts`; only the fields consumed by EDR are
+/// declared here.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HardhatV3Artifact {
+    /// The format of the artifact file. Expected to be
+    /// [`HH3_ARTIFACT_FORMAT`].
+    #[serde(rename = "_format")]
+    pub format: String,
+    /// The bare name of the contract, without the source name.
+    pub contract_name: String,
+    /// The user-facing source name: the project-relative path of the
+    /// Solidity file, or the npm module identifier (`<package>/<file>`) for
+    /// contracts from npm packages.
+    pub source_name: String,
+    /// The source name used in the compiler input. May differ from
+    /// `source_name` and is always present for artifacts compiled by Hardhat
+    /// 3's build system.
+    pub input_source_name: Option<String>,
+    /// The contract's ABI.
+    pub abi: JsonAbi,
+    /// The contract's creation bytecode as a hex string. Contains `__$...$__`
+    /// placeholders when the contract requires linking.
+    pub bytecode: Option<String>,
+    /// The link references of the creation bytecode.
+    #[serde(default)]
+    pub link_references: LinkReferences,
+    /// The contract's runtime bytecode as a hex string. Contains `__$...$__`
+    /// placeholders when the contract requires linking.
+    pub deployed_bytecode: Option<String>,
+    /// The link references of the runtime bytecode.
+    #[serde(default)]
+    pub deployed_link_references: LinkReferences,
+    /// The id of the build info that produced this artifact. May be absent
+    /// if the artifact wasn't generated by Hardhat's build system, in which
+    /// case loading fails.
+    pub build_info_id: Option<String>,
+}
+
+/// An artifact loaded from a Hardhat v3 artifacts directory.
+#[derive(Clone, Debug)]
+pub struct LoadedArtifact {
+    /// The artifact's identifier. Its `source` is the input source name when
+    /// present, falling back to the user-facing source name.
+    pub id: ArtifactId,
+    /// The user-facing source name: the project-relative path of the
+    /// Solidity file, or the npm module identifier (`<package>/<file>`) for
+    /// contracts from npm packages.
+    pub user_source_name: String,
+    /// The contract's ABI and bytecodes.
+    pub contract: CompactContractBytecode,
+}
+
+/// Loads every artifact under `artifacts_dir`.
+///
+/// Any `*.json` file in a subdirectory of `artifacts_dir` is treated as an
+/// artifact, excluding files directly at the top level and everything under the
+/// top-level [`BUILD_INFO_DIR_NAME`] directory. A missing directory yields an
+/// empty list.
+pub fn load_artifacts(artifacts_dir: &Path) -> Result<Vec<LoadedArtifact>, ArtifactLoadError> {
+    // Cache of build info id → solc version, as multiple artifacts usually
+    // share a build info.
+    let mut solc_versions: HashMap<String, Option<Version>> = HashMap::new();
+
+    find_artifact_files(artifacts_dir)?
+        .into_iter()
+        .map(|path| {
+            let contents = std::fs::read(&path).map_err(|error| ArtifactLoadError::Io {
+                path: path.clone(),
+                error,
+            })?;
+
+            let artifact: HardhatV3Artifact =
+                serde_json::from_slice(&contents).map_err(|error| {
+                    ArtifactLoadError::InvalidJson {
+                        path: path.clone(),
+                        error,
+                    }
+                })?;
+
+            if artifact.format != HH3_ARTIFACT_FORMAT {
+                return Err(ArtifactLoadError::UnsupportedFormat {
+                    path,
+                    format: artifact.format,
+                });
+            }
+
+            let build_info_id = artifact
+                .build_info_id
+                .as_deref()
+                .ok_or_else(|| ArtifactLoadError::MissingBuildInfoId { path: path.clone() })?;
+
+            let solc_version = solc_versions
+                .entry(build_info_id.to_string())
+                .or_insert_with(|| solc_version_from_build_info_id(build_info_id))
+                .clone()
+                .ok_or_else(|| ArtifactLoadError::InvalidBuildInfoId {
+                    path: path.clone(),
+                    build_info_id: build_info_id.to_string(),
+                })?;
+
+            to_loaded_artifact(&path, artifact, solc_version)
+        })
+        .collect()
+}
+
+/// Returns the paths of all artifact files under `artifacts_dir`, sorted for
+/// determinism.
+fn find_artifact_files(artifacts_dir: &Path) -> Result<Vec<PathBuf>, ArtifactLoadError> {
+    if !artifacts_dir.is_dir() {
+        return Ok(Vec::new());
+    }
+
+    let build_info_dir = artifacts_dir.join(BUILD_INFO_DIR_NAME);
+
+    let mut paths = walkdir::WalkDir::new(artifacts_dir)
+        .into_iter()
+        .filter_entry(|entry| entry.path() != build_info_dir)
+        .map(|entry| {
+            entry.map_err(|error| {
+                let path = error.path().unwrap_or(artifacts_dir).to_path_buf();
+                ArtifactLoadError::Io {
+                    path,
+                    error: error
+                        .into_io_error()
+                        .unwrap_or_else(|| std::io::Error::other("file system loop detected")),
+                }
+            })
+        })
+        .filter(|entry| {
+            entry.as_ref().is_ok_and(|entry| {
+                // Depth 1 entries are top-level files, which are ignored.
+                entry.depth() >= 2
+                    && entry.file_type().is_file()
+                    && entry.path().extension().is_some_and(|ext| ext == "json")
+            })
+        })
+        .map(|entry| entry.map(walkdir::DirEntry::into_path))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    paths.sort();
+
+    Ok(paths)
+}
+
+/// Extracts the solc version from a Hardhat v3 build info id of the form
+/// `solc-<major>_<minor>_<patch>[-<compilerType>]-<hex>`.
+///
+/// Returns `None` when the id doesn't match this format, e.g. because the
+/// build info was generated by something other than Hardhat.
+pub fn solc_version_from_build_info_id(build_info_id: &str) -> Option<Version> {
+    let rest = build_info_id.strip_prefix("solc-")?;
+
+    let parts: Vec<&str> = rest.split('-').collect();
+    let (version, compiler_type, hash) = match parts.as_slice() {
+        [version, hash] => (version, None, hash),
+        [version, compiler_type, hash] => (version, Some(compiler_type), hash),
+        _ => return None,
+    };
+
+    // The compiler type must be alphanumeric and start with a letter.
+    if let Some(compiler_type) = compiler_type {
+        let mut chars = compiler_type.chars();
+        if !chars.next().is_some_and(|c| c.is_ascii_alphabetic())
+            || !chars.all(|c| c.is_ascii_alphanumeric())
+        {
+            return None;
+        }
+    }
+
+    // The hash may be empty but must be hexadecimal.
+    if !hash.chars().all(|c| c.is_ascii_hexdigit()) {
+        return None;
+    }
+
+    let mut version_parts = version.split('_');
+    let major = version_parts.next()?.parse().ok()?;
+    let minor = version_parts.next()?.parse().ok()?;
+    let patch = version_parts.next()?.parse().ok()?;
+    if version_parts.next().is_some() {
+        return None;
+    }
+
+    Some(Version::new(major, minor, patch))
+}
+
+/// Converts a parsed artifact file into a [`LoadedArtifact`].
+fn to_loaded_artifact(
+    path: &Path,
+    artifact: HardhatV3Artifact,
+    solc_version: Version,
+) -> Result<LoadedArtifact, ArtifactLoadError> {
+    let id = ArtifactId {
+        name: artifact.contract_name,
+        source: artifact
+            .input_source_name
+            .as_ref()
+            .unwrap_or(&artifact.source_name)
+            .into(),
+        version: solc_version,
+    };
+
+    let bytecode = artifact
+        .bytecode
+        .map(|bytecode| {
+            let object = to_bytecode_object(path, bytecode, !artifact.link_references.is_empty())?;
+            Ok::<_, ArtifactLoadError>(CompactBytecode {
+                object,
+                source_map: None,
+                link_references: artifact.link_references,
+            })
+        })
+        .transpose()?;
+
+    let deployed_bytecode = artifact
+        .deployed_bytecode
+        .map(|deployed_bytecode| {
+            let object = to_bytecode_object(
+                path,
+                deployed_bytecode,
+                !artifact.deployed_link_references.is_empty(),
+            )?;
+            Ok::<_, ArtifactLoadError>(CompactDeployedBytecode {
+                bytecode: Some(CompactBytecode {
+                    object,
+                    source_map: None,
+                    link_references: artifact.deployed_link_references,
+                }),
+                immutable_references: BTreeMap::default(),
+            })
+        })
+        .transpose()?;
+
+    Ok(LoadedArtifact {
+        id,
+        user_source_name: artifact.source_name,
+        contract: CompactContractBytecode {
+            abi: Some(artifact.abi),
+            bytecode,
+            deployed_bytecode,
+        },
+    })
+}
+
+/// Converts a hex bytecode string into a [`BytecodeObject`]. Bytecode that
+/// needs linking is kept as-is, including its `__$...$__` placeholders.
+fn to_bytecode_object(
+    path: &Path,
+    bytecode: String,
+    needs_linking: bool,
+) -> Result<BytecodeObject, ArtifactLoadError> {
+    if needs_linking {
+        Ok(BytecodeObject::Unlinked(bytecode))
+    } else {
+        bytecode
+            .parse()
+            .map(BytecodeObject::Bytecode)
+            .map_err(|error| ArtifactLoadError::InvalidBytecode {
+                path: path.to_path_buf(),
+                error,
+            })
+    }
+}
+
+/// The file paths of a single build info.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BuildInfoFiles {
+    /// The build info id, i.e. the file stem of the build info file.
+    pub id: String,
+    /// The path of the build info file containing the compiler input.
+    pub build_info_path: PathBuf,
+    /// The path of the file containing the compiler output, if it exists.
+    pub output_path: Option<PathBuf>,
+}
+
+/// Returns the default build info directory for an artifacts directory.
+pub fn default_build_info_dir(artifacts_dir: &Path) -> PathBuf {
+    artifacts_dir.join(BUILD_INFO_DIR_NAME)
+}
+
+/// Finds all build infos in `build_info_dir`, pairing each `<id>.json` with
+/// its `<id>.output.json` when present.
+///
+/// The directory is expected to be flat. A missing directory yields an empty
+/// list. Results are sorted by id for determinism.
+pub fn find_build_info_files(
+    build_info_dir: &Path,
+) -> Result<Vec<BuildInfoFiles>, ArtifactLoadError> {
+    if !build_info_dir.is_dir() {
+        return Ok(Vec::new());
+    }
+
+    let entries = std::fs::read_dir(build_info_dir).map_err(|error| ArtifactLoadError::Io {
+        path: build_info_dir.to_path_buf(),
+        error,
+    })?;
+
+    let mut build_infos = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|error| ArtifactLoadError::Io {
+            path: build_info_dir.to_path_buf(),
+            error,
+        })?;
+
+        let file_name = entry.file_name();
+        let Some(file_name) = file_name.to_str() else {
+            continue;
+        };
+
+        let Some(id) = file_name.strip_suffix(".json") else {
+            continue;
+        };
+        if id.ends_with(".output") {
+            continue;
+        }
+
+        let output_path = build_info_dir.join(format!("{id}.output.json"));
+
+        build_infos.push(BuildInfoFiles {
+            id: id.to_string(),
+            build_info_path: entry.path(),
+            output_path: output_path.is_file().then_some(output_path),
+        });
+    }
+
+    build_infos.sort_by(|left, right| left.id.cmp(&right.id));
+
+    Ok(build_infos)
+}
+
+/// Error that occurs when loading a [`BuildInfoConfig`] from disk.
+#[derive(Debug, thiserror::Error)]
+pub enum BuildInfoConfigLoadError {
+    /// The build info files could not be read.
+    #[error(transparent)]
+    Load(#[from] ArtifactLoadError),
+    /// The build info files could not be parsed.
+    #[error(transparent)]
+    Parse(#[from] SplitCompilerMetadataParseError),
+}
+
+/// Reads and parses all build infos in `build_info_dir` into a
+/// [`BuildInfoConfig`].
+///
+/// Build infos without a matching output file are skipped. A missing directory
+/// yields an empty config.
+pub fn load_build_info_config(
+    build_info_dir: &Path,
+    ignore_contracts: Option<bool>,
+) -> Result<BuildInfoConfig, BuildInfoConfigLoadError> {
+    let buffers = find_build_info_files(build_info_dir)?
+        .into_iter()
+        .filter_map(|build_info| {
+            let output_path = build_info.output_path?;
+
+            let result = std::fs::read(&build_info.build_info_path)
+                .map_err(|error| ArtifactLoadError::Io {
+                    path: build_info.build_info_path,
+                    error,
+                })
+                .and_then(|build_info_buffer| {
+                    let output_buffer =
+                        std::fs::read(&output_path).map_err(|error| ArtifactLoadError::Io {
+                            path: output_path,
+                            error,
+                        })?;
+
+                    Ok((build_info_buffer, output_buffer))
+                });
+
+            Some(result)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let build_infos = buffers
+        .iter()
+        .map(|(build_info, output)| BuildInfoBufferSeparateOutput { build_info, output })
+        .collect();
+
+    let config = BuildInfoConfig::parse_from_buffers(BuildInfoConfigWithBuffers {
+        build_infos: Some(BuildInfoBuffers::SeparateInputOutput(build_infos)),
+        ignore_contracts,
+    })?;
+
+    Ok(config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_artifact(
+        dir: &Path,
+        source_name: &str,
+        contract_name: &str,
+        json: &serde_json::Value,
+    ) {
+        let contract_dir = dir.join(source_name);
+        std::fs::create_dir_all(&contract_dir).unwrap();
+        std::fs::write(
+            contract_dir.join(format!("{contract_name}.json")),
+            serde_json::to_vec(json).unwrap(),
+        )
+        .unwrap();
+    }
+
+    fn minimal_artifact(contract_name: &str, source_name: &str) -> serde_json::Value {
+        serde_json::json!({
+            "_format": HH3_ARTIFACT_FORMAT,
+            "contractName": contract_name,
+            "sourceName": source_name,
+            "inputSourceName": format!("project/{source_name}"),
+            "abi": [],
+            "bytecode": "0x6080",
+            "deployedBytecode": "0x6001",
+            "linkReferences": {},
+            "deployedLinkReferences": {},
+            // Present in `hh3-artifact-1` files but not consumed by the
+            // loader; included to make sure that parsing tolerates it.
+            "immutableReferences": {},
+            "buildInfoId": "solc-0_8_24-945510fc2baa1a6f4138887ff6bcceb6d37ed839",
+        })
+    }
+
+    #[test]
+    fn solc_version_from_build_info_id_parses_valid_ids() {
+        assert_eq!(
+            solc_version_from_build_info_id("solc-0_8_24-945510fc2baa1a6f4138887ff6bcceb6d37ed839"),
+            Some(Version::new(0, 8, 24))
+        );
+        // Optional compiler type segment.
+        assert_eq!(
+            solc_version_from_build_info_id("solc-0_8_28-solx-ABC123"),
+            Some(Version::new(0, 8, 28))
+        );
+        // The hash may be empty.
+        assert_eq!(
+            solc_version_from_build_info_id("solc-1_2_3-"),
+            Some(Version::new(1, 2, 3))
+        );
+    }
+
+    #[test]
+    fn solc_version_from_build_info_id_rejects_invalid_ids() {
+        // Not produced by Hardhat + solc.
+        assert_eq!(solc_version_from_build_info_id("vyper-0_4_0-abc123"), None);
+        // Missing hash segment.
+        assert_eq!(solc_version_from_build_info_id("solc-0_8_24"), None);
+        // Incomplete version.
+        assert_eq!(solc_version_from_build_info_id("solc-0_8-abc123"), None);
+        // Non-hexadecimal hash.
+        assert_eq!(solc_version_from_build_info_id("solc-0_8_24-xyz"), None);
+        // Compiler type must start with a letter.
+        assert_eq!(
+            solc_version_from_build_info_id("solc-0_8_24-1solx-abc123"),
+            None
+        );
+        // Too many segments.
+        assert_eq!(
+            solc_version_from_build_info_id("solc-0_8_24-solx-extra-abc123"),
+            None
+        );
+    }
+
+    #[test]
+    fn load_artifacts_reads_hh3_artifacts() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let artifacts_dir = temp_dir.path();
+
+        write_artifact(
+            artifacts_dir,
+            "contracts/Foo.sol",
+            "Foo",
+            &minimal_artifact("Foo", "contracts/Foo.sol"),
+        );
+
+        // Top-level JSON files and the build-info directory are ignored.
+        std::fs::write(artifacts_dir.join("artifacts.json"), "{}").unwrap();
+        let build_info_dir = artifacts_dir.join(BUILD_INFO_DIR_NAME);
+        std::fs::create_dir_all(&build_info_dir).unwrap();
+        std::fs::write(build_info_dir.join("ignored.json"), "{}").unwrap();
+
+        let artifacts = load_artifacts(artifacts_dir).unwrap();
+
+        assert_eq!(artifacts.len(), 1);
+        let artifact = &artifacts[0];
+        assert_eq!(artifact.id.name, "Foo");
+        // The id's source uses the input source name.
+        assert_eq!(
+            artifact.id.source,
+            PathBuf::from("project/contracts/Foo.sol")
+        );
+        assert_eq!(artifact.user_source_name, "contracts/Foo.sol");
+        assert_eq!(artifact.id.version, Version::new(0, 8, 24));
+
+        let contract = &artifact.contract;
+        assert!(contract.abi.is_some());
+        assert_eq!(
+            contract.bytecode.as_ref().unwrap().object,
+            BytecodeObject::Bytecode("0x6080".parse().unwrap())
+        );
+        assert_eq!(
+            contract
+                .deployed_bytecode
+                .as_ref()
+                .unwrap()
+                .bytecode
+                .as_ref()
+                .unwrap()
+                .object,
+            BytecodeObject::Bytecode("0x6001".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn load_artifacts_keeps_unlinked_bytecode_as_string() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let artifacts_dir = temp_dir.path();
+
+        let placeholder_bytecode = "0x73__$fb58accembedded1234567890123456789012$__63";
+        let mut artifact = minimal_artifact("Bar", "contracts/Bar.sol");
+        artifact["bytecode"] = placeholder_bytecode.into();
+        artifact["linkReferences"] = serde_json::json!({
+            "contracts/Lib.sol": {
+                "Lib": [{ "start": 1, "length": 20 }]
+            }
+        });
+
+        write_artifact(artifacts_dir, "contracts/Bar.sol", "Bar", &artifact);
+
+        let artifacts = load_artifacts(artifacts_dir).unwrap();
+
+        assert_eq!(artifacts.len(), 1);
+        let bytecode = artifacts[0].contract.bytecode.as_ref().unwrap();
+        assert_eq!(
+            bytecode.object,
+            BytecodeObject::Unlinked(placeholder_bytecode.to_string())
+        );
+        assert_eq!(
+            bytecode.link_references["contracts/Lib.sol"]["Lib"],
+            vec![Offsets {
+                start: 1,
+                length: 20
+            }]
+        );
+    }
+
+    #[test]
+    fn load_artifacts_rejects_unsupported_formats() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let artifacts_dir = temp_dir.path();
+
+        let mut artifact = minimal_artifact("Foo", "contracts/Foo.sol");
+        artifact["_format"] = "hh-sol-artifact-1".into();
+        write_artifact(artifacts_dir, "contracts/Foo.sol", "Foo", &artifact);
+
+        let error = load_artifacts(artifacts_dir).unwrap_err();
+        assert!(matches!(
+            error,
+            ArtifactLoadError::UnsupportedFormat { format, .. } if format == "hh-sol-artifact-1"
+        ));
+    }
+
+    #[test]
+    fn load_artifacts_rejects_missing_and_invalid_build_info_ids() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let artifacts_dir = temp_dir.path();
+
+        let mut artifact = minimal_artifact("Foo", "contracts/Foo.sol");
+        artifact.as_object_mut().unwrap().remove("buildInfoId");
+        write_artifact(artifacts_dir, "contracts/Foo.sol", "Foo", &artifact);
+
+        let error = load_artifacts(artifacts_dir).unwrap_err();
+        assert!(matches!(
+            error,
+            ArtifactLoadError::MissingBuildInfoId { .. }
+        ));
+
+        let mut artifact = minimal_artifact("Foo", "contracts/Foo.sol");
+        artifact["buildInfoId"] = "vyper-0_4_0-abc123".into();
+        write_artifact(artifacts_dir, "contracts/Foo.sol", "Foo", &artifact);
+
+        let error = load_artifacts(artifacts_dir).unwrap_err();
+        assert!(matches!(
+            error,
+            ArtifactLoadError::InvalidBuildInfoId { build_info_id, .. }
+                if build_info_id == "vyper-0_4_0-abc123"
+        ));
+    }
+
+    #[test]
+    fn load_artifacts_returns_empty_for_missing_directory() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let missing_dir = temp_dir.path().join("does-not-exist");
+
+        assert!(load_artifacts(&missing_dir).unwrap().is_empty());
+    }
+
+    #[test]
+    fn find_build_info_files_pairs_inputs_with_outputs() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let build_info_dir = temp_dir.path();
+
+        std::fs::write(build_info_dir.join("solc-0_8_24-aa.json"), "{}").unwrap();
+        std::fs::write(build_info_dir.join("solc-0_8_24-aa.output.json"), "{}").unwrap();
+        std::fs::write(build_info_dir.join("solc-0_7_6-bb.json"), "{}").unwrap();
+        // Non-JSON files are ignored.
+        std::fs::write(build_info_dir.join("README.md"), "").unwrap();
+
+        let build_infos = find_build_info_files(build_info_dir).unwrap();
+
+        assert_eq!(
+            build_infos,
+            vec![
+                BuildInfoFiles {
+                    id: "solc-0_7_6-bb".to_string(),
+                    build_info_path: build_info_dir.join("solc-0_7_6-bb.json"),
+                    output_path: None,
+                },
+                BuildInfoFiles {
+                    id: "solc-0_8_24-aa".to_string(),
+                    build_info_path: build_info_dir.join("solc-0_8_24-aa.json"),
+                    output_path: Some(build_info_dir.join("solc-0_8_24-aa.output.json")),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn load_artifacts_parses_integration_test_fixtures() {
+        // Real-world artifact set generated by Hardhat v3. Skipped when the
+        // fixtures are not present, e.g. outside the repository checkout.
+        let artifacts_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../js/integration-tests/solidity-tests/artifacts");
+        if !artifacts_dir.is_dir() {
+            return;
+        }
+
+        let artifacts = load_artifacts(&artifacts_dir).unwrap();
+        assert!(!artifacts.is_empty());
+
+        let build_infos = find_build_info_files(&default_build_info_dir(&artifacts_dir)).unwrap();
+        assert!(!build_infos.is_empty());
+        assert!(build_infos
+            .iter()
+            .all(|build_info| build_info.output_path.is_some()));
+
+        // Every artifact references a build info that exists on disk.
+        for artifact in &artifacts {
+            assert!(
+                !artifact.user_source_name.is_empty(),
+                "artifact {} has an empty source name",
+                artifact.id.identifier()
+            );
+        }
+    }
+
+    #[test]
+    fn load_build_info_config_parses_split_build_infos() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let build_info_dir = temp_dir.path();
+
+        let input: serde_json::Value =
+            serde_json::from_str(include_str!("../fixtures/compiler_input.json")).unwrap();
+        let output: serde_json::Value =
+            serde_json::from_str(include_str!("../fixtures/compiler_output.json")).unwrap();
+
+        let id = "solc-0_8_0-aabb";
+        let build_info = serde_json::json!({
+            "_format": "hh3-sol-build-info-1",
+            "id": id,
+            "solcVersion": "0.8.0",
+            "solcLongVersion": "0.8.0+commit.c7dfd78e",
+            "input": input,
+        });
+        let build_info_output = serde_json::json!({
+            "_format": "hh3-sol-build-info-output-1",
+            "id": id,
+            "output": output,
+        });
+
+        std::fs::write(
+            build_info_dir.join(format!("{id}.json")),
+            build_info.to_string(),
+        )
+        .unwrap();
+        std::fs::write(
+            build_info_dir.join(format!("{id}.output.json")),
+            build_info_output.to_string(),
+        )
+        .unwrap();
+
+        // Build infos without an output file are skipped without being read.
+        std::fs::write(build_info_dir.join("solc-0_8_0-nooutput.json"), "not json").unwrap();
+
+        let config = load_build_info_config(build_info_dir, None).unwrap();
+
+        assert!(!config.identified_contracts.is_empty());
+    }
+
+    #[test]
+    fn load_build_info_config_returns_empty_for_missing_directory() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let missing_dir = temp_dir.path().join("does-not-exist");
+
+        let config = load_build_info_config(&missing_dir, None).unwrap();
+
+        assert!(config.identified_contracts.is_empty());
+    }
+
+    #[test]
+    fn find_build_info_files_returns_empty_for_missing_directory() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let missing_dir = temp_dir.path().join("does-not-exist");
+
+        assert!(find_build_info_files(&missing_dir).unwrap().is_empty());
+    }
+}

--- a/crates/edr_solidity/src/project.rs
+++ b/crates/edr_solidity/src/project.rs
@@ -229,7 +229,8 @@ fn find_artifact_files(artifacts_dir: &Path) -> Result<Vec<PathBuf>, ArtifactLoa
             })
         })
         .filter(|entry| {
-            entry.as_ref().is_ok_and(|entry| {
+            // Errors are kept so that they're propagated by `collect` below.
+            entry.as_ref().map_or(true, |entry| {
                 // Depth 1 entries are top-level files, which are ignored.
                 entry.depth() >= 2
                     && entry.file_type().is_file()

--- a/js/integration-tests/solidity-tests/test/fromPaths.ts
+++ b/js/integration-tests/solidity-tests/test/fromPaths.ts
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { before, describe, it } from "node:test";
+import {
+  L1_CHAIN_TYPE,
+  SolidityTestResult,
+  SolidityTestRunnerConfigArgs,
+  SuiteResult,
+  TestSuiteReference,
+  TestStatus,
+} from "@nomicfoundation/edr";
+import { runAllSolidityTests } from "@nomicfoundation/edr-helpers";
+import { assertStackTraces, TestContext } from "./testContext.js";
+
+const ARTIFACTS_DIR = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "artifacts"
+);
+
+/**
+ * Runs test suites through `runSolidityTestsFromPaths`, resolving once both
+ * the run has completed and every suite callback has fired.
+ */
+function runAllSolidityTestsFromPaths(
+  testContext: TestContext,
+  testSuites: TestSuiteReference[],
+  config?: Partial<SolidityTestRunnerConfigArgs>
+): Promise<[SolidityTestResult, SuiteResult[]]> {
+  return new Promise((resolve, reject) => {
+    const resultsFromCallback: SuiteResult[] = [];
+    let solidityTestResult: SolidityTestResult | undefined;
+    let isTestComplete = false;
+
+    const tryResolve = () => {
+      if (isTestComplete && resultsFromCallback.length === testSuites.length) {
+        resolve([solidityTestResult!, resultsFromCallback]);
+      }
+    };
+
+    testContext.edrContext
+      .runSolidityTestsFromPaths(
+        L1_CHAIN_TYPE,
+        [ARTIFACTS_DIR],
+        testSuites,
+        {
+          ...testContext.defaultConfig(),
+          ...config,
+        },
+        (suiteResult: SuiteResult) => {
+          resultsFromCallback.push(suiteResult);
+          tryResolve();
+        }
+      )
+      .then((result) => {
+        solidityTestResult = result;
+        isTestComplete = true;
+        tryResolve();
+      })
+      .catch(reject);
+  });
+}
+
+/** Maps `<suite id source>:<suite id name>:<test name>` to its status. */
+function testStatuses(suiteResults: SuiteResult[]): Map<string, TestStatus> {
+  const statuses = new Map<string, TestStatus>();
+  for (const suiteResult of suiteResults) {
+    for (const testResult of suiteResult.testResults) {
+      statuses.set(
+        `${suiteResult.id.source}:${suiteResult.id.name}:${testResult.name}`,
+        testResult.status
+      );
+    }
+  }
+  return statuses;
+}
+
+describe("runSolidityTestsFromPaths", () => {
+  let testContext: TestContext;
+
+  before(async () => {
+    testContext = await TestContext.setup();
+  });
+
+  it("produces the same results as runSolidityTests", async function () {
+    // `LinkingTest` additionally exercises library linking of the
+    // disk-loaded artifacts.
+    const suiteNames = new Set(["SuccessAndFailureTest", "LinkingTest"]);
+    const testSuiteIds = testContext.matchingTests(suiteNames);
+    assert.equal(testSuiteIds.length, 2);
+
+    const [, suiteResultsFromArtifacts] = await runAllSolidityTests(
+      testContext.edrContext,
+      L1_CHAIN_TYPE,
+      testContext.artifacts,
+      testSuiteIds,
+      testContext.tracingConfig,
+      testContext.defaultConfig()
+    );
+
+    const [, suiteResultsFromPaths] = await runAllSolidityTestsFromPaths(
+      testContext,
+      testSuiteIds.map((id) => ({ source: id.source, name: id.name }))
+    );
+
+    assert.deepEqual(
+      testStatuses(suiteResultsFromPaths),
+      testStatuses(suiteResultsFromArtifacts)
+    );
+  });
+
+  it("resolves test suites by user-facing source name", async function () {
+    const [, suiteResults] = await runAllSolidityTestsFromPaths(testContext, [
+      {
+        source: "test-contracts/SuccessAndFailure.t.sol",
+        name: "SuccessAndFailureTest",
+      },
+    ]);
+
+    assert.equal(suiteResults.length, 1);
+    assert.equal(suiteResults[0].testResults.length, 2);
+    assert.equal(
+      suiteResults[0].testResults.filter(
+        (testResult) => testResult.status === TestStatus.Failure
+      ).length,
+      1
+    );
+  });
+
+  it("generates stack traces from disk-loaded build infos", async function () {
+    const [, suiteResults] = await runAllSolidityTestsFromPaths(testContext, [
+      {
+        source: "project/test-contracts/SuccessAndFailure.t.sol",
+        name: "SuccessAndFailureTest",
+      },
+    ]);
+
+    const failedTest = suiteResults
+      .flatMap((suiteResult) => suiteResult.testResults)
+      .find((testResult) => testResult.status === TestStatus.Failure);
+    assert.ok(failedTest !== undefined, "expected a failing test");
+
+    assertStackTraces(
+      {
+        stackTrace: failedTest.stackTrace() ?? undefined,
+        reason: failedTest.reason ?? undefined,
+      },
+      "1 is not equal to 2",
+      [{ contract: "SuccessAndFailureTest", function: "testThatFails" }]
+    );
+  });
+
+  it("rejects unknown test suites", async function () {
+    await assert.rejects(
+      runAllSolidityTestsFromPaths(testContext, [
+        { source: "test-contracts/SuccessAndFailure.t.sol", name: "Missing" },
+      ]),
+      /Unknown test suite contract: test-contracts\/SuccessAndFailure.t.sol:Missing/
+    );
+  });
+});


### PR DESCRIPTION
This PR adds the ability to load Hardhat v3 compilation artifacts and build infos
in EDR, so they are read from disk in Rust instead of being serialized and passed
over N-API.

### New API

- **`EdrContext.runSolidityTestsFromPaths`** — like `runSolidityTests`, but
  takes the paths of the project's artifact directories (in the Hardhat v3
  format) instead of `Artifact[]` and a tracing config. All artifacts and
  build infos are loaded from disk so that linking, cheatcodes and stack
  trace generation keep working. Test suites are selected with a new
  `TestSuiteReference` (`source` + `name`), which doesn't require knowing the
  solc version up front: it's resolved from the artifacts on disk, and both
  the user-facing source name (`contracts/Counter.t.sol`) and the compiler
  input source name (`project/contracts/Counter.t.sol`) are accepted.
- **`ContractDecoder.fromProject`** — creates a decoder by reading a
  project's build infos from disk (`artifactsDir`, optional `buildInfoDir`
  and `ignoreContracts`).

Both existing entry points (`runSolidityTests`, `ContractDecoder.withContracts`)
are unchanged.

### Implementation

- New `edr_solidity::project` module that understands the Hardhat v3 artifact
  layout: `hh3-artifact-1` artifact files (validated by `_format`), paired
  `build-info/<id>.json` + `<id>.output.json` files, and solc version
  extraction from build info ids
  (`solc-<major>_<minor>_<patch>[-<compilerType>]-<hex>`). Unlinked bytecode
  keeps its `__$...$__` placeholders for the linker, matching the existing
  N-API conversion.
- `edr_napi`'s test execution path is refactored so both entry points share a
  common `run_test_suites` function; the disk-loading variant runs file IO on
  a blocking thread.
  
## Code mapping: EDR ⇄ Hardhat (Claude-generated)

New EDR code vs. the Hardhat code it ports, verified against Hardhat **3.15.0**
(latest release). Hardhat paths are relative to `packages/hardhat/src/` in the
Hardhat monorepo.

| New EDR code | Ported from (Hardhat 3.15.0) |
|---|---|
| `crates/edr_solidity/src/project.rs` — `find_artifact_files` | `internal/builtin-plugins/artifacts/artifact-manager.ts` — `#readFsDataFromFileSystem`: same three conditions (`.json` files only, top-level files excluded, `build-info` dir excluded) |
| `project.rs` — `BUILD_INFO_DIR_NAME` | `artifact-manager.ts` — `BUILD_INFO_DIR_NAME` |
| `project.rs` — `HardhatV3Artifact` | The `Artifact` interface in `types/artifacts.ts` (declared fields only) |
| `project.rs` — `load_artifacts` / `to_loaded_artifact` (id from `inputSourceName ?? sourceName`, solc version from build info id, ABI + bytecodes + link references) | `internal/builtin-plugins/solidity-test/edr-artifacts.ts` — `buildEdrArtifactsWithMetadata` (JSON reads via `artifact-manager.ts` `readArtifact`) |
| `project.rs` — `solc_version_from_build_info_id` | `edr-artifacts.ts` — the `BUILD_INFO_FORMAT` regex, including 3.15.0's hyphenated compiler types (`solc-0_8_28-zk-solx-<hex>`) |
| `project.rs` — `find_build_info_files` (flat dir, `.json` minus `.output.json`, pair with output) | `artifact-manager.ts` — `getAllBuildInfoIds` + `getBuildInfoPath` + `getBuildInfoOutputPath` |
| `project.rs` — `load_build_info_config` (skips build infos without an output) | `internal/builtin-plugins/network-manager/network-manager.ts` — `#getBuildInfosAndOutputsAsBuffers` (same skip-if-either-missing behavior) |
| `crates/edr_napi/src/solidity_tests.rs` — `load_project_inputs` (loop over artifact directories, concatenate artifacts + build infos) | `internal/builtin-plugins/solidity-test/task-action.ts` — `loadArtifacts` (per-scope `getArtifactsDirectory` → `buildEdrArtifactsWithMetadata` + `getBuildInfosAndOutputs`) |
| `solidity_tests.rs` — hard error on a missing `.output.json` | `edr-artifacts.ts` — `getBuildInfosAndOutputs`'s `assertHardhatInvariant`s on both paths (the strict counterpart to network-manager's skip) |
| `solidity_tests.rs` — `resolve_test_suites` / `LoadedArtifact.user_source_name` (accepting either source name) | `task-action.ts` — the `sourceNameToUserSourceName` map and `userSourceName` metadata threading; `TestSuiteReference` resolves the `// TODO: This is a temporary solution...` comment in `edr-artifacts.ts` about input vs. user source names |
| `crates/edr_napi/src/contract_decoder.rs` — `ContractDecoder.fromProject` | Replaces the JS pipeline `network-manager.ts` `#getBuildInfosAndOutputsAsBuffers` → `internal/builtin-plugins/network-manager/edr/edr-provider.ts` `createContractDecoder` → `ContractDecoder.withContracts` |
| `crates/edr_napi/src/context.rs` — `run_solidity_tests_from_paths` | Replaces the marshaling side of `task-action.ts`'s `run(...)` call (passing `edrArtifacts`, `testSuiteIds`, `tracingConfig` over N-API) |

**Deliberately not ported** (stays in Hardhat for now): deciding *which* contracts are
test suites (`isTestSuiteArtifact` in `solidity-test/helpers.ts` plus the
test-root filtering in `task-action.ts` — EDR receives explicit
`TestSuiteReference`s), and the artifact manager's name-lookup/caching
machinery (FQN maps, edit-distance suggestions).

**Known behavioral delta**: for a build info id that doesn't match the format,
Hardhat filters it out of the solc-version map and later fails an
`assertHardhatInvariant` when an artifact references it; EDR reports the typed
`InvalidBuildInfoId` error up front.