### PR TITLE
chore(renovate): group gimli + addr2line into a lockstep PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -82,6 +82,12 @@
       "groupName": "reqwest"
     },
     {
+      "description": "gimli + addr2line: released in lockstep by gimli-rs; each addr2line pins an exact gimli minor and takes gimli types in its API, so bumping one alone cannot compile. Add `object` here too if addr2line's `object` feature is ever enabled.",
+      "matchManagers": ["cargo"],
+      "matchPackageNames": ["gimli", "addr2line"],
+      "groupName": "gimli-rs"
+    },
+    {
       "description": "napi-rs: Rust crates and @napi-rs/cli are ABI-tied; must move in lockstep with edr_napi.",
       "matchPackageNames": [
         "napi",


### PR DESCRIPTION
## What

Adds a `gimli-rs` group to `renovate.json` so `gimli` and `addr2line` are
bumped together in a single Renovate PR, alongside the existing lockstep
groups (alloy + revm, napi-rs, tokio, ...).

## Why

The two crates are released in lockstep by the gimli-rs org, and each
addr2line release pins an exact gimli minor (0.25 → gimli ^0.32,
0.27 → gimli ^0.34) while taking gimli types (`Dwarf`, `EndianReader`)
directly in its public API. Since both are pre-1.0, Cargo treats those
minors as incompatible majors — so bumping either crate alone puts two
gimli versions in `Cargo.lock`, and `edr_solidity`'s DWARF decoder fails
to compile with type mismatches at the gimli↔addr2line boundary.

This is exactly what happened with the current pair of Renovate PRs:
#1651 (gimli 0.34) and #1626 (addr2line 0.27) are each unbuildable on
their own and can only go green together.

## Why `object` is not in the group

`object` is part of the same gimli-rs release train, but nothing forces
it into lockstep in our build: addr2line's `object` dependency is behind
a feature we don't enable, and our own object usage hands gimli plain
bytes rather than shared types (see #1653, which passes CI on its own).
Grouping it would only bundle green object bumps into PRs blocked on
manual gimli API migrations. The rule's description notes to add it if
addr2line's `object` feature is ever enabled.

## Effect on open PRs

Once this merges, Renovate will fold #1651 and #1626 into one `gimli-rs`
group PR (which still needs the manual `dwarf.rs` migration to gimli
0.34's traversal API). #1653 (object 0.40) is unaffected.