### PR TITLE
perf: strip recorded EVM steps from arenas retained for call traces

### DIFF
--- a/crates/edr_solidity_tests/src/result.rs
+++ b/crates/edr_solidity_tests/src/result.rs
@@ -21,7 +21,10 @@ use foundry_evm::{
         invariant::InvariantFuzzError, stack_trace::SolidityTestStackTraceResult, RawCallResult,
     },
     fuzz::{CounterExample, FuzzFixtures},
-    traces::{CallTraceArena, CallTraceDecoder, SetupTraceKind, SetupTraces, SparsedTraceArena},
+    traces::{
+        strip_arena_steps, CallTraceArena, CallTraceDecoder, SetupTraceKind, SetupTraces,
+        SparsedTraceArena,
+    },
 };
 use serde::{Deserialize, Serialize};
 use yansi::Paint;
@@ -408,7 +411,9 @@ pub struct TestResult<HaltReasonT> {
     ///
     /// Emptied by `Self::free_unconsumed_traces` once the test has
     /// finished, unless trace decoding, the gas report or the napi conversion
-    /// will still consume them.
+    /// will still consume them. The arenas that are kept have their recorded
+    /// EVM steps stripped: only the call tree, the logs and their ordering
+    /// survive.
     #[serde(skip)]
     pub execution_traces: Vec<SparsedTraceArena>,
 
@@ -475,9 +480,13 @@ pub struct SuiteRunOutcome<HaltReasonT> {
 
 impl<HaltReasonT> TestRunOutcome<HaltReasonT> {
     /// Frees every trace arena that no longer has a consumer, as decided by
-    /// `policy`.
+    /// `policy`, and strips the recorded EVM steps from the arenas it keeps.
     pub(crate) fn free_unconsumed_traces(&mut self, policy: TraceRetentionPolicy) {
         self.result.free_unconsumed_traces(policy);
+
+        for arena in self.gas_report_samples.iter_mut().flatten().flatten() {
+            strip_arena_steps(arena);
+        }
     }
 }
 
@@ -509,7 +518,7 @@ impl<HaltReasonT> From<TestResult<HaltReasonT>> for TestRunOutcome<HaltReasonT> 
 
 impl<HaltReasonT> TestResult<HaltReasonT> {
     /// Frees every trace arena that no longer has a consumer, as decided by
-    /// `policy`.
+    /// `policy`, and strips the recorded EVM steps from the arenas it keeps.
     pub(crate) fn free_unconsumed_traces(&mut self, policy: TraceRetentionPolicy) {
         let Self {
             status,
@@ -531,7 +540,11 @@ impl<HaltReasonT> TestResult<HaltReasonT> {
             Retain::Nothing => {
                 *execution_traces = Vec::new();
             }
-            Retain::CallsOnly => {}
+            Retain::CallsOnly => {
+                for arena in execution_traces.iter_mut() {
+                    arena.strip_steps();
+                }
+            }
         }
 
         // Counterexample arenas have no consumer at all once the test has

--- a/crates/edr_solidity_tests/src/trace_retention.rs
+++ b/crates/edr_solidity_tests/src/trace_retention.rs
@@ -1,13 +1,14 @@
-//! Policy for freeing the trace arenas a finished test no longer needs.
+//! Policy for freeing the trace data a finished test no longer needs.
 //!
 //! Arenas are recorded according to
 //! [`TracingMode`](foundry_evm::traces::TracingMode) and consumed by
 //! stack-trace generation while the test runs. Whether anything consumes them
 //! *after* the test has finished depends on `include_traces` — which results
-//! carry call traces to the caller — and `generate_gas_report`. Without this
-//! policy the unconsumed arenas would stay resident until the whole suite
-//! completes, which with EVM step recording enabled is the difference between
-//! megabytes and gigabytes.
+//! carry call traces to the caller — and `generate_gas_report`. Even a
+//! retained arena only needs its call tree, never the recorded EVM steps.
+//! Without this policy the unconsumed arenas would stay resident until the
+//! whole suite completes, which with step recording enabled is the difference
+//! between megabytes and gigabytes.
 
 use edr_solidity::config::IncludeTraces;
 
@@ -18,8 +19,8 @@ use crate::result::TestStatus;
 pub(crate) enum Retain {
     /// Nothing consumes the arenas: free them.
     Nothing,
-    /// The call traces are still consumed — by trace decoding, the gas
-    /// report and the napi conversion — so the arenas must be kept.
+    /// Only the call tree is still consumed, so the arenas are kept, but
+    /// their recorded EVM steps are dropped.
     CallsOnly,
 }
 

--- a/crates/edr_solidity_tests/tests/it/repros.rs
+++ b/crates/edr_solidity_tests/tests/it/repros.rs
@@ -21,7 +21,7 @@ use foundry_evm::{
         TransactionErrorTrait,
     },
     executors::stack_trace::SolidityTestStackTraceResult,
-    traces::{CallKind, CallTraceDecoder, DecodedCallData},
+    traces::{CallKind, CallTraceDecoder, DecodedCallData, SparsedTraceArena, TraceMemberOrder},
 };
 
 use crate::helpers::{
@@ -1006,7 +1006,25 @@ async fn always_mode_frees_arenas_nothing_consumes() {
             expect_retained,
             "arenas retained at {include_traces:?}"
         );
+        if expect_retained {
+            assert!(
+                result.execution_traces.iter().all(steps_stripped),
+                "steps stripped from the retained arenas at {include_traces:?}"
+            );
+        }
     }
+}
+
+/// Whether `arena` keeps its call tree but none of the recorded EVM steps —
+/// neither the step records nor their entries in each node's ordering.
+fn steps_stripped(arena: &SparsedTraceArena) -> bool {
+    arena.nodes().iter().all(|node| {
+        node.trace.steps.is_empty()
+            && !node
+                .ordering
+                .iter()
+                .any(|item| matches!(item, TraceMemberOrder::Step(_)))
+    })
 }
 
 // A passing test's arenas are recorded in `Always` mode too; they are freed
@@ -1032,6 +1050,11 @@ async fn always_mode_frees_passing_tests_arenas_unless_all_are_included() {
                 !result.execution_traces.is_empty(),
                 expect_retained,
                 "{name}: arenas retained at {include_traces:?}"
+            );
+            // Retained arenas keep their call tree but not the recorded steps.
+            assert!(
+                result.execution_traces.iter().all(steps_stripped),
+                "{name}: steps stripped from retained arenas"
             );
         }
     }

--- a/crates/foundry/evm/traces/src/lib.rs
+++ b/crates/foundry/evm/traces/src/lib.rs
@@ -64,106 +64,38 @@ impl SparsedTraceArena {
         if self.ignored.is_empty() {
             Cow::Borrowed(&self.arena)
         } else {
-            fn clear_node(
-                nodes: &mut [CallTraceNode],
-                node_idx: usize,
-                ignored: &HashMap<(usize, usize), (usize, usize)>,
-                cur_ignore_end: &mut Option<(usize, usize)>,
-            ) {
-                // Prepend an additional None item to the ordering to handle the beginning of
-                // the trace.
-                let node = nodes
-                    .get(node_idx)
-                    .expect("node_idx should be within nodes bounds");
-                let items = std::iter::once(None)
-                    .chain(node.ordering.clone().into_iter().map(Some))
-                    .enumerate();
-
-                let mut internal_calls = Vec::new();
-                let mut items_to_remove = BTreeSet::new();
-                for (item_idx, item) in items {
-                    if let Some(end_node) = ignored.get(&(node_idx, item_idx)) {
-                        *cur_ignore_end = Some(*end_node);
-                    }
-
-                    let mut remove = cur_ignore_end.is_some() & item.is_some();
-
-                    match item {
-                        // we only remove calls if they did not start/pause tracing
-                        Some(TraceMemberOrder::Call(child_idx)) => {
-                            let node = nodes
-                                .get(node_idx)
-                                .expect("node_idx should be within nodes bounds");
-                            let &child_node_idx = node
-                                .children
-                                .get(child_idx)
-                                .expect("child_idx should be within children bounds");
-                            clear_node(nodes, child_node_idx, ignored, cur_ignore_end);
-                            remove &= cur_ignore_end.is_some();
-                        }
-                        // we only remove decoded internal calls if they did not start/pause tracing
-                        Some(TraceMemberOrder::Step(step_idx)) => {
-                            // If this is an internal call beginning, track it in `internal_calls`
-                            let node = nodes
-                                .get(node_idx)
-                                .expect("node_idx should be within nodes bounds");
-                            let step = node
-                                .trace
-                                .steps
-                                .get(step_idx)
-                                .expect("step_idx should be within steps bounds");
-                            if let Some(decoded) = &step.decoded
-                                && let DecodedTraceStep::InternalCall(_, end_step_idx) = &**decoded
-                            {
-                                internal_calls.push((item_idx, remove, *end_step_idx));
-                                // we decide if we should remove it later
-                                remove = false;
-                            }
-                            // Handle ends of internal calls
-                            internal_calls.retain(|(start_item_idx, remove_start, end_idx)| {
-                                if *end_idx != step_idx {
-                                    return true;
-                                }
-                                // only remove start if end should be removed as well
-                                if *remove_start && remove {
-                                    items_to_remove.insert(*start_item_idx);
-                                } else {
-                                    remove = false;
-                                }
-
-                                false
-                            });
-                        }
-                        _ => {}
-                    }
-
-                    if remove {
-                        items_to_remove.insert(item_idx);
-                    }
-
-                    if let Some((end_node, end_step_idx)) = cur_ignore_end
-                        && node_idx == *end_node
-                        && item_idx == *end_step_idx
-                    {
-                        *cur_ignore_end = None;
-                    }
-                }
-
-                for (offset, item_idx) in items_to_remove.into_iter().enumerate() {
-                    let ordering = &mut nodes
-                        .get_mut(node_idx)
-                        .expect("node_idx should be within nodes bounds")
-                        .ordering;
-                    ordering.remove(item_idx - offset - 1);
-                }
-            }
-
             let mut arena = self.arena.clone();
-
             clear_node(arena.nodes_mut(), 0, &self.ignored, &mut None);
-
             Cow::Owned(arena)
         }
+    }
+
+    /// Removes the ignored trace items from the arena itself, so that it no
+    /// longer needs resolving.
+    fn resolve_in_place(&mut self) {
+        if !self.ignored.is_empty() {
+            clear_node(self.arena.nodes_mut(), 0, &self.ignored, &mut None);
+            self.ignored = HashMap::default();
+        }
+    }
+
+    /// Discards the recorded EVM steps, keeping the rest of the call tree:
+    /// its nodes, their logs and their ordering. With step recording enabled
+    /// the steps are by far the largest part of an arena — one entry per
+    /// executed opcode — while in the Solidity test runner their only
+    /// consumer is stack-trace generation.
+    ///
+    /// Must only be called once a stack trace can no longer be requested for
+    /// this arena.
+    ///
+    /// Ignored ranges (from the `pauseTracing`/`resumeTracing` cheatcodes) are
+    /// resolved first: they are keyed by position in each node's `ordering`,
+    /// which dropping the step entries would shift. Afterwards the arena is
+    /// no longer sparse and [`resolve_arena`](Self::resolve_arena) borrows it
+    /// as is.
+    pub fn strip_steps(&mut self) {
+        self.resolve_in_place();
+        strip_arena_steps(&mut self.arena);
     }
 }
 
@@ -212,6 +144,130 @@ impl TracingMode {
             record_logs: true,
             record_immediate_bytes: false,
         })
+    }
+}
+
+/// Removes the trace items covered by `ignored` from the sub-tree rooted at
+/// `node_idx`, recursing into the children it visits. `cur_ignore_end` carries
+/// the end of the range currently being skipped across that recursion, so a
+/// range may start in one node and end in another.
+fn clear_node(
+    nodes: &mut [CallTraceNode],
+    node_idx: usize,
+    ignored: &HashMap<(usize, usize), (usize, usize)>,
+    cur_ignore_end: &mut Option<(usize, usize)>,
+) {
+    // The loop below borrows `nodes` mutably to recurse into children, so it
+    // cannot also iterate this node's `ordering` through `nodes`. Taking the
+    // vector out is cheaper than cloning it: with step recording enabled it
+    // holds one entry per executed opcode. The loop reads this node's
+    // `children` and `steps` through `nodes` but never its `ordering`, so
+    // nothing observes the gap.
+    let mut ordering = std::mem::take(
+        &mut nodes
+            .get_mut(node_idx)
+            .expect("node_idx should be within nodes bounds")
+            .ordering,
+    );
+    // Prepend an additional None item to the ordering to handle the beginning of
+    // the trace.
+    let items = std::iter::once(None)
+        .chain(ordering.iter().copied().map(Some))
+        .enumerate();
+
+    let mut internal_calls = Vec::new();
+    let mut items_to_remove = BTreeSet::new();
+    for (item_idx, item) in items {
+        if let Some(end_node) = ignored.get(&(node_idx, item_idx)) {
+            *cur_ignore_end = Some(*end_node);
+        }
+
+        let mut remove = cur_ignore_end.is_some() & item.is_some();
+
+        match item {
+            // we only remove calls if they did not start/pause tracing
+            Some(TraceMemberOrder::Call(child_idx)) => {
+                let node = nodes
+                    .get(node_idx)
+                    .expect("node_idx should be within nodes bounds");
+                let &child_node_idx = node
+                    .children
+                    .get(child_idx)
+                    .expect("child_idx should be within children bounds");
+                clear_node(nodes, child_node_idx, ignored, cur_ignore_end);
+                remove &= cur_ignore_end.is_some();
+            }
+            // we only remove decoded internal calls if they did not start/pause tracing
+            Some(TraceMemberOrder::Step(step_idx)) => {
+                // If this is an internal call beginning, track it in `internal_calls`
+                let node = nodes
+                    .get(node_idx)
+                    .expect("node_idx should be within nodes bounds");
+                let step = node
+                    .trace
+                    .steps
+                    .get(step_idx)
+                    .expect("step_idx should be within steps bounds");
+                if let Some(decoded) = &step.decoded
+                    && let DecodedTraceStep::InternalCall(_, end_step_idx) = &**decoded
+                {
+                    internal_calls.push((item_idx, remove, *end_step_idx));
+                    // we decide if we should remove it later
+                    remove = false;
+                }
+                // Handle ends of internal calls
+                internal_calls.retain(|(start_item_idx, remove_start, end_idx)| {
+                    if *end_idx != step_idx {
+                        return true;
+                    }
+                    // only remove start if end should be removed as well
+                    if *remove_start && remove {
+                        items_to_remove.insert(*start_item_idx);
+                    } else {
+                        remove = false;
+                    }
+
+                    false
+                });
+            }
+            _ => {}
+        }
+
+        if remove {
+            items_to_remove.insert(item_idx);
+        }
+
+        if let Some((end_node, end_step_idx)) = cur_ignore_end
+            && node_idx == *end_node
+            && item_idx == *end_step_idx
+        {
+            *cur_ignore_end = None;
+        }
+    }
+
+    for (offset, item_idx) in items_to_remove.into_iter().enumerate() {
+        ordering.remove(item_idx - offset - 1);
+    }
+    nodes
+        .get_mut(node_idx)
+        .expect("node_idx should be within nodes bounds")
+        .ordering = ordering;
+}
+
+/// Discards the recorded EVM steps of every node in `arena`, keeping the rest
+/// of the call tree: its nodes, their logs and their ordering. See
+/// [`SparsedTraceArena::strip_steps`] for when this is safe.
+///
+/// Must not be applied to the arena of a still-sparse [`SparsedTraceArena`]:
+/// its ignored ranges are keyed by position in `ordering`, which this shifts.
+/// Use [`SparsedTraceArena::strip_steps`] there instead.
+pub fn strip_arena_steps(arena: &mut CallTraceArena) {
+    for node in arena.nodes_mut() {
+        node.trace.steps = Vec::new();
+        node.ordering
+            .retain(|item| !matches!(item, TraceMemberOrder::Step(_)));
+        // `retain` keeps the capacity, which grew with one entry per step.
+        node.ordering.shrink_to_fit();
     }
 }
 
@@ -271,4 +327,97 @@ pub fn load_contracts<'a>(
         }
     }
     contracts
+}
+
+#[cfg(test)]
+mod tests {
+    use revm::bytecode::opcode::OpCode;
+
+    use super::*;
+
+    /// Returns a minimal recorded step; only its presence in a node matters.
+    fn step() -> CallTraceStep {
+        CallTraceStep {
+            pc: 0,
+            op: OpCode::STOP,
+            stack: None,
+            push_stack: None,
+            memory: None,
+            returndata: alloy_primitives::Bytes::default(),
+            gas_remaining: 0,
+            gas_refund_counter: 0,
+            gas_used: 0,
+            gas_cost: 0,
+            storage_change: None,
+            status: None,
+            immediate_bytes: None,
+            decoded: None,
+        }
+    }
+
+    /// Root node with a `pauseTracing` child (node 1), a `resumeTracing` child
+    /// (node 3) and a call in between (node 2) that should be ignored, with
+    /// steps interleaved the way the tracing inspector records them.
+    fn paused_arena() -> SparsedTraceArena {
+        use TraceMemberOrder::{Call, Log, Step};
+
+        let mut arena = CallTraceArena::default();
+        let nodes = arena.nodes_mut();
+        nodes[0].children = vec![1, 2, 3];
+        nodes[0].logs = vec![CallLog::default(), CallLog::default()];
+        nodes[0].trace.steps = (0..5).map(|_| step()).collect();
+        nodes[0].ordering = vec![
+            Step(0),
+            Log(0),
+            Step(1),
+            Call(0),
+            Step(2),
+            Call(1),
+            Log(1),
+            Step(3),
+            Call(2),
+            Step(4),
+        ];
+        for idx in 1..=3 {
+            nodes.push(CallTraceNode {
+                parent: Some(0),
+                idx,
+                ..CallTraceNode::default()
+            });
+        }
+
+        // Recorded by the cheatcodes as the position in the cheatcode call's
+        // own (still empty) ordering.
+        let mut ignored = HashMap::default();
+        ignored.insert((1, 0), (3, 0));
+
+        SparsedTraceArena { arena, ignored }
+    }
+
+    #[test]
+    fn strip_steps_matches_resolving_then_dropping_steps() {
+        let mut arena = paused_arena();
+
+        let expected: Vec<Vec<TraceMemberOrder>> = arena
+            .resolve_arena()
+            .nodes()
+            .iter()
+            .map(|node| {
+                node.ordering
+                    .iter()
+                    .filter(|item| !matches!(item, TraceMemberOrder::Step(_)))
+                    .copied()
+                    .collect()
+            })
+            .collect();
+
+        arena.strip_steps();
+
+        assert!(arena.ignored.is_empty());
+        assert!(matches!(arena.resolve_arena(), Cow::Borrowed(_)));
+        for (node, expected) in arena.nodes().iter().zip(expected) {
+            assert!(node.trace.steps.is_empty());
+            assert_eq!(node.ordering, expected);
+        }
+    }
 }


### PR DESCRIPTION
## Problem / context

Recorded EVM steps — one entry per executed opcode — are only consumed by stack-trace generation, which has already run by the time a test finishes. Yet every arena retained for call traces kept its steps until the suite completed. At `IncludeTraces::All` (Hardhat `-vvvv`) that held gigabytes of steps nothing would read, and solady OOMed a 16 GiB machine.

## Solution

Add `strip_arena_steps` and `SparsedTraceArena::strip_steps`, and apply them to every arena that is kept once a test finishes: the retained `execution_traces` (in `TestResult::free_unconsumed_traces`) and the gas-report samples (in `run_tests`, where they are kept beside the result), which at `CollectStackTraces::Always` carry steps too. Every remaining consumer reads the call tree, the logs and their ordering: trace decoding never looks at steps, the gas report walks nodes, and the napi conversion discards `TraceMemberOrder::Step`.

`strip_steps` first resolves the ignored `pauseTracing`/`resumeTracing` ranges in place, because they are keyed by position in each node's `ordering` and dropping step entries would shift them. Resolving in place avoids `resolve_arena`'s clone, so the arena's footprint does not double at the moment it is being shrunk; the arena also becomes non-sparse, so the napi conversion's later `resolve_arena` is a borrow. The `ordering` vectors are shrunk as well, since `retain` keeps the capacity that grew with one entry per step. `clear_node` moves out of `resolve_arena` so both the cloning and the in-place resolution can call it.

## Validation

- Measured on top of #1702 (peak RSS, 4 rayon threads): solady `-vvvv` no longer OOMs and peaks at 4.4 GiB; uniswap-v4-core `-vvvv` 3.4 → 2.4 GiB. `-vvv` is unchanged within noise, since only failing tests retain arenas there.
- `strip_steps_matches_resolving_then_dropping_steps` pins that in-place resolution plus stripping equals the old resolve-then-drop result, node by node.
- `cargo clippy --workspace --all-targets -- -D warnings` and the `edr_solidity_tests` integration suite (135 tests) pass.

## Notes for reviewer

- Stacked on #1702; part of the Solidity test runner memory-reduction series.
- `strip_steps` must not run on a still-sparse arena, since the ignored ranges are positional; the doc on `strip_arena_steps` states when each entry point is safe.
