### PR TITLE
fix: don't panic on a fuzz counterexample without a recorded arena

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3604,6 +3604,7 @@ dependencies = [
  "futures",
  "humantime-serde",
  "itertools 0.15.0",
+ "mockito",
  "num-traits",
  "once_cell",
  "parking_lot",

--- a/crates/edr_solidity_tests/Cargo.toml
+++ b/crates/edr_solidity_tests/Cargo.toml
@@ -54,6 +54,7 @@ paste = "1.0"
 serde_json.workspace = true
 semver.workspace = true
 serial_test = "4.0.0"
+mockito = { version = "1.7", default-features = false }
 tempfile.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 

--- a/crates/edr_solidity_tests/src/runner.rs
+++ b/crates/edr_solidity_tests/src/runner.rs
@@ -1520,25 +1520,29 @@ impl<
         self.result.stack_trace_result = if let Some(CounterExample::Single(counter_example)) =
             self.result.counterexample.as_ref()
         {
-            let stack_trace_result: SolidityTestStackTraceResult<_> =
-                if fuzzed_executor.tracer_records_steps() {
-                    let (failing_trace, prior_traces) = self
-                        .result
-                        .execution_traces
-                        .split_last()
-                        .expect("the traced counterexample call recorded an arena");
-
-                    collect_stack_trace(
+            if fuzzed_executor.tracer_records_steps() {
+                if let Some((failing_trace, prior_traces)) =
+                    self.result.execution_traces.split_last()
+                {
+                    Some(collect_stack_trace(
                         &*self.cr.contract_decoder,
                         self.setup,
                         failing_trace,
                         prior_traces,
-                    )
-                } else if let Some(indeterminism_reasons) =
-                    counter_example.indeterminism_reasons.clone()
-                {
-                    indeterminism_reasons.into()
+                    ))
                 } else {
+                    // An executor error — as opposed to a reverting call —
+                    // produces a counterexample without a recorded arena, so
+                    // no trace describes the failure; the result's `reason`
+                    // carries the error.
+                    None
+                }
+            } else if let Some(indeterminism_reasons) =
+                counter_example.indeterminism_reasons.clone()
+            {
+                Some(indeterminism_reasons.into())
+            } else {
+                Some(
                     re_run_fuzz_counterexample_for_stack_traces(
                         self.cr,
                         func,
@@ -1546,9 +1550,9 @@ impl<
                         counter_example,
                         self.setup.has_setup_method,
                     )
-                    .into()
-                };
-            Some(stack_trace_result)
+                    .into(),
+                )
+            }
         } else {
             None
         };

--- a/crates/edr_solidity_tests/tests/it/repros.rs
+++ b/crates/edr_solidity_tests/tests/it/repros.rs
@@ -12,7 +12,7 @@ use edr_solidity_tests::{
     revm::context::{BlockEnv, TxEnv},
     CollectStackTraces, SolidityTestRunnerConfig,
 };
-use foundry_cheatcodes::{FsPermissions, PathPermission};
+use foundry_cheatcodes::{FsPermissions, PathPermission, RpcEndpointUrl, RpcEndpoints};
 use foundry_evm::{
     constants::HARDHAT_CONSOLE_ADDRESS,
     decode::decode_console_logs,
@@ -800,4 +800,130 @@ async fn on_failure_mode_produces_stack_trace_for_failing_setup() {
         .expect("the AlwaysStackTraceFailingSetup suite should have run");
 
     assert_execution_error_stack_trace(suite, "setUp()");
+}
+
+/// One 32-byte zero hash as a hex literal.
+const ZERO_HASH: &str = "0x0000000000000000000000000000000000000000000000000000000000000000";
+
+/// The `id` of the JSON-RPC request, to echo in the response.
+fn request_id(request: &mockito::Request) -> u64 {
+    serde_json::from_slice::<serde_json::Value>(request.body().expect("a JSON-RPC request"))
+        .expect("a JSON-RPC request body")
+        .get("id")
+        .and_then(serde_json::Value::as_u64)
+        .expect("a numeric request id")
+}
+
+/// Serves `method` with `result` on `server`, echoing the request id.
+async fn mock_rpc_method(
+    server: &mut mockito::Server,
+    method: &'static str,
+    result: String,
+) -> mockito::Mock {
+    server
+        .mock("POST", "/")
+        .match_body(mockito::Matcher::PartialJsonString(format!(
+            r#"{{"method":"{method}"}}"#
+        )))
+        .with_body_from_request(move |request| {
+            format!(
+                r#"{{"jsonrpc":"2.0","id":{},"result":{result}}}"#,
+                request_id(request)
+            )
+            .into()
+        })
+        .create_async()
+        .await
+}
+
+// Regression test: an executor error during a fuzz run — as opposed to a
+// reverting call — produces a counterexample without a recorded trace arena.
+// The result must report the error as its reason and no stack trace, rather
+// than panicking on the missing arena. The error is provoked through a fork
+// whose RPC serves fork creation but fails the account fetch the fuzzed call
+// triggers.
+#[tokio::test(flavor = "multi_thread")]
+async fn fuzz_executor_error_reports_no_stack_trace() {
+    let mut server = mockito::Server::new_async().await;
+    let block = format!(
+        r#"{{"hash":"{ZERO_HASH}","parentHash":"{ZERO_HASH}","sha3Uncles":"{ZERO_HASH}","miner":"0x0000000000000000000000000000000000000000","stateRoot":"{ZERO_HASH}","transactionsRoot":"{ZERO_HASH}","receiptsRoot":"{ZERO_HASH}","logsBloom":"0x{bloom}","difficulty":"0x0","number":"0x100","gasLimit":"0x1c9c380","gasUsed":"0x0","timestamp":"0x66000000","extraData":"0x","mixHash":"{ZERO_HASH}","nonce":"0x0000000000000000","baseFeePerGas":"0x0","totalDifficulty":"0x0","uncles":[],"transactions":[],"size":"0x0"}}"#,
+        bloom = "00".repeat(256),
+    );
+    let _mocks = [
+        mock_rpc_method(&mut server, "eth_blockNumber", r#""0x100""#.into()).await,
+        mock_rpc_method(&mut server, "eth_gasPrice", r#""0x0""#.into()).await,
+        mock_rpc_method(&mut server, "eth_chainId", r#""0x7a69""#.into()).await,
+        mock_rpc_method(&mut server, "eth_getBlockByNumber", block).await,
+        mock_rpc_method(&mut server, "eth_getTransactionCount", r#""0x0""#.into()).await,
+        mock_rpc_method(&mut server, "eth_getCode", r#""0x""#.into()).await,
+        mock_rpc_method(&mut server, "eth_getStorageAt", format!(r#""{ZERO_HASH}""#)).await,
+        mock_rpc_method(&mut server, "eth_getBalance", r#""0x0""#.into()).await,
+    ];
+    // The fetch of the one account only the fuzzed call touches fails. This
+    // mock is created last: mockito matches most recent first, so it shadows
+    // the zero-balance mock above for this address.
+    let _balance_mock = server
+        .mock("POST", "/")
+        .match_body(mockito::Matcher::AllOf(vec![
+            mockito::Matcher::Regex("eth_getBalance".into()),
+            mockito::Matcher::Regex("(?i)dead".into()),
+        ]))
+        .with_body_from_request(|request| {
+            format!(
+                r#"{{"jsonrpc":"2.0","id":{},"error":{{"code":-32000,"message":"account fetch refused by the test"}}}}"#,
+                request_id(request)
+            )
+            .into()
+        })
+        .create_async()
+        .await;
+
+    let mut config = runner_config(None, &TEST_DATA_DEFAULT, false).await;
+    config.collect_stack_traces = CollectStackTraces::Always;
+    config.cheats_config_options.rpc_endpoints =
+        RpcEndpoints::new([("mock", RpcEndpointUrl::new(server.url()))]);
+    // Fail fast if a request slips past the mocks.
+    config.evm_opts.fork_retries = Some(1);
+    config.evm_opts.fork_retry_backoff = Some(50);
+    // Every run errors; one is enough.
+    config.fuzz.runs = 1;
+
+    let runner = TEST_DATA_DEFAULT.runner_with_config(config).await;
+    let filter = SolidityTestFilter::contract("FuzzExecutorErrorTest");
+    let suite_results = runner.test_collect(filter).await.suite_results;
+
+    let suite = suite_results
+        .get("default/repros/FuzzExecutorError.t.sol:FuzzExecutorErrorTest")
+        .expect("the FuzzExecutorError suite should have run");
+    let result = suite
+        .test_results
+        .get("testFuzzTouchesUnfetchableAccount(uint256)")
+        .unwrap_or_else(|| {
+            panic!(
+                "the fuzz test should have run; results: {:?}",
+                suite
+                    .test_results
+                    .iter()
+                    .map(|(k, r)| (k, &r.status, &r.reason, &r.decoded_logs))
+                    .collect::<Vec<_>>()
+            )
+        });
+
+    assert_eq!(result.status, TestStatus::Failure, "{:?}", result.reason);
+    assert!(
+        result.counterexample.is_some(),
+        "the failed run yields a counterexample"
+    );
+    assert!(
+        result
+            .reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("account fetch refused by the test")),
+        "expected the executor error as the failure reason, got {:?}",
+        result.reason
+    );
+    assert!(
+        result.stack_trace_result.is_none(),
+        "no recorded arena describes an executor error, so there is no stack trace"
+    );
 }

--- a/crates/edr_solidity_tests/tests/testdata/default/repros/FuzzExecutorError.t.sol
+++ b/crates/edr_solidity_tests/tests/testdata/default/repros/FuzzExecutorError.t.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.18;
+
+import "ds-test/test.sol";
+import "cheats/Vm.sol";
+
+// Fixture for `fuzz_executor_error_reports_no_stack_trace`: the fuzzed call
+// reads an account that only exists behind the fork's RPC, which the test's
+// mock server fails on purpose — an executor-level error rather than a
+// revert, so the counterexample records no trace arena.
+contract FuzzExecutorErrorTest is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+
+    function setUp() public {
+        vm.createSelectFork("mock");
+    }
+
+    function testFuzzTouchesUnfetchableAccount(uint256) public {
+        require(address(0xdEaD).balance == 0, "unreachable: the fetch fails");
+    }
+}

--- a/crates/foundry/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/foundry/evm/evm/src/executors/fuzz/mod.rs
@@ -363,7 +363,9 @@ impl<
         let mut call = self
             .executor
             .call_raw(self.sender, address, calldata.clone(), U256::ZERO)
-            .map_err(|e| TestCaseError::fail(e.to_string()))?;
+            // Alternate formatting includes the error's chain: `to_string`
+            // yields only the outermost layer — a bare "EVM error".
+            .map_err(|e| TestCaseError::fail(format!("{e:#}")))?;
 
         // Handle `vm.assume`.
         if call.result.as_ref() == MAGIC_ASSUME {


### PR DESCRIPTION
Two commits: the first adds an end-to-end reproduction of the panic and fails until the second fixes it (validated at each commit).

**`test: reproduce the fuzz counterexample panic on an executor error`**

An executor error during a fuzz run — as opposed to a reverting call — produces a counterexample without a recorded trace arena, and the stack-trace computation in `FunctionRunner::run_fuzz_test` then panics on the missing arena when the tracer records steps.

Reproduce it end to end: the fuzzed call runs on a fork whose mock RPC serves fork creation and every account fetch except the one address that only the fuzzed call reads, so `call_raw` itself fails with a database error. The test pins the intended outcome — the failure's reason carries the executor error and there is no stack trace — and fails with the panic until the following commit fixes it.

**`fix: don't panic on a fuzz counterexample without a recorded arena`**

`FunctionRunner::run_fuzz_test` expects the counterexample's call to have recorded a trace arena whenever the tracer records steps. An executor error — as opposed to a reverting call — breaks that expectation: `single_fuzz` turns it into a test-case failure without a counterexample outcome, so the counterexample is built without traces, `execution_traces` stays empty, and the `split_last().expect(..)` panics. It became reachable when the failing arena was named explicitly, because the suite's setup arenas are no longer chained into the same list.

Handle it like the invariant campaign that retains no arena: nothing describes the failure, so there is no stack trace to compute, and the result's `reason` carries the executor error — now with its error chain: `to_string` on the `eyre` report yielded only the outermost "EVM error" layer, hiding the cause. An EVM-level failure of the call itself surfaces as a revert with a recorded arena; only an executor error, such as the fork database failure in the preceding commit's reproduction, produces a traceless counterexample. That reproduction now passes.

---
Part of the Solidity test runner memory-reduction series; stacked on #1623 (merged).
