### PR TITLE
test: add EIP-7976 calldata floor test (Amsterdam)

### DIFF
--- a/crates/edr_provider/tests/integration/calldata_floor.rs
+++ b/crates/edr_provider/tests/integration/calldata_floor.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "test-utils")]
 
-mod deploy_contract;
-mod send_data_to_eoa;
+mod eip7623;
+mod eip7976;
 
 use std::sync::Arc;
 

--- a/crates/edr_provider/tests/integration/calldata_floor/eip7623.rs
+++ b/crates/edr_provider/tests/integration/calldata_floor/eip7623.rs
@@ -1,0 +1,2 @@
+mod deploy_contract;
+mod send_data_to_eoa;

--- a/crates/edr_provider/tests/integration/calldata_floor/eip7623/deploy_contract.rs
+++ b/crates/edr_provider/tests/integration/calldata_floor/eip7623/deploy_contract.rs
@@ -1,15 +1,13 @@
 use edr_chain_l1::rpc::{call::L1CallRequest, TransactionRequest};
 use edr_primitives::{address, bytes};
 
-use super::new_provider;
-use crate::integration::eip7623::assert_transaction_gas_usage;
+use crate::integration::calldata_floor::{self, assert_transaction_gas_usage, new_provider};
 
 fn call_request() -> L1CallRequest {
     let transaction_request = transaction_request();
 
     L1CallRequest {
         from: Some(transaction_request.from),
-        to: transaction_request.to,
         data: transaction_request.data,
         ..L1CallRequest::default()
     }
@@ -18,8 +16,7 @@ fn call_request() -> L1CallRequest {
 fn transaction_request() -> TransactionRequest {
     TransactionRequest {
         from: address!("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"),
-        to: Some(address!("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")),
-        data: Some(bytes!("0x11")),
+        data: Some(bytes!("0x600b380380600b5f395ff300")),
         ..TransactionRequest::default()
     }
 }
@@ -28,15 +25,14 @@ fn transaction_request() -> TransactionRequest {
 async fn estimate_gas() -> anyhow::Result<()> {
     let cancun_provider = new_provider(edr_chain_l1::Hardfork::Cancun)?;
     assert_eq!(
-        super::estimate_gas(&cancun_provider, call_request()),
-        // NOTE: Our estimate differs from the real cost by 1 gas unit.
-        21_017
+        calldata_floor::estimate_gas(&cancun_provider, call_request()),
+        53_409
     );
 
     let prague_provider = new_provider(edr_chain_l1::Hardfork::Prague)?;
     assert_eq!(
-        super::estimate_gas(&prague_provider, call_request()),
-        21_040
+        calldata_floor::estimate_gas(&prague_provider, call_request()),
+        53_409
     );
 
     Ok(())
@@ -45,10 +41,10 @@ async fn estimate_gas() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn send_transaction() -> anyhow::Result<()> {
     let cancun_provider = new_provider(edr_chain_l1::Hardfork::Cancun)?;
-    assert_transaction_gas_usage(&cancun_provider, transaction_request(), 21_016);
+    assert_transaction_gas_usage(&cancun_provider, transaction_request(), 53_409);
 
     let prague_provider = new_provider(edr_chain_l1::Hardfork::Prague)?;
-    assert_transaction_gas_usage(&prague_provider, transaction_request(), 21_040);
+    assert_transaction_gas_usage(&prague_provider, transaction_request(), 53_409);
 
     Ok(())
 }

--- a/crates/edr_provider/tests/integration/calldata_floor/eip7623/send_data_to_eoa.rs
+++ b/crates/edr_provider/tests/integration/calldata_floor/eip7623/send_data_to_eoa.rs
@@ -1,14 +1,14 @@
 use edr_chain_l1::rpc::{call::L1CallRequest, TransactionRequest};
 use edr_primitives::{address, bytes};
 
-use super::new_provider;
-use crate::integration::eip7623::assert_transaction_gas_usage;
+use crate::integration::calldata_floor::{self, assert_transaction_gas_usage, new_provider};
 
 fn call_request() -> L1CallRequest {
     let transaction_request = transaction_request();
 
     L1CallRequest {
         from: Some(transaction_request.from),
+        to: transaction_request.to,
         data: transaction_request.data,
         ..L1CallRequest::default()
     }
@@ -17,7 +17,8 @@ fn call_request() -> L1CallRequest {
 fn transaction_request() -> TransactionRequest {
     TransactionRequest {
         from: address!("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"),
-        data: Some(bytes!("0x600b380380600b5f395ff300")),
+        to: Some(address!("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")),
+        data: Some(bytes!("0x11")),
         ..TransactionRequest::default()
     }
 }
@@ -26,14 +27,15 @@ fn transaction_request() -> TransactionRequest {
 async fn estimate_gas() -> anyhow::Result<()> {
     let cancun_provider = new_provider(edr_chain_l1::Hardfork::Cancun)?;
     assert_eq!(
-        super::estimate_gas(&cancun_provider, call_request()),
-        53_409
+        calldata_floor::estimate_gas(&cancun_provider, call_request()),
+        // NOTE: Our estimate differs from the real cost by 1 gas unit.
+        21_017
     );
 
     let prague_provider = new_provider(edr_chain_l1::Hardfork::Prague)?;
     assert_eq!(
-        super::estimate_gas(&prague_provider, call_request()),
-        53_409
+        calldata_floor::estimate_gas(&prague_provider, call_request()),
+        21_040
     );
 
     Ok(())
@@ -42,10 +44,10 @@ async fn estimate_gas() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn send_transaction() -> anyhow::Result<()> {
     let cancun_provider = new_provider(edr_chain_l1::Hardfork::Cancun)?;
-    assert_transaction_gas_usage(&cancun_provider, transaction_request(), 53_409);
+    assert_transaction_gas_usage(&cancun_provider, transaction_request(), 21_016);
 
     let prague_provider = new_provider(edr_chain_l1::Hardfork::Prague)?;
-    assert_transaction_gas_usage(&prague_provider, transaction_request(), 53_409);
+    assert_transaction_gas_usage(&prague_provider, transaction_request(), 21_040);
 
     Ok(())
 }

--- a/crates/edr_provider/tests/integration/calldata_floor/eip7976.rs
+++ b/crates/edr_provider/tests/integration/calldata_floor/eip7976.rs
@@ -1,0 +1,31 @@
+//! From Amsterdam onward (EIP-7976), the calldata floor cost rises from 10/40
+//! to 64/64 gas per (zero/nonzero) byte.
+
+use edr_chain_l1::rpc::TransactionRequest;
+use edr_primitives::{address, bytes};
+
+use crate::integration::calldata_floor::{assert_transaction_gas_usage, new_provider};
+
+/// A transfer to an EOA carrying 4 nonzero and 4 zero calldata bytes, so the
+/// floor exceeds the intrinsic gas and determines the transaction's gas usage.
+fn transaction_request() -> TransactionRequest {
+    TransactionRequest {
+        from: address!("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"),
+        to: Some(address!("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")),
+        data: Some(bytes!("0x1111111100000000")),
+        ..TransactionRequest::default()
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn calldata_floor_increases_in_amsterdam() -> anyhow::Result<()> {
+    // 21_000 + 10 * (4 zero + 4 * 4 nonzero) = 21_200
+    let osaka_provider = new_provider(edr_chain_l1::Hardfork::Osaka)?;
+    assert_transaction_gas_usage(&osaka_provider, transaction_request(), 21_200);
+
+    // 21_000 + 16 * 4 * (4 zero + 4 nonzero) = 21_512
+    let amsterdam_provider = new_provider(edr_chain_l1::Hardfork::Amsterdam)?;
+    assert_transaction_gas_usage(&amsterdam_provider, transaction_request(), 21_512);
+
+    Ok(())
+}

--- a/crates/edr_provider/tests/integration/mod.rs
+++ b/crates/edr_provider/tests/integration/mod.rs
@@ -1,11 +1,11 @@
 mod block_timestamp_in_logs;
 mod call_traces;
+mod calldata_floor;
 mod coverage;
 mod disable_balance_check;
 mod disable_block_gas_limit;
 mod eip2537;
 mod eip4844;
-mod eip7623;
 mod eip7691;
 mod eip7702;
 mod eip7708;


### PR DESCRIPTION
## Changes

- added integration test to assert the EIP-7976 is properly gated by Amsterdam
- created a new `calldata_floor` module to organize this and EIP-7623 tests