### PR TITLE
fix(tools): avoid uppercasing OpHardfork variants in op-chain-config generator

### DIFF
--- a/crates/tool/op_chain_config_generator/src/main.rs
+++ b/crates/tool/op_chain_config_generator/src/main.rs
@@ -440,10 +440,9 @@ fn generate_hardfork_activations_for(
             format!(
                 "
             HardforkActivation {{
-                condition: ForkCondition::Timestamp({}),
-                hardfork: OpHardfork::{},
-            }},",
-                activation, hardfork_str
+                condition: ForkCondition::Timestamp({activation}),
+                hardfork: OpHardfork::{hardfork_str},
+            }},"
             )
         })
         .collect();

--- a/crates/tool/op_chain_config_generator/src/main.rs
+++ b/crates/tool/op_chain_config_generator/src/main.rs
@@ -443,8 +443,7 @@ fn generate_hardfork_activations_for(
                 condition: ForkCondition::Timestamp({}),
                 hardfork: OpHardfork::{},
             }},",
-                activation,
-                hardfork_str.to_uppercase()
+                activation, hardfork_str
             )
         })
         .collect();


### PR DESCRIPTION
The hardfork variants were renamed to PascalCase in #1637, but the generator still emitted `OpHardfork::BEDROCK`-style names, breaking the ["Check generated files" CI workflow](https://github.com/NomicFoundation/edr/actions/runs/32454139339).