### PR TITLE
test(bench): add the ability to temporarily pin Hardhat to an open PR

### DIFF
--- a/.github/scripts/hardhat-compat-pin.cjs
+++ b/.github/scripts/hardhat-compat-pin.cjs
@@ -1,0 +1,56 @@
+// Shared definition of the Hardhat compatibility pin.
+//
+// The pin is an optional file checked into the EDR repo while a breaking EDR
+// change needs a not-yet-merged Hardhat counterpart. Format:
+//
+//   {
+//     "pr": <Hardhat PR number>,
+//     "sha": "<full 40-hex commit sha on that PR>",
+//     "reason": "<optional free-form note>"
+//   }
+//
+// Consumed by:
+//   - resolve-regression-trigger.cjs: while the Hardhat PR is open, regression
+//     benchmark runs that don't name an explicit hardhat-ref use the pinned
+//     sha instead of `main`.
+//   - validate-hardhat-compat-pin.cjs: CI check that validates the file on
+//     PRs that touch it, before the pin is ever consumed.
+
+// The Hardhat repository the pin (and the benchmark) refers to. The pinned PR
+// must live here (not in a fork), so the benchmark job can check the sha out
+// directly.
+const HARDHAT_OWNER = "NomicFoundation";
+const HARDHAT_REPO = "hardhat";
+
+// Where the pin lives in the EDR repo.
+const HARDHAT_PIN_PATH = ".github/hardhat-compat-pin.json";
+
+// Parse and validate the raw file contents. Returns the pin with a lowercased
+// sha; throws a descriptive error on invalid JSON or a malformed shape.
+function parseHardhatPin(raw) {
+  let pin;
+  try {
+    pin = JSON.parse(raw);
+  } catch (e) {
+    throw new Error(`${HARDHAT_PIN_PATH} is not valid JSON: ${e.message}`);
+  }
+  if (
+    !Number.isInteger(pin.pr) ||
+    pin.pr <= 0 ||
+    typeof pin.sha !== "string" ||
+    !/^[0-9a-f]{40}$/i.test(pin.sha)
+  ) {
+    throw new Error(
+      `${HARDHAT_PIN_PATH} must contain {"pr": <Hardhat PR number>, ` +
+        `"sha": "<full 40-hex commit sha>"}; got: ${raw.trim()}`
+    );
+  }
+  return { ...pin, sha: pin.sha.toLowerCase() };
+}
+
+module.exports = {
+  HARDHAT_OWNER,
+  HARDHAT_REPO,
+  HARDHAT_PIN_PATH,
+  parseHardhatPin,
+};

--- a/.github/scripts/resolve-regression-trigger.cjs
+++ b/.github/scripts/resolve-regression-trigger.cjs
@@ -244,16 +244,14 @@ module.exports = async ({ github, context, core }) => {
           }
         }
 
-        // Gate on EDR CI being green for the PR head before spending
-        // ~3h on the self-hosted runner.
-        const green =
-          pinError === undefined && (await waitForEdrCi(pr.head.sha));
         if (pinError !== undefined) {
           await postComment(
             `⚠️ Could not resolve the Hardhat compat pin, so the regression ` +
               `benchmark was not started: ${pinError}`
           );
-        } else if (green) {
+          // Gate on EDR CI being green for the PR head before spending
+          // ~3h on the self-hosted runner.
+        } else if (await waitForEdrCi(pr.head.sha)) {
           shouldRun = true;
           // Only mention a filter that actually narrows the run (`*` = all).
           const filterNotes = [

--- a/.github/scripts/resolve-regression-trigger.cjs
+++ b/.github/scripts/resolve-regression-trigger.cjs
@@ -28,25 +28,17 @@ const CI_POLL_INTERVAL_MS = 30 * 1000; // 30 seconds
 const DEFAULT_SCENARIO_FILTER = "*";
 const DEFAULT_BENCHMARK_FILTER = "test solidity,test mocha,test vitest";
 
-// The Hardhat repository the benchmark runs against.
-const HARDHAT_OWNER = "NomicFoundation";
-const HARDHAT_REPO = "hardhat";
-
-// Optional Hardhat compatibility pin, checked into the EDR repo while a
-// breaking EDR change needs a not-yet-merged Hardhat counterpart. Format:
-//
-//   {
-//     "pr": <Hardhat PR number>,
-//     "sha": "<full 40-hex commit sha on that PR>",
-//     "reason": "<optional free-form note>"
-//   }
-//
-// While the Hardhat PR is open, runs that don't name an explicit hardhat-ref
-// benchmark against the pinned sha; once it's merged (or closed) they revert
-// to `main` automatically. Delete the file after the Hardhat PR merges.
-// The pinned PR must live in NomicFoundation/hardhat (not a fork), so the
-// benchmark job can check the sha out directly.
-const HARDHAT_PIN_PATH = ".github/hardhat-compat-pin.json";
+// Optional Hardhat compatibility pin (see hardhat-compat-pin.cjs for the file
+// format). While the pinned Hardhat PR is open, runs that don't name an
+// explicit hardhat-ref benchmark against the pinned sha; once it's merged (or
+// closed) they revert to `main` automatically. Delete the file after the
+// Hardhat PR merges.
+const {
+  HARDHAT_OWNER,
+  HARDHAT_REPO,
+  HARDHAT_PIN_PATH,
+  parseHardhatPin,
+} = require("./hardhat-compat-pin.cjs");
 
 module.exports = async ({ github, context, core }) => {
   const { owner, repo } = context.repo;
@@ -113,23 +105,7 @@ module.exports = async ({ github, context, core }) => {
       throw e;
     }
 
-    let pin;
-    try {
-      pin = JSON.parse(raw);
-    } catch (e) {
-      throw new Error(`${HARDHAT_PIN_PATH} is not valid JSON: ${e.message}`);
-    }
-    if (
-      !Number.isInteger(pin.pr) ||
-      pin.pr <= 0 ||
-      typeof pin.sha !== "string" ||
-      !/^[0-9a-f]{40}$/i.test(pin.sha)
-    ) {
-      throw new Error(
-        `${HARDHAT_PIN_PATH} must contain {"pr": <Hardhat PR number>, ` +
-          `"sha": "<full 40-hex commit sha>"}; got: ${raw.trim()}`
-      );
-    }
+    const pin = parseHardhatPin(raw);
 
     const { data: hardhatPr } = await github.rest.pulls.get({
       owner: HARDHAT_OWNER,
@@ -152,7 +128,7 @@ module.exports = async ({ github, context, core }) => {
       return { ref: "main" };
     }
     core.info(`Hardhat compat pin active: ${prName} @ ${pin.sha}`);
-    return { ref: pin.sha.toLowerCase(), pin };
+    return { ref: pin.sha, pin };
   }
 
   // Cosmetic side effects (reactions, status comments) must never fail the job:

--- a/.github/scripts/resolve-regression-trigger.cjs
+++ b/.github/scripts/resolve-regression-trigger.cjs
@@ -5,6 +5,12 @@
 //   workflow_dispatch   -> run HEAD against the requested Hardhat ref
 //   issue_comment        -> a `/bench` comment on a same-repo PR, gated on the
 //                          commenter's permissions and EDR CI being green
+//
+// Whenever a run would default to Hardhat `main` (push baselines, and
+// dispatch/`/bench` runs without an explicit hardhat-ref), the resolver honors
+// an optional "compat pin" (HARDHAT_PIN_PATH below): while the pinned Hardhat
+// PR is open, the benchmark runs against the pinned commit instead of `main`;
+// once that PR is merged (or closed), runs revert to `main` automatically.
 
 // How long to wait for the EDR CI run to conclude before giving up, and how
 // often to re-check while waiting. Tunable independently.
@@ -21,6 +27,26 @@ const CI_POLL_INTERVAL_MS = 30 * 1000; // 30 seconds
 // inputs / `scenarios=`/`benchmarks=` comment args; pass `*` for the full suite.
 const DEFAULT_SCENARIO_FILTER = "*";
 const DEFAULT_BENCHMARK_FILTER = "test solidity,test mocha,test vitest";
+
+// The Hardhat repository the benchmark runs against.
+const HARDHAT_OWNER = "NomicFoundation";
+const HARDHAT_REPO = "hardhat";
+
+// Optional Hardhat compatibility pin, checked into the EDR repo while a
+// breaking EDR change needs a not-yet-merged Hardhat counterpart. Format:
+//
+//   {
+//     "pr": <Hardhat PR number>,
+//     "sha": "<full 40-hex commit sha on that PR>",
+//     "reason": "<optional free-form note>"
+//   }
+//
+// While the Hardhat PR is open, runs that don't name an explicit hardhat-ref
+// benchmark against the pinned sha; once it's merged (or closed) they revert
+// to `main` automatically. Delete the file after the Hardhat PR merges.
+// The pinned PR must live in NomicFoundation/hardhat (not a fork), so the
+// benchmark job can check the sha out directly.
+const HARDHAT_PIN_PATH = ".github/hardhat-compat-pin.json";
 
 module.exports = async ({ github, context, core }) => {
   const { owner, repo } = context.repo;
@@ -66,6 +92,69 @@ module.exports = async ({ github, context, core }) => {
     return false;
   }
 
+  // Resolve the Hardhat ref for runs that didn't name one explicitly: `main`,
+  // unless a compat pin (HARDHAT_PIN_PATH) exists on `ref` and its Hardhat PR
+  // is still open. Returns { ref, pin? }, with `pin` set only when the pinned
+  // sha is actually used. Throws on a malformed pin (or an unreadable pinned
+  // PR) so misconfiguration fails loudly instead of silently benchmarking
+  // `main` — which is exactly the incompatible state the pin exists to avoid.
+  async function resolveDefaultHardhatRef(ref) {
+    let raw;
+    try {
+      const { data } = await github.rest.repos.getContent({
+        owner,
+        repo,
+        path: HARDHAT_PIN_PATH,
+        ref,
+      });
+      raw = Buffer.from(data.content, "base64").toString("utf8");
+    } catch (e) {
+      if (e.status === 404) return { ref: "main" }; // no pin
+      throw e;
+    }
+
+    let pin;
+    try {
+      pin = JSON.parse(raw);
+    } catch (e) {
+      throw new Error(`${HARDHAT_PIN_PATH} is not valid JSON: ${e.message}`);
+    }
+    if (
+      !Number.isInteger(pin.pr) ||
+      pin.pr <= 0 ||
+      typeof pin.sha !== "string" ||
+      !/^[0-9a-f]{40}$/i.test(pin.sha)
+    ) {
+      throw new Error(
+        `${HARDHAT_PIN_PATH} must contain {"pr": <Hardhat PR number>, ` +
+          `"sha": "<full 40-hex commit sha>"}; got: ${raw.trim()}`
+      );
+    }
+
+    const { data: hardhatPr } = await github.rest.pulls.get({
+      owner: HARDHAT_OWNER,
+      repo: HARDHAT_REPO,
+      pull_number: pin.pr,
+    });
+    const prName = `${HARDHAT_OWNER}/${HARDHAT_REPO}#${pin.pr}`;
+    if (hardhatPr.merged) {
+      core.notice(
+        `Hardhat compat pin ${prName} has been merged; benchmarking against ` +
+          `Hardhat main. ${HARDHAT_PIN_PATH} can now be removed.`
+      );
+      return { ref: "main" };
+    }
+    if (hardhatPr.state === "closed") {
+      core.warning(
+        `Hardhat compat pin ${prName} was closed without merging; ` +
+          `benchmarking against Hardhat main. Remove or update ${HARDHAT_PIN_PATH}.`
+      );
+      return { ref: "main" };
+    }
+    core.info(`Hardhat compat pin active: ${prName} @ ${pin.sha}`);
+    return { ref: pin.sha.toLowerCase(), pin };
+  }
+
   // Cosmetic side effects (reactions, status comments) must never fail the job:
   // the gating decision (`should_run`) is the only thing that matters. Run them
   // through this wrapper so any API rejection — insufficient token permissions,
@@ -94,12 +183,15 @@ module.exports = async ({ github, context, core }) => {
   if (eventName === "push") {
     shouldRun = true;
     edrRef = context.sha;
-    hardhatRef = "main";
+    hardhatRef = (await resolveDefaultHardhatRef(edrRef)).ref;
     isBaseline = true;
   } else if (eventName === "workflow_dispatch") {
     shouldRun = true;
     edrRef = context.sha;
-    hardhatRef = context.payload.inputs["hardhat-ref"] || "main";
+    // An explicit hardhat-ref input always wins over the compat pin.
+    hardhatRef =
+      context.payload.inputs["hardhat-ref"] ||
+      (await resolveDefaultHardhatRef(edrRef)).ref;
     scenarioFilter =
       context.payload.inputs["scenario-filter"] || DEFAULT_SCENARIO_FILTER;
     benchmarkFilter =
@@ -152,14 +244,40 @@ module.exports = async ({ github, context, core }) => {
           return m ? (m[1] ?? m[2]) : "";
         };
 
-        hardhatRef = parseParam("hardhat-ref") || "main";
+        hardhatRef = parseParam("hardhat-ref");
         scenarioFilter = parseParam("scenarios") || DEFAULT_SCENARIO_FILTER;
         benchmarkFilter = parseParam("benchmarks") || DEFAULT_BENCHMARK_FILTER;
 
+        // No explicit hardhat-ref= → Hardhat main, or the compat pin if one
+        // is active on the PR head. A malformed pin is reported back to the
+        // PR (instead of failing the job with no feedback) and skips the run.
+        let pinNote = "";
+        let pinError;
+        if (hardhatRef === "") {
+          try {
+            const resolved = await resolveDefaultHardhatRef(edrRef);
+            hardhatRef = resolved.ref;
+            if (resolved.pin !== undefined) {
+              pinNote =
+                ` (compat pin for ${HARDHAT_OWNER}/${HARDHAT_REPO}` +
+                `#${resolved.pin.pr})`;
+            }
+          } catch (e) {
+            hardhatRef = "main";
+            pinError = e instanceof Error ? e.message : String(e);
+          }
+        }
+
         // Gate on EDR CI being green for the PR head before spending
         // ~3h on the self-hosted runner.
-        const green = await waitForEdrCi(pr.head.sha);
-        if (green) {
+        const green =
+          pinError === undefined && (await waitForEdrCi(pr.head.sha));
+        if (pinError !== undefined) {
+          await postComment(
+            `⚠️ Could not resolve the Hardhat compat pin, so the regression ` +
+              `benchmark was not started: ${pinError}`
+          );
+        } else if (green) {
           shouldRun = true;
           // Only mention a filter that actually narrows the run (`*` = all).
           const filterNotes = [
@@ -172,7 +290,8 @@ module.exports = async ({ github, context, core }) => {
             : "";
           await postComment(
             `🚀 [Starting regression benchmark](${runUrl}) for ` +
-              `\`${edrRef.slice(0, 12)}\` against Hardhat \`${hardhatRef}\`${filterNote}.`
+              `\`${edrRef.slice(0, 12)}\` against Hardhat ` +
+              `\`${hardhatRef}\`${pinNote}${filterNote}.`
           );
         } else {
           await postComment(

--- a/.github/scripts/resolve-regression-trigger.test.cjs
+++ b/.github/scripts/resolve-regression-trigger.test.cjs
@@ -14,10 +14,23 @@ const FULL = `${OWNER}/${REPO}`;
 
 // Build a mocked { github, context, core } plus a `captured` record of the
 // side effects the module produced (outputs, logs, comments, reactions).
-function makeDeps({ eventName, sha, payload = {}, ci, pr } = {}) {
+//
+// `pinFile` is the raw content of .github/hardhat-compat-pin.json (absent →
+// repos.getContent 404s, i.e. no pin). `hardhatPr` is the Hardhat PR that a
+// valid pin's pulls.get resolves to.
+function makeDeps({
+  eventName,
+  sha,
+  payload = {},
+  ci,
+  pr,
+  pinFile,
+  hardhatPr,
+} = {}) {
   const captured = {
     outputs: {},
     infos: [],
+    notices: [],
     warnings: [],
     comments: [],
     reactions: [],
@@ -28,6 +41,7 @@ function makeDeps({ eventName, sha, payload = {}, ci, pr } = {}) {
       captured.outputs[k] = v;
     },
     info: (m) => captured.infos.push(m),
+    notice: (m) => captured.notices.push(m),
     warning: (m) => captured.warnings.push(m),
   };
 
@@ -39,9 +53,26 @@ function makeDeps({ eventName, sha, payload = {}, ci, pr } = {}) {
         }),
       },
       pulls: {
-        get: async () => {
+        get: async ({ repo: pullRepo }) => {
+          if (pullRepo === "hardhat") {
+            if (hardhatPr === undefined)
+              throw new Error("hardhat pulls.get not expected");
+            return { data: hardhatPr };
+          }
           if (pr === undefined) throw new Error("pulls.get not expected");
           return { data: pr };
+        },
+      },
+      repos: {
+        getContent: async () => {
+          if (pinFile === undefined) {
+            const e = new Error("Not Found");
+            e.status = 404;
+            throw e;
+          }
+          return {
+            data: { content: Buffer.from(pinFile).toString("base64") },
+          };
         },
       },
       issues: {
@@ -256,6 +287,147 @@ test("issue_comment → parses an unquoted single-token filter", async () => {
   assert.equal(captured.outputs.benchmark_filter, "cold-compile");
   // No scenarios= given → default `*` (all projects).
   assert.equal(captured.outputs.scenario_filter, "*");
+});
+
+// ---------------------------------------------------------------------------
+// Hardhat compat pin (.github/hardhat-compat-pin.json)
+// ---------------------------------------------------------------------------
+
+const PIN_SHA = "a".repeat(40);
+const PIN_FILE = JSON.stringify({
+  pr: 5678,
+  sha: PIN_SHA,
+  reason: "needs hardhat counterpart",
+});
+
+test("push → open pin PR pins the Hardhat ref", async () => {
+  const { captured, ...deps } = makeDeps({
+    eventName: "push",
+    sha: "deadbeefcafe1234",
+    pinFile: PIN_FILE,
+    hardhatPr: { state: "open", merged: false },
+  });
+  await resolve(deps);
+  assert.equal(captured.outputs.should_run, "true");
+  assert.equal(captured.outputs.hardhat_ref, PIN_SHA);
+  assert.equal(captured.outputs.is_baseline, "true");
+});
+
+test("push → merged pin PR reverts to main and suggests removing the pin", async () => {
+  const { captured, ...deps } = makeDeps({
+    eventName: "push",
+    sha: "deadbeefcafe1234",
+    pinFile: PIN_FILE,
+    hardhatPr: { state: "closed", merged: true },
+  });
+  await resolve(deps);
+  assert.equal(captured.outputs.hardhat_ref, "main");
+  assert.equal(captured.notices.length, 1);
+  assert.match(captured.notices[0], /can now be removed/);
+});
+
+test("push → pin PR closed without merging reverts to main with a warning", async () => {
+  const { captured, ...deps } = makeDeps({
+    eventName: "push",
+    sha: "deadbeefcafe1234",
+    pinFile: PIN_FILE,
+    hardhatPr: { state: "closed", merged: false },
+  });
+  await resolve(deps);
+  assert.equal(captured.outputs.hardhat_ref, "main");
+  assert.equal(captured.warnings.length, 1);
+  assert.match(captured.warnings[0], /closed without merging/);
+});
+
+test("push → malformed pin fails the run loudly", async () => {
+  for (const pinFile of [
+    "not json",
+    JSON.stringify({ pr: 5678 }), // missing sha
+    JSON.stringify({ pr: 5678, sha: "abc123" }), // short sha
+    JSON.stringify({ pr: "5678", sha: PIN_SHA }), // pr not a number
+  ]) {
+    const { captured, ...deps } = makeDeps({
+      eventName: "push",
+      sha: "deadbeefcafe1234",
+      pinFile,
+    });
+    await assert.rejects(resolve(deps), /hardhat-compat-pin\.json/);
+  }
+});
+
+test("workflow_dispatch → empty hardhat-ref uses an open pin", async () => {
+  const { captured, ...deps } = makeDeps({
+    eventName: "workflow_dispatch",
+    sha: "abc123",
+    payload: { inputs: {} },
+    pinFile: PIN_FILE,
+    hardhatPr: { state: "open", merged: false },
+  });
+  await resolve(deps);
+  assert.equal(captured.outputs.hardhat_ref, PIN_SHA);
+  assert.equal(captured.outputs.is_baseline, "false");
+});
+
+test("workflow_dispatch → explicit hardhat-ref wins over the pin", async () => {
+  // No `hardhatPr` in the mock: resolving the pin would throw, proving the
+  // pin file isn't even consulted when an explicit ref is given.
+  const { captured, ...deps } = makeDeps({
+    eventName: "workflow_dispatch",
+    sha: "abc123",
+    payload: { inputs: { "hardhat-ref": "v-next" } },
+    pinFile: PIN_FILE,
+  });
+  await resolve(deps);
+  assert.equal(captured.outputs.hardhat_ref, "v-next");
+});
+
+test("issue_comment → `/bench` without hardhat-ref uses an open pin and says so", async () => {
+  const { captured, ...deps } = makeDeps({
+    eventName: "issue_comment",
+    payload: commentPayload("/bench"),
+    pr: { head: { repo: { full_name: FULL }, sha: "1234567890ab" } },
+    ci: { id: 1, status: "completed", conclusion: "success" },
+    pinFile: PIN_FILE,
+    hardhatPr: { state: "open", merged: false },
+  });
+  await resolve(deps);
+  assert.equal(captured.outputs.should_run, "true");
+  assert.equal(captured.outputs.hardhat_ref, PIN_SHA);
+  assert.match(
+    captured.comments[0],
+    /compat pin for NomicFoundation\/hardhat#5678/
+  );
+});
+
+test("issue_comment → explicit hardhat-ref= wins over the pin", async () => {
+  const { captured, ...deps } = makeDeps({
+    eventName: "issue_comment",
+    payload: commentPayload("/bench hardhat-ref=feature/x"),
+    pr: { head: { repo: { full_name: FULL }, sha: "1234567890ab" } },
+    ci: { id: 1, status: "completed", conclusion: "success" },
+    pinFile: PIN_FILE,
+  });
+  await resolve(deps);
+  assert.equal(captured.outputs.should_run, "true");
+  assert.equal(captured.outputs.hardhat_ref, "feature/x");
+  assert.doesNotMatch(captured.comments[0], /compat pin/);
+});
+
+test("issue_comment → malformed pin posts an error comment and skips the run", async () => {
+  const { captured, ...deps } = makeDeps({
+    eventName: "issue_comment",
+    payload: commentPayload("/bench"),
+    pr: { head: { repo: { full_name: FULL }, sha: "1234567890ab" } },
+    ci: { id: 1, status: "completed", conclusion: "success" },
+    pinFile: "not json",
+  });
+  await resolve(deps);
+  assert.equal(captured.outputs.should_run, "false");
+  assert.equal(captured.comments.length, 1);
+  assert.match(
+    captured.comments[0],
+    /Could not resolve the Hardhat compat pin/
+  );
 });
 
 test("issue_comment → same-repo PR with failing CI does not run", async () => {

--- a/.github/scripts/resolve-regression-trigger.test.cjs
+++ b/.github/scripts/resolve-regression-trigger.test.cjs
@@ -55,11 +55,20 @@ function makeDeps({
       pulls: {
         get: async ({ repo: pullRepo }) => {
           if (pullRepo === "hardhat") {
-            if (hardhatPr === undefined)
-              throw new Error("hardhat pulls.get not expected");
+            if (hardhatPr === undefined) {
+              throw new Error(
+                "unexpected pulls.get for the Hardhat repo: this test did " +
+                  "not provide a `hardhatPr` fixture"
+              );
+            }
             return { data: hardhatPr };
           }
-          if (pr === undefined) throw new Error("pulls.get not expected");
+          if (pr === undefined) {
+            throw new Error(
+              "unexpected pulls.get for the EDR repo: this test did not " +
+                "provide a `pr` fixture"
+            );
+          }
           return { data: pr };
         },
       },

--- a/.github/scripts/validate-hardhat-compat-pin.cjs
+++ b/.github/scripts/validate-hardhat-compat-pin.cjs
@@ -1,0 +1,111 @@
+// Validate the Hardhat compat pin (`.github/hardhat-compat-pin.json`) in CI.
+//
+// Run by validate-hardhat-compat-pin.yml on PRs that touch the pin file, so a
+// broken pin is caught at review time instead of in the next regression
+// benchmark run — which may never happen on the PR that adds the pin (e.g. if
+// `/bench` was not commented there).
+//
+// Checks:
+//   - the file parses and matches the expected shape, using the same parser
+//     the benchmark resolver (resolve-regression-trigger.cjs) uses;
+//   - the referenced Hardhat PR exists in NomicFoundation/hardhat;
+//   - for an open Hardhat PR, the pinned sha is a commit reachable from the
+//     PR's head (i.e. actually part of what would be benchmarked).
+//
+// Non-failures:
+//   - a missing file: deleting the pin is the normal cleanup after the
+//     Hardhat PR merges;
+//   - a merged/closed Hardhat PR: the resolver reverts to `main` in that
+//     state, so the pin is inert, not broken — reported as a notice/warning
+//     (also keeps this check from breaking retroactively when the Hardhat PR
+//     state changes after the pin was added).
+
+const fs = require("node:fs");
+
+const {
+  HARDHAT_OWNER,
+  HARDHAT_REPO,
+  HARDHAT_PIN_PATH,
+  parseHardhatPin,
+} = require("./hardhat-compat-pin.cjs");
+
+// `pinPath` is overridable for tests; in CI the file is read from the
+// checked-out workspace.
+module.exports = async ({ github, core, pinPath = HARDHAT_PIN_PATH }) => {
+  let raw;
+  try {
+    raw = fs.readFileSync(pinPath, "utf8");
+  } catch (e) {
+    if (e.code === "ENOENT") {
+      core.info(`${HARDHAT_PIN_PATH} not present; nothing to validate.`);
+      return;
+    }
+    throw e;
+  }
+
+  // Throws a descriptive error on invalid JSON or a malformed shape.
+  const pin = parseHardhatPin(raw);
+
+  const prName = `${HARDHAT_OWNER}/${HARDHAT_REPO}#${pin.pr}`;
+  let hardhatPr;
+  try {
+    ({ data: hardhatPr } = await github.rest.pulls.get({
+      owner: HARDHAT_OWNER,
+      repo: HARDHAT_REPO,
+      pull_number: pin.pr,
+    }));
+  } catch (e) {
+    if (e.status === 404) {
+      throw new Error(`${HARDHAT_PIN_PATH}: Hardhat PR ${prName} not found`);
+    }
+    throw e;
+  }
+
+  if (hardhatPr.merged) {
+    core.notice(
+      `Hardhat compat pin ${prName} has already been merged; the benchmark ` +
+        `will run against Hardhat main. ${HARDHAT_PIN_PATH} can be removed.`
+    );
+    return;
+  }
+  if (hardhatPr.state === "closed") {
+    core.warning(
+      `Hardhat compat pin ${prName} was closed without merging; the ` +
+        `benchmark will run against Hardhat main. Remove or update ` +
+        `${HARDHAT_PIN_PATH}.`
+    );
+    return;
+  }
+
+  // The pin must reference a commit that's part of the open PR: reachable
+  // from its head. (Commits already on main are also "reachable", but such a
+  // pin is merely redundant, not broken.)
+  let comparison;
+  try {
+    ({ data: comparison } = await github.rest.repos.compareCommitsWithBasehead({
+      owner: HARDHAT_OWNER,
+      repo: HARDHAT_REPO,
+      basehead: `${pin.sha}...${hardhatPr.head.sha}`,
+    }));
+  } catch (e) {
+    if (e.status === 404) {
+      throw new Error(
+        `${HARDHAT_PIN_PATH}: pinned sha ${pin.sha} does not exist in ` +
+          `${HARDHAT_OWNER}/${HARDHAT_REPO}`
+      );
+    }
+    throw e;
+  }
+  if (comparison.status !== "identical" && comparison.status !== "ahead") {
+    throw new Error(
+      `${HARDHAT_PIN_PATH}: pinned sha ${pin.sha} is not reachable from the ` +
+        `head of ${prName} (${hardhatPr.head.sha}); pin a commit on that PR ` +
+        `(comparison status: ${comparison.status})`
+    );
+  }
+
+  core.info(
+    `Hardhat compat pin OK: ${prName} (open) @ ${pin.sha}` +
+      (pin.reason ? ` — ${pin.reason}` : "")
+  );
+};

--- a/.github/scripts/validate-hardhat-compat-pin.test.cjs
+++ b/.github/scripts/validate-hardhat-compat-pin.test.cjs
@@ -1,0 +1,146 @@
+// Unit tests for validate-hardhat-compat-pin.cjs.
+//
+// Run with Node's built-in test runner (no extra dependencies):
+//   node --test .github/scripts/
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const validate = require("./validate-hardhat-compat-pin.cjs");
+
+const SHA = "d57964b9bb2814089b26aa7d593dc222a1820848";
+const HEAD_SHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+// Write `raw` (or nothing, for the missing-file case) to a temp pin file and
+// build mocked { github, core } plus a `captured` record of side effects.
+//
+// `hardhatPr` is what pulls.get resolves to (absent → 404). `comparison` is
+// what compareCommitsWithBasehead resolves to (absent → 404, i.e. unknown sha).
+function makeDeps({ raw, hardhatPr, comparison } = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "compat-pin-"));
+  const pinPath = path.join(dir, "hardhat-compat-pin.json");
+  if (raw !== undefined) fs.writeFileSync(pinPath, raw);
+
+  const captured = { infos: [], notices: [], warnings: [], compared: [] };
+  const core = {
+    info: (m) => captured.infos.push(m),
+    notice: (m) => captured.notices.push(m),
+    warning: (m) => captured.warnings.push(m),
+  };
+
+  const notFound = () => {
+    const e = new Error("Not Found");
+    e.status = 404;
+    return e;
+  };
+
+  const github = {
+    rest: {
+      pulls: {
+        get: async () => {
+          if (hardhatPr === undefined) throw notFound();
+          return { data: hardhatPr };
+        },
+      },
+      repos: {
+        compareCommitsWithBasehead: async ({ basehead }) => {
+          captured.compared.push(basehead);
+          if (comparison === undefined) throw notFound();
+          return { data: comparison };
+        },
+      },
+    },
+  };
+
+  return { github, core, pinPath, captured };
+}
+
+const openPr = { state: "open", merged: false, head: { sha: HEAD_SHA } };
+const validRaw = JSON.stringify({ pr: 8548, sha: SHA, reason: "compat" });
+
+test("missing pin file passes with an info message", async () => {
+  const { captured, ...deps } = makeDeps();
+  await validate(deps);
+  assert.match(captured.infos.join("\n"), /not present; nothing to validate/);
+});
+
+test("invalid JSON fails", async () => {
+  const { captured: _, ...deps } = makeDeps({ raw: "{ oops" });
+  await assert.rejects(validate(deps), /is not valid JSON/);
+});
+
+test("malformed shape fails (truncated sha)", async () => {
+  const { captured: _, ...deps } = makeDeps({
+    raw: JSON.stringify({ pr: 8548, sha: SHA.slice(0, 12) }),
+  });
+  await assert.rejects(validate(deps), /full 40-hex commit sha/);
+});
+
+test("nonexistent Hardhat PR fails", async () => {
+  const { captured: _, ...deps } = makeDeps({ raw: validRaw });
+  await assert.rejects(validate(deps), /Hardhat PR .*#8548 not found/);
+});
+
+test("open PR with the sha on it passes", async () => {
+  const { captured, ...deps } = makeDeps({
+    raw: validRaw,
+    hardhatPr: openPr,
+    comparison: { status: "ahead" },
+  });
+  await validate(deps);
+  assert.deepEqual(captured.compared, [`${SHA}...${HEAD_SHA}`]);
+  assert.match(captured.infos.join("\n"), /compat pin OK: .*#8548 \(open\)/);
+});
+
+test("sha is lowercased before comparing", async () => {
+  const { captured, ...deps } = makeDeps({
+    raw: JSON.stringify({ pr: 8548, sha: SHA.toUpperCase() }),
+    hardhatPr: openPr,
+    comparison: { status: "identical" },
+  });
+  await validate(deps);
+  assert.deepEqual(captured.compared, [`${SHA}...${HEAD_SHA}`]);
+});
+
+test("sha unknown to the Hardhat repo fails", async () => {
+  const { captured: _, ...deps } = makeDeps({
+    raw: validRaw,
+    hardhatPr: openPr,
+  });
+  await assert.rejects(validate(deps), /does not exist in/);
+});
+
+test("sha not reachable from the PR head fails", async () => {
+  const { captured: _, ...deps } = makeDeps({
+    raw: validRaw,
+    hardhatPr: openPr,
+    comparison: { status: "diverged" },
+  });
+  await assert.rejects(
+    validate(deps),
+    /not reachable from the head .*diverged/s
+  );
+});
+
+test("merged PR passes with a remove-the-pin notice, skipping the sha check", async () => {
+  const { captured, ...deps } = makeDeps({
+    raw: validRaw,
+    hardhatPr: { state: "closed", merged: true, head: { sha: HEAD_SHA } },
+  });
+  await validate(deps);
+  assert.match(captured.notices.join("\n"), /already been merged/);
+  assert.deepEqual(captured.compared, []);
+});
+
+test("PR closed without merging passes with a warning, skipping the sha check", async () => {
+  const { captured, ...deps } = makeDeps({
+    raw: validRaw,
+    hardhatPr: { state: "closed", merged: false, head: { sha: HEAD_SHA } },
+  });
+  await validate(deps);
+  assert.match(captured.warnings.join("\n"), /closed without merging/);
+  assert.deepEqual(captured.compared, []);
+});

--- a/.github/workflows/hh3-regression-benchmark.yml
+++ b/.github/workflows/hh3-regression-benchmark.yml
@@ -18,7 +18,8 @@ name: Hardhat 3 Regression Benchmark
 # dispatch/`/bench` runs without an explicit hardhat-ref) then benchmark
 # against the pinned sha while the Hardhat PR is open, and revert to `main`
 # automatically once it's merged. Delete the pin file after the merge. See
-# `.github/scripts/resolve-regression-trigger.cjs` for details.
+# `.github/scripts/resolve-regression-trigger.cjs` for details. PRs that touch
+# the pin file get it validated by `validate-hardhat-compat-pin.yml`.
 
 on:
   # Records baselines for main.

--- a/.github/workflows/hh3-regression-benchmark.yml
+++ b/.github/workflows/hh3-regression-benchmark.yml
@@ -5,6 +5,20 @@ name: Hardhat 3 Regression Benchmark
 # is pinned on npm), this workflow builds EDR locally, publishes it to a local
 # Verdaccio registry, repoints Hardhat's `@nomicfoundation/edr` dependency at it,
 # and then runs Hardhat's `pnpm bench:regression --use-local`.
+#
+# Hardhat compat pin: when an EDR change breaks compatibility with current
+# Hardhat main (so the baseline benchmark would fail until the matching
+# Hardhat PR lands), the EDR PR can check in
+# `.github/hardhat-compat-pin.json` referencing that Hardhat PR + a commit
+# sha on it:
+#
+#   { "pr": <Hardhat PR number>, "sha": "<full commit sha>", "reason": "..." }
+#
+# Runs that would default to Hardhat `main` (push baselines, and
+# dispatch/`/bench` runs without an explicit hardhat-ref) then benchmark
+# against the pinned sha while the Hardhat PR is open, and revert to `main`
+# automatically once it's merged. Delete the pin file after the merge. See
+# `.github/scripts/resolve-regression-trigger.cjs` for details.
 
 on:
   # Records baselines for main.
@@ -15,10 +29,9 @@ on:
   workflow_dispatch:
     inputs:
       hardhat-ref:
-        description: "The branch, tag or SHA of Hardhat to benchmark against"
+        description: "The branch, tag or SHA of Hardhat to benchmark against. Empty defaults to `main`, or to the compat pin (`.github/hardhat-compat-pin.json`) if one is active."
         required: false
         type: string
-        default: "main"
       scenario-filter:
         description: "Glob(s) selecting which projects/scenarios to run, by directory name (e.g. `1inch*`). Comma-separated. Defaults to `*` (all projects). Forwarded to `bench:regression --scenarios`."
         required: false
@@ -30,7 +43,8 @@ on:
         type: string
         default: "test solidity,test mocha,test vitest"
   # ChatOps: comment `/bench` on a same-repo PR, optionally with
-  # `hardhat-ref=<branch|sha|PR>`, `scenarios="<glob>[,<glob>...]"` and/or
+  # `hardhat-ref=<branch|sha|PR>` (defaults to `main`, or the compat pin if
+  # one is active on the PR head), `scenarios="<glob>[,<glob>...]"` and/or
   # `benchmarks="<glob>[,<glob>...]"` to select which projects/benchmarks run
   # (quote values containing spaces). Authorization + gating happens in `setup`.
   issue_comment:

--- a/.github/workflows/validate-hardhat-compat-pin.yml
+++ b/.github/workflows/validate-hardhat-compat-pin.yml
@@ -1,0 +1,45 @@
+# Validates the Hardhat compat pin (`.github/hardhat-compat-pin.json`) on
+# every PR that touches it: JSON shape (same parser the regression-benchmark
+# resolver uses), the referenced Hardhat PR exists, and the pinned sha is a
+# commit on that PR. This catches a broken pin at review time — the pin is
+# otherwise only exercised when the benchmark actually runs, which may never
+# happen on the PR that adds it (e.g. if `/bench` was not commented there).
+#
+# See `.github/scripts/validate-hardhat-compat-pin.cjs` for the exact rules.
+
+name: Validate Hardhat compat pin
+
+on:
+  pull_request:
+    paths:
+      - .github/hardhat-compat-pin.json
+      - .github/scripts/hardhat-compat-pin.cjs
+      - .github/scripts/validate-hardhat-compat-pin.cjs
+      - .github/workflows/validate-hardhat-compat-pin.yml
+
+concurrency:
+  group: ${{github.workflow}}-${{github.ref}}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Validate Hardhat compat pin
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read # checkout + (public) Hardhat repo reads
+    steps:
+      # Sparse-checkout only what the validation needs: the pin file itself
+      # and the scripts. For pull_request events this is the PR's merge
+      # commit, i.e. the pin as it would land on main.
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          sparse-checkout: .github
+          persist-credentials: false
+
+      - name: Validate pin file
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const validate = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/validate-hardhat-compat-pin.cjs`);
+            await validate({ github, core });


### PR DESCRIPTION
This PR adds a Hardhat compatibility pin to the HH3 regression benchmark

### Why

When an EDR change breaks compatibility with current Hardhat `main`, the regression benchmark starts failing until the matching Hardhat PR merges. This PR lets an EDR branch pin the benchmark to a specific commit on an open Hardhat PR.

### How it works

An EDR PR can check in `.github/hardhat-compat-pin.json`:

```json
{ "pr": <Hardhat PR number>, "sha": "<full 40-hex commit sha>", "reason": "..." }
```

Any run that would otherwise default to Hardhat `main` — push baselines, and `workflow_dispatch` / `/bench` runs without an explicit `hardhat-ref` — resolves the pin (read at the EDR ref being benchmarked) and:

- **Hardhat PR open** → benchmarks against the pinned sha; `/bench` status comments note the active pin.
- **Hardhat PR merged** → reverts to `main` automatically and emits a notice that the pin file can be removed.
- **Hardhat PR closed without merging** → reverts to `main` with a warning.
- **Malformed pin** (bad JSON, missing/invalid `pr` or `sha`) → fails loudly instead of silently benchmarking `main` — that's exactly the incompatible state the pin exists to avoid. On `/bench`, the error is reported back to the PR and the run is skipped.

An explicit `hardhat-ref` (dispatch input or `hardhat-ref=` comment arg) always wins over the pin. The pinned PR must live in `NomicFoundation/hardhat` (not a fork) so the runner can check the sha out directly. The `hardhat-ref` dispatch input's `default: "main"` is dropped (empty now means "main, or the pin if active").

### Testing

- Unit tests in `resolve-regression-trigger.test.cjs` covering all pin states (open / merged / closed / malformed) across all three triggers, plus explicit-ref precedence.
- Verified live via `workflow_dispatch` on this branch with a pin targeting an open Hardhat PR ([run](https://github.com/NomicFoundation/edr/actions/runs/32716610698)): the resolver logged `Hardhat compat pin active: NomicFoundation/hardhat#8548 @ d57964b…` and the benchmark checked out Hardhat at the pinned sha. Also verified the merged-PR case reverts to `main`. The test pin file is not part of this PR.