### PR TITLE
perf: serialize JSON-RPC responses once

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -354,11 +354,13 @@ similar-asserts = "2.0"
 rand = "0.9"
 rustc-hash = "2.0"
 serde = { version = "1.0", features = ["derive", "std"] }
-# Arbitrary precision is needed by the `parseJson` cheatcode and preserve order is needed by `edr_solidity`.
+# Arbitrary precision is needed by the `parseJson` cheatcode, preserve order by
+# `edr_solidity`, and raw value by `edr_provider::ResponseWithCallTraces`.
 # The features are listed here instead of in the Cargo.toml of those packages to avoid surprises from feature unification.
 serde_json = { version = "1.0", features = [
     "arbitrary_precision",
     "preserve_order",
+    "raw_value",
     "std",
 ] }
 strum = "0.28"

--- a/crates/edr_napi/src/context.rs
+++ b/crates/edr_napi/src/context.rs
@@ -407,7 +407,7 @@ impl EdrContext {
         };
 
         Ok(GcProvider::from(Provider::new(
-            Arc::new(MockProvider::new(mocked_response)),
+            Arc::new(MockProvider::new(mocked_response)?),
             runtime,
             Arc::default(),
             dropped_provider_sender,

--- a/crates/edr_napi/src/mock.rs
+++ b/crates/edr_napi/src/mock.rs
@@ -7,12 +7,15 @@ use edr_rpc_client::jsonrpc;
 
 /// A mock provider that always returns the given mocked response.
 pub struct MockProvider {
-    mocked_response: serde_json::Value,
+    mocked_response: Box<serde_json::value::RawValue>,
 }
 
 impl MockProvider {
-    pub fn new(mocked_response: serde_json::Value) -> Self {
-        Self { mocked_response }
+    pub fn new(mocked_response: serde_json::Value) -> napi::Result<Self> {
+        let mocked_response = serde_json::value::to_raw_value(&mocked_response)
+            .map_err(|error| napi::Error::new(napi::Status::InvalidArg, error.to_string()))?;
+
+        Ok(Self { mocked_response })
     }
 }
 

--- a/crates/edr_napi_core/src/spec.rs
+++ b/crates/edr_napi_core/src/spec.rs
@@ -326,8 +326,13 @@ mod tests {
         }
     }
 
+    /// Pins that the fallback's re-parse keeps the digits rather than narrowing
+    /// to `f64`.
+    ///
+    /// JS never receives this value. `napi` panics marshalling a `Value` number
+    /// wider than `u64`, so the `Value` arm cannot carry one.
     #[test]
-    fn marshal_response_data_preserves_precision_above_the_limit() {
+    fn marshal_response_data_does_not_reformat_an_oversized_number() {
         const DIGITS: &str =
             "115792089237316195423570985008687907853269984665640564039457584007913129639935";
 

--- a/crates/edr_napi_core/src/spec.rs
+++ b/crates/edr_napi_core/src/spec.rs
@@ -147,23 +147,35 @@ impl<TimerT: Clone + TimeSinceEpoch> SyncNapiSpec<TimerT> for GenericChainSpec {
     }
 }
 
+/// We experimentally determined that `500_000_000` was the maximum string
+/// length that can be returned without causing the error:
+///
+/// > Failed to convert rust `String` into napi `string`
+///
+/// To be safe, we're limiting string lengths to half of that.
+const MAX_STRING_LENGTH: usize = 250_000_000;
+
 /// Marshals a JSON-RPC response data into a `ResponseData`, taking into account
 /// large responses.
 pub fn marshal_response_data(
     response: jsonrpc::ResponseData<Box<serde_json::value::RawValue>>,
 ) -> napi::Result<ResponseData> {
-    // We experimentally determined that 500_000_000 was the maximum string length
-    // that can be returned without causing the error:
-    //
-    // > Failed to convert rust `String` into napi `string`
-    //
-    // To be safe, we're limiting string lengths to half of that.
-    const MAX_STRING_LENGTH: usize = 250_000_000;
+    marshal_response_data_with_limit(response, MAX_STRING_LENGTH)
+}
 
+/// Marshals a JSON-RPC response data, returning a `serde_json::Value` for
+/// envelopes longer than `max_string_length`.
+///
+/// The limit is a parameter so that tests can reach it without allocating
+/// hundreds of megabytes.
+fn marshal_response_data_with_limit(
+    response: jsonrpc::ResponseData<Box<serde_json::value::RawValue>>,
+    max_string_length: usize,
+) -> napi::Result<ResponseData> {
     // A success envelope's length is known before it is built, so an oversized
     // response never has to be serialized only to be discarded.
     if let jsonrpc::ResponseData::Success { result } = &response
-        && envelope_len(result) > MAX_STRING_LENGTH
+        && envelope_len(result) > max_string_length
     {
         return serde_json::to_value(response)
             .map(Either::B)
@@ -173,7 +185,7 @@ pub fn marshal_response_data(
     let json = serialize_response(&response)
         .map_err(|error| napi::Error::new(Status::GenericFailure, error.to_string()))?;
 
-    if json.len() <= MAX_STRING_LENGTH {
+    if json.len() <= max_string_length {
         Ok(Either::A(json))
     } else {
         serde_json::to_value(response)
@@ -259,5 +271,101 @@ mod tests {
             "boom",
             Some(serde_json::json!({ "method": "eth_call" })),
         ));
+    }
+
+    #[test]
+    fn envelope_len_matches_the_serialized_success() {
+        let results = [
+            "null",
+            "\"0x1\"",
+            "[]",
+            "{\"blockNumber\":\"0x1\",\"logs\":[]}",
+        ];
+
+        for result in results {
+            let result = raw_value(result);
+
+            let json = serde_json::to_string(&jsonrpc::ResponseData::Success {
+                result: result.clone(),
+            })
+            .expect("serialization succeeds");
+
+            assert_eq!(envelope_len(&result), json.len());
+        }
+    }
+
+    #[test]
+    fn marshal_response_data_returns_a_string_at_the_limit() {
+        let result = raw_value("{\"blockNumber\":\"0x1\"}");
+        let limit = envelope_len(&result);
+
+        let response = jsonrpc::ResponseData::Success { result };
+        let expected = serde_json::to_string(&response).expect("serialization succeeds");
+
+        match marshal_response_data_with_limit(response, limit).expect("marshalling succeeds") {
+            Either::A(json) => assert_eq!(json, expected),
+            Either::B(_) => panic!("an envelope at the limit is returned as a string"),
+        }
+    }
+
+    #[test]
+    fn marshal_response_data_returns_a_value_above_the_limit() {
+        let result = raw_value("{\"blockNumber\":\"0x1\"}");
+        let limit = envelope_len(&result) - 1;
+
+        match marshal_response_data_with_limit(jsonrpc::ResponseData::Success { result }, limit)
+            .expect("marshalling succeeds")
+        {
+            Either::A(_) => panic!("an envelope above the limit is returned as a value"),
+            Either::B(value) => {
+                assert_eq!(
+                    value,
+                    serde_json::json!({ "result": { "blockNumber": "0x1" } })
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn marshal_response_data_preserves_precision_above_the_limit() {
+        const DIGITS: &str =
+            "115792089237316195423570985008687907853269984665640564039457584007913129639935";
+
+        let result = raw_value(DIGITS);
+        let limit = envelope_len(&result) - 1;
+
+        let value = match marshal_response_data_with_limit(
+            jsonrpc::ResponseData::Success { result },
+            limit,
+        )
+        .expect("marshalling succeeds")
+        {
+            Either::A(_) => panic!("an envelope above the limit is returned as a value"),
+            Either::B(value) => value,
+        };
+
+        assert_eq!(
+            serde_json::to_string(&value).expect("serialization succeeds"),
+            format!("{{\"result\":{DIGITS}}}")
+        );
+    }
+
+    #[test]
+    fn marshal_response_data_returns_a_value_for_an_oversized_error() {
+        let response: jsonrpc::ResponseData<Box<serde_json::value::RawValue>> =
+            jsonrpc::ResponseData::new_error(-32000, "boom", None);
+
+        let expected = serde_json::to_string(&response).expect("serialization succeeds");
+        let limit = expected.len() - 1;
+
+        match marshal_response_data_with_limit(response, limit).expect("marshalling succeeds") {
+            Either::A(_) => panic!("an envelope above the limit is returned as a value"),
+            Either::B(value) => {
+                assert_eq!(
+                    serde_json::to_string(&value).expect("serialization succeeds"),
+                    expected
+                );
+            }
+        }
     }
 }

--- a/crates/edr_napi_core/src/spec.rs
+++ b/crates/edr_napi_core/src/spec.rs
@@ -150,7 +150,7 @@ impl<TimerT: Clone + TimeSinceEpoch> SyncNapiSpec<TimerT> for GenericChainSpec {
 /// Marshals a JSON-RPC response data into a `ResponseData`, taking into account
 /// large responses.
 pub fn marshal_response_data(
-    response: jsonrpc::ResponseData<serde_json::Value>,
+    response: jsonrpc::ResponseData<Box<serde_json::value::RawValue>>,
 ) -> napi::Result<ResponseData> {
     serde_json::to_string(&response)
         .and_then(|json| {

--- a/crates/edr_napi_core/src/spec.rs
+++ b/crates/edr_napi_core/src/spec.rs
@@ -152,21 +152,112 @@ impl<TimerT: Clone + TimeSinceEpoch> SyncNapiSpec<TimerT> for GenericChainSpec {
 pub fn marshal_response_data(
     response: jsonrpc::ResponseData<Box<serde_json::value::RawValue>>,
 ) -> napi::Result<ResponseData> {
-    serde_json::to_string(&response)
-        .and_then(|json| {
-            // We experimentally determined that 500_000_000 was the maximum string length
-            // that can be returned without causing the error:
-            //
-            // > Failed to convert rust `String` into napi `string`
-            //
-            // To be safe, we're limiting string lengths to half of that.
-            const MAX_STRING_LENGTH: usize = 250_000_000;
+    // We experimentally determined that 500_000_000 was the maximum string length
+    // that can be returned without causing the error:
+    //
+    // > Failed to convert rust `String` into napi `string`
+    //
+    // To be safe, we're limiting string lengths to half of that.
+    const MAX_STRING_LENGTH: usize = 250_000_000;
 
-            if json.len() <= MAX_STRING_LENGTH {
-                Ok(Either::A(json))
-            } else {
-                serde_json::to_value(response).map(Either::B)
-            }
-        })
-        .map_err(|error| napi::Error::new(Status::GenericFailure, error.to_string()))
+    // A success envelope's length is known before it is built, so an oversized
+    // response never has to be serialized only to be discarded.
+    if let jsonrpc::ResponseData::Success { result } = &response
+        && envelope_len(result) > MAX_STRING_LENGTH
+    {
+        return serde_json::to_value(response)
+            .map(Either::B)
+            .map_err(|error| napi::Error::new(Status::GenericFailure, error.to_string()));
+    }
+
+    let json = serialize_response(&response)
+        .map_err(|error| napi::Error::new(Status::GenericFailure, error.to_string()))?;
+
+    if json.len() <= MAX_STRING_LENGTH {
+        Ok(Either::A(json))
+    } else {
+        serde_json::to_value(response)
+            .map(Either::B)
+            .map_err(|error| napi::Error::new(Status::GenericFailure, error.to_string()))
+    }
+}
+
+/// Returns the length of the response envelope around an already-serialized
+/// result.
+fn envelope_len(result: &serde_json::value::RawValue) -> usize {
+    // `{"result":` and `}`
+    const OVERHEAD: usize = 11;
+
+    result.get().len() + OVERHEAD
+}
+
+/// Serializes a JSON-RPC response into a buffer that never has to grow.
+///
+/// `serde_json::to_string` starts at 128 bytes and doubles, so it copies a
+/// large result several times over.
+fn serialize_response(
+    response: &jsonrpc::ResponseData<Box<serde_json::value::RawValue>>,
+) -> Result<String, serde_json::Error> {
+    /// What `serde_json::to_string` would start from, for the envelope whose
+    /// length is not known up front.
+    const ERROR_CAPACITY: usize = 128;
+
+    let capacity = match response {
+        jsonrpc::ResponseData::Success { result } => envelope_len(result),
+        jsonrpc::ResponseData::Error { .. } => ERROR_CAPACITY,
+    };
+
+    let mut buffer = Vec::with_capacity(capacity);
+    serde_json::to_writer(&mut buffer, response)?;
+
+    // SAFETY: `serde_json` only emits UTF-8.
+    Ok(unsafe { String::from_utf8_unchecked(buffer) })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn raw_value(json: &str) -> Box<serde_json::value::RawValue> {
+        serde_json::value::RawValue::from_string(json.to_string()).expect("the JSON is valid")
+    }
+
+    fn assert_matches_serde(response: jsonrpc::ResponseData<Box<serde_json::value::RawValue>>) {
+        let expected = serde_json::to_string(&response).expect("serialization succeeds");
+
+        let json = match marshal_response_data(response).expect("marshalling succeeds") {
+            Either::A(json) => json,
+            Either::B(_) => panic!("the response is small enough to be a string"),
+        };
+
+        assert_eq!(json, expected);
+    }
+
+    #[test]
+    fn marshal_response_data_matches_serde_for_success() {
+        let results = [
+            "null",
+            "true",
+            "\"0x1\"",
+            "[]",
+            "[\"0x1\",{\"a\":[1,2,3]}]",
+            "{\"blockNumber\":\"0x1\",\"logs\":[]}",
+            "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+        ];
+
+        for result in results {
+            assert_matches_serde(jsonrpc::ResponseData::Success {
+                result: raw_value(result),
+            });
+        }
+    }
+
+    #[test]
+    fn marshal_response_data_matches_serde_for_errors() {
+        assert_matches_serde(jsonrpc::ResponseData::new_error(
+            -32000,
+            "boom",
+            Some(serde_json::json!({ "method": "eth_call" })),
+        ));
+    }
 }

--- a/crates/edr_napi_core/src/spec.rs
+++ b/crates/edr_napi_core/src/spec.rs
@@ -172,6 +172,9 @@ fn marshal_response_data_with_limit(
     response: jsonrpc::ResponseData<Box<serde_json::value::RawValue>>,
     max_string_length: usize,
 ) -> napi::Result<ResponseData> {
+    let to_napi_error =
+        |error: serde_json::Error| napi::Error::new(Status::GenericFailure, error.to_string());
+
     // A success envelope's length is known before it is built, so an oversized
     // response never has to be serialized only to be discarded.
     if let jsonrpc::ResponseData::Success { result } = &response
@@ -179,18 +182,17 @@ fn marshal_response_data_with_limit(
     {
         return serde_json::to_value(response)
             .map(Either::B)
-            .map_err(|error| napi::Error::new(Status::GenericFailure, error.to_string()));
+            .map_err(to_napi_error);
     }
 
-    let json = serialize_response(&response)
-        .map_err(|error| napi::Error::new(Status::GenericFailure, error.to_string()))?;
+    let json = serialize_response(&response).map_err(to_napi_error)?;
 
     if json.len() <= max_string_length {
         Ok(Either::A(json))
     } else {
         serde_json::to_value(response)
             .map(Either::B)
-            .map_err(|error| napi::Error::new(Status::GenericFailure, error.to_string()))
+            .map_err(to_napi_error)
     }
 }
 

--- a/crates/edr_op/tests/integration/isthmus_operator_fee.rs
+++ b/crates/edr_op/tests/integration/isthmus_operator_fee.rs
@@ -46,7 +46,10 @@ async fn operator_fee_parameters_storage_defaults_to_0() -> anyhow::Result<()> {
         ),
     ))?;
 
-    assert_eq!(operator_fee.result, format!("{:#066x}", U256::ZERO),);
+    assert_eq!(
+        operator_fee.deserialize_result::<String>()?,
+        format!("{:#066x}", U256::ZERO),
+    );
     Ok(())
 }
 
@@ -142,7 +145,7 @@ fn get_transaction_receipt(
         MethodInvocation::GetTransactionReceipt(transaction_hash),
     ))?;
 
-    let receipt: edr_op::rpc::OpRpcBlockReceipt = serde_json::from_value(result.result)?;
+    let receipt: edr_op::rpc::OpRpcBlockReceipt = result.deserialize_result()?;
     Ok(receipt)
 }
 
@@ -158,7 +161,7 @@ fn send_transaction(provider: &Provider<OpChainSpec>) -> anyhow::Result<B256> {
         MethodInvocation::SendTransaction(transaction),
     ))?;
 
-    let transaction_hash: B256 = serde_json::from_value(result.result)?;
+    let transaction_hash: B256 = result.deserialize_result()?;
     Ok(transaction_hash)
 }
 fn set_operator_fee_params_in_storage(

--- a/crates/edr_op/tests/integration/provider.rs
+++ b/crates/edr_op/tests/integration/provider.rs
@@ -57,7 +57,7 @@ async fn sepolia_call_with_remote_chain_id() -> anyhow::Result<()> {
             MethodInvocation::BlockNumber(()),
         ))?;
 
-        serde_json::from_value::<U64>(response.result)?.to::<u64>()
+        response.deserialize_result::<U64>()?.to::<u64>()
     };
 
     let data = bytes!(
@@ -140,7 +140,9 @@ mod base_fee_params {
                 false,
             ),
         ))?;
-        serde_json::from_value::<L1RpcBlock<B256>>(response.result).map_err(Into::into)
+        response
+            .deserialize_result::<L1RpcBlock<B256>>()
+            .map_err(Into::into)
     }
 
     mod local {

--- a/crates/edr_provider/src/lib.rs
+++ b/crates/edr_provider/src/lib.rs
@@ -67,8 +67,18 @@ pub type ProviderResultWithCallTraces<T, ChainSpecT> =
 
 #[derive(Clone, Debug)]
 pub struct ResponseWithCallTraces {
-    pub result: serde_json::Value,
+    /// The serialized JSON-RPC result.
+    pub result: Box<serde_json::value::RawValue>,
     pub call_trace_arenas: Vec<CallTraceArena>,
+}
+
+impl ResponseWithCallTraces {
+    /// Parses the result on each call.
+    pub fn deserialize_result<T: serde::de::DeserializeOwned>(
+        &self,
+    ) -> Result<T, serde_json::Error> {
+        serde_json::from_str(self.result.get())
+    }
 }
 
 fn to_json<
@@ -78,7 +88,7 @@ fn to_json<
 >(
     value: T,
 ) -> Result<ResponseWithCallTraces, ProviderErrorForChainSpec<ChainSpecT>> {
-    let response = serde_json::to_value(value).map_err(ProviderError::Serialization)?;
+    let response = serde_json::value::to_raw_value(&value).map_err(ProviderError::Serialization)?;
 
     Ok(ResponseWithCallTraces {
         result: response,
@@ -93,7 +103,8 @@ fn to_json_with_trace<
 >(
     value: (T, Option<CallTraceArena>),
 ) -> Result<ResponseWithCallTraces, ProviderErrorForChainSpec<ChainSpecT>> {
-    let response = serde_json::to_value(value.0).map_err(ProviderError::Serialization)?;
+    let response =
+        serde_json::value::to_raw_value(&value.0).map_err(ProviderError::Serialization)?;
 
     Ok(ResponseWithCallTraces {
         result: response,
@@ -108,7 +119,8 @@ fn to_json_with_traces<
 >(
     value: (T, Vec<CallTraceArena>),
 ) -> Result<ResponseWithCallTraces, ProviderErrorForChainSpec<ChainSpecT>> {
-    let response = serde_json::to_value(value.0).map_err(ProviderError::Serialization)?;
+    let response =
+        serde_json::value::to_raw_value(&value.0).map_err(ProviderError::Serialization)?;
 
     Ok(ResponseWithCallTraces {
         result: response,

--- a/crates/edr_provider/src/requests/dispatch.rs
+++ b/crates/edr_provider/src/requests/dispatch.rs
@@ -61,9 +61,32 @@ where
     }
 
     Ok(ResponseWithCallTraces {
-        result: serde_json::Value::Array(results),
+        result: to_json_array(&results),
         call_trace_arenas,
     })
+}
+
+/// Collects already-serialized JSON values into a JSON array.
+fn to_json_array(values: &[Box<serde_json::value::RawValue>]) -> Box<serde_json::value::RawValue> {
+    let capacity = values
+        .iter()
+        .map(|value| value.get().len() + 1)
+        .sum::<usize>()
+        + 1;
+
+    let mut json = String::with_capacity(capacity);
+    json.push('[');
+    for (index, value) in values.iter().enumerate() {
+        if index > 0 {
+            json.push(',');
+        }
+        json.push_str(value.get());
+    }
+    json.push(']');
+
+    // SAFETY: every element is a single well-formed JSON value, so the array is
+    // one too.
+    unsafe { serde_json::value::RawValue::from_string_unchecked(json) }
 }
 
 /// Executes a single JSON-RPC request, printing its method logs unless the
@@ -400,21 +423,19 @@ mod tests {
             ]),
         )?;
 
-        let serde_json::Value::Array(results) = &response.result else {
-            panic!("expected an array, got {:?}", response.result);
-        };
+        let results: Vec<Box<serde_json::value::RawValue>> = response.deserialize_result()?;
         assert_eq!(results.len(), 3);
 
-        let chain_id: U256 = serde_json::from_value(results[0].clone())?;
+        let chain_id: U256 = serde_json::from_str(results[0].get())?;
         assert_eq!(chain_id.to::<u64>(), fixture.config.chain_id);
 
-        let block_number: U256 = serde_json::from_value(results[1].clone())?;
+        let block_number: U256 = serde_json::from_str(results[1].get())?;
         assert_eq!(
             block_number.to::<u64>(),
             fixture.provider_data.last_block_number()
         );
 
-        let network_id: String = serde_json::from_value(results[2].clone())?;
+        let network_id: String = serde_json::from_str(results[2].get())?;
         assert_eq!(network_id, fixture.config.network_id.to_string());
 
         Ok(())
@@ -429,7 +450,7 @@ mod tests {
             ProviderRequest::Batch(Vec::new()),
         )?;
 
-        assert_eq!(response.result, serde_json::Value::Array(Vec::new()));
+        assert_eq!(response.result.get(), "[]");
         assert!(response.call_trace_arenas.is_empty());
 
         Ok(())

--- a/crates/edr_provider/src/requests/dispatch.rs
+++ b/crates/edr_provider/src/requests/dispatch.rs
@@ -66,15 +66,18 @@ where
     })
 }
 
+/// Returns the length of the JSON array [`to_json_array`] builds from `values`.
+fn json_array_len(values: &[Box<serde_json::value::RawValue>]) -> usize {
+    // The brackets, the values, and one separator between each pair.
+    let separators = values.len().saturating_sub(1);
+    let values = values.iter().map(|value| value.get().len()).sum::<usize>();
+
+    2 + values + separators
+}
+
 /// Collects already-serialized JSON values into a JSON array.
 fn to_json_array(values: &[Box<serde_json::value::RawValue>]) -> Box<serde_json::value::RawValue> {
-    let capacity = values
-        .iter()
-        .map(|value| value.get().len() + 1)
-        .sum::<usize>()
-        + 1;
-
-    let mut json = String::with_capacity(capacity);
+    let mut json = String::with_capacity(json_array_len(values));
     json.push('[');
     for (index, value) in values.iter().enumerate() {
         if index > 0 {
@@ -409,6 +412,60 @@ mod tests {
 
     use super::*;
     use crate::test_utils::ProviderTestFixture;
+
+    fn raw_values(json: &[&str]) -> Vec<Box<serde_json::value::RawValue>> {
+        json.iter()
+            .map(|json| {
+                serde_json::value::RawValue::from_string((*json).to_string())
+                    .expect("the JSON is valid")
+            })
+            .collect()
+    }
+
+    /// `from_string_unchecked` re-parses in debug builds, so every case here
+    /// also asserts the output is a single well-formed JSON value.
+    #[test]
+    fn to_json_array_separates_values() {
+        let cases = [
+            (vec![], "[]"),
+            (vec!["1"], "[1]"),
+            (vec!["1", "2"], "[1,2]"),
+            (vec!["1", "2", "3"], "[1,2,3]"),
+        ];
+
+        for (values, expected) in cases {
+            let values = raw_values(&values);
+
+            assert_eq!(to_json_array(&values).get(), expected);
+        }
+    }
+
+    /// Values are copied verbatim, so a separator inside one is not a
+    /// separator.
+    #[test]
+    fn to_json_array_preserves_values_containing_separators() {
+        let values = raw_values(&[r#""a,b""#, r#"{"c":[1,2]}"#, r#""]""#]);
+
+        assert_eq!(to_json_array(&values).get(), r#"["a,b",{"c":[1,2]},"]"]"#);
+    }
+
+    /// The buffer is sized once, so the reservation has to be exact.
+    #[test]
+    fn json_array_len_matches_the_built_array() {
+        let cases = [
+            vec![],
+            vec!["null"],
+            vec!["1", "2"],
+            vec![r#""a,b""#, r#"{"c":[1,2]}"#],
+            vec!["1", "2", "3", "4", "5"],
+        ];
+
+        for values in cases {
+            let values = raw_values(&values);
+
+            assert_eq!(json_array_len(&values), to_json_array(&values).get().len());
+        }
+    }
 
     #[test]
     fn execute_batch_request_preserves_order() -> anyhow::Result<()> {

--- a/crates/edr_provider/src/test_utils.rs
+++ b/crates/edr_provider/src/test_utils.rs
@@ -280,13 +280,13 @@ where
         MethodInvocation::SendTransaction(deploy_transaction),
     ))?;
 
-    let transaction_hash: B256 = serde_json::from_value(result.result)?;
+    let transaction_hash: B256 = result.deserialize_result()?;
 
     let result = provider.handle_request(ProviderRequest::with_single(
         MethodInvocation::GetTransactionReceipt(transaction_hash),
     ))?;
 
-    let receipt: L1RpcTransactionReceipt = serde_json::from_value(result.result)?;
+    let receipt: L1RpcTransactionReceipt = result.deserialize_result()?;
     let contract_address = receipt.contract_address.expect("Call must create contract");
 
     Ok(contract_address)
@@ -304,17 +304,18 @@ where
         .expect("evm_mine should succeed");
 }
 
-/// Returns the raw JSON of the latest block.
+/// Returns the latest block as JSON.
 pub fn get_latest_block<TimerT>(provider: &Provider<L1ChainSpec, TimerT>) -> serde_json::Value
 where
     TimerT: Clone + TimeSinceEpoch,
 {
-    provider
+    let response = provider
         .handle_request(ProviderRequest::with_single(
             MethodInvocation::GetBlockByNumber(PreEip1898BlockSpec::latest(), false),
         ))
-        .expect("eth_getBlockByNumber should succeed")
-        .result
+        .expect("eth_getBlockByNumber should succeed");
+
+    response.deserialize_result().expect("the block is JSON")
 }
 
 /// Fixture for testing `ProviderData`.
@@ -499,8 +500,9 @@ pub fn transfer_value(
         ))
         .expect("eth_sendTransaction should succeed");
 
-    let transaction_hash: B256 =
-        serde_json::from_value(response.result).expect("response should be a transaction hash");
+    let transaction_hash: B256 = response
+        .deserialize_result()
+        .expect("response should be a transaction hash");
 
     let response = provider
         .handle_request(ProviderRequest::with_single(
@@ -508,8 +510,9 @@ pub fn transfer_value(
         ))
         .expect("eth_getTransactionReceipt should succeed");
 
-    let receipt: Option<L1RpcTransactionReceipt> =
-        serde_json::from_value(response.result).expect("response should be a receipt");
+    let receipt: Option<L1RpcTransactionReceipt> = response
+        .deserialize_result()
+        .expect("response should be a receipt");
 
     receipt.expect("receipt should exist")
 }

--- a/crates/edr_provider/tests/common/provider.rs
+++ b/crates/edr_provider/tests/common/provider.rs
@@ -57,8 +57,9 @@ pub fn gas_used(provider: &Provider<L1ChainSpec>, transaction_hash: B256) -> u64
         ))
         .expect("eth_getTransactionReceipt should succeed");
 
-    let receipt: Option<L1RpcTransactionReceipt> =
-        serde_json::from_value(response.result).expect("response should be Receipt");
+    let receipt: Option<L1RpcTransactionReceipt> = response
+        .deserialize_result()
+        .expect("response should be Receipt");
 
     let receipt = receipt.expect("receipt should exist");
 
@@ -74,5 +75,5 @@ pub fn send_transaction(
         MethodInvocation::SendTransaction(request),
     ))?;
 
-    Ok(serde_json::from_value(response.result)?)
+    Ok(response.deserialize_result()?)
 }

--- a/crates/edr_provider/tests/integration/block_timestamp_in_logs.rs
+++ b/crates/edr_provider/tests/integration/block_timestamp_in_logs.rs
@@ -72,7 +72,7 @@ fn block_timestamp(
         MethodInvocation::GetBlockByNumber(PreEip1898BlockSpec::Number(block_number), false),
     ))?;
 
-    let block: L1RpcBlock<B256> = serde_json::from_value(response.result)?;
+    let block: L1RpcBlock<B256> = response.deserialize_result()?;
     Ok(block.timestamp)
 }
 
@@ -89,7 +89,7 @@ fn call_log_emitter(
         }),
     ))?;
 
-    Ok(serde_json::from_value::<B256>(response.result)?)
+    Ok(response.deserialize_result::<B256>()?)
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -116,7 +116,7 @@ async fn logs_carry_the_timestamp_of_their_own_block() -> anyhow::Result<()> {
                 ..LogFilterOptions::default()
             }),
         ))?;
-        serde_json::from_value::<Vec<serde_json::Value>>(response.result)?
+        response.deserialize_result::<Vec<serde_json::Value>>()?
     };
 
     assert_eq!(logs.len(), 2, "expected one log per call");
@@ -166,7 +166,7 @@ async fn receipt_logs_carry_the_block_timestamp_too() -> anyhow::Result<()> {
     let response = provider.handle_request(ProviderRequest::with_single(
         MethodInvocation::GetTransactionReceipt(call_hash),
     ))?;
-    let receipt: serde_json::Value = serde_json::from_value(response.result)?;
+    let receipt: serde_json::Value = response.deserialize_result()?;
 
     let log_timestamp = quantity(&receipt["logs"][0], "blockTimestamp")?;
 

--- a/crates/edr_provider/tests/integration/calldata_floor.rs
+++ b/crates/edr_provider/tests/integration/calldata_floor.rs
@@ -32,7 +32,9 @@ fn estimate_gas(provider: &Provider<L1ChainSpec>, request: L1CallRequest) -> u64
         )))
         .expect("eth_estimateGas should succeed");
 
-    let gas: U64 = serde_json::from_value(response.result).expect("response should be U64");
+    let gas: U64 = response
+        .deserialize_result()
+        .expect("response should be U64");
 
     gas.into_limbs()[0]
 }

--- a/crates/edr_provider/tests/integration/coverage.rs
+++ b/crates/edr_provider/tests/integration/coverage.rs
@@ -104,7 +104,8 @@ fn provider_with_deployed_test_contract(
             ))
             .expect("Failed to deploy test contract");
 
-        serde_json::from_value::<B256>(response.result)
+        response
+            .deserialize_result::<B256>()
             .expect("Failed to deserialize transaction hash")
     };
 
@@ -116,7 +117,8 @@ fn provider_with_deployed_test_contract(
             ))
             .expect("Failed to get transaction receipt");
 
-        let receipt: L1RpcTransactionReceipt = serde_json::from_value(response.result)
+        let receipt: L1RpcTransactionReceipt = response
+            .deserialize_result()
             .expect("Failed to deserialize transaction receipt");
 
         receipt
@@ -209,7 +211,9 @@ async fn debug_trace_transaction() -> anyhow::Result<()> {
             }),
         ))?;
 
-        serde_json::from_value(response.result).expect("Failed to deserialize transaction hash")
+        response
+            .deserialize_result()
+            .expect("Failed to deserialize transaction hash")
     };
 
     // Reset the hits after the transaction
@@ -369,7 +373,7 @@ mod returndata {
             )))?;
 
         // Target.getValue() returns uint256(42), forwarded via returndatacopy.
-        let result: String = serde_json::from_value(response.result)?;
+        let result: String = response.deserialize_result()?;
         let expected = format!("0x{:0>64}", hex::encode(42u32.to_be_bytes()));
         assert_eq!(result, expected, "forwardSuccessfulCall() should return 42");
 
@@ -400,7 +404,7 @@ mod returndata {
 
         // forwardRevertedCall() returns the raw ABI-encoded revert data from
         // Target.willRevert() via returndatacopy.
-        let result: String = serde_json::from_value(response.result)?;
+        let result: String = response.deserialize_result()?;
         let reason = decode_revert_reason(&result);
         assert_eq!(reason, "expected revert reason");
 
@@ -431,7 +435,7 @@ mod returndata {
 
         // The EVM does not populate returndata for successful deployments, so
         // returndatasize() is 0 and the raw assembly return produces empty output.
-        let result: String = serde_json::from_value(response.result)?;
+        let result: String = response.deserialize_result()?;
         assert_eq!(
             result, "0x",
             "deployChild() should return empty data after successful CREATE"
@@ -464,7 +468,7 @@ mod returndata {
 
         // deployRevertingChild() returns the raw ABI-encoded revert data from the
         // failed CoverageDeployRevert constructor via returndatacopy.
-        let result: String = serde_json::from_value(response.result)?;
+        let result: String = response.deserialize_result()?;
         let reason = decode_revert_reason(&result);
         assert_eq!(reason, "constructor failed");
 

--- a/crates/edr_provider/tests/integration/eip2537.rs
+++ b/crates/edr_provider/tests/integration/eip2537.rs
@@ -27,7 +27,7 @@ fn send_call(
         )))
         .expect("request should succeed");
 
-    let output: Bytes = serde_json::from_value(response.result)?;
+    let output: Bytes = response.deserialize_result()?;
 
     Ok(output)
 }

--- a/crates/edr_provider/tests/integration/eip4844.rs
+++ b/crates/edr_provider/tests/integration/eip4844.rs
@@ -221,7 +221,7 @@ async fn send_raw_transaction() -> anyhow::Result<()> {
         MethodInvocation::SendRawTransaction(raw_eip4844_transaction),
     ))?;
 
-    let transaction_hash: B256 = serde_json::from_value(result.result)?;
+    let transaction_hash: B256 = result.deserialize_result()?;
     assert_eq!(transaction_hash, *expected.transaction_hash());
 
     Ok(())
@@ -259,13 +259,13 @@ async fn get_transaction() -> anyhow::Result<()> {
         MethodInvocation::SendRawTransaction(raw_eip4844_transaction),
     ))?;
 
-    let transaction_hash: B256 = serde_json::from_value(result.result)?;
+    let transaction_hash: B256 = result.deserialize_result()?;
 
     let result = provider.handle_request(ProviderRequest::with_single(
         MethodInvocation::GetTransactionByHash(transaction_hash),
     ))?;
 
-    let transaction: L1RpcTransactionWithSignature = serde_json::from_value(result.result)?;
+    let transaction: L1RpcTransactionWithSignature = result.deserialize_result()?;
     let transaction = edr_chain_l1::L1SignedTransaction::try_from(transaction)?;
 
     assert_eq!(transaction, expected);
@@ -313,7 +313,7 @@ async fn block_header() -> anyhow::Result<()> {
         MethodInvocation::GetBlockByNumber(PreEip1898BlockSpec::latest(), false),
     ))?;
 
-    let first_block: L1RpcBlock<B256> = serde_json::from_value(result.result)?;
+    let first_block: L1RpcBlock<B256> = result.deserialize_result()?;
     assert_eq!(first_block.blob_gas_used, Some(DATA_GAS_PER_BLOB));
 
     assert_eq!(
@@ -337,7 +337,7 @@ async fn block_header() -> anyhow::Result<()> {
         MethodInvocation::GetBlockByNumber(PreEip1898BlockSpec::latest(), false),
     ))?;
 
-    let second_block: L1RpcBlock<B256> = serde_json::from_value(result.result)?;
+    let second_block: L1RpcBlock<B256> = result.deserialize_result()?;
     assert_eq!(second_block.blob_gas_used, Some(4 * DATA_GAS_PER_BLOB));
 
     assert_eq!(
@@ -361,7 +361,7 @@ async fn block_header() -> anyhow::Result<()> {
         MethodInvocation::GetBlockByNumber(PreEip1898BlockSpec::latest(), false),
     ))?;
 
-    let third_block: L1RpcBlock<B256> = serde_json::from_value(result.result)?;
+    let third_block: L1RpcBlock<B256> = result.deserialize_result()?;
     assert_eq!(third_block.blob_gas_used, Some(5 * DATA_GAS_PER_BLOB));
 
     assert_eq!(
@@ -381,7 +381,7 @@ async fn block_header() -> anyhow::Result<()> {
         MethodInvocation::GetBlockByNumber(PreEip1898BlockSpec::latest(), false),
     ))?;
 
-    let fourth_block: L1RpcBlock<B256> = serde_json::from_value(result.result)?;
+    let fourth_block: L1RpcBlock<B256> = result.deserialize_result()?;
     assert_eq!(fourth_block.blob_gas_used, Some(0u64));
 
     assert_eq!(
@@ -402,7 +402,7 @@ async fn block_header() -> anyhow::Result<()> {
         MethodInvocation::GetBlockByNumber(PreEip1898BlockSpec::latest(), false),
     ))?;
 
-    let fifth_block: L1RpcBlock<B256> = serde_json::from_value(result.result)?;
+    let fifth_block: L1RpcBlock<B256> = result.deserialize_result()?;
     assert_eq!(fifth_block.blob_gas_used, Some(0u64));
 
     assert_eq!(
@@ -441,7 +441,7 @@ async fn blob_hash_opcode() -> anyhow::Result<()> {
                 MethodInvocation::GetStorageAt(*contract_address, index, None),
             ))?;
 
-            let storage_value: B256 = serde_json::from_value(result.result)?;
+            let storage_value: B256 = result.deserialize_result()?;
             assert_eq!(storage_value, blob_hash);
         }
 
@@ -452,7 +452,7 @@ async fn blob_hash_opcode() -> anyhow::Result<()> {
                 MethodInvocation::GetStorageAt(*contract_address, index, None),
             ))?;
 
-            let storage_value: B256 = serde_json::from_value(result.result)?;
+            let storage_value: B256 = result.deserialize_result()?;
             assert_eq!(storage_value, B256::ZERO);
         }
 

--- a/crates/edr_provider/tests/integration/eip7691.rs
+++ b/crates/edr_provider/tests/integration/eip7691.rs
@@ -49,7 +49,7 @@ async fn block_header() -> anyhow::Result<()> {
         MethodInvocation::GetBlockByNumber(PreEip1898BlockSpec::latest(), false),
     ))?;
 
-    let first_block: L1RpcBlock<B256> = serde_json::from_value(result.result)?;
+    let first_block: L1RpcBlock<B256> = result.deserialize_result()?;
     assert_eq!(first_block.blob_gas_used, Some(DATA_GAS_PER_BLOB));
 
     assert_eq!(
@@ -72,7 +72,7 @@ async fn block_header() -> anyhow::Result<()> {
         MethodInvocation::GetBlockByNumber(PreEip1898BlockSpec::latest(), false),
     ))?;
 
-    let second_block: L1RpcBlock<B256> = serde_json::from_value(result.result)?;
+    let second_block: L1RpcBlock<B256> = result.deserialize_result()?;
     assert_eq!(second_block.blob_gas_used, Some(7 * DATA_GAS_PER_BLOB));
 
     assert_eq!(
@@ -96,7 +96,7 @@ async fn block_header() -> anyhow::Result<()> {
         MethodInvocation::GetBlockByNumber(PreEip1898BlockSpec::latest(), false),
     ))?;
 
-    let third_block: L1RpcBlock<B256> = serde_json::from_value(result.result)?;
+    let third_block: L1RpcBlock<B256> = result.deserialize_result()?;
     assert_eq!(third_block.blob_gas_used, Some(8 * DATA_GAS_PER_BLOB));
 
     assert_eq!(
@@ -116,7 +116,7 @@ async fn block_header() -> anyhow::Result<()> {
         MethodInvocation::GetBlockByNumber(PreEip1898BlockSpec::latest(), false),
     ))?;
 
-    let fourth_block: L1RpcBlock<B256> = serde_json::from_value(result.result)?;
+    let fourth_block: L1RpcBlock<B256> = result.deserialize_result()?;
     assert_eq!(fourth_block.blob_gas_used, Some(0u64));
 
     assert_eq!(
@@ -137,7 +137,7 @@ async fn block_header() -> anyhow::Result<()> {
         MethodInvocation::GetBlockByNumber(PreEip1898BlockSpec::latest(), false),
     ))?;
 
-    let fifth_block: L1RpcBlock<B256> = serde_json::from_value(result.result)?;
+    let fifth_block: L1RpcBlock<B256> = result.deserialize_result()?;
     assert_eq!(fifth_block.blob_gas_used, Some(0u64));
 
     assert_eq!(

--- a/crates/edr_provider/tests/integration/eip7702.rs
+++ b/crates/edr_provider/tests/integration/eip7702.rs
@@ -37,7 +37,9 @@ fn assert_code_at(provider: &Provider<L1ChainSpec>, address: Address, expected: 
             )))
             .expect("eth_getCode should succeed");
 
-        serde_json::from_value(response.result).expect("response should be Bytes")
+        response
+            .deserialize_result()
+            .expect("response should be Bytes")
     };
 
     assert_eq!(code, *expected);
@@ -85,7 +87,7 @@ async fn trace_transaction() -> anyhow::Result<()> {
         ))
         .expect("eth_sendTransaction should succeed");
 
-    let transaction_hash: B256 = serde_json::from_value(response.result)?;
+    let transaction_hash: B256 = response.deserialize_result()?;
 
     let _response = provider
         .handle_request(ProviderRequest::with_single(
@@ -129,13 +131,13 @@ async fn get_transaction() -> anyhow::Result<()> {
         ))
         .expect("eth_sendTransaction should succeed");
 
-    let transaction_hash: B256 = serde_json::from_value(response.result)?;
+    let transaction_hash: B256 = response.deserialize_result()?;
 
     let response = provider.handle_request(ProviderRequest::with_single(
         MethodInvocation::GetTransactionByHash(transaction_hash),
     ))?;
 
-    let transaction: L1RpcTransactionWithSignature = serde_json::from_value(response.result)?;
+    let transaction: L1RpcTransactionWithSignature = response.deserialize_result()?;
     let transaction = edr_chain_l1::L1SignedTransaction::try_from(transaction)?;
 
     if let edr_chain_l1::L1SignedTransaction::Eip7702(transaction) = transaction {

--- a/crates/edr_provider/tests/integration/eip7778.rs
+++ b/crates/edr_provider/tests/integration/eip7778.rs
@@ -92,7 +92,7 @@ fn transaction_receipt(
         MethodInvocation::GetTransactionReceipt(transaction_hash),
     ))?;
 
-    let receipt: Option<L1RpcTransactionReceipt> = serde_json::from_value(response.result)?;
+    let receipt: Option<L1RpcTransactionReceipt> = response.deserialize_result()?;
     receipt.ok_or_else(|| anyhow::anyhow!("receipt should exist"))
 }
 
@@ -101,7 +101,7 @@ fn latest_block(provider: &Provider<L1ChainSpec>) -> anyhow::Result<L1RpcBlock<B
         MethodInvocation::GetBlockByNumber(PreEip1898BlockSpec::latest(), false),
     ))?;
 
-    Ok(serde_json::from_value(response.result)?)
+    Ok(response.deserialize_result()?)
 }
 
 /// Clears the seeded slot, generating an SSTORE refund. With automining the

--- a/crates/edr_provider/tests/integration/eip7843.rs
+++ b/crates/edr_provider/tests/integration/eip7843.rs
@@ -178,7 +178,7 @@ async fn slotnum_opcode_returns_block_slot_number() -> anyhow::Result<()> {
             None,
         )))?;
 
-    let call_result: String = serde_json::from_value(response.result)?;
+    let call_result: String = response.deserialize_result()?;
     let slotnum_opcode_returned_value = U256::from_str(&call_result)?;
 
     assert_eq!(

--- a/crates/edr_provider/tests/integration/estimate_gas.rs
+++ b/crates/edr_provider/tests/integration/estimate_gas.rs
@@ -85,7 +85,9 @@ impl Fixture {
             ),
         ))?;
 
-        let gas: U64 = serde_json::from_value(response.result).expect("estimate should be U64");
+        let gas: U64 = response
+            .deserialize_result()
+            .expect("estimate should be U64");
         Ok(gas.to::<u64>())
     }
 
@@ -122,8 +124,9 @@ impl Fixture {
             )))
             .expect("eth_call n() should succeed");
 
-        let bytes: Bytes =
-            serde_json::from_value(response.result).expect("call should return Bytes");
+        let bytes: Bytes = response
+            .deserialize_result()
+            .expect("call should return Bytes");
         U256::from_be_slice(bytes.as_ref())
     }
 }
@@ -242,7 +245,7 @@ async fn plain_transfer_estimation_unchanged_with_no_internal_out_of_gas() -> an
             None,
         )))?;
 
-    let gas: U64 = serde_json::from_value(response.result)?;
+    let gas: U64 = response.deserialize_result()?;
     // The same value `estimate_gas` produces today for a plain transfer:
     // `minimum_cost + 1` (the clamp in `estimate_gas`). What matters here
     // is that changing the estimation mode does not affect this output.

--- a/crates/edr_provider/tests/integration/eth_get_proof.rs
+++ b/crates/edr_provider/tests/integration/eth_get_proof.rs
@@ -52,9 +52,9 @@ fn verify_account_proof<'proof>(
         )))
         .unwrap();
 
-    let account_proof_response: EIP1186AccountProofResponse =
-        serde_json::from_value(proof_response.result)
-            .expect("Failed to deserialize account proof response");
+    let account_proof_response: EIP1186AccountProofResponse = proof_response
+        .deserialize_result()
+        .expect("Failed to deserialize account proof response");
 
     assert_eq!(account_proof_response.account_proof, expected_proof);
 }
@@ -78,9 +78,9 @@ fn verify_storage_proof<'proof>(
         )))
         .unwrap();
 
-    let account_proof_response: EIP1186AccountProofResponse =
-        serde_json::from_value(proof_response.result)
-            .expect("Failed to deserialize account proof response");
+    let account_proof_response: EIP1186AccountProofResponse = proof_response
+        .deserialize_result()
+        .expect("Failed to deserialize account proof response");
 
     assert_eq!(
         account_proof_response
@@ -249,8 +249,9 @@ mod fork {
                 (),
             )))
             .expect("Failed to get block number");
-        let block_number: U256 =
-            serde_json::from_value(response.result).expect("Block number should be a quantity");
+        let block_number: U256 = response
+            .deserialize_result()
+            .expect("Block number should be a quantity");
         block_number.to::<u64>()
     }
 
@@ -272,7 +273,8 @@ mod fork {
                 BlockSpec::Number(block_number),
             )))
             .expect("Failed to get proof");
-        let proof: EIP1186AccountProofResponse = serde_json::from_value(response.result)
+        let proof: EIP1186AccountProofResponse = response
+            .deserialize_result()
             .expect("Failed to deserialize account proof response");
 
         let response = provider
@@ -283,8 +285,10 @@ mod fork {
                 ),
             ))
             .expect("Failed to get block");
-        let state_root = response
-            .result
+        let block: serde_json::Value = response
+            .deserialize_result()
+            .expect("Failed to deserialize block");
+        let state_root = block
             .get("stateRoot")
             .expect("Block should have a state root");
         let state_root: B256 =

--- a/crates/edr_provider/tests/integration/eth_max_priority_fee_per_gas.rs
+++ b/crates/edr_provider/tests/integration/eth_max_priority_fee_per_gas.rs
@@ -30,7 +30,7 @@ async fn eth_max_priority_fee_per_gas() -> anyhow::Result<()> {
     ))?;
 
     // 1 gwei in hex
-    assert_eq!(response.result, "0x3b9aca00");
+    assert_eq!(response.deserialize_result::<String>()?, "0x3b9aca00");
 
     Ok(())
 }

--- a/crates/edr_provider/tests/integration/interval_mining.rs
+++ b/crates/edr_provider/tests/integration/interval_mining.rs
@@ -46,7 +46,7 @@ fn block_number(provider: &Provider<L1ChainSpec>) -> anyhow::Result<u64> {
     let response = provider.handle_request(ProviderRequest::with_single(
         MethodInvocation::BlockNumber(()),
     ))?;
-    let block_number: U256 = serde_json::from_value(response.result)?;
+    let block_number: U256 = response.deserialize_result()?;
     Ok(block_number.to::<u64>())
 }
 

--- a/crates/edr_provider/tests/integration/issues/issue_324.rs
+++ b/crates/edr_provider/tests/integration/issues/issue_324.rs
@@ -57,7 +57,7 @@ async fn issue_324() -> anyhow::Result<()> {
     )))?;
 
     assert_eq!(
-        x.result,
+        x.deserialize_result::<String>()?,
         "0x0000000000000000000000000000000000000000000000000000000000000001"
     );
 
@@ -72,7 +72,7 @@ async fn issue_324() -> anyhow::Result<()> {
     )))?;
 
     assert_eq!(
-        y.result,
+        y.deserialize_result::<String>()?,
         "0x0000000000000000000000000000000000000000000000000000000000000002"
     );
 
@@ -90,7 +90,7 @@ async fn issue_324() -> anyhow::Result<()> {
         MethodInvocation::GetStorageAt(contract_address, x_storage_index, None),
     ))?;
 
-    assert_eq!(new_x.result, expected_x);
+    assert_eq!(new_x.deserialize_result::<String>()?, expected_x);
 
     let new_x = provider.handle_request(ProviderRequest::with_single(MethodInvocation::Call(
         L1CallRequest {
@@ -102,7 +102,7 @@ async fn issue_324() -> anyhow::Result<()> {
         None,
     )))?;
 
-    assert_eq!(new_x.result, expected_x);
+    assert_eq!(new_x.deserialize_result::<String>()?, expected_x);
 
     let y_storage_index = U256::from(1u64);
     let expected_y = "0x0000000000000000000000000000000000000000000000000000000000000003";
@@ -118,7 +118,7 @@ async fn issue_324() -> anyhow::Result<()> {
         MethodInvocation::GetStorageAt(contract_address, y_storage_index, None),
     ))?;
 
-    assert_eq!(new_y.result, expected_y);
+    assert_eq!(new_y.deserialize_result::<String>()?, expected_y);
 
     let new_y = provider.handle_request(ProviderRequest::with_single(MethodInvocation::Call(
         L1CallRequest {
@@ -130,7 +130,7 @@ async fn issue_324() -> anyhow::Result<()> {
         None,
     )))?;
 
-    assert_eq!(new_y.result, expected_y);
+    assert_eq!(new_y.deserialize_result::<String>()?, expected_y);
 
     Ok(())
 }

--- a/crates/edr_provider/tests/integration/issues/issue_325.rs
+++ b/crates/edr_provider/tests/integration/issues/issue_325.rs
@@ -55,13 +55,13 @@ async fn issue_325() -> anyhow::Result<()> {
         }),
     ))?;
 
-    let transaction_hash: B256 = serde_json::from_value(result.result)?;
+    let transaction_hash: B256 = result.deserialize_result()?;
 
     let result = provider.handle_request(ProviderRequest::with_single(
         MethodInvocation::DropTransaction(transaction_hash),
     ))?;
 
-    let dropped: bool = serde_json::from_value(result.result)?;
+    let dropped: bool = result.deserialize_result()?;
 
     assert!(dropped);
 

--- a/crates/edr_provider/tests/integration/issues/issue_356.rs
+++ b/crates/edr_provider/tests/integration/issues/issue_356.rs
@@ -66,7 +66,7 @@ async fn issue_356() -> anyhow::Result<()> {
         )))?;
 
     assert_eq!(
-        response.result,
+        response.deserialize_result::<String>()?,
         "0x0000000000000000000000000000000000000000000000000000000000000006"
     );
 

--- a/crates/edr_provider/tests/integration/issues/issue_407.rs
+++ b/crates/edr_provider/tests/integration/issues/issue_407.rs
@@ -71,7 +71,7 @@ async fn issue_407_uint() -> anyhow::Result<()> {
     let response = provider.handle_request(serde_json::from_value(request_with_uint)?)?;
 
     assert_eq!(
-        response.result,
+        response.deserialize_result::<String>()?,
         "0x2d9b08a9086931cc3ebb9ae446d440e43f0e4ca0abedd2d973af8278c5471bb54181a8dae6018d14d29d62facc535fbba5b4010cdb3f06c0ddcf72e2663583361b"
     );
 
@@ -140,7 +140,7 @@ async fn issue_407_int() -> anyhow::Result<()> {
     let response = provider.handle_request(serde_json::from_value(request_with_uint)?)?;
 
     assert_eq!(
-        response.result,
+        response.deserialize_result::<String>()?,
         "0x30622c2e4318a3ffb2755ca111f42409bd5a4190b4b8a9b5f42227313708ecb54889d229dfb7dcfb246f15e7567ef7471fb26a7e99d83631d266a144502ee29f1c"
     );
 

--- a/crates/edr_provider/tests/integration/rip7212.rs
+++ b/crates/edr_provider/tests/integration/rip7212.rs
@@ -58,7 +58,7 @@ async fn rip7212_disabled() -> anyhow::Result<()> {
             None,
         )))?;
 
-    assert_eq!(response.result, "0x");
+    assert_eq!(response.deserialize_result::<String>()?, "0x");
 
     Ok(())
 }
@@ -99,7 +99,7 @@ async fn rip7212_enabled() -> anyhow::Result<()> {
 
     // 1 gwei in hex
     assert_eq!(
-        response.result,
+        response.deserialize_result::<String>()?,
         "0x0000000000000000000000000000000000000000000000000000000000000001"
     );
 
@@ -149,7 +149,7 @@ async fn rip7212_enabled_post_osaka() -> anyhow::Result<()> {
 
     // 1 gwei in hex
     assert_eq!(
-        response.result,
+        response.deserialize_result::<String>()?,
         "0x0000000000000000000000000000000000000000000000000000000000000001"
     );
 

--- a/crates/edr_provider/tests/integration/timestamp.rs
+++ b/crates/edr_provider/tests/integration/timestamp.rs
@@ -75,7 +75,7 @@ impl TimestampFixture {
             MethodInvocation::GetBlockByNumber(PreEip1898BlockSpec::latest(), false),
         ))?;
 
-        let block: L1RpcBlock<B256> = serde_json::from_value(result.result)?;
+        let block: L1RpcBlock<B256> = result.deserialize_result()?;
         Ok(block.timestamp)
     }
 

--- a/crates/edr_rpc_client/src/jsonrpc.rs
+++ b/crates/edr_rpc_client/src/jsonrpc.rs
@@ -48,6 +48,9 @@ pub struct Response<SuccessT> {
 }
 
 /// Represents JSON-RPC 2.0 success response.
+///
+/// `SuccessT` must not contain a `serde_json::value::RawValue`. The untagged
+/// representation buffers its input, which cannot yield one.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ResponseData<SuccessT> {

--- a/crates/edr_rpc_client/src/jsonrpc.rs
+++ b/crates/edr_rpc_client/src/jsonrpc.rs
@@ -49,8 +49,9 @@ pub struct Response<SuccessT> {
 
 /// Represents JSON-RPC 2.0 success response.
 ///
-/// `SuccessT` must not contain a `serde_json::value::RawValue`. The untagged
-/// representation buffers its input, which cannot yield one.
+/// When deserializing this untagged enum, `SuccessT` must not contain a
+/// `serde_json::value::RawValue`: the representation buffers its input and
+/// cannot yield one. Serialization with `RawValue` is supported.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ResponseData<SuccessT> {


### PR DESCRIPTION
Follow-up to #1486, and stacked on it.

`ResponseWithCallTraces.result` was a `serde_json::Value`. Handlers built it with `serde_json::to_value`, then `marshal_response_data` walked the tree again with `serde_json::to_string`. Holding the serialized bytes instead makes the second pass a copy.

The performance gain is not significant but it is a prerequisite for further JSON-RPC round-trip optimisations.

## What changes

- `result` becomes a `Box<serde_json::value::RawValue>`, so each handler serializes once. Readers go through `RawValue::get` or the new `deserialize_result`.
- `marshal_response_data` sizes its buffer from the result's length rather than growing from 128 bytes. That same length also decides the string limit up front, so an oversized response no longer serializes a 250 MB string only to discard it.
- Batch responses are assembled from the already-serialized elements instead of being re-serialized through a `Value::Array`.
- serde_json's `raw_value` feature is enabled workspace-wide, alongside the features already declared there.

## Compatibility

The JSON reaching callers is byte-for-byte unchanged. A `Box<RawValue>` inside the untagged `jsonrpc::ResponseData` serializes exactly as the `Value` did, including through `#[serde(flatten)]`, and arbitrary-precision numbers survive. `marshal_response_data_matches_serde_for_success` and its error counterpart pin both arms against serde's own output.

No `#[napi]` signature changes, so `index.d.ts` is untouched.

## Benchmark Results

[JS scenario runner benchmark](https://github.com/NomicFoundation/edr/actions/runs/33388230122/attempts/2#summary-99621088615) (CI, vs latest main):

| Scenario | main | #1486 | #1698 | #1486 / main | #1698 / main | #1698 / #1486 |
|-|-:|-:|-:|-:|-:|-:|
| **All Scenarios** | **210,629** | **153,020** | **148,833** | **0.73** | **0.71** | **0.97** |
| `synthetix_9a3a109f` | 156,751 | 111,860 | 108,024 | 0.71 | 0.69 | 0.97 |
| `neptune-mutual-blue-protocol_8db6480` | 21,999 | 17,240 | 16,885 | 0.78 | 0.77 | 0.98 |
| `rocketpool_6a9dbfd8` | 12,998 | 8,940 | 8,838 | 0.69 | 0.68 | 0.99 |
| `openzeppelin-contracts_0a5fba7a` | 9,110 | 7,250 | 7,337 | 0.80 | 0.81 | 1.01 |
| `seaport_585b2ef8` | 5,041 | 4,050 | 4,047 | 0.80 | 0.80 | 1.00 |
| `uniswap-v3-core_d8b1c63` | 4,068 | 3,190 | 3,205 | 0.78 | 0.79 | 1.00 |
| `safe-contracts_914d0f8` | 662 | 490 | 496 | 0.74 | 0.75 | 1.01 |

[HH3 regression benchmark](https://github.com/NomicFoundation/edr/actions/runs/33478335441) (CI, vs latest main):


| Benchmark suite | #1698 | #1486 | Ratio |
|-|-|-|-|
| `ens-contracts / test vitest` | `3.9861710216199997` s (`± 0.09548535425823759`) | `4.06399684068` s (`± 0.012688302868408073`) | `0.98` |
| `ens-contracts / test vitest (peak RSS)` | `637` MB | `638` MB | `1.00` |
| `ens-contracts / test vitest (cpu)` | `81.23737028` s (`± 0`) | `80.07114505999999` s (`± 0`) | `1.01` |
| `lidofinance-core / test mocha` | `10.451533232740001` s (`± 0.11958584155861957`) | `10.36830099496` s (`± 0.020690816987286226`) | `1.01` |
| `lidofinance-core / test mocha (peak RSS)` | `795` MB | `804` MB | `0.99` |
| `lidofinance-core / test mocha (cpu)` | `379.8732149` s (`± 0`) | `378.19546216` s (`± 0`) | `1.00` |
| `openzeppelin-contracts / test mocha` | `57.92275289228` s (`± 0.019179380485141086`) | `57.84666742306` s (`± 0.010488213657848557`) | `1.00` |
| `openzeppelin-contracts / test mocha (peak RSS)` | `3531` MB | `3498` MB | `1.01` |
| `openzeppelin-contracts / test mocha (cpu)` | `62.59357925999999` s (`± 0`) | `62.39426504` s (`± 0`) | `1.00` |

## Validation

- New unit tests for the envelope and for batch assembly.
- Scenario replay is unchanged on every fixture.

## Notes for review

- `raw_value` is declared workspace-wide deliberately. Four crates name `RawValue`, and `edr_rpc_client` sits upstream of `edr_provider`, so it never inherits the feature.
- The envelope is built through `serde_json::to_writer` into a pre-sized buffer rather than by hand. Concatenating `{"result":` measures the same but duplicates the wire format of a type in another crate.