### PR TITLE
docs: state the contracts the stack-trace computation relies on

### DIFF
--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -146,7 +146,10 @@ export declare class TestResult {
    * Compute the error stack trace.
    * The result is either the stack trace or the reason why we couldn't
    * generate the stack trace.
-   * Returns null if the test status is succeeded or skipped.
+   * Returns null if the test succeeded or was skipped. Also returns null
+   * when the failure left no trace behind, for example an invariant
+   * campaign whose calls were all rejected by `vm.assume`; the `reason`
+   * field then explains the failure.
    * Cannot throw.
    */
   stackTrace(): StackTrace | UnexpectedError | HeuristicFailed | UnsafeToReplay | null

--- a/crates/edr_napi/src/solidity_tests/test_results.rs
+++ b/crates/edr_napi/src/solidity_tests/test_results.rs
@@ -241,7 +241,10 @@ impl TestResult {
     /// Compute the error stack trace.
     /// The result is either the stack trace or the reason why we couldn't
     /// generate the stack trace.
-    /// Returns null if the test status is succeeded or skipped.
+    /// Returns null if the test succeeded or was skipped. Also returns null
+    /// when the failure left no trace behind, for example an invariant
+    /// campaign whose calls were all rejected by `vm.assume`; the `reason`
+    /// field then explains the failure.
     /// Cannot throw.
     #[napi]
     pub fn stack_trace(

--- a/crates/edr_solidity/src/solidity_stack_trace.rs
+++ b/crates/edr_solidity/src/solidity_stack_trace.rs
@@ -280,6 +280,13 @@ pub struct DeployedCode<'a> {
 ///    converted, so they need no recorded EVM steps.
 /// 3. `failing_trace` itself, since execution may deploy a contract and then
 ///    fail inside it.
+///
+/// `failing_trace` must carry recorded EVM steps: the heuristics walk the
+/// executed instructions to locate the failure. Without steps, only the few
+/// inferences based on calldata and contract metadata can run.
+///
+/// An empty `Ok` result means the heuristics could not explain the failure.
+/// Callers present it as a failed heuristic, not as a missing stack trace.
 pub fn get_stack_trace<
     'arena,
     HaltReasonT: HaltReasonTrait,

--- a/crates/edr_solidity_tests/src/result.rs
+++ b/crates/edr_solidity_tests/src/result.rs
@@ -424,10 +424,10 @@ pub struct TestResult<HaltReasonT> {
 
     /// The outcome of the stack trace computation.
     /// None if the test succeeded or was skipped. Also None when the failure
-    /// left no trace arena behind; `reason` then explains the failure. That
-    /// happens when every call of an invariant campaign was rejected by
-    /// `vm.assume`, when the campaign failed before its first call, and when
-    /// an executor error produced the fuzz counterexample.
+    /// left no trace arena behind; `reason` then explains the failure. Examples
+    /// include a fuzz test whose inputs or an invariant campaign whose calls
+    /// were all rejected by `vm.assume`, an invariant campaign that failed
+    /// before its first call, and an executor-error fuzz counterexample.
     /// If the heuristic failed the vec is set but empty.
     /// Error if there was an error computing the stack trace.
     #[serde(skip)]

--- a/crates/edr_solidity_tests/src/result.rs
+++ b/crates/edr_solidity_tests/src/result.rs
@@ -394,7 +394,13 @@ pub struct TestResult<HaltReasonT> {
     /// What kind of test this was
     pub kind: TestKind,
 
-    /// Traces
+    /// Trace arenas of the calls the test executed, in execution order.
+    ///
+    /// When the test failed and the tracer recorded steps, the last arena is
+    /// the call that produced the failure. The stack-trace computation splits
+    /// that arena off; it walks the earlier ones only for the contracts they
+    /// deployed. Can be empty even for a failing test — see
+    /// [`Self::stack_trace_result`].
     #[serde(skip)]
     pub execution_traces: Vec<SparsedTraceArena>,
 
@@ -416,9 +422,13 @@ pub struct TestResult<HaltReasonT> {
     /// execution which should be accumulated.
     pub value_snapshots: BTreeMap<String, BTreeMap<String, String>>,
 
-    /// The outcome of the stack trace error computation.
-    /// None if the test status is succeeded or skipped.
-    /// If the heuristic failed the vec is set but emtpy.
+    /// The outcome of the stack trace computation.
+    /// None if the test succeeded or was skipped. Also None when the failure
+    /// left no trace arena behind; `reason` then explains the failure. That
+    /// happens when every call of an invariant campaign was rejected by
+    /// `vm.assume`, when the campaign failed before its first call, and when
+    /// an executor error produced the fuzz counterexample.
+    /// If the heuristic failed the vec is set but empty.
     /// Error if there was an error computing the stack trace.
     #[serde(skip)]
     pub stack_trace_result: Option<SolidityTestStackTraceResult<HaltReasonT>>,
@@ -920,9 +930,10 @@ pub struct TestSetup<HaltReasonT> {
     /// Whether the test failed to deploy.
     pub deployment_failure: bool,
 
-    /// The outcome of the stack trace error computation.
-    /// None if the test status is succeeded or skipped.
-    /// If the heuristic failed the vec is set but emtpy.
+    /// The outcome of the stack trace computation.
+    /// None if setup succeeded, the suite was skipped, or no setup trace was
+    /// recorded for the failure.
+    /// If the heuristic failed the vec is set but empty.
     /// Error if there was an error computing the stack trace.
     pub stack_trace_result: Option<SolidityTestStackTraceResult<HaltReasonT>>,
     /// Whether the test had a setup method.

--- a/crates/edr_solidity_tests/tests/it/repros.rs
+++ b/crates/edr_solidity_tests/tests/it/repros.rs
@@ -776,6 +776,49 @@ async fn always_mode_produces_stack_trace_for_failing_test() {
     );
 }
 
+// An invariant campaign whose calls are all rejected by `vm.assume`
+// executes them but discards every trace. No arena then describes the
+// failure, so even `Always` mode reports no stack trace. The result's
+// reason explains the failure instead.
+#[tokio::test(flavor = "multi_thread")]
+async fn always_mode_reports_no_stack_trace_without_a_failing_arena() {
+    let mut config = runner_config(None, &TEST_DATA_VIA_IR, false).await;
+    config.collect_stack_traces = CollectStackTraces::Always;
+    // Abort the campaign quickly; every fuzzed call is rejected.
+    config.invariant.runs = 2;
+    config.invariant.depth = 2;
+    config.invariant.max_assume_rejects = 8;
+
+    let contract_decoder = contract_decoder(TEST_DATA_VIA_IR.build_info_path());
+    let runner = TEST_DATA_VIA_IR
+        .runner_with_contract_decoder(config, contract_decoder)
+        .await;
+    let filter = SolidityTestFilter::contract("AlwaysStackTraceInvariantNoCallTest");
+    let suite_results = runner.test_collect(filter).await.suite_results;
+
+    let suite = suite_results
+        .get("via-ir/repros/StackTraceAlwaysMode.t.sol:AlwaysStackTraceInvariantNoCallTest")
+        .expect("the AlwaysStackTraceInvariantNoCall suite should have run");
+    let result = suite
+        .test_results
+        .get("invariantNothing()")
+        .expect("the invariant test should have run");
+
+    assert_eq!(result.status, TestStatus::Failure, "{:?}", result.reason);
+    assert!(
+        result
+            .reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("`vm.assume`")),
+        "expected the campaign to abort on assume rejects, got {:?}",
+        result.reason
+    );
+    assert!(
+        result.stack_trace_result.is_none(),
+        "no recorded arena describes the failure, so there is no stack trace"
+    );
+}
+
 // A failing `setUp()` must produce a stack trace via the re-execution
 // fallback in the default `CollectStackTraces::OnFailure` mode too, matching
 // the `Always` mode behavior.

--- a/crates/edr_solidity_tests/tests/it/repros.rs
+++ b/crates/edr_solidity_tests/tests/it/repros.rs
@@ -814,6 +814,10 @@ async fn always_mode_reports_no_stack_trace_without_a_failing_arena() {
         result.reason
     );
     assert!(
+        result.execution_traces.is_empty(),
+        "rejected calls should leave no recorded trace arena"
+    );
+    assert!(
         result.stack_trace_result.is_none(),
         "no recorded arena describes the failure, so there is no stack trace"
     );

--- a/crates/edr_solidity_tests/tests/testdata/via-ir/repros/StackTraceAlwaysMode.t.sol
+++ b/crates/edr_solidity_tests/tests/testdata/via-ir/repros/StackTraceAlwaysMode.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.18;
 
 import "ds-test/test.sol";
+import "cheats/Vm.sol";
 
 // Fixture for `always_mode_produces_stack_trace_for_failing_test`: a failing
 // test that has a `setUp`, and reverts inside a called contract.
@@ -88,5 +89,33 @@ contract AlwaysStackTraceInvariantInitialTest is DSTest {
 
     function invariantAlwaysBroken() public view {
         reverter.boom();
+    }
+}
+
+// Covers the invariant campaign that keeps no trace arena. Every fuzzed
+// call hits `vm.assume(false)`, so the campaign rejects the call and
+// discards its trace. After `max_assume_rejects` rejects, the campaign
+// aborts without an arena describing the failure. The result therefore
+// carries a reason but no stack trace.
+contract AlwaysStackTraceInvariantNoCallTest is DSTest {
+    Rejecter rejecter;
+
+    function setUp() public {
+        rejecter = new Rejecter();
+    }
+
+    function invariantNothing() public view {}
+}
+
+contract Rejecter {
+    Vm constant vm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+
+    uint256 public counter;
+
+    // The only fuzzable function (view functions are excluded from
+    // selection), so every campaign call is rejected.
+    function poke() public {
+        counter += 1;
+        vm.assume(false);
     }
 }

--- a/crates/foundry/evm/traces/src/lib.rs
+++ b/crates/foundry/evm/traces/src/lib.rs
@@ -38,6 +38,9 @@ pub mod decoder;
 pub use decoder::{CallTraceDecoder, CallTraceDecoderBuilder};
 use foundry_evm_core::contracts::{ContractsByAddress, ContractsByArtifact};
 
+/// A suite's `setUp()` trace arenas in execution order. When setup failed,
+/// the last arena is the failing call; the setup stack-trace computation
+/// relies on that.
 pub type SetupTraces = Vec<SetupTrace>;
 
 pub type SetupTrace = (SetupTraceKind, SparsedTraceArena);

--- a/crates/foundry/evm/traces/src/lib.rs
+++ b/crates/foundry/evm/traces/src/lib.rs
@@ -38,9 +38,9 @@ pub mod decoder;
 pub use decoder::{CallTraceDecoder, CallTraceDecoderBuilder};
 use foundry_evm_core::contracts::{ContractsByAddress, ContractsByArtifact};
 
-/// A suite's `setUp()` trace arenas in execution order. When setup failed,
-/// the last arena is the failing call; the setup stack-trace computation
-/// relies on that.
+/// A suite's setup-phase trace arenas, including deployments and `setUp()`,
+/// in execution order. When setup failed, the last arena is the failing call;
+/// the setup stack-trace computation relies on that.
 pub type SetupTraces = Vec<SetupTrace>;
 
 pub type SetupTrace = (SetupTraceKind, SparsedTraceArena);


### PR DESCRIPTION
## Problem / context

#1623 made `get_stack_trace` take the failing arena explicitly. That turned two implicit assumptions into contracts the code relies on, and it silently changed one documented contract. None of this was written down where the next reader needs it.

## Solution

Documentation only, plus one regression test:

- `TestResult::execution_traces` is ordered by execution and its last arena is the failing call. Six `split_last` sites across two crates rely on this, so the field doc now states it. The same holds for a failed suite's `SetupTraces`.
- `stack_trace_result` (and the napi `stackTrace()` mirror) claimed `None` implies the test succeeded or was skipped. A failure is also `None` when no retained arena describes it; `reason` then explains the failure. That happens for an assume-rejected invariant campaign, a campaign that failed before its first call, and a fuzz counterexample produced by an executor error (#1700).
- `get_stack_trace` returns `Ok` with an empty vec when the heuristics cannot explain the failure; callers present that as a failed heuristic. It also needs the failing arena to carry recorded EVM steps, since only the calldata- and metadata-based inferences work without them.

## Validation

- New repro `always_mode_reports_no_stack_trace_without_a_failing_arena`: an invariant campaign whose calls are all rejected by `vm.assume` fails with a reason and no stack trace. It pins the previously untested `None`-on-failure case.

## Notes for reviewer

- Stacked on #1700 (merged); part of the Solidity test runner memory-reduction series.
- No behavior changes. The one code addition is the test fixture (`AlwaysStackTraceInvariantNoCallTest`).
