### PR TITLE
rename compiler type to slang-solx

### DIFF
--- a/.changeset/slang-solx-compiler-type.md
+++ b/.changeset/slang-solx-compiler-type.md
@@ -1,0 +1,6 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+- Added support for compilation artifacts with `slang-solx` compiler type string.
+- BREAKING CHANGE: Removed support for compilation artifacts with `slangSolx` compiler type string. Instead, use the `slang-solx` compiler type string.

--- a/crates/edr_solidity/src/artifacts.rs
+++ b/crates/edr_solidity/src/artifacts.rs
@@ -151,6 +151,7 @@ pub enum CompilerType {
     #[default]
     Solc,
     /// Slang solx compiler
+    #[strum(serialize = "slang-solx")]
     SlangSolx,
 }
 
@@ -578,7 +579,7 @@ mod tests {
     #[test]
     fn to_compiler_type_reads_the_build_info_sentinel() {
         const SOLC_COMPILER_TYPE: &str = "solc";
-        const SLANG_SOLX_COMPILER_TYPE: &str = "slangSolx";
+        const SLANG_SOLX_COMPILER_TYPE: &str = "slang-solx";
 
         assert_eq!(CompilerType::Solc.to_string(), SOLC_COMPILER_TYPE);
         assert_eq!(


### PR DESCRIPTION
The Hardhat `hardhat-slang-solx` plugin is changing the compiler type value to `slang-solx` (from `slangSolx`).

This is now the value that is expected on the wire from Hardhat, and off of which conditional per compiler execution will be based.

`slangSolx` will no longer be recognized.