### PR TITLE
ci(bench): notify Slack on perf regressions in main baseline runs

### DIFF
--- a/.github/workflows/hh3-regression-benchmark.yml
+++ b/.github/workflows/hh3-regression-benchmark.yml
@@ -392,7 +392,15 @@ jobs:
             || echo "(no regression-report.json produced)"
 
       - name: Store benchmark result
+        id: benchmark
         uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
+        # On baseline runs the alert fires *after* the new data point is pushed,
+        # so absorbing the failure here keeps main green while still recording
+        # the baseline; the step's `outcome` drives the Slack regression alert
+        # below. Side effect: a genuine failure of this step on main (e.g. a
+        # push error) also surfaces as that regression ping instead of the
+        # generic failure one.
+        continue-on-error: ${{ needs.setup.outputs.is_baseline == 'true' }}
         with:
           tool: customSmallerIsBetter
           output-file-path: hardhat/regression-report.json
@@ -408,9 +416,27 @@ jobs:
           # Only push a new baseline on main-branch pushes; PRs/dispatch only compare.
           auto-push: ${{ needs.setup.outputs.is_baseline == 'true' }}
           alert-threshold: "110%"
-          # Fail the run on a regression for comparisons; never break main.
-          fail-on-alert: ${{ needs.setup.outputs.is_baseline != 'true' }}
+          # Fail the step on a regression. For comparisons (PR `/bench`,
+          # dispatch) this fails the run; for baseline runs `continue-on-error`
+          # above keeps main green and the failed outcome only triggers the
+          # Slack notification below.
+          fail-on-alert: "true"
           summary-always: true
+
+      - name: Notify perf regression on main
+        # Baseline runs record the new (regressed) data point as the baseline
+        # and stay green, so ping Slack explicitly when the store step raised
+        # a regression alert.
+        if: ${{ needs.setup.outputs.is_baseline == 'true' && steps.benchmark.outcome == 'failure' }}
+        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
+        with:
+          webhook: ${{ secrets.GH_ACTION_NOTIFICATIONS_SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            {
+              "workflow_name": "${{ github.workflow }} — perf regression on main (baseline was updated)",
+              "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }
 
       - name: Notify failures
         # Only ping Slack for failed baseline runs (pushes to main)

--- a/.github/workflows/hh3-regression-benchmark.yml
+++ b/.github/workflows/hh3-regression-benchmark.yml
@@ -117,8 +117,10 @@ jobs:
     runs-on: hardhat-linux-amd64-self-hosted
     timeout-minutes: 180
     permissions:
-      # Lets the short-lived GITHUB_TOKEN used on non-baseline runs read commit
-      # metadata via the REST API (see "Store benchmark result").
+      # Lets the GITHUB_TOKEN used by "Compare benchmark result against
+      # baseline" read commit metadata via the REST API. Only needed on
+      # dispatch and `/bench` runs; push events carry the commit in the
+      # event payload.
       contents: read
     env:
       # Hardhat is checked out into ./hardhat; the EDR repo is the workspace root.
@@ -391,15 +393,23 @@ jobs:
             || cat regression-report.json 2>/dev/null \
             || echo "(no regression-report.json produced)"
 
-      - name: Store benchmark result
-        id: benchmark
+      # Comparing and recording are split so that a regression can be told
+      # apart from a failed write. This invocation only reads, so it cannot
+      # fail the way "Record baseline in the results repo" can.
+      #
+      # It can still fail on a fetch or clone error instead of on the alert.
+      # Nothing here distinguishes the two, so the Slack message calls both a
+      # regression. The step's error annotation on the run says which it was.
+      #
+      # The comparison is against the last recorded data point, i.e. the
+      # previous push to main. So the baseline moves: a regression alerts
+      # once, then becomes the new normal.
+      - name: Compare benchmark result against baseline
+        id: compare
         uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
-        # On baseline runs the alert fires *after* the new data point is pushed,
-        # so absorbing the failure here keeps main green while still recording
-        # the baseline; the step's `outcome` drives the Slack regression alert
-        # below. Side effect: a genuine failure of this step on main (e.g. a
-        # push error) also surfaces as that regression ping instead of the
-        # generic failure one.
+        # A regression must not break main, so absorb the alert on baseline
+        # runs and let the Slack step report it instead. Comparison runs
+        # (`/bench`, dispatch) still fail.
         continue-on-error: ${{ needs.setup.outputs.is_baseline == 'true' }}
         with:
           tool: customSmallerIsBetter
@@ -407,47 +417,76 @@ jobs:
           gh-repository: github.com/nomic-foundation-automation/edr-benchmark-results
           gh-pages-branch: main
           benchmark-data-dir-path: hardhat3
-          # Baseline (main push) runs push to the external results repo, which
-          # needs the cross-repo PAT. Non-baseline runs (PR/dispatch and the
-          # `/bench` issue_comment path) never push — the token is only used to
-          # read commit metadata and to clone the (public) results repo for
-          # comparison — so use the short-lived GITHUB_TOKEN.
-          github-token: ${{ needs.setup.outputs.is_baseline == 'true' && secrets.BENCHMARK_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
-          # Only push a new baseline on main-branch pushes; PRs/dispatch only compare.
-          auto-push: ${{ needs.setup.outputs.is_baseline == 'true' }}
+          # This invocation only reads the (public) results repo, so the
+          # short-lived GITHUB_TOKEN suffices on every trigger. A token is
+          # still required: with `gh-repository` set, the action rejects an
+          # empty `github-token` during config validation.
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: false
           alert-threshold: "110%"
-          # Fail the step on a regression. For comparisons (PR `/bench`,
-          # dispatch) this fails the run; for baseline runs `continue-on-error`
-          # above keeps main green and the failed outcome only triggers the
-          # Slack notification below.
-          fail-on-alert: "true"
+          fail-on-alert: true
           summary-always: true
 
-      - name: Notify perf regression on main
-        # Baseline runs record the new (regressed) data point as the baseline
-        # and stay green, so ping Slack explicitly when the store step raised
-        # a regression alert.
-        if: ${{ needs.setup.outputs.is_baseline == 'true' && steps.benchmark.outcome == 'failure' }}
-        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
-        with:
-          webhook: ${{ secrets.GH_ACTION_NOTIFICATIONS_SLACK_WEBHOOK_URL }}
-          webhook-type: webhook-trigger
-          payload: |
-            {
-              "workflow_name": "${{ github.workflow }} — perf regression on main (baseline was updated)",
-              "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-            }
+      - name: Clear the results-repo clone
+        # "Compare benchmark result against baseline" leaves its clone of the
+        # results repo in the workspace, and `git clone` refuses a non-empty
+        # destination, so remove it before "Record baseline in the results
+        # repo" clones again. `always()` because a comparison run that
+        # fails on a regression has to clean up too.
+        if: always()
+        run: rm -rf "${GITHUB_WORKSPACE:?}/benchmark-data-repository"
 
-      - name: Notify failures
-        # Only ping Slack for failed baseline runs (pushes to main)
-        if: ${{ failure() && needs.setup.outputs.is_baseline == 'true' }}
+      # Record the data point whether or not it regressed, so main's baseline
+      # always tracks the newest commit. `fail-on-alert` is off here, so the
+      # only way this fails is a genuine store failure (clone, auth or push
+      # error) — which fails the run and gets the generic Slack notification
+      # rather than the regression one.
+      - name: Record baseline in the results repo
+        id: record
+        if: ${{ needs.setup.outputs.is_baseline == 'true' }}
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
+        # `tool` through `benchmark-data-dir-path` must stay identical to
+        # "Compare benchmark result against baseline" — the two invocations
+        # have to address the same dataset.
+        with:
+          tool: customSmallerIsBetter
+          output-file-path: hardhat/regression-report.json
+          gh-repository: github.com/nomic-foundation-automation/edr-benchmark-results
+          gh-pages-branch: main
+          benchmark-data-dir-path: hardhat3
+          # Pushing to another repository needs the cross-repo PAT.
+          github-token: ${{ secrets.BENCHMARK_GITHUB_TOKEN }}
+          auto-push: true
+          fail-on-alert: false
+          # The comparison above already wrote the summary.
+          summary-always: false
+
+      - name: Notify failures and regressions
+        # Fires on baseline runs for a failed run, or for a regression that
+        # `continue-on-error` deliberately left green.
+        #
+        # Two details in the condition that look removable but are not:
+        # 1. `failure()` suppresses the implicit `success()` that GitHub wraps
+        #    every step `if:` in. Without it, this step is skipped on the
+        #    failed runs it exists to report.
+        # 2. It reads `outcome`, not `conclusion`, because `continue-on-error`
+        #    rewrites `conclusion` to `success`.
+        #
+        # The regression wording needs the record step to have succeeded too.
+        # An infra error that trips both steps therefore reads as a plain
+        # failure.
+        if: ${{ needs.setup.outputs.is_baseline == 'true' && (failure() || steps.compare.outcome == 'failure') }}
         uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
         with:
           webhook: ${{ secrets.GH_ACTION_NOTIFICATIONS_SLACK_WEBHOOK_URL }}
           webhook-type: webhook-trigger
+          # Slack is the only channel a regression is reported on, so a
+          # rejected delivery must fail the step rather than just warn — even
+          # though on the green regression path that reddens the run.
+          errors: true
           payload: |
             {
-              "workflow_name": "${{ github.workflow }}",
+              "workflow_name": "${{ github.workflow }}${{ (steps.compare.outcome == 'failure' && steps.record.outcome == 'success') && ' — perf regression on main (baseline updated)' || '' }}",
               "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }
 


### PR DESCRIPTION
## Problem

The Hardhat 3 regression benchmark records every push to `main` as the new
baseline and never fails the run ("never break main"). That means a perf
regression merged to `main` was silently absorbed: the regressed numbers became
the baseline, subsequent `/bench` comparisons ran against them, and nobody was
notified — the existing Slack notification only fires for genuinely failed
baseline runs (infra errors, validation failures), never for an exceeded
threshold.

## Fix

Adds a Slack notification for perf regressions detected on `main` baseline
runs, while keeping the existing behavior of always recording the new baseline
and keeping the run green:

- `fail-on-alert` is now on for all runs (previously only for comparison runs).
  `github-action-benchmark` raises the alert *after* pushing the new data
  point, so the baseline is still recorded first.
- On baseline runs the store step gets `continue-on-error`, so the alert fails
  the step but not the job — `main` stays green.
- A new **Notify perf regression on main** step fires on
  `steps.benchmark.outcome == 'failure'` for baseline runs, reusing the
  existing Slack webhook with a distinguishable `workflow_name`
  (`… — perf regression on main (baseline was updated)`).

Comparison runs (PR `/bench`, `workflow_dispatch`) are unchanged: they still
fail on alert and never push.

## Notes

- No double notifications: an absorbed (`continue-on-error`) failure doesn't
  set the job status, so `failure()` stays false and the generic "Notify
  failures" step is skipped; conversely, if an earlier step fails, the store
  step is skipped and only the generic notification fires.
- Known trade-off: a genuine failure of the store step on `main` (e.g. a push
  error to the results repo) now also surfaces as the regression ping instead
  of the generic failure one — you still get exactly one notification either
  way.
- The Slack side is untouched; since the webhook template reads
  "Github Action workflow {workflow_name} failed", the regression message will
  read slightly awkwardly. A dedicated Slack variable could clean that up
  later if desired.