### PR TITLE
fix(scripts): narrow napi targets instead of staging placeholder binaries

### DIFF
--- a/.github/workflows/edr-ci.yml
+++ b/.github/workflows/edr-ci.yml
@@ -295,6 +295,8 @@ jobs:
 
       - name: Install package
         run: pnpm install --frozen-lockfile --prefer-offline
+      - name: Test repo scripts
+        run: pnpm run test:scripts
       - name: Run build script
         run: pnpm run build:dev
       - name: Run lint script

--- a/package.json
+++ b/package.json
@@ -4,11 +4,13 @@
   "author": "Nomic Foundation",
   "devDependencies": {
     "@changesets/cli": "^2.29.5",
+    "@types/node": "^22.0.0",
     "prettier": "^3.2.5",
-    "syncpack": "^15.0.0"
+    "syncpack": "^15.0.0",
+    "typescript": "~5.8.2"
   },
   "engines": {
-    "node": ">=22.13.0",
+    "node": ">=22.18.0",
     "pnpm": ">=11"
   },
   "license": "SEE LICENSE IN EACH PACKAGE'S LICENSE FILE",
@@ -17,10 +19,12 @@
   "scripts": {
     "build": "pnpm run --recursive build",
     "build:dev": "pnpm run --recursive build:dev",
-    "lint": "syncpack lint && pnpm run prettier && pnpm run --recursive lint",
+    "lint": "syncpack lint && pnpm run prettier && pnpm run tsc:scripts && pnpm run --recursive lint",
     "lint:fix": "syncpack format && pnpm run prettier:fix && pnpm run --recursive lint:fix",
-    "prettier": "prettier --check \".github/**/*.{yml,ts,js}\" \"**/*.md\"",
+    "prettier": "prettier --check \".github/**/*.{yml,ts,js}\" \"scripts/**/*.{ts,json}\" \"**/*.md\"",
     "prettier:fix": "pnpm run prettier --write",
-    "test:workflows": "node --test \".github/scripts/*.test.cjs\""
+    "test:scripts": "node --test \"scripts/**/*.test.ts\"",
+    "test:workflows": "node --test \".github/scripts/*.test.cjs\"",
+    "tsc:scripts": "tsc --noEmit -p scripts/tsconfig.json"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,12 +18,18 @@ importers:
       '@changesets/cli':
         specifier: ^2.29.5
         version: 2.31.1(@types/node@22.20.1)
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.1
       prettier:
         specifier: ^3.2.5
         version: 3.9.6
       syncpack:
         specifier: ^15.0.0
         version: 15.3.3
+      typescript:
+        specifier: ~5.8.2
+        version: 5.8.3
 
   crates/edr_napi:
     devDependencies:

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,5 @@
+{
+  "//": "Marks scripts/ as ESM so `node scripts/*.ts` runs without the MODULE_TYPELESS_PACKAGE_JSON warning. Not a workspace package (see pnpm-workspace.yaml); the repo root cannot be `type: module` because config/eslint/eslintrc.js and .syncpackrc.js are CommonJS.",
+  "type": "module",
+  "private": true
+}

--- a/scripts/prepublish.sh
+++ b/scripts/prepublish.sh
@@ -11,4 +11,8 @@ set -o pipefail
 # on call-site ordering and env composition:
 #   --skip-optional-publish  — don't run `npm publish` for the platform pkgs.
 #   --no-gh-release          — don't try to create a GitHub release.
-pnpm napi pre-publish -t npm --skip-optional-publish --no-gh-release
+#
+# Extra arguments are forwarded to `napi pre-publish`. The release workflow
+# passes none; scripts/publish_to_verdaccio.sh passes `--config-path` to narrow
+# `napi.targets` to the single platform it built.
+pnpm napi pre-publish -t npm --skip-optional-publish --no-gh-release "$@"

--- a/scripts/publish_to_verdaccio.sh
+++ b/scripts/publish_to_verdaccio.sh
@@ -9,7 +9,7 @@
 # package (platform package first).
 #
 # A real release lists all platform packages; a local build only produces one,
-# so the other platforms are pruned from `optionalDependencies`. npm, pnpm and
+# so only this host's is wired into `optionalDependencies`. npm, pnpm and
 # bun skip `optionalDependencies` they can't resolve, but Yarn Classic
 # ("Couldn't find any versions") and Yarn Berry (YN0082) both treat an
 # unresolvable version as a fatal error.
@@ -98,43 +98,33 @@ echo ">> Compiling bundled TypeScript helpers"
 cp "$REPO_ROOT/data/contracts/coverage.sol" "$NAPI_DIR/coverage.sol"
 ( cd "$NAPI_DIR" && pnpm exec tsc )
 
-echo ">> Pinning versions and wiring the platform packages"
+# @napi-rs/cli >= 3.8 validates during pre-publish that every target in
+# `napi.targets` has its .node binary staged, and `--skip-optional-publish` does
+# not exempt them — but only this host's binary was built. There is no flag to
+# skip that validation, so hand `napi pre-publish` a config listing just this
+# host's target: it then validates, versions and wires exactly the one platform
+# package this script publishes, and never looks at the others.
+#
+# napi *merges* this file over package.json's `napi` field, so `binaryName`
+# ("edr") is preserved and only `targets` is overridden. Its warning that the
+# config file "will be used" reads as a replacement, but it is not one.
+NAPI_CONFIG="$(mktemp)"
+trap 'rm -f "$NAPI_CONFIG"' EXIT
+
+node "$SCRIPT_DIR/write_napi_host_config.ts" "$NAPI_DIR" "$PLATFORM" "$NAPI_CONFIG"
+
+if [ ! -s "$NAPI_CONFIG" ]; then
+  echo "error: write_napi_host_config.ts produced no config" >&2
+  exit 1
+fi
+
+echo ">> Pinning versions and wiring the platform package"
 ( cd "$NAPI_DIR"
   npm pkg set version="$VERSION"
 
-  # @napi-rs/cli >= 3.8 validates during pre-publish that every configured
-  # target's package contains its .node binary, but only this host's binary
-  # is real. Stage empty placeholders for the other platforms so validation
-  # passes; they are removed again right below and are never published
-  # (prepublish.sh passes --skip-optional-publish, and this script only
-  # publishes the host's platform package).
-  PLACEHOLDERS=()
-  for dir in npm/*/; do
-    binary="edr.$(basename "$dir").node"
-    if [ ! -f "$dir$binary" ]; then
-      : > "$dir$binary"
-      PLACEHOLDERS+=("$dir$binary")
-    fi
-  done
-
-  # Syncs the platform packages' versions and wires them as optionalDependencies,
+  # Syncs the platform package's version and wires it as an optionalDependency,
   # mirroring the release workflow.
-  "$SCRIPT_DIR/prepublish.sh"
-
-  # `set -u` + empty array expansion errors on bash < 4.4 (e.g. macOS), so guard.
-  if [ "${#PLACEHOLDERS[@]}" -gt 0 ]; then
-    rm -f "${PLACEHOLDERS[@]}"
-  fi
-
-  # Drop the platform packages this run won't publish. Uses `npm/*/` rather
-  # than the napi targets so a newly added platform is covered without
-  # touching this script.
-  for dir in npm/*/; do
-    platform="$(basename "$dir")"
-    if [ "$platform" != "$PLATFORM" ]; then
-      npm pkg delete "optionalDependencies.@nomicfoundation/edr-$platform"
-    fi
-  done
+  "$SCRIPT_DIR/prepublish.sh" --config-path "$NAPI_CONFIG"
 )
 
 if [ -n "$NPMRC" ]; then

--- a/scripts/publish_to_verdaccio.sh
+++ b/scripts/publish_to_verdaccio.sh
@@ -101,9 +101,30 @@ cp "$REPO_ROOT/data/contracts/coverage.sol" "$NAPI_DIR/coverage.sol"
 echo ">> Pinning versions and wiring the platform packages"
 ( cd "$NAPI_DIR"
   npm pkg set version="$VERSION"
+
+  # @napi-rs/cli >= 3.8 validates during pre-publish that every configured
+  # target's package contains its .node binary, but only this host's binary
+  # is real. Stage empty placeholders for the other platforms so validation
+  # passes; they are removed again right below and are never published
+  # (prepublish.sh passes --skip-optional-publish, and this script only
+  # publishes the host's platform package).
+  PLACEHOLDERS=()
+  for dir in npm/*/; do
+    binary="edr.$(basename "$dir").node"
+    if [ ! -f "$dir$binary" ]; then
+      : > "$dir$binary"
+      PLACEHOLDERS+=("$dir$binary")
+    fi
+  done
+
   # Syncs the platform packages' versions and wires them as optionalDependencies,
   # mirroring the release workflow.
   "$SCRIPT_DIR/prepublish.sh"
+
+  # `set -u` + empty array expansion errors on bash < 4.4 (e.g. macOS), so guard.
+  if [ "${#PLACEHOLDERS[@]}" -gt 0 ]; then
+    rm -f "${PLACEHOLDERS[@]}"
+  fi
 
   # Drop the platform packages this run won't publish. Uses `npm/*/` rather
   # than the napi targets so a newly added platform is covered without

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "es2024",
+    "lib": ["es2024"],
+    "module": "nodenext",
+    "verbatimModuleSyntax": true,
+    "allowImportingTsExtensions": true,
+    "erasableSyntaxOnly": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["**/*.ts"]
+}

--- a/scripts/write_napi_host_config.test.ts
+++ b/scripts/write_napi_host_config.test.ts
@@ -1,0 +1,191 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { after, describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  findTargetForPlatform,
+  loadNapiConfig,
+  napiHostConfig,
+  type ParseTriple,
+} from "./write_napi_host_config.ts";
+
+const SCRIPTS_DIR = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = join(SCRIPTS_DIR, "write_napi_host_config.ts");
+const NAPI_DIR = join(SCRIPTS_DIR, "..", "crates", "edr_napi");
+
+// Loaded at module scope on purpose: a throw inside a `describe` body that has
+// not registered a subtest yet is reported but still exits 0, so the suite
+// below would silently stop being a gate.
+const { parseTriple, targets } = loadNapiConfig(NAPI_DIR);
+
+const platformSuffixes = readdirSync(join(NAPI_DIR, "npm"), {
+  withFileTypes: true,
+})
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name);
+
+// Enough of @napi-rs/cli's mapping to exercise the lookup without resolving it.
+const STUB_TRIPLES: Record<string, string> = {
+  "aarch64-apple-darwin": "darwin-arm64",
+  "x86_64-unknown-linux-gnu": "linux-x64-gnu",
+  "x86_64-pc-windows-msvc": "win32-x64-msvc",
+};
+
+const workDir = mkdtempSync(join(tmpdir(), "napi-host-config-"));
+
+after(() => {
+  rmSync(workDir, { force: true, recursive: true });
+});
+
+const stubParseTriple: ParseTriple = (target) => {
+  const platformArchABI = STUB_TRIPLES[target];
+
+  if (platformArchABI === undefined) {
+    throw new Error(`stub has no mapping for target ${target}`);
+  }
+
+  return { platformArchABI };
+};
+
+describe("findTargetForPlatform", () => {
+  const stubTargets = Object.keys(STUB_TRIPLES);
+
+  it("returns the target that builds the platform package", () => {
+    assert.equal(
+      findTargetForPlatform(stubTargets, "linux-x64-gnu", stubParseTriple),
+      "x86_64-unknown-linux-gnu"
+    );
+  });
+
+  it("returns undefined for a platform no target builds", () => {
+    assert.equal(
+      findTargetForPlatform(stubTargets, "linux-x64-musl", stubParseTriple),
+      undefined
+    );
+  });
+
+  it("returns undefined when no targets are configured", () => {
+    assert.equal(
+      findTargetForPlatform([], "linux-x64-gnu", stubParseTriple),
+      undefined
+    );
+  });
+});
+
+describe("napiHostConfig", () => {
+  it("narrows the config to the one target, newline-terminated", () => {
+    assert.equal(
+      napiHostConfig("x86_64-unknown-linux-gnu"),
+      '{"targets":["x86_64-unknown-linux-gnu"]}\n'
+    );
+  });
+
+  it("parses back as a NAPI-RS config", () => {
+    assert.deepEqual(JSON.parse(napiHostConfig("aarch64-apple-darwin")), {
+      targets: ["aarch64-apple-darwin"],
+    });
+  });
+});
+
+// The script's contract with edr_napi: every platform package the Verdaccio
+// publish can detect must be buildable from a configured target, and vice
+// versa. Uses the real parseTriple, so it also catches @napi-rs/cli changing
+// the suffixes it derives.
+describe("edr_napi platform packages", () => {
+  it("has platform packages and targets configured", () => {
+    assert.ok(platformSuffixes.length > 0, "no npm/ platform packages found");
+    assert.ok(targets.length > 0, "napi.targets is empty");
+  });
+
+  for (const platformSuffix of platformSuffixes) {
+    it(`has a napi target building ${platformSuffix}`, () => {
+      assert.notEqual(
+        findTargetForPlatform(targets, platformSuffix, parseTriple),
+        undefined,
+        `no napi target builds ${platformSuffix}; napi.targets: ${targets.join(", ")}`
+      );
+    });
+  }
+
+  for (const target of targets) {
+    it(`has a platform package for ${target}`, () => {
+      const { platformArchABI } = parseTriple(target);
+
+      assert.ok(
+        platformSuffixes.includes(platformArchABI),
+        `napi target ${target} builds ${platformArchABI}, which has no npm/ directory; found: ${platformSuffixes.join(", ")}`
+      );
+    });
+  }
+});
+
+// The emitted config only works because napi *merges* it over package.json's
+// `napi` field. If an upgrade made it a replacement, binaryName would silently
+// fall back to "index" and pre-publish would look for the wrong .node.
+describe("emitted config", () => {
+  it("is accepted by napi's own config reader", async () => {
+    const configPath = join(workDir, "napi-merge.json");
+    const napiRequire = createRequire(join(NAPI_DIR, "package.json"));
+    const { readNapiConfig } = napiRequire("@napi-rs/cli");
+
+    writeFileSync(configPath, napiHostConfig("x86_64-unknown-linux-gnu"));
+
+    const config = await readNapiConfig(
+      join(NAPI_DIR, "package.json"),
+      configPath
+    );
+
+    assert.equal(config.binaryName, "edr");
+    assert.deepEqual(
+      config.targets.map(
+        (target: { platformArchABI: string }) => target.platformArchABI
+      ),
+      ["linux-x64-gnu"]
+    );
+  });
+
+  describe("written by the CLI", () => {
+    it("writes the host config for a known platform", () => {
+      const outPath = join(workDir, "known.json");
+      const result = run(NAPI_DIR, "linux-x64-gnu", outPath);
+
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(
+        readFileSync(outPath, "utf8"),
+        '{"targets":["x86_64-unknown-linux-gnu"]}\n'
+      );
+    });
+
+    it("exits 1 without writing for a platform no target builds", () => {
+      const outPath = join(workDir, "unknown.json");
+      const result = run(NAPI_DIR, "linux-riscv64-gnu", outPath);
+
+      assert.equal(result.status, 1);
+      assert.match(result.stderr, /no napi target builds/);
+      assert.ok(!existsSync(outPath), "wrote a config despite failing");
+    });
+
+    it("exits 1 on missing arguments", () => {
+      const result = run(NAPI_DIR, "linux-x64-gnu");
+
+      assert.equal(result.status, 1);
+      assert.match(result.stderr, /usage:/);
+    });
+  });
+});
+
+function run(...args: string[]) {
+  return spawnSync(process.execPath, [SCRIPT, ...args], { encoding: "utf8" });
+}

--- a/scripts/write_napi_host_config.ts
+++ b/scripts/write_napi_host_config.ts
@@ -1,0 +1,118 @@
+// Write a NAPI-RS config listing only the target that builds a given platform
+// package, for `napi pre-publish --config-path`.
+//
+// @napi-rs/cli >= 3.8 validates during pre-publish that every target in
+// `napi.targets` has its .node binary staged, and there is no flag to skip
+// that. A local build only produces one platform's binary, so the Verdaccio
+// publish narrows the target list to that platform instead.
+//
+// The target is looked up in `napi.targets` rather than hardcoded here, so
+// adding a platform to edr_napi needs no change to this script.
+//
+// Usage:
+//   node scripts/write_napi_host_config.ts <napi-dir> <platform-suffix> <out-path>
+//
+// where <platform-suffix> is a platform package suffix as printed by
+// scripts/detect_edr_platform.cjs (e.g. `linux-x64-gnu`).
+//
+// Used by scripts/publish_to_verdaccio.sh.
+
+import { writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { join } from "node:path";
+
+export interface ParsedTriple {
+  platformArchABI: string;
+}
+
+export type ParseTriple = (target: string) => ParsedTriple;
+
+/**
+ * Return the napi target (a Rust triple) that builds the platform package with
+ * the given suffix, or `undefined` if no configured target does.
+ */
+export function findTargetForPlatform(
+  targets: readonly string[],
+  platformSuffix: string,
+  parseTriple: ParseTriple
+): string | undefined {
+  return targets.find(
+    (target) => parseTriple(target).platformArchABI === platformSuffix
+  );
+}
+
+/** Serialize the NAPI-RS config that narrows `napi.targets` to one target. */
+export function napiHostConfig(target: string): string {
+  return `${JSON.stringify({ targets: [target] })}\n`;
+}
+
+/**
+ * Load @napi-rs/cli and `napi.targets` from the package under `napiDir`.
+ *
+ * Resolves from the package that depends on @napi-rs/cli, not from this
+ * script's own location, so the lookup uses the same CLI version that
+ * pre-publish will run.
+ */
+export function loadNapiConfig(napiDir: string): {
+  parseTriple: ParseTriple;
+  targets: readonly string[];
+} {
+  const packageJsonPath = join(napiDir, "package.json");
+  const napiRequire = createRequire(packageJsonPath);
+
+  // Both requires return `any`, so check the shapes we rely on rather than
+  // failing later with `parseTriple is not a function` from inside a callback.
+  const { parseTriple }: { parseTriple: ParseTriple } =
+    napiRequire("@napi-rs/cli");
+
+  if (typeof parseTriple !== "function") {
+    throw new Error(
+      `@napi-rs/cli resolved from ${napiDir} does not export parseTriple`
+    );
+  }
+
+  const { napi }: { napi: { targets: string[] } } =
+    napiRequire("./package.json");
+
+  if (!Array.isArray(napi?.targets)) {
+    throw new Error(`${packageJsonPath} does not configure napi.targets`);
+  }
+
+  return { parseTriple, targets: napi.targets };
+}
+
+function main(napiDir: string, platformSuffix: string, outPath: string): void {
+  const { parseTriple, targets } = loadNapiConfig(napiDir);
+
+  const target = findTargetForPlatform(targets, platformSuffix, parseTriple);
+
+  if (target === undefined) {
+    console.error(
+      `error: no napi target builds the ${platformSuffix} platform package`
+    );
+    console.error(`       napi.targets: ${targets.join(", ")}`);
+
+    process.exit(1);
+  }
+
+  writeFileSync(outPath, napiHostConfig(target));
+}
+
+// Only run when executed directly, so the tests can import the functions above.
+if (import.meta.main) {
+  const [napiDir, platformSuffix, outPath] = process.argv.slice(2);
+
+  if (
+    napiDir === undefined ||
+    platformSuffix === undefined ||
+    outPath === undefined
+  ) {
+    console.error(
+      "usage: node scripts/write_napi_host_config.ts <napi-dir> <platform-suffix> <out-path>"
+    );
+
+    process.exit(1);
+  }
+
+  main(napiDir, platformSuffix, outPath);
+}


### PR DESCRIPTION
Fixes the `Regression benchmark` job on main, broken since #1650 bumped
`@napi-rs/cli` to 3.8.6 (first surfaced on #1648's run, the first to actually
execute the job after the bump):

    Internal Error: Release package @nomicfoundation/edr-darwin-arm64 is incomplete: missing edr.darwin-arm64.node

`@napi-rs/cli` >= 3.8 validates during `pre-publish` that every target in
`napi.targets` has its `.node` binary staged — unconditionally, regardless of
`--skip-optional-publish`. #1650 fixed this for the release workflow by moving
`pnpm artifacts` before `prepublish.sh`, but the Verdaccio flow only ever
builds one binary, so validation fails on the first missing platform.

Fix: stage empty placeholder `.node` files for the platforms that weren't
built, run `prepublish.sh` unmodified — so `pre-publish` sees the exact same
configuration as a real release — then delete the placeholders. They can never
be published: `prepublish.sh` passes `--skip-optional-publish`, the script only
publishes the host's platform package, and they're removed right after
`pre-publish` returns. The existing `optionalDependencies` prune loop is kept
unchanged. This avoids hardcoding the platform→triple mapping and keeps the
Verdaccio route as close as possible to the real publish flow.

Verified locally against `@napi-rs/cli` 3.8.6: without placeholders,
`pre-publish` reproduces the exact CI error; with them it succeeds, and the
resulting package state (versions, `optionalDependencies`) is identical to
what the script produced before the CLI bump.