### PR TITLE
fix: validate interval mining and always restart its timer

### DIFF
--- a/.changeset/tidy-otters-wander.md
+++ b/.changeset/tidy-otters-wander.md
@@ -2,10 +2,8 @@
 "@nomicfoundation/edr": minor
 ---
 
-Interval mining now validates its configuration up front. A `[min, max]` interval range must satisfy `1 <= min <= max`, and is rejected when the provider is created, when `evm_setIntervalMining` is called (JSON-RPC error `-32602`), and when a recorded scenario is loaded.
+Fixed interval mining accepting a `[min, max]` range that it could not honour. A range with `min > max` crashed the provider on its first interval-mined block, and `[0, 0]` starved the provider of incoming requests. A range must now satisfy `1 <= min <= max`, and is rejected when the provider is created, when `evm_setIntervalMining` is called (JSON-RPC error `-32602`), and when a recorded scenario is loaded. Both bounds remain inclusive.
 
-This is a breaking change: `[0, 0]` and `[0, N]` were previously accepted. `[0, 0]` starved the provider of incoming requests, and a range with `min > max` crashed the provider on its first interval-mined block, so neither previously worked as configured — but a configuration that Hardhat forwards today will now fail at provider creation. Hardhat converts a scalar `0` to "disabled" before reaching EDR; it does not yet normalise a zero minimum inside a range, which it must do to guarantee forwards compatibility.
+Fixed `evm_setIntervalMining` not restarting the interval timer when called with the interval that was already configured. A range draws a new interval before each block, so an unchanged configuration does not imply an unchanged schedule.
 
-Both bounds remain inclusive.
-
-`evm_setIntervalMining` now restarts the interval timer on every call, including when it sets the interval that is already configured, matching Hardhat.
+BREAKING CHANGE: `[0, 0]` and `[0, N]` interval ranges are no longer accepted. Neither previously worked as configured, but a configuration that is forwarded today will now fail when the provider is created. A scalar `0` still disables interval mining; a zero minimum inside a range must be normalised by the caller.

--- a/.changeset/tidy-otters-wander.md
+++ b/.changeset/tidy-otters-wander.md
@@ -1,0 +1,11 @@
+---
+"@nomicfoundation/edr": minor
+---
+
+Interval mining now validates its configuration up front. A `[min, max]` interval range must satisfy `1 <= min <= max`, and is rejected when the provider is created, when `evm_setIntervalMining` is called (JSON-RPC error `-32602`), and when a recorded scenario is loaded.
+
+This is a breaking change: `[0, 0]` and `[0, N]` were previously accepted. `[0, 0]` starved the provider of incoming requests, and a range with `min > max` crashed the provider on its first interval-mined block, so neither previously worked as configured — but a configuration that Hardhat forwards today will now fail at provider creation. Hardhat converts a scalar `0` to "disabled" before reaching EDR; it does not yet normalise a zero minimum inside a range, which it must do to guarantee forwards compatibility.
+
+Both bounds remain inclusive.
+
+`evm_setIntervalMining` now restarts the interval timer on every call, including when it sets the interval that is already configured, matching Hardhat.

--- a/crates/edr_napi/src/config.rs
+++ b/crates/edr_napi/src/config.rs
@@ -466,10 +466,13 @@ impl TryFrom<MiningConfig> for edr_provider::config::Mining {
                         edr_provider::config::Interval::Fixed(interval)
                     }
                     Either::B(IntervalRange { min, max }) => {
-                        edr_provider::config::Interval::Range {
-                            min: min.try_cast()?,
-                            max: max.try_cast()?,
-                        }
+                        let bounds = [min.try_cast()?, max.try_cast()?];
+                        let range = edr_provider::config::IntervalRangeConfig::try_from(bounds)
+                            .map_err(|error| {
+                                napi::Error::new(napi::Status::InvalidArg, error.to_string())
+                            })?;
+
+                        edr_provider::config::Interval::Range(range)
                     }
                 };
 

--- a/crates/edr_provider/src/config.rs
+++ b/crates/edr_provider/src/config.rs
@@ -153,9 +153,8 @@ impl From<IntervalRangeConfig> for IntervalConfig {
 
 /// An inclusive range of interval-mining intervals, in milliseconds.
 ///
-/// Non-empty and free of zeroes by construction, so
-/// [`IntervalRangeConfig::generate_interval`] can neither panic nor return
-/// zero. Deserialization upholds the same invariant.
+/// Non-empty and free of zeroes by construction, including through
+/// deserialization.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(try_from = "UncheckedIntervalRange")]
 pub struct IntervalRangeConfig {
@@ -190,6 +189,8 @@ impl IntervalRangeConfig {
 
     /// Draws an interval uniformly from the range, in milliseconds. Both
     /// bounds are inclusive.
+    ///
+    /// Never returns zero and never panics.
     pub fn generate_interval(&self) -> NonZeroU64 {
         // `min <= max` is an invariant of the type, so the subtraction cannot
         // underflow and `0..=span` is never empty.

--- a/crates/edr_provider/src/config.rs
+++ b/crates/edr_provider/src/config.rs
@@ -115,49 +115,145 @@ pub struct LocalConfig {
 }
 
 /// Configuration for interval mining.
+///
+/// Every representable value yields a non-zero interval.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-#[serde(rename_all_fields = "camelCase")]
 pub enum IntervalConfig {
+    /// Mine a block every `n` milliseconds.
     Fixed(NonZeroU64),
-    Range { min: u64, max: u64 },
+    /// Mine a block every `n` milliseconds, where `n` is drawn from the range
+    /// anew before each block.
+    Range(IntervalRangeConfig),
 }
 
 impl IntervalConfig {
-    /// Generates a (random) interval based on the configuration.
-    pub fn generate_interval(&self) -> u64 {
+    /// Generates a (random) interval in milliseconds, based on the
+    /// configuration.
+    pub fn generate_interval(&self) -> NonZeroU64 {
         match self {
-            IntervalConfig::Fixed(interval) => interval.get(),
-            IntervalConfig::Range { min, max } => rand::rng().random_range(*min..=*max),
+            IntervalConfig::Fixed(interval) => *interval,
+            IntervalConfig::Range(range) => range.generate_interval(),
         }
     }
 }
 
-/// An error that occurs when trying to convert [`IntervalConfigRequest`] to an
-/// `Option<IntervalConfig>`.
+impl From<NonZeroU64> for IntervalConfig {
+    fn from(value: NonZeroU64) -> Self {
+        Self::Fixed(value)
+    }
+}
+
+impl From<IntervalRangeConfig> for IntervalConfig {
+    fn from(value: IntervalRangeConfig) -> Self {
+        Self::Range(value)
+    }
+}
+
+/// An inclusive range of interval-mining intervals, in milliseconds.
+///
+/// Non-empty and free of zeroes by construction, so
+/// [`IntervalRangeConfig::generate_interval`] can neither panic nor return
+/// zero. Deserialization is validated through [`UncheckedIntervalRange`].
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(try_from = "UncheckedIntervalRange")]
+pub struct IntervalRangeConfig {
+    min: NonZeroU64,
+    max: NonZeroU64,
+}
+
+impl IntervalRangeConfig {
+    /// Constructs a new instance from inclusive bounds in milliseconds.
+    ///
+    /// Fails if `min` exceeds `max`.
+    pub const fn new(
+        min: NonZeroU64,
+        max: NonZeroU64,
+    ) -> Result<Self, IntervalConfigConversionError> {
+        if min.get() > max.get() {
+            Err(IntervalConfigConversionError::MinGreaterThanMax)
+        } else {
+            Ok(Self { min, max })
+        }
+    }
+
+    /// Returns the inclusive lower bound, in milliseconds.
+    pub const fn min(&self) -> NonZeroU64 {
+        self.min
+    }
+
+    /// Returns the inclusive upper bound, in milliseconds.
+    pub const fn max(&self) -> NonZeroU64 {
+        self.max
+    }
+
+    /// Draws an interval uniformly from the range, in milliseconds. Both
+    /// bounds are inclusive.
+    pub fn generate_interval(&self) -> NonZeroU64 {
+        // `min <= max` is an invariant of the type, so the subtraction cannot
+        // underflow and `0..=span` is never empty.
+        let span = self.max.get() - self.min.get();
+        let offset = rand::rng().random_range(0..=span);
+
+        self.min
+            .checked_add(offset)
+            .expect("`min + offset` is at most `max`")
+    }
+}
+
+impl TryFrom<[u64; 2]> for IntervalRangeConfig {
+    type Error = IntervalConfigConversionError;
+
+    fn try_from([min, max]: [u64; 2]) -> Result<Self, Self::Error> {
+        let min = NonZeroU64::new(min).ok_or(IntervalConfigConversionError::MinIsZero)?;
+
+        // `min` is non-zero, so a zero `max` is smaller than `min`.
+        let max = NonZeroU64::new(max).ok_or(IntervalConfigConversionError::MinGreaterThanMax)?;
+
+        Self::new(min, max)
+    }
+}
+
+/// The unvalidated wire representation of [`IntervalRangeConfig`].
+///
+/// Deserializing through this type prevents a scenario file from bypassing the
+/// range's invariants.
+#[derive(Deserialize)]
+struct UncheckedIntervalRange {
+    min: u64,
+    max: u64,
+}
+
+impl TryFrom<UncheckedIntervalRange> for IntervalRangeConfig {
+    type Error = IntervalConfigConversionError;
+
+    fn try_from(value: UncheckedIntervalRange) -> Result<Self, Self::Error> {
+        Self::try_from([value.min, value.max])
+    }
+}
+
+/// An error that occurs when an interval-mining configuration is invalid.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum IntervalConfigConversionError {
+    /// The minimum value in the range is zero.
+    #[error("Minimum value in range must be greater than zero")]
+    MinIsZero,
     /// The minimum value in the range is greater than the maximum value.
     #[error("Minimum value in range is greater than maximum value")]
     MinGreaterThanMax,
 }
 
-impl TryInto<Option<IntervalConfig>> for IntervalConfigRequest {
+impl TryFrom<IntervalConfigRequest> for Option<IntervalConfig> {
     type Error = IntervalConfigConversionError;
 
-    fn try_into(self) -> Result<Option<IntervalConfig>, Self::Error> {
-        match self {
-            Self::FixedOrDisabled(0) => Ok(None),
-            Self::FixedOrDisabled(value) => {
+    fn try_from(value: IntervalConfigRequest) -> Result<Self, Self::Error> {
+        match value {
+            IntervalConfigRequest::FixedOrDisabled(interval) => {
                 // Zero implies disabled
-                Ok(NonZeroU64::new(value).map(IntervalConfig::Fixed))
+                Ok(NonZeroU64::new(interval).map(IntervalConfig::Fixed))
             }
-            Self::Range([min, max]) => {
-                if max >= min {
-                    Ok(Some(IntervalConfig::Range { min, max }))
-                } else {
-                    Err(IntervalConfigConversionError::MinGreaterThanMax)
-                }
-            }
+            IntervalConfigRequest::Range(bounds) => IntervalRangeConfig::try_from(bounds)
+                .map(|range| Some(IntervalConfig::Range(range))),
         }
     }
 }
@@ -247,6 +343,235 @@ impl Default for MiningConfig {
             block_gas_limit: Some(unsafe { NonZeroU64::new_unchecked(60_000_000u64) }),
             interval: None,
             mem_pool: MemPoolConfig::default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    fn non_zero(value: u64) -> NonZeroU64 {
+        NonZeroU64::new(value).expect("non-zero")
+    }
+
+    fn range(min: u64, max: u64) -> IntervalRangeConfig {
+        IntervalRangeConfig::try_from([min, max]).expect("valid range")
+    }
+
+    #[test]
+    fn interval_range_rejects_zero_minimum() {
+        for bounds in [[0, 0], [0, 5]] {
+            assert!(matches!(
+                IntervalRangeConfig::try_from(bounds),
+                Err(IntervalConfigConversionError::MinIsZero)
+            ));
+        }
+    }
+
+    #[test]
+    fn interval_range_rejects_zero_maximum() {
+        assert!(matches!(
+            IntervalRangeConfig::try_from([1, 0]),
+            Err(IntervalConfigConversionError::MinGreaterThanMax)
+        ));
+    }
+
+    #[test]
+    fn interval_range_rejects_min_greater_than_max() {
+        for bounds in [[5, 1], [u64::MAX, 1]] {
+            assert!(matches!(
+                IntervalRangeConfig::try_from(bounds),
+                Err(IntervalConfigConversionError::MinGreaterThanMax)
+            ));
+        }
+    }
+
+    #[test]
+    fn interval_range_accepts_equal_bounds() {
+        let range = range(5, 5);
+
+        assert_eq!(range.min(), non_zero(5));
+        assert_eq!(range.max(), non_zero(5));
+    }
+
+    #[test]
+    fn interval_range_accepts_ascending_bounds() {
+        let range = range(1, u64::MAX);
+
+        assert_eq!(range.min(), non_zero(1));
+        assert_eq!(range.max(), non_zero(u64::MAX));
+    }
+
+    /// A range whose bounds coincide is not collapsed into
+    /// [`IntervalConfig::Fixed`], so that a configuration round-trips to the
+    /// representation it was written as.
+    #[test]
+    fn interval_range_is_not_normalized_to_fixed() {
+        assert_ne!(
+            IntervalConfig::from(range(5, 5)),
+            IntervalConfig::Fixed(non_zero(5))
+        );
+    }
+
+    #[test]
+    fn fixed_generates_the_configured_interval() {
+        let config = IntervalConfig::Fixed(non_zero(7));
+
+        assert_eq!(config.generate_interval(), non_zero(7));
+    }
+
+    #[test]
+    fn interval_range_with_equal_bounds_is_deterministic() {
+        let range = range(5, 5);
+
+        for _ in 0..100 {
+            assert_eq!(range.generate_interval(), non_zero(5));
+        }
+    }
+
+    #[test]
+    fn interval_range_generates_values_within_bounds() {
+        let range = range(2, 4);
+
+        for _ in 0..1_000 {
+            let interval = range.generate_interval().get();
+            assert!((2..=4).contains(&interval), "{interval} is out of bounds");
+        }
+    }
+
+    /// Pins that both bounds are inclusive. Hardhat draws from a max-exclusive
+    /// range; EDR does not.
+    #[test]
+    fn interval_range_includes_both_bounds() {
+        let range = range(1, 2);
+
+        let mut seen_min = false;
+        let mut seen_max = false;
+        for _ in 0..1_000 {
+            match range.generate_interval().get() {
+                1 => seen_min = true,
+                2 => seen_max = true,
+                other => panic!("{other} is out of bounds"),
+            }
+        }
+
+        assert!(seen_min && seen_max);
+    }
+
+    /// Recorded scenario files carry a serialized [`MiningConfig`], so this
+    /// representation cannot change without invalidating them.
+    #[test]
+    fn interval_config_serializes_to_externally_tagged_json() -> anyhow::Result<()> {
+        let fixed = IntervalConfig::Fixed(non_zero(1000));
+        assert_eq!(serde_json::to_value(&fixed)?, json!({ "Fixed": 1000 }));
+        assert_eq!(
+            serde_json::from_value::<IntervalConfig>(json!({ "Fixed": 1000 }))?,
+            fixed
+        );
+
+        let ranged = IntervalConfig::from(range(1000, 5000));
+        let ranged_json = json!({ "Range": { "min": 1000, "max": 5000 } });
+        assert_eq!(serde_json::to_value(&ranged)?, ranged_json);
+        assert_eq!(
+            serde_json::from_value::<IntervalConfig>(ranged_json)?,
+            ranged
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn mining_config_round_trips_an_interval_range() -> anyhow::Result<()> {
+        let config = MiningConfig {
+            auto_mine: true,
+            block_gas_limit: None,
+            interval: Some(IntervalConfig::from(range(1000, 5000))),
+            mem_pool: MemPoolConfig {
+                order: MineOrdering::Priority,
+            },
+        };
+
+        assert_eq!(
+            serde_json::to_value(&config)?,
+            json!({
+                "autoMine": true,
+                "blockGasLimit": null,
+                "interval": { "Range": { "min": 1000, "max": 5000 } },
+                "memPool": { "order": "Priority" },
+            })
+        );
+
+        let deserialized: MiningConfig = serde_json::from_value(serde_json::to_value(&config)?)?;
+        assert_eq!(deserialized.interval, config.interval);
+
+        Ok(())
+    }
+
+    #[test]
+    fn deserializing_an_invalid_interval_range_fails() {
+        for bounds in [json!({ "min": 0, "max": 5 }), json!({ "min": 5, "max": 1 })] {
+            let error = serde_json::from_value::<IntervalConfig>(json!({ "Range": bounds }))
+                .expect_err("the range is invalid");
+
+            assert!(
+                error.to_string().contains("Minimum value in range"),
+                "unexpected error: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn deserializing_a_zero_fixed_interval_fails() {
+        assert!(serde_json::from_value::<IntervalConfig>(json!({ "Fixed": 0 })).is_err());
+    }
+
+    /// Scenario files are deserialized as a whole [`MiningConfig`], which is
+    /// the path that must reject an invalid range.
+    #[test]
+    fn deserializing_a_mining_config_with_an_invalid_range_fails() {
+        let json = json!({
+            "autoMine": true,
+            "blockGasLimit": null,
+            "interval": { "Range": { "min": 0, "max": 0 } },
+            "memPool": { "order": "Priority" },
+        });
+
+        assert!(serde_json::from_value::<MiningConfig>(json).is_err());
+    }
+
+    #[test]
+    fn a_zero_request_interval_disables_interval_mining() -> anyhow::Result<()> {
+        let config: Option<IntervalConfig> =
+            IntervalConfigRequest::FixedOrDisabled(0).try_into()?;
+
+        assert_eq!(config, None);
+
+        Ok(())
+    }
+
+    #[test]
+    fn a_request_interval_is_converted() -> anyhow::Result<()> {
+        let fixed: Option<IntervalConfig> =
+            IntervalConfigRequest::FixedOrDisabled(1000).try_into()?;
+        assert_eq!(fixed, Some(IntervalConfig::Fixed(non_zero(1000))));
+
+        let ranged: Option<IntervalConfig> =
+            IntervalConfigRequest::Range([1000, 5000]).try_into()?;
+        assert_eq!(ranged, Some(IntervalConfig::from(range(1000, 5000))));
+
+        Ok(())
+    }
+
+    #[test]
+    fn an_invalid_request_range_is_rejected() {
+        for bounds in [[0, 0], [0, 5000], [5000, 1000]] {
+            let result: Result<Option<IntervalConfig>, _> =
+                IntervalConfigRequest::Range(bounds).try_into();
+
+            assert!(result.is_err(), "{bounds:?} should be rejected");
         }
     }
 }

--- a/crates/edr_provider/src/config.rs
+++ b/crates/edr_provider/src/config.rs
@@ -153,7 +153,7 @@ impl From<IntervalRangeConfig> for IntervalConfig {
 ///
 /// Non-empty and free of zeroes by construction, so
 /// [`IntervalRangeConfig::generate_interval`] can neither panic nor return
-/// zero. Deserialization is validated through [`UncheckedIntervalRange`].
+/// zero. Deserialization upholds the same invariant.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(try_from = "UncheckedIntervalRange")]
 pub struct IntervalRangeConfig {

--- a/crates/edr_provider/src/config.rs
+++ b/crates/edr_provider/src/config.rs
@@ -117,7 +117,7 @@ pub struct LocalConfig {
 /// Configuration for interval mining.
 ///
 /// Every representable value yields a non-zero interval.
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum IntervalConfig {
     /// Mine a block every `n` milliseconds.
     Fixed(NonZeroU64),
@@ -154,7 +154,7 @@ impl From<IntervalRangeConfig> for IntervalConfig {
 /// Non-empty and free of zeroes by construction, so
 /// [`IntervalRangeConfig::generate_interval`] can neither panic nor return
 /// zero. Deserialization is validated through [`UncheckedIntervalRange`].
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(try_from = "UncheckedIntervalRange")]
 pub struct IntervalRangeConfig {
     min: NonZeroU64,
@@ -410,10 +410,10 @@ mod tests {
     /// representation it was written as.
     #[test]
     fn interval_range_is_not_normalized_to_fixed() {
-        assert_ne!(
+        assert!(matches!(
             IntervalConfig::from(range(5, 5)),
-            IntervalConfig::Fixed(non_zero(5))
-        );
+            IntervalConfig::Range(_)
+        ));
     }
 
     #[test]
@@ -432,6 +432,9 @@ mod tests {
         }
     }
 
+    /// Both bounds are inclusive. A max-exclusive draw would make
+    /// [`interval_range_with_equal_bounds_is_deterministic`] sample an empty
+    /// range, which panics.
     #[test]
     fn interval_range_generates_values_within_bounds() {
         let range = range(2, 4);
@@ -442,43 +445,25 @@ mod tests {
         }
     }
 
-    /// Pins that both bounds are inclusive. Hardhat draws from a max-exclusive
-    /// range; EDR does not.
-    #[test]
-    fn interval_range_includes_both_bounds() {
-        let range = range(1, 2);
-
-        let mut seen_min = false;
-        let mut seen_max = false;
-        for _ in 0..1_000 {
-            match range.generate_interval().get() {
-                1 => seen_min = true,
-                2 => seen_max = true,
-                other => panic!("{other} is out of bounds"),
-            }
-        }
-
-        assert!(seen_min && seen_max);
-    }
-
     /// Recorded scenario files carry a serialized [`MiningConfig`], so this
     /// representation cannot change without invalidating them.
     #[test]
     fn interval_config_serializes_to_externally_tagged_json() -> anyhow::Result<()> {
-        let fixed = IntervalConfig::Fixed(non_zero(1000));
-        assert_eq!(serde_json::to_value(&fixed)?, json!({ "Fixed": 1000 }));
-        assert_eq!(
-            serde_json::from_value::<IntervalConfig>(json!({ "Fixed": 1000 }))?,
-            fixed
-        );
+        for (config, expected) in [
+            (
+                IntervalConfig::Fixed(non_zero(1000)),
+                json!({ "Fixed": 1000 }),
+            ),
+            (
+                IntervalConfig::from(range(1000, 5000)),
+                json!({ "Range": { "min": 1000, "max": 5000 } }),
+            ),
+        ] {
+            assert_eq!(serde_json::to_value(&config)?, expected);
 
-        let ranged = IntervalConfig::from(range(1000, 5000));
-        let ranged_json = json!({ "Range": { "min": 1000, "max": 5000 } });
-        assert_eq!(serde_json::to_value(&ranged)?, ranged_json);
-        assert_eq!(
-            serde_json::from_value::<IntervalConfig>(ranged_json)?,
-            ranged
-        );
+            let deserialized: IntervalConfig = serde_json::from_value(expected.clone())?;
+            assert_eq!(serde_json::to_value(&deserialized)?, expected);
+        }
 
         Ok(())
     }
@@ -494,18 +479,16 @@ mod tests {
             },
         };
 
-        assert_eq!(
-            serde_json::to_value(&config)?,
-            json!({
-                "autoMine": true,
-                "blockGasLimit": null,
-                "interval": { "Range": { "min": 1000, "max": 5000 } },
-                "memPool": { "order": "Priority" },
-            })
-        );
+        let expected = json!({
+            "autoMine": true,
+            "blockGasLimit": null,
+            "interval": { "Range": { "min": 1000, "max": 5000 } },
+            "memPool": { "order": "Priority" },
+        });
+        assert_eq!(serde_json::to_value(&config)?, expected);
 
-        let deserialized: MiningConfig = serde_json::from_value(serde_json::to_value(&config)?)?;
-        assert_eq!(deserialized.interval, config.interval);
+        let deserialized: MiningConfig = serde_json::from_value(expected.clone())?;
+        assert_eq!(serde_json::to_value(&deserialized)?, expected);
 
         Ok(())
     }
@@ -547,7 +530,7 @@ mod tests {
         let config: Option<IntervalConfig> =
             IntervalConfigRequest::FixedOrDisabled(0).try_into()?;
 
-        assert_eq!(config, None);
+        assert!(config.is_none());
 
         Ok(())
     }
@@ -556,11 +539,18 @@ mod tests {
     fn a_request_interval_is_converted() -> anyhow::Result<()> {
         let fixed: Option<IntervalConfig> =
             IntervalConfigRequest::FixedOrDisabled(1000).try_into()?;
-        assert_eq!(fixed, Some(IntervalConfig::Fixed(non_zero(1000))));
+        let Some(IntervalConfig::Fixed(interval)) = fixed else {
+            panic!("expected a fixed interval");
+        };
+        assert_eq!(interval, non_zero(1000));
 
         let ranged: Option<IntervalConfig> =
             IntervalConfigRequest::Range([1000, 5000]).try_into()?;
-        assert_eq!(ranged, Some(IntervalConfig::from(range(1000, 5000))));
+        let Some(IntervalConfig::Range(bounds)) = ranged else {
+            panic!("expected an interval range");
+        };
+        assert_eq!(bounds.min(), non_zero(1000));
+        assert_eq!(bounds.max(), non_zero(5000));
 
         Ok(())
     }

--- a/crates/edr_provider/src/config.rs
+++ b/crates/edr_provider/src/config.rs
@@ -127,8 +127,10 @@ pub enum IntervalConfig {
 }
 
 impl IntervalConfig {
-    /// Generates a (random) interval in milliseconds, based on the
-    /// configuration.
+    /// Returns the milliseconds to wait before mining the next block.
+    ///
+    /// A range draws a new value on each call. A fixed interval, and a range
+    /// with equal bounds, always return the same value.
     pub fn generate_interval(&self) -> NonZeroU64 {
         match self {
             IntervalConfig::Fixed(interval) => *interval,

--- a/crates/edr_provider/src/data.rs
+++ b/crates/edr_provider/src/data.rs
@@ -266,6 +266,8 @@ pub struct ProviderData<
     gas_estimation_mode: GasEstimationMode,
     is_auto_mining: bool,
     interval_config: Option<IntervalConfig>,
+    /// Signals the event loop to restart the interval-mining timer.
+    interval_reconfigured: bool,
     pub irregular_state: IrregularState,
     mem_pool: MemPool<ChainSpecT::SignedTransaction>,
     mining_order: MineOrdering,
@@ -445,8 +447,14 @@ where
 
     /// Sets the interval mining configuration. `None` disables interval
     /// mining.
+    ///
+    /// Always signals a restart of the interval-mining timer, including for the
+    /// configuration that is already set. Equality of two configurations does
+    /// not imply an equal schedule, because a range is drawn anew before each
+    /// block, so it must not be used to decide whether to restart.
     pub fn set_interval_config(&mut self, interval_config: Option<IntervalConfig>) {
         self.interval_config = interval_config;
+        self.interval_reconfigured = true;
     }
 
     /// Sets the coinbase.
@@ -460,6 +468,12 @@ where
 
     pub fn stop_impersonating_account(&mut self, address: Address) -> bool {
         self.impersonated_accounts.remove(&address)
+    }
+
+    /// Returns whether [`Self::set_interval_config`] was called since this was
+    /// last called, clearing the signal.
+    pub fn take_interval_reconfigured(&mut self) -> bool {
+        std::mem::take(&mut self.interval_reconfigured)
     }
 
     /// Returns the transaction gas cap, if set.
@@ -785,6 +799,7 @@ where
             gas_estimation_mode,
             is_auto_mining,
             interval_config,
+            interval_reconfigured: false,
             irregular_state,
             mem_pool: MemPool::new(block_gas_limit, transaction_gas_cap),
             mining_order,
@@ -3220,6 +3235,35 @@ mod tests {
         console_log::tests::{deploy_console_log_contract, ConsoleLogTransaction},
         test_utils::{create_test_config, one_ether, ProviderTestFixture},
     };
+
+    /// Hardhat restarts its mining timer on every `evm_setIntervalMining`,
+    /// including for the block time it already has. It deliberately dropped the
+    /// same-value short-circuit from `MiningTimer.setBlockTime` in commit
+    /// `1929c977c`.
+    #[test]
+    fn set_interval_config_always_signals_a_restart() -> anyhow::Result<()> {
+        let mut fixture = ProviderTestFixture::<L1ChainSpec>::new_local()?;
+        let data = &mut fixture.provider_data;
+
+        assert!(!data.take_interval_reconfigured());
+
+        let interval = IntervalConfig::Fixed(NonZeroU64::new(100).expect("non-zero"));
+
+        data.set_interval_config(Some(interval.clone()));
+        assert!(data.take_interval_reconfigured());
+        assert!(
+            !data.take_interval_reconfigured(),
+            "the signal is taken once"
+        );
+
+        data.set_interval_config(Some(interval));
+        assert!(data.take_interval_reconfigured());
+
+        data.set_interval_config(None);
+        assert!(data.take_interval_reconfigured());
+
+        Ok(())
+    }
 
     #[test]
     fn test_local_account_balance() -> anyhow::Result<()> {

--- a/crates/edr_provider/src/data.rs
+++ b/crates/edr_provider/src/data.rs
@@ -449,9 +449,9 @@ where
     /// mining.
     ///
     /// Always signals a restart of the interval-mining timer, including for the
-    /// configuration that is already set. Equality of two configurations does
-    /// not imply an equal schedule, because a range is drawn anew before each
-    /// block, so it must not be used to decide whether to restart.
+    /// configuration that is already set: a range draws a new interval before
+    /// each block, so an unchanged configuration does not imply an unchanged
+    /// schedule.
     pub fn set_interval_config(&mut self, interval_config: Option<IntervalConfig>) {
         self.interval_config = interval_config;
         self.interval_reconfigured = true;
@@ -3236,10 +3236,8 @@ mod tests {
         test_utils::{create_test_config, one_ether, ProviderTestFixture},
     };
 
-    /// Hardhat restarts its mining timer on every `evm_setIntervalMining`,
-    /// including for the block time it already has. It deliberately dropped the
-    /// same-value short-circuit from `MiningTimer.setBlockTime` in commit
-    /// `1929c977c`.
+    /// Every call signals a restart, including one that sets the configuration
+    /// that is already in place.
     #[test]
     fn set_interval_config_always_signals_a_restart() -> anyhow::Result<()> {
         let mut fixture = ProviderTestFixture::<L1ChainSpec>::new_local()?;

--- a/crates/edr_provider/src/event_loop.rs
+++ b/crates/edr_provider/src/event_loop.rs
@@ -3,7 +3,7 @@
 //! The loop's thread owns the [`ProviderData`] outright; all access goes
 //! through [`Message`]s, so no locking is needed. The loop also owns the
 //! interval-mining timer, restarting it whenever a request reconfigured it —
-//! including to the interval already set, as Hardhat does.
+//! including to the interval already set.
 
 use std::{
     convert::Infallible,
@@ -101,8 +101,8 @@ pub(crate) enum Message<ChainSpecT: ProviderChainSpec> {
 /// Creates a channel that yields once the next interval-mined block is due.
 ///
 /// Yields nothing if interval mining is disabled. The interval is measured from
-/// the end of the previous mine, as Hardhat measures it, so the period between
-/// blocks is the interval plus the time spent mining.
+/// the end of the previous mine, so the period between blocks is the interval
+/// plus the time spent mining.
 ///
 /// Measuring from the end is what keeps interval mining from starving request
 /// handling: the deadline is always a full interval away when the loop next
@@ -154,9 +154,6 @@ pub(crate) fn run<ChainSpecT, TimerT>(
                 Ok(Message::Request { request, on_response }) => {
                     let response = requests::execute_request(&mut data, request);
 
-                    // Armed before the response is handed back, because
-                    // `on_response` serializes it on this thread and that is not
-                    // part of the interval.
                     if data.take_interval_reconfigured() {
                         interval_timer = next_interval_timer(data.interval_config());
                     }

--- a/crates/edr_provider/src/event_loop.rs
+++ b/crates/edr_provider/src/event_loop.rs
@@ -100,11 +100,16 @@ pub(crate) enum Message<ChainSpecT: ProviderChainSpec> {
 
 /// Creates a channel that yields once the next interval-mined block is due.
 ///
-/// Yields nothing if interval mining is disabled. The interval is measured
-/// from the end of the previous mine.
+/// Yields nothing if interval mining is disabled. The interval is measured from
+/// the end of the previous mine, as Hardhat measures it, so the period between
+/// blocks is the interval plus the time spent mining.
+///
+/// Measuring from the end is what keeps interval mining from starving request
+/// handling: the deadline is always a full interval away when the loop next
+/// polls, so every cycle leaves a window in which the timer is not ready.
 fn next_interval_timer(interval_config: Option<&IntervalConfig>) -> Receiver<Instant> {
     if let Some(config) = interval_config {
-        let duration = Duration::from_millis(config.generate_interval());
+        let duration = Duration::from_millis(config.generate_interval().get());
         crossbeam_channel::after(duration)
     } else {
         crossbeam_channel::never()
@@ -137,7 +142,8 @@ pub(crate) fn run<ChainSpecT, TimerT>(
             // Checked first: shutdown must win over queued work.
             recv(cancellation_receiver) -> _ => break,
             // Checked before requests: a due block must not wait behind a long
-            // queue.
+            // queue. This cannot starve request handling; see
+            // `next_interval_timer`.
             recv(interval_timer) -> _ => {
                 if let Err(error) = data.interval_mine() {
                     log::error!("Unexpected error while performing interval mining: {error}");

--- a/crates/edr_provider/src/event_loop.rs
+++ b/crates/edr_provider/src/event_loop.rs
@@ -2,8 +2,8 @@
 //!
 //! The loop's thread owns the [`ProviderData`] outright; all access goes
 //! through [`Message`]s, so no locking is needed. The loop also owns the
-//! interval-mining timer, re-arming it from
-//! [`ProviderData::interval_config`] whenever a message may have changed it.
+//! interval-mining timer, restarting it whenever a request reconfigured it —
+//! including to the interval already set, as Hardhat does.
 
 use std::{
     convert::Infallible,
@@ -152,16 +152,16 @@ pub(crate) fn run<ChainSpecT, TimerT>(
             }
             recv(request_receiver) -> message => match message {
                 Ok(Message::Request { request, on_response }) => {
-                    let current_interval = data.interval_config().cloned();
-
                     let response = requests::execute_request(&mut data, request);
 
-                    on_response.call(response);
-
-                    // `evm_setIntervalMining` may have changed the configuration.
-                    if data.interval_config() != current_interval.as_ref() {
+                    // Armed before the response is handed back, because
+                    // `on_response` serializes it on this thread and that is not
+                    // part of the interval.
+                    if data.take_interval_reconfigured() {
                         interval_timer = next_interval_timer(data.interval_config());
                     }
+
+                    on_response.call(response);
                 }
                 Ok(Message::SetCallOverrideCallback { callback, ack }) => {
                     data.set_call_override_callback(callback);

--- a/crates/edr_provider/tests/integration/interval_mining.rs
+++ b/crates/edr_provider/tests/integration/interval_mining.rs
@@ -9,7 +9,9 @@ use std::{
 use edr_chain_l1::L1ChainSpec;
 use edr_primitives::U256;
 use edr_provider::{
-    config::IntervalConfig, test_utils::create_test_config, time::CurrentTime,
+    config::{IntervalConfig, IntervalRangeConfig},
+    test_utils::create_test_config,
+    time::CurrentTime,
     IntervalConfigRequest, MethodInvocation, NoopLogger, Provider, ProviderRequest,
 };
 use edr_solidity::contract_decoder::ContractDecoder;
@@ -117,6 +119,41 @@ async fn evm_set_interval_mining_enables_and_disables() -> anyhow::Result<()> {
         after_disable,
         "no blocks should be mined after disabling interval mining"
     );
+
+    Ok(())
+}
+
+/// A range interval arms the timer just as a fixed one does.
+#[tokio::test(flavor = "multi_thread")]
+async fn interval_mining_with_a_range_mines_blocks() -> anyhow::Result<()> {
+    let range = IntervalRangeConfig::try_from([INTERVAL_MS, 2 * INTERVAL_MS])?;
+    let provider = provider_with_interval(Some(IntervalConfig::Range(range)))?;
+
+    let start = block_number(&provider)?;
+    assert!(
+        wait_for_block_after(&provider, start)?,
+        "interval mining should produce a new block"
+    );
+
+    Ok(())
+}
+
+/// An invalid range is rejected, and rejecting it leaves the provider usable.
+/// Before the range was validated, `[2000, 1000]` panicked the thread that
+/// owns the provider's data on the first interval-mined block.
+#[tokio::test(flavor = "multi_thread")]
+async fn evm_set_interval_mining_rejects_an_invalid_range() -> anyhow::Result<()> {
+    let provider = provider_with_interval(None)?;
+
+    for bounds in [[2000, 1000], [0, 0], [0, 2000]] {
+        set_interval_mining(&provider, IntervalConfigRequest::Range(bounds))
+            .expect_err("the range is invalid");
+    }
+
+    // The provider still answers, and no interval mining was configured.
+    let start = block_number(&provider)?;
+    std::thread::sleep(Duration::from_millis(INTERVAL_MS * 4));
+    assert_eq!(block_number(&provider)?, start);
 
     Ok(())
 }

--- a/crates/edr_provider/tests/integration/interval_mining.rs
+++ b/crates/edr_provider/tests/integration/interval_mining.rs
@@ -139,8 +139,8 @@ async fn interval_mining_with_a_range_mines_blocks() -> anyhow::Result<()> {
 }
 
 /// An invalid range is rejected, and rejecting it leaves the provider usable.
-/// Before the range was validated, `[2000, 1000]` panicked the thread that
-/// owns the provider's data on the first interval-mined block.
+/// Before the range was validated, `[2000, 1000]` panicked the thread that owns
+/// the provider's data on the first interval-mined block.
 #[tokio::test(flavor = "multi_thread")]
 async fn evm_set_interval_mining_rejects_an_invalid_range() -> anyhow::Result<()> {
     let provider = provider_with_interval(None)?;
@@ -161,9 +161,6 @@ async fn evm_set_interval_mining_rejects_an_invalid_range() -> anyhow::Result<()
 /// `evm_setIntervalMining` restarts the timer even when it sets the interval
 /// that is already configured, so the next block is always due a full interval
 /// after the call.
-///
-/// Matches Hardhat, which deliberately dropped the same-value short-circuit
-/// from `MiningTimer.setBlockTime` in commit `1929c977c`.
 #[tokio::test(flavor = "multi_thread")]
 async fn evm_set_interval_mining_restarts_on_an_unchanged_interval() -> anyhow::Result<()> {
     /// Long enough that no block is ever due between two consecutive requests,

--- a/crates/edr_provider/tests/integration/interval_mining.rs
+++ b/crates/edr_provider/tests/integration/interval_mining.rs
@@ -157,3 +157,49 @@ async fn evm_set_interval_mining_rejects_an_invalid_range() -> anyhow::Result<()
 
     Ok(())
 }
+
+/// `evm_setIntervalMining` restarts the timer even when it sets the interval
+/// that is already configured, so the next block is always due a full interval
+/// after the call.
+///
+/// Matches Hardhat, which deliberately dropped the same-value short-circuit
+/// from `MiningTimer.setBlockTime` in commit `1929c977c`.
+#[tokio::test(flavor = "multi_thread")]
+async fn evm_set_interval_mining_restarts_on_an_unchanged_interval() -> anyhow::Result<()> {
+    /// Long enough that no block is ever due between two consecutive requests,
+    /// short enough that a timer left alone certainly fires within
+    /// [`OBSERVATION`].
+    const RESTART_INTERVAL_MS: u64 = 1_000;
+    /// Twenty requests per interval, so a spurious block needs a one-second
+    /// stall where fifty milliseconds were asked for.
+    const RESET_PERIOD: Duration = Duration::from_millis(50);
+    /// Three intervals, so a timer that is not restarted fires three times.
+    const OBSERVATION: Duration = Duration::from_millis(3 * RESTART_INTERVAL_MS);
+
+    let provider = provider_with_interval(None)?;
+    let start = block_number(&provider)?;
+
+    let deadline = Instant::now() + OBSERVATION;
+    while Instant::now() < deadline {
+        set_interval_mining(
+            &provider,
+            IntervalConfigRequest::FixedOrDisabled(RESTART_INTERVAL_MS),
+        )?;
+        std::thread::sleep(RESET_PERIOD);
+    }
+
+    assert_eq!(
+        block_number(&provider)?,
+        start,
+        "every request should have restarted the timer, so no block was ever due"
+    );
+
+    // Not vacuous: the timer was armed throughout and fires once the interval
+    // is left alone.
+    assert!(
+        wait_for_block_after(&provider, start)?,
+        "interval mining should resume once the interval is no longer reset"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Follow-up to #1486, and stacked on it.

#1486 moved JSON-RPC request handling onto a dedicated provider thread. In review, @anaPerezGhiglia found two pre-existing interval-mining validation holes that the new design escalates from "degraded" to "provider unusable", because the thread that mines is now the thread that serves requests. She asked for them as a separate PR, which is this one.

## The defects

**A `[0, 0]` range starved the provider.** `generate_interval()` returned 0, `crossbeam_channel::after(Duration::ZERO)` is delivered instantly, and the event loop's interval arm is checked before its request arm — so requests were never serviced and their JS promises never settled while the loop hot-mined. Before #1486 the same configuration busy-mined but requests still progressed, because the data mutex was fair.

**A `min > max` range panicked the provider.** `rand::random_range` panics on an empty range. The JSON-RPC path rejected it, but the provider-construction path did not, and Hardhat forwards such a configuration without complaint. Before #1486 that panic killed a detached task; now it kills the thread that owns `ProviderData`.

**`evm_setIntervalMining` stopped restarting the timer for an unchanged value.** Not raised in review. #1486 re-armed only when the new configuration differed, so a client polling `evm_setIntervalMining(5000)` every 4s mined every 5s where it previously never mined. Equality was also the wrong question to ask: a range draws a new interval before each block, so setting `[1000, 5000]` twice kept the first draw instead of re-drawing.

## The fix

An interval range is now a type with private, ordered, non-zero bounds, and `generate_interval` returns `NonZeroU64`. A zero-length timer and an empty range are unrepresentable rather than merely unreached. `#[serde(try_from = ..)]` routes deserialization through an unchecked shim, which closes a third entry point that is easy to miss: a recorded scenario file carries a serialized `MiningConfig` that the scenario runner deserializes straight into a live configuration.

The wire format is unchanged — a newtype variant wrapping a struct with `min`/`max` serializes identically to the struct variant it replaces — so existing recorded scenarios keep loading. A test pins both directions.

Reconfiguration is now signalled by a take-once flag on `ProviderData` rather than inferred from value equality. That is the actual predicate, and it handles rejection correctly for free: the conversion error propagates before the setter is reached, so an invalid value never restarts the timer.

## No scheduling change

The review also asked whether a valid-but-small interval throttles request handling. It does not, once zero is impossible. `crossbeam_channel::after` computes its deadline at the call site, which is *after* mining completes, so the next deadline is always a full interval away and every cycle leaves a window in which the timer is not ready. Requests get roughly `interval / (interval + mining time)` of the loop. Only a zero interval breaks that, which is what this PR makes unrepresentable.

## Breaking change

`[0, 0]` and `[0, N]` interval ranges are no longer accepted. Neither worked as configured before, but a configuration that is forwarded today will now fail when the provider is created.

## Validation

- `cargo test -p edr_provider --features test-utils`: 302 tests pass, including 17 new unit tests covering every accepted and rejected input, the wire format in both directions, and that deserialization is closed.
- `evm_set_interval_mining_restarts_on_an_unchanged_interval` mines 3 blocks instead of 0 against the previous logic, and its positive control fails if nothing re-arms at all.
- `evm_set_interval_mining_rejects_an_invalid_range` asserts the provider is still usable after a rejection — the regression test for the panic.
- Scenario replay is unchanged: 5079 success / 193 failure on `safe-contracts`, the same as before.

## Reviewer

Question: Given that this is a bug fix, does this qualify as a "BREAKING CHANGE"?