### PR TITLE
refactor(tests): extract shared provider helpers

### DIFF
--- a/crates/edr_provider/tests/common/mod.rs
+++ b/crates/edr_provider/tests/common/mod.rs
@@ -1,8 +1,6 @@
 /// Test utilities for blob transactions.
 #[allow(dead_code)]
 pub mod blob;
-/// Test utilities for constructing an L1 provider and issuing common requests.
-#[cfg(feature = "test-utils")]
 pub mod provider;
 
 pub fn help_test_method_invocation_serde<MethodInvocation>(call: MethodInvocation)

--- a/crates/edr_provider/tests/common/mod.rs
+++ b/crates/edr_provider/tests/common/mod.rs
@@ -1,6 +1,9 @@
 /// Test utilities for blob transactions.
 #[allow(dead_code)]
 pub mod blob;
+/// Test utilities for constructing an L1 provider and issuing common requests.
+#[cfg(feature = "test-utils")]
+pub mod provider;
 
 pub fn help_test_method_invocation_serde<MethodInvocation>(call: MethodInvocation)
 where

--- a/crates/edr_provider/tests/common/provider.rs
+++ b/crates/edr_provider/tests/common/provider.rs
@@ -1,0 +1,58 @@
+//! Helpers for constructing an L1 test provider and issuing common requests.
+
+use std::sync::Arc;
+
+use edr_chain_l1::{rpc::TransactionRequest, L1ChainSpec};
+use edr_primitives::B256;
+use edr_provider::{
+    config::ProviderConfig, test_utils::create_test_config, time::CurrentTime, MethodInvocation,
+    NoopLogger, Provider, ProviderRequest,
+};
+use edr_solidity::contract_decoder::ContractDecoder;
+use parking_lot::RwLock;
+use tokio::runtime;
+
+/// Creates a provider from the default test config with the given hardfork.
+pub fn new_provider(hardfork: edr_chain_l1::Hardfork) -> anyhow::Result<Provider<L1ChainSpec>> {
+    new_provider_with_config(|config| config.hardfork = hardfork)
+}
+
+/// Creates a provider from the default test config after applying `customize`
+/// to it.
+pub fn new_provider_with_config(
+    customize: impl FnOnce(&mut ProviderConfig<edr_chain_l1::Hardfork>),
+) -> anyhow::Result<Provider<L1ChainSpec>> {
+    let mut config = create_test_config();
+    customize(&mut config);
+
+    new_provider_from_config(config)
+}
+
+/// Creates a provider with a no-op logger and subscriber and an empty contract
+/// decoder.
+pub fn new_provider_from_config(
+    config: ProviderConfig<edr_chain_l1::Hardfork>,
+) -> anyhow::Result<Provider<L1ChainSpec>> {
+    let provider = Provider::new(
+        runtime::Handle::current(),
+        Box::new(NoopLogger::<L1ChainSpec>::default()),
+        Box::new(|_event| {}),
+        config,
+        Arc::new(RwLock::<ContractDecoder>::default()),
+        CurrentTime,
+    )?;
+
+    Ok(provider)
+}
+
+/// Sends the transaction via `eth_sendTransaction`, returning its hash.
+pub fn send_transaction(
+    provider: &Provider<L1ChainSpec>,
+    request: TransactionRequest,
+) -> anyhow::Result<B256> {
+    let response = provider.handle_request(ProviderRequest::with_single(
+        MethodInvocation::SendTransaction(request),
+    ))?;
+
+    Ok(serde_json::from_value(response.result)?)
+}

--- a/crates/edr_provider/tests/common/provider.rs
+++ b/crates/edr_provider/tests/common/provider.rs
@@ -1,4 +1,5 @@
 //! Helpers for constructing an L1 test provider and issuing common requests.
+#![cfg(feature = "test-utils")]
 
 use std::sync::Arc;
 

--- a/crates/edr_provider/tests/integration/block_timestamp_in_logs.rs
+++ b/crates/edr_provider/tests/integration/block_timestamp_in_logs.rs
@@ -7,7 +7,7 @@
 //! the latest block, so these tests assert it against `eth_getBlockByNumber`
 //! rather than merely asserting the field is present.
 
-use std::{str::FromStr as _, sync::Arc};
+use std::str::FromStr as _;
 
 use edr_chain_l1::{
     rpc::{block::L1RpcBlock, TransactionRequest},
@@ -18,12 +18,11 @@ use edr_primitives::{Address, Bytes, B256};
 use edr_provider::{
     test_utils::{create_test_config, deploy_contract},
     time::CurrentTime,
-    MethodInvocation, NoopLogger, Provider, ProviderRequest,
+    MethodInvocation, Provider, ProviderRequest,
 };
 use edr_signer::public_key_to_address;
-use edr_solidity::contract_decoder::ContractDecoder;
-use parking_lot::RwLock;
-use tokio::runtime;
+
+use crate::common::provider::new_provider_from_config;
 
 /// Deployment code for a contract whose fallback emits one anonymous log:
 /// `MSTORE(0, 1); LOG0(0, 32)`.
@@ -40,14 +39,7 @@ fn new_provider() -> anyhow::Result<(Provider<L1ChainSpec, CurrentTime>, Address
             .public_key(),
     );
 
-    let provider = Provider::new(
-        runtime::Handle::current(),
-        Box::new(NoopLogger::<L1ChainSpec>::default()),
-        Box::new(|_event| {}),
-        config,
-        Arc::new(RwLock::<ContractDecoder>::default()),
-        CurrentTime,
-    )?;
+    let provider = new_provider_from_config(config)?;
 
     Ok((provider, caller))
 }

--- a/crates/edr_provider/tests/integration/calldata_floor.rs
+++ b/crates/edr_provider/tests/integration/calldata_floor.rs
@@ -3,24 +3,14 @@
 mod eip7623;
 mod eip7976;
 
-use std::sync::Arc;
-
 use edr_chain_l1::{
     rpc::{call::L1CallRequest, receipt::L1RpcTransactionReceipt, TransactionRequest},
     L1ChainSpec,
 };
 use edr_primitives::{B256, U64};
-use edr_provider::{
-    test_utils::{create_test_config, one_ether, set_genesis_state_with_owned_accounts},
-    time::CurrentTime,
-    MethodInvocation, NoopLogger, Provider, ProviderRequest,
-};
-use edr_solidity::contract_decoder::ContractDecoder;
-use edr_test_utils::secret_key::secret_key_from_str;
-use parking_lot::RwLock;
-use tokio::runtime;
+use edr_provider::{MethodInvocation, Provider, ProviderRequest};
 
-const CHAIN_ID: u64 = 0x7a69;
+use crate::common::provider::send_transaction;
 
 fn assert_transaction_gas_usage(
     provider: &Provider<L1ChainSpec>,
@@ -33,6 +23,7 @@ fn assert_transaction_gas_usage(
     assert_eq!(gas_used, expected_gas_usage);
 }
 
+/// Estimates the request's gas usage via `eth_estimateGas`.
 fn estimate_gas(provider: &Provider<L1ChainSpec>, request: L1CallRequest) -> u64 {
     let response = provider
         .handle_request(ProviderRequest::with_single(MethodInvocation::EstimateGas(
@@ -45,6 +36,7 @@ fn estimate_gas(provider: &Provider<L1ChainSpec>, request: L1CallRequest) -> u64
     gas.into_limbs()[0]
 }
 
+/// Returns the `gasUsed` from the transaction's receipt.
 fn gas_used(provider: &Provider<L1ChainSpec>, transaction_hash: B256) -> u64 {
     let response = provider
         .handle_request(ProviderRequest::with_single(
@@ -58,42 +50,4 @@ fn gas_used(provider: &Provider<L1ChainSpec>, transaction_hash: B256) -> u64 {
     let receipt = receipt.expect("receipt should exist");
 
     receipt.gas_used
-}
-
-fn new_provider(hardfork: edr_chain_l1::Hardfork) -> anyhow::Result<Provider<L1ChainSpec>> {
-    let secret_key = secret_key_from_str(edr_defaults::SECRET_KEYS[0])?;
-
-    let logger = Box::new(NoopLogger::<L1ChainSpec>::default());
-    let subscriber = Box::new(|_event| {});
-
-    let mut config = create_test_config();
-    set_genesis_state_with_owned_accounts(&mut config, vec![secret_key], one_ether());
-    config.chain_id = CHAIN_ID;
-    config.hardfork = hardfork;
-
-    let provider = Provider::new(
-        runtime::Handle::current(),
-        logger,
-        subscriber,
-        config,
-        Arc::new(RwLock::<ContractDecoder>::default()),
-        CurrentTime,
-    )?;
-
-    Ok(provider)
-}
-
-fn send_transaction(
-    provider: &Provider<L1ChainSpec>,
-    request: TransactionRequest,
-) -> anyhow::Result<B256> {
-    let response = provider
-        .handle_request(ProviderRequest::with_single(
-            MethodInvocation::SendTransaction(request),
-        ))
-        .expect("eth_sendTransaction should succeed");
-
-    let transaction_hash: B256 = serde_json::from_value(response.result)?;
-
-    Ok(transaction_hash)
 }

--- a/crates/edr_provider/tests/integration/calldata_floor/eip7623/deploy_contract.rs
+++ b/crates/edr_provider/tests/integration/calldata_floor/eip7623/deploy_contract.rs
@@ -1,7 +1,10 @@
 use edr_chain_l1::rpc::{call::L1CallRequest, TransactionRequest};
 use edr_primitives::{address, bytes};
 
-use crate::integration::calldata_floor::{self, assert_transaction_gas_usage, new_provider};
+use crate::{
+    common::provider::new_provider,
+    integration::calldata_floor::{self, assert_transaction_gas_usage},
+};
 
 fn call_request() -> L1CallRequest {
     let transaction_request = transaction_request();

--- a/crates/edr_provider/tests/integration/calldata_floor/eip7623/send_data_to_eoa.rs
+++ b/crates/edr_provider/tests/integration/calldata_floor/eip7623/send_data_to_eoa.rs
@@ -1,7 +1,10 @@
 use edr_chain_l1::rpc::{call::L1CallRequest, TransactionRequest};
 use edr_primitives::{address, bytes};
 
-use crate::integration::calldata_floor::{self, assert_transaction_gas_usage, new_provider};
+use crate::{
+    common::provider::new_provider,
+    integration::calldata_floor::{self, assert_transaction_gas_usage},
+};
 
 fn call_request() -> L1CallRequest {
     let transaction_request = transaction_request();

--- a/crates/edr_provider/tests/integration/calldata_floor/eip7976.rs
+++ b/crates/edr_provider/tests/integration/calldata_floor/eip7976.rs
@@ -4,7 +4,9 @@
 use edr_chain_l1::rpc::TransactionRequest;
 use edr_primitives::{address, bytes};
 
-use crate::integration::calldata_floor::{assert_transaction_gas_usage, new_provider};
+use crate::{
+    common::provider::new_provider, integration::calldata_floor::assert_transaction_gas_usage,
+};
 
 /// A transfer to an EOA carrying 4 nonzero and 4 zero calldata bytes, so the
 /// floor exceeds the intrinsic gas and determines the transaction's gas usage.

--- a/crates/edr_provider/tests/integration/disable_block_gas_limit.rs
+++ b/crates/edr_provider/tests/integration/disable_block_gas_limit.rs
@@ -1,19 +1,18 @@
 #![cfg(feature = "test-utils")]
 
-use std::{num::NonZeroU64, sync::Arc};
+use std::num::NonZeroU64;
 
 use edr_chain_l1::{rpc::TransactionRequest, L1ChainSpec};
 use edr_defaults::SECRET_KEYS;
 use edr_mem_pool::MemPoolAddTransactionError;
 use edr_primitives::address;
 use edr_provider::{
-    test_utils::create_test_config, time::CurrentTime, MethodInvocation, NoopLogger, Provider,
-    ProviderError, ProviderErrorForChainSpec, ProviderRequest, ResponseWithCallTraces,
+    MethodInvocation, Provider, ProviderError, ProviderErrorForChainSpec, ProviderRequest,
+    ResponseWithCallTraces,
 };
-use edr_solidity::contract_decoder::ContractDecoder;
 use edr_test_utils::secret_key::secret_key_to_address;
-use parking_lot::RwLock;
-use tokio::runtime;
+
+use crate::common::provider::new_provider_with_config;
 
 const BLOCK_GAS_LIMIT: u64 = 30_000_000;
 const EXCEEDS_BLOCK_GAS_LIMIT: u64 = BLOCK_GAS_LIMIT + 1;
@@ -22,22 +21,10 @@ fn new_provider(
     auto_mine: bool,
     block_gas_limit: Option<NonZeroU64>,
 ) -> anyhow::Result<Provider<L1ChainSpec>> {
-    let mut config = create_test_config();
-    config.mining.block_gas_limit = block_gas_limit;
-    config.mining.auto_mine = auto_mine;
-
-    let logger = Box::new(NoopLogger::<L1ChainSpec>::default());
-    let subscriber = Box::new(|_event| {});
-    let provider = Provider::new(
-        runtime::Handle::current(),
-        logger,
-        subscriber,
-        config,
-        Arc::new(RwLock::<ContractDecoder>::default()),
-        CurrentTime,
-    )?;
-
-    Ok(provider)
+    new_provider_with_config(|config| {
+        config.mining.block_gas_limit = block_gas_limit;
+        config.mining.auto_mine = auto_mine;
+    })
 }
 
 fn send_transaction(

--- a/crates/edr_provider/tests/integration/eip2537.rs
+++ b/crates/edr_provider/tests/integration/eip2537.rs
@@ -1,36 +1,18 @@
 #![cfg(feature = "test-utils")]
 
 use core::str::FromStr as _;
-use std::sync::Arc;
 
 use edr_chain_l1::{rpc::call::L1CallRequest, L1ChainSpec};
 use edr_primitives::{address, Bytes};
-use edr_provider::{
-    test_utils::create_test_config, time::CurrentTime, MethodInvocation, NoopLogger, Provider,
-    ProviderRequest,
-};
-use edr_solidity::contract_decoder::ContractDecoder;
-use parking_lot::RwLock;
-use tokio::runtime;
+use edr_provider::{MethodInvocation, Provider, ProviderRequest};
+
+use crate::common::provider::new_provider_with_config;
 
 fn new_provider(hardfork: edr_chain_l1::Hardfork) -> anyhow::Result<Provider<L1ChainSpec>> {
-    let logger = Box::new(NoopLogger::<L1ChainSpec>::default());
-    let subscriber = Box::new(|_event| {});
-
-    let mut config = create_test_config();
-    config.chain_id = 0x7a69;
-    config.hardfork = hardfork;
-
-    let provider = Provider::new(
-        runtime::Handle::current(),
-        logger,
-        subscriber,
-        config,
-        Arc::new(RwLock::<ContractDecoder>::default()),
-        CurrentTime,
-    )?;
-
-    Ok(provider)
+    new_provider_with_config(|config| {
+        config.chain_id = 0x7a69;
+        config.hardfork = hardfork;
+    })
 }
 
 fn send_call(

--- a/crates/edr_provider/tests/integration/eip7702.rs
+++ b/crates/edr_provider/tests/integration/eip7702.rs
@@ -8,8 +8,6 @@ mod reset;
 mod same_sender_and_authorizer;
 mod zeroed_chain_id;
 
-use std::sync::Arc;
-
 use edr_chain_l1::{
     rpc::{transaction::L1RpcTransactionWithSignature, TransactionRequest},
     L1ChainSpec,
@@ -21,15 +19,13 @@ use edr_provider::{
     test_utils::{
         create_test_config, one_ether, set_genesis_state_with_owned_accounts, sign_authorization,
     },
-    time::CurrentTime,
-    MethodInvocation, NoopLogger, Provider, ProviderRequest,
+    MethodInvocation, Provider, ProviderRequest,
 };
 use edr_signer::public_key_to_address;
-use edr_solidity::contract_decoder::ContractDecoder;
 use edr_test_utils::secret_key::secret_key_from_str;
 use k256::SecretKey;
-use parking_lot::RwLock;
-use tokio::runtime;
+
+use crate::common::provider::new_provider_from_config;
 
 const CHAIN_ID: u64 = 0x7a69;
 
@@ -53,19 +49,7 @@ fn new_provider(
 ) -> anyhow::Result<Provider<L1ChainSpec>> {
     set_genesis_state_with_owned_accounts(&mut config, owned_accounts, one_ether());
 
-    let logger = Box::new(NoopLogger::<L1ChainSpec>::default());
-    let subscriber = Box::new(|_event| {});
-
-    let provider = Provider::new(
-        runtime::Handle::current(),
-        logger,
-        subscriber,
-        config,
-        Arc::new(RwLock::<ContractDecoder>::default()),
-        CurrentTime,
-    )?;
-
-    Ok(provider)
+    new_provider_from_config(config)
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/edr_provider/tests/integration/eip7708.rs
+++ b/crates/edr_provider/tests/integration/eip7708.rs
@@ -6,40 +6,13 @@
 //! A value-bearing transfer emits a LOG3 from a system address mirroring the
 //! ERC-20 `Transfer(address,address,uint256)` event.
 
-use std::sync::Arc;
-
-use edr_chain_l1::L1ChainSpec;
 use edr_primitives::{address, eip7708, Address, Bytes, B256, U256};
-use edr_provider::{
-    test_utils::{create_test_config, transfer_value},
-    time::CurrentTime,
-    NoopLogger, Provider,
-};
-use edr_solidity::contract_decoder::ContractDecoder;
-use parking_lot::RwLock;
-use tokio::runtime;
+use edr_provider::test_utils::transfer_value;
+
+use crate::common::provider::new_provider;
 
 const SENDER: Address = address!("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
 const RECIPIENT: Address = address!("0x70997970C51812dc3A010C7d01b50e0d17dc79C8");
-
-fn new_provider(hardfork: edr_chain_l1::Hardfork) -> anyhow::Result<Provider<L1ChainSpec>> {
-    let logger = Box::new(NoopLogger::<L1ChainSpec>::default());
-    let subscriber = Box::new(|_event| {});
-
-    let mut config = create_test_config();
-    config.hardfork = hardfork;
-
-    let provider = Provider::new(
-        runtime::Handle::current(),
-        logger,
-        subscriber,
-        config,
-        Arc::new(RwLock::<ContractDecoder>::default()),
-        CurrentTime,
-    )?;
-
-    Ok(provider)
-}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn emits_transfer_log_on_amsterdam_provider() -> anyhow::Result<()> {

--- a/crates/edr_provider/tests/integration/eip7778.rs
+++ b/crates/edr_provider/tests/integration/eip7778.rs
@@ -8,8 +8,6 @@
 //! block header's `gas_used` no longer matches the last receipt's
 //! `cumulative_gas_used`: it is greater whenever the block contains refunds.
 
-use std::sync::Arc;
-
 use edr_chain_l1::{
     rpc::{block::L1RpcBlock, receipt::L1RpcTransactionReceipt, TransactionRequest},
     L1ChainSpec,
@@ -17,15 +15,13 @@ use edr_chain_l1::{
 use edr_eth::PreEip1898BlockSpec;
 use edr_primitives::{address, bytes, Address, Bytecode, Bytes, B256, U256};
 use edr_provider::{
-    test_utils::{create_test_config, one_ether, set_genesis_state_with_owned_accounts},
-    time::CurrentTime,
-    AccountOverride, MethodInvocation, NoopLogger, Provider, ProviderRequest,
+    test_utils::{one_ether, set_genesis_state_with_owned_accounts},
+    AccountOverride, MethodInvocation, Provider, ProviderRequest,
 };
-use edr_solidity::contract_decoder::ContractDecoder;
 use edr_state_api::{EvmStorage, EvmStorageSlot, TransactionId};
 use edr_test_utils::secret_key::secret_key_from_str;
-use parking_lot::RwLock;
-use tokio::runtime;
+
+use crate::common::provider::{new_provider_with_config, send_transaction};
 
 const CHAIN_ID: u64 = 0x7a69;
 
@@ -56,34 +52,21 @@ fn seeded_storage() -> EvmStorage {
 fn new_provider(hardfork: edr_chain_l1::Hardfork) -> anyhow::Result<Provider<L1ChainSpec>> {
     let secret_key = secret_key_from_str(edr_defaults::SECRET_KEYS[0])?;
 
-    let logger = Box::new(NoopLogger::<L1ChainSpec>::default());
-    let subscriber = Box::new(|_event| {});
+    new_provider_with_config(|config| {
+        set_genesis_state_with_owned_accounts(config, vec![secret_key], one_ether());
+        config.chain_id = CHAIN_ID;
+        config.hardfork = hardfork;
 
-    let mut config = create_test_config();
-    set_genesis_state_with_owned_accounts(&mut config, vec![secret_key], one_ether());
-    config.chain_id = CHAIN_ID;
-    config.hardfork = hardfork;
-
-    // Seed the storage-writer contract with a non-zero slot to clear.
-    config.genesis_state.insert(
-        CONTRACT,
-        AccountOverride {
-            code: Some(Bytecode::new_raw(STORAGE_WRITER_CODE)),
-            storage: Some(seeded_storage()),
-            ..AccountOverride::default()
-        },
-    );
-
-    let provider = Provider::new(
-        runtime::Handle::current(),
-        logger,
-        subscriber,
-        config,
-        Arc::new(RwLock::<ContractDecoder>::default()),
-        CurrentTime,
-    )?;
-
-    Ok(provider)
+        // Seed the storage-writer contract with a non-zero slot to clear.
+        config.genesis_state.insert(
+            CONTRACT,
+            AccountOverride {
+                code: Some(Bytecode::new_raw(STORAGE_WRITER_CODE)),
+                storage: Some(seeded_storage()),
+                ..AccountOverride::default()
+            },
+        );
+    })
 }
 
 /// Transaction clearing [`SLOT`] to zero. The storage-writer contract takes
@@ -99,17 +82,6 @@ fn clear_slot() -> TransactionRequest {
         data: Some(data.into()),
         ..TransactionRequest::default()
     }
-}
-
-fn send_transaction(
-    provider: &Provider<L1ChainSpec>,
-    request: TransactionRequest,
-) -> anyhow::Result<B256> {
-    let response = provider.handle_request(ProviderRequest::with_single(
-        MethodInvocation::SendTransaction(request),
-    ))?;
-
-    Ok(serde_json::from_value(response.result)?)
 }
 
 fn transaction_receipt(

--- a/crates/edr_provider/tests/integration/eip7825.rs
+++ b/crates/edr_provider/tests/integration/eip7825.rs
@@ -1,7 +1,5 @@
 #![cfg(feature = "test-utils")]
 
-use std::sync::Arc;
-
 use edr_chain_l1::{
     rpc::{call::L1CallRequest, TransactionRequest},
     InvalidTransaction, L1ChainSpec,
@@ -11,13 +9,12 @@ use edr_defaults::SECRET_KEYS;
 use edr_mem_pool::MemPoolAddTransactionError;
 use edr_primitives::address;
 use edr_provider::{
-    test_utils::create_test_config, time::CurrentTime, MethodInvocation, NoopLogger, Provider,
-    ProviderError, ProviderErrorForChainSpec, ProviderRequest, ResponseWithCallTraces,
+    MethodInvocation, Provider, ProviderError, ProviderErrorForChainSpec, ProviderRequest,
+    ResponseWithCallTraces,
 };
-use edr_solidity::contract_decoder::ContractDecoder;
 use edr_test_utils::secret_key::secret_key_to_address;
-use parking_lot::RwLock;
-use tokio::runtime;
+
+use crate::common::provider::new_provider_with_config;
 
 const TRANSACTION_GAS_CAP: u64 = 50_000;
 const EXCEEDS_TRANSACTION_GAS_LIMIT: u64 = TRANSACTION_GAS_CAP + 1;
@@ -26,23 +23,11 @@ fn new_provider(
     auto_mine: bool,
     transaction_gas_cap: Option<u64>,
 ) -> anyhow::Result<Provider<L1ChainSpec>> {
-    let mut config = create_test_config();
-    config.hardfork = edr_chain_l1::Hardfork::Osaka;
-    config.transaction_gas_cap = transaction_gas_cap;
-    config.mining.auto_mine = auto_mine;
-
-    let logger = Box::new(NoopLogger::<L1ChainSpec>::default());
-    let subscriber = Box::new(|_event| {});
-    let provider = Provider::new(
-        runtime::Handle::current(),
-        logger,
-        subscriber,
-        config,
-        Arc::new(RwLock::<ContractDecoder>::default()),
-        CurrentTime,
-    )?;
-
-    Ok(provider)
+    new_provider_with_config(|config| {
+        config.hardfork = edr_chain_l1::Hardfork::Osaka;
+        config.transaction_gas_cap = transaction_gas_cap;
+        config.mining.auto_mine = auto_mine;
+    })
 }
 
 fn send_transaction(

--- a/crates/edr_provider/tests/integration/eip7843.rs
+++ b/crates/edr_provider/tests/integration/eip7843.rs
@@ -26,6 +26,8 @@ use edr_solidity::contract_decoder::ContractDecoder;
 use parking_lot::RwLock;
 use tokio::runtime;
 
+use crate::common::provider::new_provider;
+
 const SLOT_NUMBER_JSON_KEY: &str = "slotNumber";
 
 const SENDER: Address = address!("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
@@ -41,25 +43,6 @@ const SENDER: Address = address!("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
 // TODO: once Solidity exposes SLOTNUM, replace this hand-assembled bytecode
 // with a compiled Solidity source for readability.
 const SLOT_NUMBER_CONTRACT: Bytes = bytes!("0x6009600c60003960096000f34b60005260206000f3");
-
-fn new_provider(hardfork: edr_chain_l1::Hardfork) -> anyhow::Result<Provider<L1ChainSpec>> {
-    let logger = Box::new(NoopLogger::<L1ChainSpec>::default());
-    let subscriber = Box::new(|_event| {});
-
-    let mut config = create_test_config();
-    config.hardfork = hardfork;
-
-    let provider = Provider::new(
-        runtime::Handle::current(),
-        logger,
-        subscriber,
-        config,
-        Arc::new(RwLock::<ContractDecoder>::default()),
-        CurrentTime,
-    )?;
-
-    Ok(provider)
-}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn block_header_includes_slot_number_on_amsterdam() -> anyhow::Result<()> {

--- a/crates/edr_provider/tests/integration/eip7928.rs
+++ b/crates/edr_provider/tests/integration/eip7928.rs
@@ -6,42 +6,16 @@
 //! From Amsterdam onward, the block header carries a `blockAccessListHash`
 //! field. On earlier hardforks the field is omitted from the RPC response.
 
-use std::sync::Arc;
-
-use edr_chain_l1::{rpc::block::L1RpcBlock, L1ChainSpec};
+use edr_chain_l1::rpc::block::L1RpcBlock;
 use edr_primitives::{address, Address, B256, KECCAK_RLP_EMPTY_ARRAY, U256};
-use edr_provider::{
-    test_utils::{create_test_config, get_latest_block, mine_block, transfer_value},
-    time::CurrentTime,
-    NoopLogger, Provider,
-};
-use edr_solidity::contract_decoder::ContractDecoder;
-use parking_lot::RwLock;
-use tokio::runtime;
+use edr_provider::test_utils::{get_latest_block, mine_block, transfer_value};
+
+use crate::common::provider::new_provider;
 
 const BLOCK_ACCESS_LIST_HASH_JSON_KEY: &str = "blockAccessListHash";
 
 const SENDER: Address = address!("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
 const RECIPIENT: Address = address!("0x70997970C51812dc3A010C7d01b50e0d17dc79C8");
-
-fn new_provider(hardfork: edr_chain_l1::Hardfork) -> anyhow::Result<Provider<L1ChainSpec>> {
-    let logger = Box::new(NoopLogger::<L1ChainSpec>::default());
-    let subscriber = Box::new(|_event| {});
-
-    let mut config = create_test_config();
-    config.hardfork = hardfork;
-
-    let provider = Provider::new(
-        runtime::Handle::current(),
-        logger,
-        subscriber,
-        config,
-        Arc::new(RwLock::<ContractDecoder>::default()),
-        CurrentTime,
-    )?;
-
-    Ok(provider)
-}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn block_header_includes_block_access_list_hash_on_amsterdam() -> anyhow::Result<()> {
@@ -102,14 +76,17 @@ async fn block_header_omits_block_access_list_hash_before_amsterdam() -> anyhow:
 
 #[cfg(feature = "test-remote")]
 mod fork {
+    use edr_chain_l1::L1ChainSpec;
     use edr_primitives::HashMap;
     use edr_provider::{
         config::ForkConfig,
         test_utils::{create_test_config_with, MinimalProviderConfig},
+        Provider,
     };
     use edr_test_utils::env::json_rpc_url_provider;
 
     use super::*;
+    use crate::common::provider::new_provider_from_config;
 
     /// Mines a state-modifying block and returns its block access list hash.
     fn mine_and_get_bal_hash(provider: &Provider<L1ChainSpec>) -> B256 {
@@ -125,9 +102,6 @@ mod fork {
     // forked mode.
     #[tokio::test(flavor = "multi_thread")]
     async fn block_access_list_hash_differs_across_forked_amsterdam_blocks() -> anyhow::Result<()> {
-        let logger = Box::new(NoopLogger::<L1ChainSpec>::default());
-        let subscriber = Box::new(|_event| {});
-
         let mut config =
             create_test_config_with(MinimalProviderConfig::fork_with_accounts(ForkConfig {
                 block_number: Some(20_384_300),
@@ -138,14 +112,7 @@ mod fork {
             }));
         config.hardfork = edr_chain_l1::Hardfork::Amsterdam;
 
-        let provider = Provider::new(
-            runtime::Handle::current(),
-            logger,
-            subscriber,
-            config,
-            Arc::new(RwLock::<ContractDecoder>::default()),
-            CurrentTime,
-        )?;
+        let provider = new_provider_from_config(config)?;
 
         let first_block = mine_and_get_bal_hash(&provider);
         let second_block = mine_and_get_bal_hash(&provider);

--- a/crates/edr_provider/tests/integration/estimate_gas.rs
+++ b/crates/edr_provider/tests/integration/estimate_gas.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "test-utils")]
 
-use std::{num::NonZeroU64, str::FromStr, sync::Arc};
+use std::{num::NonZeroU64, str::FromStr};
 
 use edr_chain_l1::{
     rpc::{call::L1CallRequest, TransactionRequest},
@@ -11,14 +11,12 @@ use edr_primitives::{bytes, Address, Bytes, U256, U64};
 use edr_provider::{
     config::{GasEstimationMode, ProviderConfig},
     test_utils::{create_test_config, deploy_contract},
-    time::CurrentTime,
-    MethodInvocation, NoopLogger, Provider, ProviderError, ProviderErrorForChainSpec,
-    ProviderRequest, TransactionFailureReason,
+    MethodInvocation, Provider, ProviderError, ProviderErrorForChainSpec, ProviderRequest,
+    TransactionFailureReason,
 };
 use edr_signer::public_key_to_address;
-use edr_solidity::contract_decoder::ContractDecoder;
-use parking_lot::RwLock;
-use tokio::runtime;
+
+use crate::common::provider::new_provider_from_config;
 
 const INTERNAL_OOG_BYTECODE: &str =
     include_str!("../../../../data/deployment_bytecode/InternalOOGContract.bin");
@@ -42,14 +40,7 @@ fn new_provider(
             .expect("config should have an account")
             .public_key(),
     );
-    let provider = Provider::new(
-        runtime::Handle::current(),
-        Box::new(NoopLogger::<L1ChainSpec>::default()),
-        Box::new(|_event| {}),
-        config,
-        Arc::new(RwLock::<ContractDecoder>::default()),
-        CurrentTime,
-    )?;
+    let provider = new_provider_from_config(config)?;
     Ok((provider, from))
 }
 


### PR DESCRIPTION
- create new `tests::common::provider` module
- extract `new_provider` and similar customizable functions, together with `send_transaction` helper into it
