### PR TITLE
perf: free unconsumed trace arenas as soon as each test finishes

### DIFF
--- a/crates/edr_napi/src/solidity_tests/test_results.rs
+++ b/crates/edr_napi/src/solidity_tests/test_results.rs
@@ -301,8 +301,8 @@ impl TestResult {
         setup_traces: &edr_solidity_tests::traces::SetupTraces,
         include_traces: IncludeTraces,
     ) -> Self {
-        let include_trace = include_traces == IncludeTraces::All
-            || (include_traces == IncludeTraces::Failing && test_result.status.is_failure());
+        let include_trace = edr_solidity::config::IncludeTraces::from(include_traces)
+            .should_include(|| test_result.status.is_failure());
 
         Self {
             name,

--- a/crates/edr_solidity_tests/src/lib.rs
+++ b/crates/edr_solidity_tests/src/lib.rs
@@ -24,6 +24,7 @@ pub use foundry_evm::executors::stack_trace::SolidityTestStackTraceError;
 
 mod error;
 mod test_filter;
+mod trace_retention;
 
 pub use foundry_evm::*;
 pub use test_filter::{TestFilter, TestFilterConfig};

--- a/crates/edr_solidity_tests/src/multi_runner.rs
+++ b/crates/edr_solidity_tests/src/multi_runner.rs
@@ -42,7 +42,7 @@ use crate::{
     error::TestRunnerError,
     fuzz::{invariant::InvariantConfig, FuzzConfig},
     inline_config::{self, InlineConfigRoot, SharedInlineConfigProvider},
-    result::SuiteResult,
+    result::{SuiteResult, SuiteRunOutcome, TestRunOutcome},
     runner::{ContractRunnerArtifacts, ContractRunnerOptions},
     ContractRunner, SolidityTestRunnerConfig, SolidityTestRunnerConfigError, TestFilter,
     TestFunctionConfigOverride,
@@ -510,23 +510,34 @@ impl<
                     invariant_config: &self.invariant_config,
                     test_function_overrides: &inline_overrides,
                     generate_gas_report: self.generate_gas_report,
+                    include_traces: self.include_traces,
                 },
                 span,
             );
-        let mut r = runner.run_tests(filter, handle)?;
-        r.warnings.extend(inline_config_warnings);
+        let SuiteRunOutcome {
+            duration,
+            mut setup_traces,
+            test_outcomes,
+            mut warnings,
+        } = runner.run_tests(filter, handle)?;
+        warnings.extend(inline_config_warnings);
 
         let mut gas_report = self
             .generate_gas_report
             .then(crate::gas_report::GasReport::default);
 
-        if self.include_traces != IncludeTraces::None {
+        let test_results = if self.include_traces == IncludeTraces::None {
+            test_outcomes
+                .into_iter()
+                .map(|(signature, outcome)| (signature, outcome.result))
+                .collect()
+        } else {
             let mut decoder = CallTraceDecoderBuilder::new().build();
             let mut trace_identifier = TraceIdentifiers::new().with_local(&self.known_contracts);
 
             // Setup traces are shared across all tests in the suite, so decode and analyze
             // them only once.
-            for (_, arena) in &mut r.setup_traces {
+            for (_, arena) in &mut setup_traces {
                 decoder.identify(arena, &mut trace_identifier);
                 tokio::task::block_in_place(|| {
                     handle.block_on(decode_trace_arena(arena, &decoder));
@@ -536,64 +547,76 @@ impl<
             if let Some(gas_report) = gas_report.as_mut() {
                 tokio::task::block_in_place(|| {
                     handle.block_on(
-                        gas_report.analyze(r.setup_traces.iter().map(|(_, a)| &a.arena), &decoder),
+                        gas_report.analyze(setup_traces.iter().map(|(_, a)| &a.arena), &decoder),
                     );
                 });
             }
 
-            for result in r.test_results.values_mut() {
-                if result.status.is_success() && self.include_traces != IncludeTraces::All {
-                    continue;
-                }
+            test_outcomes
+                .into_iter()
+                .map(|(signature, outcome)| {
+                    let TestRunOutcome {
+                        mut result,
+                        gas_report_samples,
+                    } = outcome;
 
-                decoder.clear_addresses();
-                decoder.labels.extend(
-                    result
-                        .labeled_addresses
-                        .iter()
-                        .map(|(k, v)| (*k, v.clone())),
-                );
-
-                // Re-execute setup traces to collect identities of deployed contracts.
-                for (_, arena) in &mut r.setup_traces {
-                    decoder.identify(arena, &mut trace_identifier);
-                }
-
-                for arena in &mut result.execution_traces {
-                    decoder.identify(arena, &mut trace_identifier);
-                    tokio::task::block_in_place(|| {
-                        handle.block_on(decode_trace_arena(arena, &decoder));
-                    });
-                }
-
-                if let Some(gas_report) = gas_report.as_mut() {
-                    tokio::task::block_in_place(|| {
-                        handle.block_on(gas_report.analyze(
-                            result.execution_traces.iter().map(|arena| &arena.arena),
-                            &decoder,
-                        ));
-                    });
-
-                    for trace in &result.gas_report_traces {
+                    if self
+                        .include_traces
+                        .should_include(|| result.status.is_failure())
+                    {
                         decoder.clear_addresses();
+                        decoder.labels.extend(
+                            result
+                                .labeled_addresses
+                                .iter()
+                                .map(|(k, v)| (*k, v.clone())),
+                        );
 
                         // Re-execute setup traces to collect identities of deployed contracts.
-                        for (_, arena) in &r.setup_traces {
+                        for (_, arena) in &setup_traces {
                             decoder.identify(arena, &mut trace_identifier);
                         }
 
-                        for arena in trace {
+                        for arena in &mut result.execution_traces {
                             decoder.identify(arena, &mut trace_identifier);
                             tokio::task::block_in_place(|| {
-                                handle.block_on(gas_report.analyze([arena], &decoder));
+                                handle.block_on(decode_trace_arena(arena, &decoder));
                             });
                         }
+
+                        if let Some(gas_report) = gas_report.as_mut() {
+                            tokio::task::block_in_place(|| {
+                                handle.block_on(gas_report.analyze(
+                                    result.execution_traces.iter().map(|arena| &arena.arena),
+                                    &decoder,
+                                ));
+                            });
+
+                            for trace in gas_report_samples.into_iter().flatten() {
+                                decoder.clear_addresses();
+
+                                // Re-execute setup traces to collect identities of deployed
+                                // contracts.
+                                for (_, arena) in &setup_traces {
+                                    decoder.identify(arena, &mut trace_identifier);
+                                }
+
+                                for arena in trace {
+                                    decoder.identify(&arena, &mut trace_identifier);
+                                    tokio::task::block_in_place(|| {
+                                        handle.block_on(gas_report.analyze([&arena], &decoder));
+                                    });
+                                }
+                            }
+                        }
                     }
-                }
-                // Clear memory.
-                result.gas_report_traces.clear();
-            }
-        }
+
+                    (signature, result)
+                })
+                .collect()
+        };
+
+        let r = SuiteResult::new(duration, setup_traces, test_results, warnings);
         debug!(duration=?r.duration, "executed all tests in contract");
 
         Ok((r, gas_report))

--- a/crates/edr_solidity_tests/src/result.rs
+++ b/crates/edr_solidity_tests/src/result.rs
@@ -31,6 +31,7 @@ use crate::{
     decode::decode_console_logs,
     fuzz::{BaseCounterExample, FuzzTestResult, FuzzedCases},
     gas_report::GasReport,
+    trace_retention::{Retain, TraceRetentionPolicy},
 };
 
 /// The aggregated result of a test run.
@@ -380,7 +381,10 @@ pub struct TestResult<HaltReasonT> {
     /// expected to fail.
     pub reason: Option<String>,
 
-    /// Minimal reproduction test case for failing test
+    /// Minimal reproduction test case for failing test.
+    ///
+    /// Its trace arenas are freed once the test has finished — nothing
+    /// consumes them.
     pub counterexample: Option<CounterExample>,
 
     /// Any captured & parsed as strings logs along the test's execution which
@@ -401,12 +405,12 @@ pub struct TestResult<HaltReasonT> {
     /// that arena off; it walks the earlier ones only for the contracts they
     /// deployed. Can be empty even for a failing test — see
     /// [`Self::stack_trace_result`].
+    ///
+    /// Emptied by `Self::free_unconsumed_traces` once the test has
+    /// finished, unless trace decoding, the gas report or the napi conversion
+    /// will still consume them.
     #[serde(skip)]
     pub execution_traces: Vec<SparsedTraceArena>,
-
-    /// Additional traces to use for gas report.
-    #[serde(skip)]
-    pub gas_report_traces: Vec<Vec<CallTraceArena>>,
 
     /// Raw coverage info
     #[serde(skip)]
@@ -439,7 +443,109 @@ pub struct TestResult<HaltReasonT> {
     pub deprecated_cheatcodes: HashMap<&'static str, Option<&'static str>>,
 }
 
+/// A finished test's result together with the trace arenas sampled for the
+/// gas report.
+///
+/// The samples live beside the result instead of on it because they have
+/// exactly one consumer: the gas-report pass in
+/// `MultiContractRunner::run_test_suite` takes them by value. `TestResult`
+/// therefore never carries arenas that would need freeing after that pass.
+pub struct TestRunOutcome<HaltReasonT> {
+    /// The test's result, as surfaced to the caller.
+    pub result: TestResult<HaltReasonT>,
+    /// The trace arenas sampled for the gas report, one collection per
+    /// sampled run. `None` when no gas report was requested.
+    pub gas_report_samples: Option<Vec<Vec<CallTraceArena>>>,
+}
+
+/// A suite's run: the per-test outcomes plus everything else that goes into
+/// its [`SuiteResult`], which the caller assembles once it has consumed each
+/// outcome's gas-report samples. The samples stay on their outcome, so no
+/// bookkeeping beside the outcomes can orphan them.
+pub struct SuiteRunOutcome<HaltReasonT> {
+    /// Wall clock time it took to run the suite.
+    pub duration: Duration,
+    /// Traces from the suite's setup phase.
+    pub setup_traces: SetupTraces,
+    /// Each test's outcome: `test fn signature -> outcome`.
+    pub test_outcomes: BTreeMap<String, TestRunOutcome<HaltReasonT>>,
+    /// Generated warnings.
+    pub warnings: Vec<String>,
+}
+
+impl<HaltReasonT> TestRunOutcome<HaltReasonT> {
+    /// Frees every trace arena that no longer has a consumer, as decided by
+    /// `policy`.
+    pub(crate) fn free_unconsumed_traces(&mut self, policy: TraceRetentionPolicy) {
+        self.result.free_unconsumed_traces(policy);
+    }
+}
+
+impl<HaltReasonT: HaltReasonTrait> SuiteRunOutcome<HaltReasonT> {
+    /// Wraps a suite result whose tests produced no gas-report samples.
+    pub fn without_samples(suite_result: SuiteResult<HaltReasonT>) -> Self {
+        Self {
+            duration: suite_result.duration,
+            setup_traces: suite_result.setup_traces,
+            test_outcomes: suite_result
+                .test_results
+                .into_iter()
+                .map(|(signature, result)| (signature, TestRunOutcome::from(result)))
+                .collect(),
+            warnings: suite_result.warnings,
+        }
+    }
+}
+
+impl<HaltReasonT> From<TestResult<HaltReasonT>> for TestRunOutcome<HaltReasonT> {
+    /// Wraps a result that produced no gas-report samples.
+    fn from(result: TestResult<HaltReasonT>) -> Self {
+        Self {
+            result,
+            gas_report_samples: None,
+        }
+    }
+}
+
 impl<HaltReasonT> TestResult<HaltReasonT> {
+    /// Frees every trace arena that no longer has a consumer, as decided by
+    /// `policy`.
+    pub(crate) fn free_unconsumed_traces(&mut self, policy: TraceRetentionPolicy) {
+        let Self {
+            status,
+            reason: _,
+            counterexample,
+            logs: _,
+            decoded_logs: _,
+            kind: _,
+            execution_traces,
+            line_coverage: _,
+            labeled_addresses: _,
+            duration: _,
+            value_snapshots: _,
+            stack_trace_result: _,
+            deprecated_cheatcodes: _,
+        } = self;
+
+        match policy.retain_after(*status) {
+            Retain::Nothing => {
+                *execution_traces = Vec::new();
+            }
+            Retain::CallsOnly => {}
+        }
+
+        // Counterexample arenas have no consumer at all once the test has
+        // finished: they are neither decoded nor exposed over napi.
+        let counterexamples: &mut [BaseCounterExample] = match counterexample {
+            Some(CounterExample::Single(counterexample)) => std::slice::from_mut(counterexample),
+            Some(CounterExample::Sequence(_, counterexamples)) => counterexamples,
+            None => &mut [],
+        };
+        for counterexample in counterexamples {
+            counterexample.traces = None;
+        }
+    }
+
     pub fn map_halt_reason<
         ConversionFnT: Copy + Fn(HaltReasonT) -> NewHaltReasonT,
         NewHaltReasonT,
@@ -455,7 +561,6 @@ impl<HaltReasonT> TestResult<HaltReasonT> {
             decoded_logs: self.decoded_logs,
             kind: self.kind,
             execution_traces: self.execution_traces,
-            gas_report_traces: self.gas_report_traces,
             line_coverage: self.line_coverage,
             labeled_addresses: self.labeled_addresses,
             duration: self.duration,
@@ -604,7 +709,6 @@ impl<HaltReasonT: HaltReasonTrait> TestResult<HaltReasonT> {
         };
         self.reason = reason;
         self.duration = duration;
-        self.gas_report_traces = Vec::new();
 
         if let Some(cheatcodes) = raw_call_result.cheatcodes {
             self.value_snapshots = cheatcodes.gas_snapshots;
@@ -639,11 +743,6 @@ impl<HaltReasonT: HaltReasonTrait> TestResult<HaltReasonT> {
         self.reason = result.reason;
         self.counterexample = result.counterexample;
         self.duration = duration;
-        self.gas_report_traces = result
-            .gas_report_traces
-            .into_iter()
-            .map(|t| vec![t])
-            .collect();
         self.deprecated_cheatcodes = result.deprecated_cheatcodes;
     }
 
@@ -709,7 +808,6 @@ impl<HaltReasonT: HaltReasonTrait> TestResult<HaltReasonT> {
     #[expect(clippy::too_many_arguments)]
     pub fn invariant_result(
         &mut self,
-        gas_report_traces: Vec<Vec<CallTraceArena>>,
         success: bool,
         reason: Option<String>,
         counterexample: Option<CounterExample>,
@@ -732,7 +830,6 @@ impl<HaltReasonT: HaltReasonTrait> TestResult<HaltReasonT> {
         };
         self.reason = reason;
         self.counterexample = counterexample;
-        self.gas_report_traces = gas_report_traces;
         self.duration = duration;
     }
 

--- a/crates/edr_solidity_tests/src/runner.rs
+++ b/crates/edr_solidity_tests/src/runner.rs
@@ -17,6 +17,7 @@ use edr_artifact::ArtifactId;
 use edr_chain_spec::{EvmHaltReason, HaltReasonTrait};
 use edr_decoder_revert::RevertDecoder;
 use edr_solidity::{
+    config::IncludeTraces,
     contract_decoder::SyncNestedTraceDecoder,
     solidity_stack_trace::{get_stack_trace, DeployedCode, StackTraceEntry},
 };
@@ -44,7 +45,9 @@ use foundry_evm::{
         invariant::{CallDetails, InvariantContract},
         CounterExample, FuzzFixtures,
     },
-    traces::{load_contracts, SetupTraceKind, SetupTraces, SparsedTraceArena, TracingMode},
+    traces::{
+        load_contracts, CallTraceArena, SetupTraceKind, SetupTraces, SparsedTraceArena, TracingMode,
+    },
 };
 use itertools::Itertools;
 use proptest::test_runner::{FailurePersistence, RngAlgorithm, TestError, TestRng, TestRunner};
@@ -56,8 +59,9 @@ use crate::{
     error::TestRunnerError,
     fuzz::{invariant::BasicTxDetails, BaseCounterExample, FuzzConfig},
     multi_runner::TestContract,
-    result::{SuiteResult, TestResult, TestSetup},
+    result::{SuiteResult, SuiteRunOutcome, TestResult, TestRunOutcome, TestSetup, TestStatus},
     revm::context::result::HaltReason,
+    trace_retention::TraceRetentionPolicy,
     TestFilter, TestFunctionConfigOverride,
 };
 
@@ -109,6 +113,8 @@ pub struct ContractRunner<
     /// Whether gas reports are being generated. When enabled, isolation cannot
     /// be disabled by function-level overrides.
     generate_gas_report: bool,
+    /// Which trace arenas to retain once a test has finished.
+    trace_retention: TraceRetentionPolicy,
 
     #[allow(clippy::type_complexity)]
     _phantom: PhantomData<fn() -> (EvmBuilderT, HaltReasonT, TransactionErrorT)>,
@@ -134,6 +140,8 @@ pub struct ContractRunnerOptions<'a> {
     /// Whether gas reports are being generated. When enabled, isolation cannot
     /// be disabled by function-level overrides.
     pub generate_gas_report: bool,
+    /// Which test results carry call traces to the caller.
+    pub include_traces: IncludeTraces,
 }
 
 /// Contract artifact related arguments to the contract runner.
@@ -197,6 +205,7 @@ impl<
             invariant_config,
             test_function_overrides,
             generate_gas_report,
+            include_traces,
         } = options;
 
         Self {
@@ -217,6 +226,7 @@ impl<
             span,
             test_function_overrides,
             generate_gas_report,
+            trace_retention: TraceRetentionPolicy::new(include_traces, generate_gas_report),
             _phantom: PhantomData,
         }
     }
@@ -517,7 +527,7 @@ impl<
         self,
         filter: &dyn TestFilter,
         tokio_handle: &tokio::runtime::Handle,
-    ) -> Result<SuiteResult<HaltReasonT>, TestRunnerError> {
+    ) -> Result<SuiteRunOutcome<HaltReasonT>, TestRunnerError> {
         // Forge doesn't include building the executor in the test time, so we're
         // excluding it as well.
         let mut executor = self.executor_builder.clone().build()?;
@@ -552,7 +562,7 @@ impl<
         // There are multiple setUp function, so we return a single test result for
         // `setUp`
         if setup_fns.len() > 1 {
-            return Ok(SuiteResult::new(
+            return Ok(SuiteRunOutcome::without_samples(SuiteResult::new(
                 start.elapsed(),
                 Vec::new(),
                 [(
@@ -561,7 +571,7 @@ impl<
                 )]
                 .into(),
                 warnings,
-            ));
+            )));
         }
 
         // Check if `afterInvariant` function with valid signature declared.
@@ -573,7 +583,7 @@ impl<
             .collect();
         if after_invariant_fns.len() > 1 {
             // Return a single test result failure if multiple functions declared.
-            return Ok(SuiteResult::new(
+            return Ok(SuiteRunOutcome::without_samples(SuiteResult::new(
                 start.elapsed(),
                 Vec::new(),
                 [(
@@ -582,7 +592,7 @@ impl<
                 )]
                 .into(),
                 warnings,
-            ));
+            )));
         }
         let call_after_invariant = after_invariant_fns.first().is_some_and(|after_invariant_fn| {
             let match_sig = after_invariant_fn.name == "afterInvariant";
@@ -614,12 +624,12 @@ impl<
 
         // Avoid set-up if there are no test functions to run
         if functions.is_empty() {
-            return Ok(SuiteResult::new(
+            return Ok(SuiteRunOutcome::without_samples(SuiteResult::new(
                 start.elapsed(),
                 Vec::new(),
                 BTreeMap::new(),
                 warnings,
-            ));
+            )));
         }
 
         // Invariant testing requires tracing to figure out what contracts were created.
@@ -673,12 +683,15 @@ impl<
             } else {
                 "constructor()".to_string()
             };
-            return Ok(SuiteResult::new(
+            // `setup_failure_result` does not read the traces, so move rather
+            // than clone them.
+            let setup_traces = std::mem::take(&mut setup.traces);
+            return Ok(SuiteRunOutcome::without_samples(SuiteResult::new(
                 elapsed,
-                setup.traces.clone(),
+                setup_traces,
                 [(fail_msg, TestResult::setup_failure_result(setup))].into(),
                 warnings,
-            ));
+            )));
         }
 
         let identified_contracts = has_invariants.then(|| {
@@ -698,15 +711,15 @@ impl<
             let test_results = test_fail_functions
                 .map(|func| (func.signature(), fail()))
                 .collect();
-            return Ok(SuiteResult::new(
+            return Ok(SuiteRunOutcome::without_samples(SuiteResult::new(
                 start.elapsed(),
                 setup.traces,
                 test_results,
                 warnings,
-            ));
+            )));
         }
 
-        let test_results = functions
+        let test_outcomes = functions
             .par_iter()
             .map(|&func| {
                 let _tokio_guard = tokio_handle.enter();
@@ -727,26 +740,38 @@ impl<
                 )
                 .entered();
 
-                let res = FunctionRunner::new(&self, &executor, &setup).run(
+                let mut outcome = FunctionRunner::new(&self, &executor, &setup).run(
                     func,
                     kind,
                     call_after_invariant,
                     identified_contracts.as_ref(),
                 );
 
-                (sig, res)
+                // Stack-trace generation has just run. Nothing reads the
+                // freed traces after it.
+                outcome.free_unconsumed_traces(self.trace_retention);
+
+                (sig, outcome)
             })
             .collect::<BTreeMap<_, _>>();
 
         let duration = start.elapsed();
-        let suite_result = SuiteResult::new(duration, setup.traces, test_results, warnings);
+        let passed = test_outcomes
+            .values()
+            .filter(|outcome| outcome.result.status == TestStatus::Success)
+            .count();
         info!(
-            duration=?suite_result.duration,
+            duration=?duration,
             "done. {}/{} successful",
-            suite_result.passed(),
-            suite_result.test_results.len()
+            passed,
+            test_outcomes.len()
         );
-        Ok(suite_result)
+        Ok(SuiteRunOutcome {
+            duration,
+            setup_traces: setup.traces,
+            test_outcomes,
+            warnings,
+        })
     }
 }
 
@@ -791,6 +816,9 @@ struct FunctionRunner<
     setup: &'a TestSetup<HaltReasonT>,
     /// The test result. Returned after running the test.
     result: TestResult<HaltReasonT>,
+    /// The trace arenas the test sampled for the gas report; `None` when no
+    /// gas report was requested. Returned beside the result.
+    gas_report_samples: Option<Vec<Vec<CallTraceArena>>>,
 }
 
 impl<
@@ -845,6 +873,15 @@ impl<
             cr,
             setup,
             result: TestResult::new(setup),
+            gas_report_samples: None,
+        }
+    }
+
+    /// Finishes the run, pairing the result with the gas-report samples.
+    fn outcome(self) -> TestRunOutcome<HaltReasonT> {
+        TestRunOutcome {
+            result: self.result,
+            gas_report_samples: self.gas_report_samples,
         }
     }
 
@@ -854,14 +891,14 @@ impl<
         kind: TestFunctionKind,
         call_after_invariant: bool,
         identified_contracts: Option<&ContractsByAddress>,
-    ) -> TestResult<HaltReasonT> {
+    ) -> TestRunOutcome<HaltReasonT> {
         // Apply executor config overrides.
         if let Err(err) = self
             .cr
             .apply_executor_overrides(func, self.executor.to_mut())
         {
             self.result.single_fail(Some(err), Instant::now().elapsed());
-            return self.result;
+            return self.outcome();
         }
 
         match kind {
@@ -891,12 +928,12 @@ impl<
     /// modified state). State modifications of before test txes and unit
     /// test function call are discarded after test ends, similar to
     /// `eth_call`.
-    fn run_unit_test(mut self, func: &Function) -> TestResult<HaltReasonT> {
+    fn run_unit_test(mut self, func: &Function) -> TestRunOutcome<HaltReasonT> {
         let start: Instant = Instant::now();
 
         // Prepare unit test execution.
         if self.prepare_test(func, start).is_err() {
-            return self.result;
+            return self.outcome();
         }
 
         // Run current unit test.
@@ -912,12 +949,12 @@ impl<
             Err(EvmError::Execution(err)) => (err.raw, Some(err.reason)),
             Err(EvmError::Skip(reason)) => {
                 self.result.single_skip(reason);
-                return self.result;
+                return self.outcome();
             }
             Err(err) => {
                 self.result
                     .single_fail(Some(err.to_string()), start.elapsed());
-                return self.result;
+                return self.outcome();
             }
         };
 
@@ -959,7 +996,7 @@ impl<
             None
         };
 
-        self.result
+        self.outcome()
     }
 
     /// Runs a table test.
@@ -970,7 +1007,7 @@ impl<
     /// - `uint256[] public fixtureAmount = [2, 5]`
     /// - `bool[] public fixtureSwap = [true, false]` The `table_test` is then
     ///   called with the pair of args `(2, true)` and `(5, false)`.
-    fn run_table_test(mut self, func: &Function) -> TestResult<HaltReasonT> {
+    fn run_table_test(mut self, func: &Function) -> TestRunOutcome<HaltReasonT> {
         let start = Instant::now();
 
         if !self.cr.enable_table_tests {
@@ -978,12 +1015,12 @@ impl<
                 Some("Table tests are not supported".into()),
                 start.elapsed(),
             );
-            return self.result;
+            return self.outcome();
         };
 
         // Prepare unit test execution.
         if self.prepare_test(func, start).is_err() {
-            return self.result;
+            return self.outcome();
         }
 
         // Extract and validate fixtures for the first table test parameter.
@@ -992,7 +1029,7 @@ impl<
                 Some("Table test should have at least one parameter".into()),
                 start.elapsed(),
             );
-            return self.result;
+            return self.outcome();
         };
 
         let Some(first_param_fixtures) =
@@ -1002,7 +1039,7 @@ impl<
                 Some("Table test should have fixtures defined".into()),
                 start.elapsed(),
             );
-            return self.result;
+            return self.outcome();
         };
 
         if first_param_fixtures.is_empty() {
@@ -1010,7 +1047,7 @@ impl<
                 Some("Table test should have at least one fixture".into()),
                 start.elapsed(),
             );
-            return self.result;
+            return self.outcome();
         }
 
         let fixtures_len = first_param_fixtures.len();
@@ -1024,7 +1061,7 @@ impl<
                     Some(format!("No fixture defined for param {param_name}")),
                     start.elapsed(),
                 );
-                return self.result;
+                return self.outcome();
             };
 
             if fixtures.len() != fixtures_len {
@@ -1036,7 +1073,7 @@ impl<
                     )),
                     start.elapsed(),
                 );
-                return self.result;
+                return self.outcome();
             }
 
             table_fixtures.push(&fixtures[..]);
@@ -1060,12 +1097,12 @@ impl<
                 Err(EvmError::Execution(err)) => (err.raw, Some(err.reason)),
                 Err(EvmError::Skip(reason)) => {
                     self.result.single_skip(reason);
-                    return self.result;
+                    return self.outcome();
                 }
                 Err(err) => {
                     self.result
                         .single_fail(Some(err.to_string()), start.elapsed());
-                    return self.result;
+                    return self.outcome();
                 }
             };
 
@@ -1081,7 +1118,9 @@ impl<
                                 .expect("args have valid abi encoding"),
                         ),
                         &args,
-                        raw_call_result.traces.clone(),
+                        // Counterexample arenas are never consumed; the
+                        // failing arena lives on in `execution_traces`.
+                        None,
                         raw_call_result.indeterminism_reasons.clone(),
                     )));
                 let elapsed = start.elapsed();
@@ -1114,7 +1153,7 @@ impl<
                     };
                 self.result.stack_trace_result = Some(stack_trace_result);
 
-                return self.result;
+                return self.outcome();
             }
 
             // If it's the last iteration and all other runs succeeded, then use last call
@@ -1122,11 +1161,11 @@ impl<
             if i == fixtures_len - 1 {
                 self.result
                     .single_result(true, None, raw_call_result, start.elapsed());
-                return self.result;
+                return self.outcome();
             }
         }
 
-        self.result
+        self.outcome()
     }
 
     fn run_invariant_test(
@@ -1135,7 +1174,7 @@ impl<
         call_after_invariant: bool,
         identified_contracts: &ContractsByAddress,
         test_bytecode: &Bytes,
-    ) -> TestResult<HaltReasonT> {
+    ) -> TestRunOutcome<HaltReasonT> {
         let start = Instant::now();
 
         // First, run the test normally to see if it needs to be skipped.
@@ -1148,7 +1187,7 @@ impl<
             Some(self.cr.revert_decoder),
         ) {
             self.result.invariant_skip(reason, start.elapsed());
-            return self.result;
+            return self.outcome();
         };
 
         let mut invariant_config = self.cr.invariant_config.clone();
@@ -1272,7 +1311,7 @@ impl<
                     stack_trace_result,
                     start.elapsed(),
                 );
-                return self.result;
+                return self.outcome();
             }
         }
 
@@ -1320,7 +1359,7 @@ impl<
                 };
                 self.result.stack_trace_result = stack_trace_result;
 
-                return self.result;
+                return self.outcome();
             }
         };
         // Merge coverage collected during invariant run with test setup coverage.
@@ -1443,8 +1482,12 @@ impl<
             }
         }
 
+        self.gas_report_samples = self
+            .cr
+            .trace_retention
+            .retains_gas_report_samples()
+            .then_some(invariant_result.gas_report_traces);
         self.result.invariant_result(
-            invariant_result.gas_report_traces,
             success,
             reason,
             counterexample,
@@ -1454,7 +1497,7 @@ impl<
             invariant_result.failed_corpus_replays,
             start.elapsed(),
         );
-        self.result
+        self.outcome()
     }
 
     /// Runs a fuzzed test.
@@ -1466,12 +1509,12 @@ impl<
     /// to the EVM database (therefore the fuzz test will use the modified
     /// state). State modifications of before test txes and fuzz test are
     /// discarded after test ends, similar to `eth_call`.
-    fn run_fuzz_test(mut self, func: &Function) -> TestResult<HaltReasonT> {
+    fn run_fuzz_test(mut self, func: &Function) -> TestRunOutcome<HaltReasonT> {
         let start = Instant::now();
 
         // Prepare fuzz test execution.
         if self.prepare_test(func, start).is_err() {
-            return self.result;
+            return self.outcome();
         }
 
         let mut fuzz_config = self.cr.fuzz_config.clone();
@@ -1516,13 +1559,23 @@ impl<
             self.cr.sender,
             fuzz_config,
         );
-        let result = fuzzed_executor.fuzz(
+        let mut result = fuzzed_executor.fuzz(
             func,
             &self.setup.fuzz_fixtures,
             &self.setup.deployed_libs,
             self.setup.address,
             self.cr.revert_decoder,
         );
+        self.gas_report_samples = self
+            .cr
+            .trace_retention
+            .retains_gas_report_samples()
+            .then(|| {
+                std::mem::take(&mut result.gas_report_traces)
+                    .into_iter()
+                    .map(|traces| vec![traces])
+                    .collect()
+            });
         self.result.fuzz_result(result, start.elapsed());
 
         self.result.stack_trace_result = if let Some(CounterExample::Single(counter_example)) =
@@ -1565,7 +1618,12 @@ impl<
             None
         };
 
-        self.result
+        // `Self::outcome` cannot consume `self` here: `self.executor` was
+        // moved into `fuzzed_executor` at the start of the run.
+        TestRunOutcome {
+            result: self.result,
+            gas_report_samples: self.gas_report_samples,
+        }
     }
 
     /// Prepares single unit test and fuzz test execution:

--- a/crates/edr_solidity_tests/src/trace_retention.rs
+++ b/crates/edr_solidity_tests/src/trace_retention.rs
@@ -1,0 +1,141 @@
+//! Policy for freeing the trace arenas a finished test no longer needs.
+//!
+//! Arenas are recorded according to
+//! [`TracingMode`](foundry_evm::traces::TracingMode) and consumed by
+//! stack-trace generation while the test runs. Whether anything consumes them
+//! *after* the test has finished depends on `include_traces` — which results
+//! carry call traces to the caller — and `generate_gas_report`. Without this
+//! policy the unconsumed arenas would stay resident until the whole suite
+//! completes, which with EVM step recording enabled is the difference between
+//! megabytes and gigabytes.
+
+use edr_solidity::config::IncludeTraces;
+
+use crate::result::TestStatus;
+
+/// What a finished test's recorded arenas are still needed for.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum Retain {
+    /// Nothing consumes the arenas: free them.
+    Nothing,
+    /// The call traces are still consumed — by trace decoding, the gas
+    /// report and the napi conversion — so the arenas must be kept.
+    CallsOnly,
+}
+
+/// Decides which trace arenas to retain once a test has finished and its
+/// stack trace (if any) has been computed.
+///
+/// Derived from the test runner's `include_traces` and `generate_gas_report`
+/// settings in `MultiContractRunner::run_test_suite`.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct TraceRetentionPolicy {
+    /// Which results carry call traces to the caller.
+    include_traces: IncludeTraces,
+    /// Whether a gas report is being generated, which consumes every test's
+    /// call traces.
+    generate_gas_report: bool,
+}
+
+impl TraceRetentionPolicy {
+    /// Creates a policy from the test runner's trace-related settings.
+    pub(crate) fn new(include_traces: IncludeTraces, generate_gas_report: bool) -> Self {
+        Self {
+            include_traces,
+            generate_gas_report,
+        }
+    }
+
+    /// Returns what the arenas of a finished test with the given status are
+    /// still needed for.
+    pub(crate) fn retain_after(self, status: TestStatus) -> Retain {
+        // The gas report consumes every test's call traces.
+        // `MultiContractRunner::new` already forces `include_traces` to `All`
+        // when one is requested; checking here keeps the policy right on its
+        // own.
+        if self.generate_gas_report || self.include_traces.should_include(|| status.is_failure()) {
+            Retain::CallsOnly
+        } else {
+            Retain::Nothing
+        }
+    }
+
+    /// Returns whether the gas-report samples a test produced still have a
+    /// consumer: the gas-report pass in `MultiContractRunner::run_test_suite`.
+    pub(crate) fn retains_gas_report_samples(self) -> bool {
+        self.generate_gas_report
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{map::HashMap, Bytes};
+    use edr_chain_spec::EvmHaltReason;
+    use foundry_evm::traces::{CallTraceArena, SparsedTraceArena};
+
+    use super::*;
+    use crate::{
+        fuzz::{BaseCounterExample, CounterExample},
+        result::TestResult,
+    };
+
+    #[test]
+    fn retains_arenas_only_for_results_that_surface_call_traces() {
+        let cases = [
+            (IncludeTraces::None, TestStatus::Failure, false),
+            (IncludeTraces::None, TestStatus::Success, false),
+            (IncludeTraces::Failing, TestStatus::Failure, true),
+            (IncludeTraces::Failing, TestStatus::Success, false),
+            // Skipped tests follow the same rule as passing ones.
+            (IncludeTraces::Failing, TestStatus::Skipped, false),
+            (IncludeTraces::All, TestStatus::Success, true),
+            (IncludeTraces::All, TestStatus::Skipped, true),
+        ];
+        for (include_traces, status, retained) in cases {
+            let policy = TraceRetentionPolicy::new(include_traces, false);
+            assert_eq!(
+                matches!(policy.retain_after(status), Retain::CallsOnly),
+                retained,
+                "{include_traces:?} {status:?}"
+            );
+
+            // A gas report consumes every test's call traces.
+            let policy = TraceRetentionPolicy::new(include_traces, true);
+            assert!(
+                matches!(policy.retain_after(status), Retain::CallsOnly),
+                "{include_traces:?} {status:?} with a gas report"
+            );
+        }
+    }
+
+    #[test]
+    fn frees_counterexample_arenas_without_consumers() {
+        let arena = || SparsedTraceArena {
+            arena: CallTraceArena::default(),
+            ignored: HashMap::default(),
+        };
+        let counterexample =
+            || BaseCounterExample::from_fuzz_call(Bytes::new(), &[], Some(arena()), None);
+
+        let mut result = TestResult::<EvmHaltReason> {
+            execution_traces: vec![arena()],
+            counterexample: Some(CounterExample::Sequence(
+                2,
+                vec![counterexample(), counterexample()],
+            )),
+            ..TestResult::default()
+        };
+
+        // `All` keeps the call traces, but the counterexample arenas have no
+        // consumer.
+        result.free_unconsumed_traces(TraceRetentionPolicy::new(IncludeTraces::All, false));
+
+        assert_eq!(result.execution_traces.len(), 1);
+        let Some(CounterExample::Sequence(_, counterexamples)) = &result.counterexample else {
+            panic!("counterexample kind changed");
+        };
+        assert!(counterexamples
+            .iter()
+            .all(|counterexample| counterexample.traces.is_none()));
+    }
+}

--- a/crates/edr_solidity_tests/tests/it/repros.rs
+++ b/crates/edr_solidity_tests/tests/it/repros.rs
@@ -972,6 +972,70 @@ async fn on_failure_mode_produces_stack_trace_for_failing_setup() {
     assert_execution_error_stack_trace(suite, "setUp()");
 }
 
+// Once a failing test's stack trace has been computed, its arenas are freed
+// unless something will still consume them.
+#[tokio::test(flavor = "multi_thread")]
+async fn always_mode_frees_arenas_nothing_consumes() {
+    for (include_traces, expect_retained) in [
+        // Nothing surfaces call traces: the arenas go, the stack trace stays.
+        (IncludeTraces::None, false),
+        // The failing test's call traces are surfaced.
+        (IncludeTraces::Failing, true),
+    ] {
+        let mut config = runner_config(None, &TEST_DATA_VIA_IR, false).await;
+        config.collect_stack_traces = CollectStackTraces::Always;
+        config.include_traces = include_traces;
+
+        let contract_decoder = contract_decoder(TEST_DATA_VIA_IR.build_info_path());
+        let runner = TEST_DATA_VIA_IR
+            .runner_with_contract_decoder(config, contract_decoder)
+            .await;
+        let filter = SolidityTestFilter::new(
+            ".*",
+            "AlwaysStackTraceTest",
+            ".*repros/StackTraceAlwaysMode.t.sol",
+        );
+        let suite_results = runner.test_collect(filter).await.suite_results;
+        let suite = suite_results
+            .get("via-ir/repros/StackTraceAlwaysMode.t.sol:AlwaysStackTraceTest")
+            .expect("the AlwaysStackTrace suite should have run");
+
+        let result = assert_execution_error_stack_trace(suite, "testRevertHasStackTrace()");
+        assert_eq!(
+            !result.execution_traces.is_empty(),
+            expect_retained,
+            "arenas retained at {include_traces:?}"
+        );
+    }
+}
+
+// A passing test's arenas are recorded in `Always` mode too; they are freed
+// unless every result surfaces its call traces.
+#[tokio::test(flavor = "multi_thread")]
+async fn always_mode_frees_passing_tests_arenas_unless_all_are_included() {
+    for (include_traces, expect_retained) in
+        [(IncludeTraces::Failing, false), (IncludeTraces::All, true)]
+    {
+        let mut config = runner_config(None, &TEST_DATA_DEFAULT, false).await;
+        config.collect_stack_traces = CollectStackTraces::Always;
+        config.include_traces = include_traces;
+
+        let runner = TEST_DATA_DEFAULT.runner_with_fuzz_persistence(config).await;
+        let suite_results = runner.test_collect(repro_filter(3347)).await.suite_results;
+        let suite = suite_results
+            .get("default/repros/Issue3347.t.sol:Issue3347Test")
+            .expect("the Issue3347 suite should have run");
+
+        for (name, result) in &suite.test_results {
+            assert_eq!(result.status, TestStatus::Success, "{name}");
+            assert_eq!(
+                !result.execution_traces.is_empty(),
+                expect_retained,
+                "{name}: arenas retained at {include_traces:?}"
+            );
+        }
+    }
+}
 /// One 32-byte zero hash as a hex literal.
 const ZERO_HASH: &str = "0x0000000000000000000000000000000000000000000000000000000000000000";
 

--- a/crates/foundry/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/foundry/evm/evm/src/executors/fuzz/mod.rs
@@ -272,7 +272,10 @@ impl<
         let last_run_traces = if run_result.is_ok() {
             traces.pop()
         } else {
-            call.traces.clone()
+            // Nothing reads `BaseCounterExample::traces`, so the failing
+            // arena can move into `FuzzTestResult::traces` rather than be
+            // cloned for both.
+            call.traces
         };
 
         let mut result = FuzzTestResult {
@@ -322,7 +325,8 @@ impl<
                         Some(CounterExample::Single(BaseCounterExample::from_fuzz_call(
                             calldata,
                             &args,
-                            call.traces,
+                            // Nothing consumes counterexample arenas; see above.
+                            None,
                             call.indeterminism_reasons,
                         )));
                 }


### PR DESCRIPTION
## Problem / context

Every test's `SparsedTraceArena`s stayed resident in `TestResult::execution_traces` until the whole suite completed and the napi conversion filtered them — regardless of `include_traces`. Under `CollectStackTraces::Always` (Hardhat `-vvv` and above) each arena also carries per-opcode EVM steps, which is the difference between megabytes and gigabytes: solady peaked at 5.2 GiB at `-vvv` and OOMed a 16 GiB machine at `-vvvv`.

## Solution

Introduce `TraceRetentionPolicy`, which decides what a finished test's arenas are still needed for, and free the rest as soon as the test returns. The freeing lives in `TestResult::free_unconsumed_traces`, which destructures the result exhaustively: adding a field to `TestResult` then fails to compile there, forcing a decision on the new field's retention. It runs after stack-trace generation — the last consumer of the arenas it frees — and frees `execution_traces` when neither `include_traces` nor the gas report will consume them, plus the counterexample arenas, which have no consumer once the test has finished.

The gas-report samples move off `TestResult` entirely, since their one consumer is the gas-report pass in `run_test_suite`. `FunctionRunner` returns a `TestRunOutcome` carrying them beside the result, and `run_tests` returns the outcomes as a `SuiteRunOutcome`. The suite pass destructures each outcome, analyzing or dropping its samples within that loop iteration, and assembles the `SuiteResult` from the results afterwards. A sample therefore cannot outlive its test's turn in that pass; nothing frees a field afterwards, and no assertion is needed to tie samples to their consumer. Without a gas report the field is `None`: `FunctionRunner` gates the collection on the retention policy, so nothing is collected only to be dropped. Without a gas report the samples are dropped as each test finishes, on the rayon worker that allocated them. The old `clear()` sat inside the decode loop of `MultiContractRunner::run_test_suite`, so it never ran at `IncludeTraces::None` and the loop's `continue` skipped it for passing tests at `Failing`.

Since the retention decision now destroys arenas, the decode loop and the napi filter route through the same `IncludeTraces::should_include` predicate. The two hand-written variants disagreed on skipped tests: the decode loop decoded a skipped test's arenas at `Failing` even though the napi filter then dropped them. The fuzz and table-test paths also stop cloning the failing arena into `BaseCounterExample::traces`, which nothing reads; the setup-failure path moves rather than clones the setup traces.

## Validation

- Measured on its own (solady, peak RSS, 4 rayon threads): `-vvv` 5.2 → 4.5 GiB. `-vvvv` still OOMs; #1703 addresses that by stripping steps from the arenas that are retained.
- New regression tests in `repros.rs` cover freeing under `Always` mode, including that arenas nothing consumes are freed and that stack traces still come out.
- `cargo clippy --workspace --all-targets -- -D warnings` and the `edr_solidity_tests` integration suite (135 tests) pass.

## Notes for reviewer

- Stacked on #1701; part of the Solidity test runner memory-reduction series.
- The policy runs after stack-trace generation on purpose: that generation is the last reader of the freed arenas.
- The unified `should_include` predicate slightly changes skipped-test handling, as described above; it removes wasted decoding rather than any surfaced data.
