### PR TITLE
test(cheatcodes): filter JSON-object strings out of roundtrip proptests

### DIFF
--- a/crates/foundry/cheatcodes/src/json.rs
+++ b/crates/foundry/cheatcodes/src/json.rs
@@ -2064,14 +2064,26 @@ mod tests {
 
     use super::*;
 
-    fn contains_tuple(value: &DynSolValue) -> bool {
+    /// `serialize_value_as_json` re-parses any string whose content is a JSON
+    /// object, so such strings do not survive the round trip.
+    fn roundtrippable_strings(value: &DynSolValue) -> bool {
         match value {
-            DynSolValue::Tuple(_) | DynSolValue::CustomStruct { .. } => true,
-            DynSolValue::Array(v) | DynSolValue::FixedArray(v) => {
-                v.first().is_some_and(contains_tuple)
+            DynSolValue::String(s) => serde_json::from_str::<Map<String, Value>>(s).is_err(),
+            DynSolValue::Array(v) | DynSolValue::FixedArray(v) | DynSolValue::Tuple(v) => {
+                v.iter().all(roundtrippable_strings)
             }
-            _ => false,
+            DynSolValue::CustomStruct { tuple, .. } => tuple.iter().all(roundtrippable_strings),
+            _ => true,
         }
+    }
+
+    fn valid_value(value: &DynSolValue) -> bool {
+        (match value {
+            DynSolValue::Tuple(_) | DynSolValue::CustomStruct { .. } => false,
+            DynSolValue::Array(v) | DynSolValue::FixedArray(v) => v.iter().all(valid_value),
+            _ => true,
+        }) && roundtrippable_strings(value)
+            && value.as_type().is_some()
     }
 
     /// [`DynSolValue::Bytes`] of length 32 and 20 are converted to
@@ -2102,8 +2114,7 @@ mod tests {
     fn guessable_types() -> impl proptest::strategy::Strategy<Value = DynSolValue> {
         proptest::arbitrary::any::<DynSolValue>()
             .prop_map(fixup_guessable)
-            .prop_filter("tuples are not supported", |v| !contains_tuple(v))
-            .prop_filter("filter out values without type", |v| v.as_type().is_some())
+            .prop_filter("invalid value", valid_value)
     }
 
     // Tests to ensure that conversion [DynSolValue] -> [serde_json::Value] ->
@@ -2120,10 +2131,13 @@ mod tests {
         }
 
         #[test]
-        fn test_json_roundtrip(v in proptest::arbitrary::any::<DynSolValue>().prop_filter("filter out values without type", |v| v.as_type().is_some())) {
-                let json = serialize_value_as_json(v.clone()).unwrap();
+        fn test_json_roundtrip(v in proptest::arbitrary::any::<DynSolValue>()
+            .prop_filter("filter out values without type", |v| v.as_type().is_some())
+            .prop_filter("JSON-object strings are not roundtrippable", roundtrippable_strings))
+        {
+            let json = serialize_value_as_json(v.clone()).unwrap();
             let value = parse_json_as(&json, &v.as_type().unwrap()).unwrap();
-                assert_eq!(value, v);
+            assert_eq!(value, v);
         }
     }
 }


### PR DESCRIPTION
Noticed a CI failure in the fuzz tests for foundry-cheatcodes, see [33375387311](https://github.com/NomicFoundation/edr/actions/runs/33375387311/job/99436069912). It's a JSON roundtrip failure that's PARTIALLY fixed upstream., I've adapted the upstream fix and fixed also the un-fixed test method. 

# Claude summary

Fixes an intermittent CI failure in the `foundry-cheatcodes` JSON roundtrip proptests, most recently seen in merge-queue run [33375387311](https://github.com/NomicFoundation/edr/actions/runs/33375387311/job/99436069912) (for #1692, which was unrelated).

## The flake

`serialize_value_as_json` deliberately re-parses a Solidity string whose *content* is a JSON object — `vm.serializeString` accepts stringified JSON. So `String("{}")` serializes to `{}` instead of `"{}"`, and the `DynSolValue -> serde_json::Value -> DynSolValue` round trip is genuinely not identity for such strings. Both roundtrip proptests draw fresh random cases every run (no persisted seeds), so whenever the generator happens to draw a JSON-object-shaped string, CI fails:

- `test_json_roundtrip_guessed`: `SolTypes(Overrun)` — the `{}` comes back as an empty tuple, whose ABI encoding overruns when decoded as `string[]`
- `test_json_roundtrip`: `"expected string, found JSON object"` from `parse_json_as`

Minimal failing input in both observed CI failures: `Array([String("{}")])`.

## The fix

Backport of upstream [foundry-rs/foundry#12335](https://github.com/foundry-rs/foundry/pull/12335), generalized:

- Replace `contains_tuple` with `valid_value`, which also rejects values containing JSON-object strings and checks **all** array elements — the old helper only inspected the first, so a tuple in any later position slipped through the filter.
- Instead of upstream's literal `s == "{}"` exclusion, a `roundtrippable_strings` helper rejects any string `serde_json` parses as an object — the exact check the serializer performs — recursing through arrays, tuples, and custom structs. This also covers whitespace variants like `" {}"` that the literal misses.
- Also filter the plain `test_json_roundtrip`, which upstream left flaky; its strategy keeps tuple/struct coverage and only excludes the JSON-object strings.

Upstream's earlier band-aid (foundry-rs/foundry#11391, `failure_persistence: None` + reduced case count) was later removed there by #11612 and is not ported; the strategy filter makes it unnecessary.

## Validation

- Replaying the failing CI seed (`cc d6ac72fd…` via a temporary `proptest-regressions/json.txt`) reproduces the exact `SolTypes(Overrun)` failure on `main` and passes with this change (the filter rejects the replayed value).
- Both tests pass a `PROPTEST_CASES=20000` soak; the full `foundry-cheatcodes` lib suite and clippy are clean.
