### PR TITLE
perf: strip EVM steps from displaced arenas as traces accumulate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4513,6 +4513,7 @@ dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
  "alloy-sol-types",
+ "derive-where",
  "edr_artifact",
  "edr_common",
  "edr_decoder_revert",

--- a/crates/edr_solidity_tests/src/multi_runner.rs
+++ b/crates/edr_solidity_tests/src/multi_runner.rs
@@ -30,9 +30,7 @@ use foundry_evm::{
     fork::CreateFork,
     inspectors::{cheatcodes::CheatsConfigOptions, CheatsConfig},
     opts::EvmOpts,
-    traces::{
-        decode_trace_arena, identifier::TraceIdentifiers, CallTraceDecoderBuilder, TracingMode,
-    },
+    traces::{identifier::TraceIdentifiers, CallTraceDecoderBuilder, TracingMode},
 };
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
@@ -537,12 +535,11 @@ impl<
 
             // Setup traces are shared across all tests in the suite, so decode and analyze
             // them only once.
-            for (_, arena) in &mut setup_traces {
-                decoder.identify(arena, &mut trace_identifier);
-                tokio::task::block_in_place(|| {
-                    handle.block_on(decode_trace_arena(arena, &decoder));
-                });
-            }
+            tokio::task::block_in_place(|| {
+                handle.block_on(
+                    setup_traces.identify_and_decode(&mut decoder, &mut trace_identifier),
+                );
+            });
 
             if let Some(gas_report) = gas_report.as_mut() {
                 tokio::task::block_in_place(|| {
@@ -577,12 +574,13 @@ impl<
                             decoder.identify(arena, &mut trace_identifier);
                         }
 
-                        for arena in &mut result.execution_traces {
-                            decoder.identify(arena, &mut trace_identifier);
-                            tokio::task::block_in_place(|| {
-                                handle.block_on(decode_trace_arena(arena, &decoder));
-                            });
-                        }
+                        tokio::task::block_in_place(|| {
+                            handle.block_on(
+                                result
+                                    .execution_traces
+                                    .identify_and_decode(&mut decoder, &mut trace_identifier),
+                            );
+                        });
 
                         if let Some(gas_report) = gas_report.as_mut() {
                             tokio::task::block_in_place(|| {

--- a/crates/edr_solidity_tests/src/result.rs
+++ b/crates/edr_solidity_tests/src/result.rs
@@ -713,7 +713,8 @@ impl<HaltReasonT: HaltReasonTrait> TestResult<HaltReasonT> {
         self.logs.extend(raw_call_result.logs);
         self.decoded_logs = decode_console_logs(&self.logs);
         self.labeled_addresses.extend(raw_call_result.labels);
-        self.execution_traces.extend(raw_call_result.traces);
+        self.execution_traces
+            .extend(raw_call_result.call_trace_arena);
         self.merge_coverages(raw_call_result.line_coverage);
 
         self.status = match success {
@@ -743,7 +744,7 @@ impl<HaltReasonT: HaltReasonTrait> TestResult<HaltReasonT> {
         self.logs.extend(result.logs);
         self.decoded_logs = decode_console_logs(&self.logs);
         self.labeled_addresses.extend(result.labeled_addresses);
-        self.execution_traces.extend(result.traces);
+        self.execution_traces.extend(result.call_trace_arena);
         self.merge_coverages(result.line_coverage);
 
         self.status = if result.skipped {
@@ -809,7 +810,7 @@ impl<HaltReasonT: HaltReasonTrait> TestResult<HaltReasonT> {
             metrics: HashMap::default(),
             failed_corpus_replays: 0,
         };
-        self.execution_traces.extend(e.take_traces());
+        self.execution_traces.extend(e.take_call_trace_arena());
         self.status = TestStatus::Failure;
         self.reason = Some(format!(
             "failed to set up invariant testing environment: {e}"
@@ -879,7 +880,7 @@ impl<HaltReasonT: HaltReasonTrait> TestResult<HaltReasonT> {
         self.logs.extend(call_result.logs);
         self.decoded_logs = decode_console_logs(&self.logs);
         self.labeled_addresses.extend(call_result.labels);
-        self.execution_traces.extend(call_result.traces);
+        self.execution_traces.extend(call_result.call_trace_arena);
         self.merge_coverages(call_result.line_coverage);
     }
 
@@ -1091,7 +1092,7 @@ impl<HaltReasonT: HaltReasonTrait> TestSetup<HaltReasonT> {
         self.logs.extend(raw.logs);
         self.labels.extend(raw.labels);
         self.traces
-            .extend(raw.traces.map(|traces| (trace_kind, traces)));
+            .extend(raw.call_trace_arena.map(|traces| (trace_kind, traces)));
         if let Some(indeterminism_reasons) = self.indeterminism_reasons.as_mut() {
             indeterminism_reasons.merge(raw.indeterminism_reasons);
         } else {

--- a/crates/edr_solidity_tests/src/result.rs
+++ b/crates/edr_solidity_tests/src/result.rs
@@ -22,8 +22,8 @@ use foundry_evm::{
     },
     fuzz::{CounterExample, FuzzFixtures},
     traces::{
-        strip_arena_steps, CallTraceArena, CallTraceDecoder, SetupTraceKind, SetupTraces,
-        SparsedTraceArena,
+        strip_arena_steps, CallTraceArena, CallTraceDecoder, ExecutionTraces, SetupTraceKind,
+        SetupTraces,
     },
 };
 use serde::{Deserialize, Serialize};
@@ -415,7 +415,7 @@ pub struct TestResult<HaltReasonT> {
     /// EVM steps stripped: only the call tree, the logs and their ordering
     /// survive.
     #[serde(skip)]
-    pub execution_traces: Vec<SparsedTraceArena>,
+    pub execution_traces: ExecutionTraces,
 
     /// Raw coverage info
     #[serde(skip)]
@@ -538,12 +538,10 @@ impl<HaltReasonT> TestResult<HaltReasonT> {
 
         match policy.retain_after(*status) {
             Retain::Nothing => {
-                *execution_traces = Vec::new();
+                *execution_traces = ExecutionTraces::default();
             }
             Retain::CallsOnly => {
-                for arena in execution_traces.iter_mut() {
-                    arena.strip_steps();
-                }
+                execution_traces.strip_steps();
             }
         }
 
@@ -713,8 +711,9 @@ impl<HaltReasonT: HaltReasonTrait> TestResult<HaltReasonT> {
         self.logs.extend(raw_call_result.logs);
         self.decoded_logs = decode_console_logs(&self.logs);
         self.labeled_addresses.extend(raw_call_result.labels);
-        self.execution_traces
-            .extend(raw_call_result.call_trace_arena);
+        if let Some(arena) = raw_call_result.call_trace_arena {
+            self.execution_traces.push(arena);
+        }
         self.merge_coverages(raw_call_result.line_coverage);
 
         self.status = match success {
@@ -744,7 +743,9 @@ impl<HaltReasonT: HaltReasonTrait> TestResult<HaltReasonT> {
         self.logs.extend(result.logs);
         self.decoded_logs = decode_console_logs(&self.logs);
         self.labeled_addresses.extend(result.labeled_addresses);
-        self.execution_traces.extend(result.call_trace_arena);
+        if let Some(arena) = result.call_trace_arena {
+            self.execution_traces.push(arena);
+        }
         self.merge_coverages(result.line_coverage);
 
         self.status = if result.skipped {
@@ -810,7 +811,9 @@ impl<HaltReasonT: HaltReasonTrait> TestResult<HaltReasonT> {
             metrics: HashMap::default(),
             failed_corpus_replays: 0,
         };
-        self.execution_traces.extend(e.take_call_trace_arena());
+        if let Some(arena) = e.take_call_trace_arena() {
+            self.execution_traces.push(arena);
+        }
         self.status = TestStatus::Failure;
         self.reason = Some(format!(
             "failed to set up invariant testing environment: {e}"
@@ -880,7 +883,9 @@ impl<HaltReasonT: HaltReasonTrait> TestResult<HaltReasonT> {
         self.logs.extend(call_result.logs);
         self.decoded_logs = decode_console_logs(&self.logs);
         self.labeled_addresses.extend(call_result.labels);
-        self.execution_traces.extend(call_result.call_trace_arena);
+        if let Some(arena) = call_result.call_trace_arena {
+            self.execution_traces.push(arena);
+        }
         self.merge_coverages(call_result.line_coverage);
     }
 
@@ -1091,8 +1096,9 @@ impl<HaltReasonT: HaltReasonTrait> TestSetup<HaltReasonT> {
     ) {
         self.logs.extend(raw.logs);
         self.labels.extend(raw.labels);
-        self.traces
-            .extend(raw.call_trace_arena.map(|traces| (trace_kind, traces)));
+        if let Some(arena) = raw.call_trace_arena {
+            self.traces.push((trace_kind, arena));
+        }
         if let Some(indeterminism_reasons) = self.indeterminism_reasons.as_mut() {
             indeterminism_reasons.merge(raw.indeterminism_reasons);
         } else {

--- a/crates/edr_solidity_tests/src/runner.rs
+++ b/crates/edr_solidity_tests/src/runner.rs
@@ -1724,8 +1724,8 @@ impl<
             U256::ZERO,
             Some(self.cr.revert_decoder),
         ) {
-            Ok(res) => res.raw.traces,
-            Err(EvmError::Execution(err)) => err.raw.traces,
+            Ok(res) => res.raw.call_trace_arena,
+            Err(EvmError::Execution(err)) => err.raw.call_trace_arena,
             Err(err) => return Err(err.into()),
         }
         .expect("enabled tracing");
@@ -1846,7 +1846,7 @@ fn re_run_fuzz_counterexample_for_stack_traces<
         )
         .map_err(|err| SolidityTestStackTraceError::Evm(err.to_string()))?;
 
-    let new_trace_arena = call.traces.expect("tracing is on");
+    let new_trace_arena = call.call_trace_arena.expect("tracing is on");
 
     get_stack_trace(
         &*contract_runner.contract_decoder,

--- a/crates/edr_solidity_tests/src/runner.rs
+++ b/crates/edr_solidity_tests/src/runner.rs
@@ -564,7 +564,7 @@ impl<
         if setup_fns.len() > 1 {
             return Ok(SuiteRunOutcome::without_samples(SuiteResult::new(
                 start.elapsed(),
-                Vec::new(),
+                SetupTraces::default(),
                 [(
                     "setUp()".to_string(),
                     TestResult::fail("multiple setUp functions".to_string()),
@@ -585,7 +585,7 @@ impl<
             // Return a single test result failure if multiple functions declared.
             return Ok(SuiteRunOutcome::without_samples(SuiteResult::new(
                 start.elapsed(),
-                Vec::new(),
+                SetupTraces::default(),
                 [(
                     "afterInvariant()".to_string(),
                     TestResult::fail("multiple afterInvariant functions".to_string()),
@@ -626,7 +626,7 @@ impl<
         if functions.is_empty() {
             return Ok(SuiteRunOutcome::without_samples(SuiteResult::new(
                 start.elapsed(),
-                Vec::new(),
+                SetupTraces::default(),
                 BTreeMap::new(),
                 warnings,
             )));

--- a/crates/edr_solidity_tests/src/trace_retention.rs
+++ b/crates/edr_solidity_tests/src/trace_retention.rs
@@ -119,7 +119,7 @@ mod tests {
             || BaseCounterExample::from_fuzz_call(Bytes::new(), &[], Some(arena()), None);
 
         let mut result = TestResult::<EvmHaltReason> {
-            execution_traces: vec![arena()],
+            execution_traces: [arena()].into_iter().collect(),
             counterexample: Some(CounterExample::Sequence(
                 2,
                 vec![counterexample(), counterexample()],

--- a/crates/edr_solidity_tests/tests/it/helpers/config.rs
+++ b/crates/edr_solidity_tests/tests/it/helpers/config.rs
@@ -18,9 +18,8 @@ use foundry_evm::{
         BlockEnvTr, ChainContextTr, EvmBuilderTrait, HardforkTr, TransactionEnvTr,
         TransactionErrorTrait,
     },
-    traces::{decode_trace_arena, render_trace_arena, CallTraceDecoderBuilder},
+    traces::{identifier::TraceIdentifiers, render_trace_arena, CallTraceDecoderBuilder},
 };
-use futures::future::join_all;
 use itertools::Itertools;
 
 use crate::helpers::{tracing::init_tracing_for_solidity_tests, SolidityTestFilter};
@@ -157,19 +156,17 @@ impl<
                 {
                     let logs = decode_console_logs(&result.logs);
                     let outcome = if should_fail { "fail" } else { "pass" };
-                    let call_trace_decoder = CallTraceDecoderBuilder::default()
+                    let mut call_trace_decoder = CallTraceDecoderBuilder::default()
                         .with_known_contracts(&known_contracts)
                         .build();
-                    let decoded_traces =
-                        join_all(result.execution_traces.iter_mut().map(|arena| {
-                            let decoder = &call_trace_decoder;
-                            async move {
-                                decode_trace_arena(arena, decoder).await;
-                                render_trace_arena(arena)
-                            }
-                        }))
-                        .await
-                        .into_iter()
+                    result
+                        .execution_traces
+                        .identify_and_decode(&mut call_trace_decoder, &mut TraceIdentifiers::new())
+                        .await;
+                    let decoded_traces = result
+                        .execution_traces
+                        .iter()
+                        .map(|arena| render_trace_arena(arena))
                         .collect::<Vec<String>>();
                     eyre::bail!(
                         "Test {} did not {} as expected.\nReason: {:?}\nLogs:\n{}\n\nTraces:\n{}",

--- a/crates/foundry/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/foundry/evm/evm/src/executors/fuzz/mod.rs
@@ -229,7 +229,7 @@ impl<
                         data.first_case.replace(case.case);
                     }
 
-                    if let Some(call_traces) = case.traces {
+                    if let Some(call_traces) = case.call_trace_arena {
                         if data.traces.len() == max_traces_to_collect {
                             data.traces.pop();
                         }
@@ -273,9 +273,9 @@ impl<
             traces.pop()
         } else {
             // Nothing reads `BaseCounterExample::traces`, so the failing
-            // arena can move into `FuzzTestResult::traces` rather than be
-            // cloned for both.
-            call.traces
+            // arena can move into `FuzzTestResult::call_trace_arena` rather than
+            // be cloned for both.
+            call.call_trace_arena
         };
 
         let mut result = FuzzTestResult {
@@ -287,7 +287,7 @@ impl<
             counterexample: None,
             logs: fuzz_result.logs,
             labeled_addresses: call.labels,
-            traces: last_run_traces,
+            call_trace_arena: last_run_traces,
             gas_report_traces: traces.into_iter().map(|a| a.arena).collect(),
             line_coverage: fuzz_result.coverage,
             deprecated_cheatcodes: fuzz_result.deprecated_cheatcodes,
@@ -402,7 +402,7 @@ impl<
                     gas: call.gas_used,
                     stipend: call.stipend,
                 },
-                traces: call.traces,
+                call_trace_arena: call.call_trace_arena,
                 coverage: call.line_coverage,
                 logs: call.logs,
                 deprecated_cheatcodes,

--- a/crates/foundry/evm/evm/src/executors/fuzz/types.rs
+++ b/crates/foundry/evm/evm/src/executors/fuzz/types.rs
@@ -18,8 +18,8 @@ use crate::executors::RawCallResult;
 pub struct CaseOutcome {
     /// Data of a single fuzz test case.
     pub case: FuzzCase,
-    /// The traces of the call.
-    pub traces: Option<SparsedTraceArena>,
+    /// The call trace arena of the call.
+    pub call_trace_arena: Option<SparsedTraceArena>,
     /// The coverage info collected during the call.
     pub coverage: Option<HitMaps>,
     /// logs of a single fuzz test case.

--- a/crates/foundry/evm/evm/src/executors/invariant/error.rs
+++ b/crates/foundry/evm/evm/src/executors/invariant/error.rs
@@ -86,10 +86,13 @@ impl InvariantFuzzError {
         }
     }
 
-    /// Removes and returns the traces of the offending call, if recorded.
-    pub fn take_traces(&mut self) -> Option<SparsedTraceArena> {
+    /// Removes and returns the call trace arena of the offending call, if
+    /// recorded.
+    pub fn take_call_trace_arena(&mut self) -> Option<SparsedTraceArena> {
         match self {
-            Self::BrokenInvariant(case_data) | Self::Revert(case_data) => case_data.traces.take(),
+            Self::BrokenInvariant(case_data) | Self::Revert(case_data) => {
+                case_data.call_trace_arena.take()
+            }
             Self::Abi(_) | Self::Other(_) | Self::MaxAssumeRejects(_) => None,
         }
     }
@@ -127,8 +130,8 @@ pub struct FailedInvariantCaseData {
     pub fail_on_revert: bool,
     /// Indeterminism from cheatcodes if any.
     pub indeterminism_reasons: Option<IndeterminismReasons>,
-    /// The traces of the offending call, if recorded.
-    pub traces: Option<SparsedTraceArena>,
+    /// The call trace arena of the offending call, if recorded.
+    pub call_trace_arena: Option<SparsedTraceArena>,
 }
 
 impl FailedInvariantCaseData {
@@ -178,7 +181,7 @@ impl FailedInvariantCaseData {
             shrink_run_limit: invariant_config.shrink_run_limit,
             fail_on_revert: invariant_config.fail_on_revert,
             indeterminism_reasons: call_result.indeterminism_reasons,
-            traces: call_result.traces,
+            call_trace_arena: call_result.call_trace_arena,
         }
     }
 }

--- a/crates/foundry/evm/evm/src/executors/invariant/replay.rs
+++ b/crates/foundry/evm/evm/src/executors/invariant/replay.rs
@@ -22,7 +22,7 @@ use foundry_evm_fuzz::{
     invariant::{BasicTxDetails, InvariantContract},
     BaseCounterExample,
 };
-use foundry_evm_traces::{load_contracts, SetupTraces, SparsedTraceArena, TracingMode};
+use foundry_evm_traces::{load_contracts, ExecutionTraces, SetupTraces, TracingMode};
 use parking_lot::RwLock;
 use proptest::test_runner::TestError;
 use revm::{
@@ -37,7 +37,7 @@ use super::{
 };
 use crate::executors::{
     stack_trace::{SolidityTestStackTraceError, SolidityTestStackTraceResult},
-    Executor,
+    Executor, RawCallResult,
 };
 
 /// Arguments to `replay_run`.
@@ -52,7 +52,7 @@ pub struct ReplayRunArgs<
     TransactionErrorT: TransactionErrorTrait,
     ChainContextT: ChainContextTr,
 > {
-    pub execution_traces: &'a mut Vec<SparsedTraceArena>,
+    pub execution_traces: &'a mut ExecutionTraces,
     pub executor: Executor<
         BlockT,
         TxT,
@@ -148,26 +148,41 @@ pub fn replay_run<
 
     // Replay each call from the sequence, collect logs, traces and coverage.
     for tx in inputs.iter() {
-        let call_result = executor.transact_raw(
+        let RawCallResult {
+            exit_reason,
+            reverted,
+            has_state_snapshot_failure: _,
+            result,
+            gas_used: _,
+            gas_refunded: _,
+            stipend: _,
+            logs: call_logs,
+            labels: _,
+            call_trace_arena,
+            line_coverage,
+            edge_coverage: _,
+            state_changeset: _,
+            env: _,
+            cheatcodes: _,
+            out: _,
+            reverter: _,
+            indeterminism_reasons,
+        } = executor.transact_raw(
             tx.sender,
             tx.call_details.target,
             tx.call_details.calldata.clone(),
             U256::ZERO,
         )?;
-        logs.extend(call_result.logs);
-        execution_traces.push(
-            call_result
-                .call_trace_arena
-                .clone()
-                .expect("enabled tracing"),
-        );
-        HitMaps::merge_opt(coverage, call_result.line_coverage);
+        logs.extend(call_logs);
+        HitMaps::merge_opt(coverage, line_coverage);
 
         // Identify newly generated contracts, if they exist.
         ided_contracts.extend(load_contracts(
-            call_result.call_trace_arena.iter().map(|a| &a.arena),
+            call_trace_arena.iter().map(|a| &a.arena),
             known_contracts,
         ));
+
+        execution_traces.push(call_trace_arena.expect("enabled tracing"));
 
         // Create counter example to be used in failed case.
         counterexample_sequence.push(BaseCounterExample::from_invariant_call(
@@ -175,47 +190,49 @@ pub fn replay_run<
             tx.call_details.target,
             &tx.call_details.calldata,
             &ided_contracts,
-            call_result.call_trace_arena,
+            // Counterexample arenas are never consumed; the failing arena
+            // lives on in `execution_traces`.
+            None,
             /* indeterminism_reason */ None,
         ));
 
         // If this call failed, but didn't revert, this is terminal for sure.
         // If this call reverted, only exit if `fail_on_revert` is true.
-        if !call_result
-            .exit_reason
-            .is_some_and(InstructionResult::is_ok)
-            && (fail_on_revert || !call_result.reverted)
-        {
-            let stack_trace_result =
-                if let Some(indeterminism_reasons) = call_result.indeterminism_reasons {
-                    Some(indeterminism_reasons.into())
-                } else {
-                    contract_decoder.map(|decoder| {
-                        let (failing_trace, prior_traces) = execution_traces
-                            .split_last()
-                            .expect("an arena was pushed for this call above");
+        if !exit_reason.is_some_and(InstructionResult::is_ok) && (fail_on_revert || !reverted) {
+            let stack_trace_result = if let Some(indeterminism_reasons) = indeterminism_reasons {
+                Some(indeterminism_reasons.into())
+            } else {
+                contract_decoder.map(|decoder| {
+                    let (failing_trace, prior_traces) = execution_traces
+                        .split_last()
+                        .expect("an arena was pushed for this call above");
 
-                        get_stack_trace(
-                            decoder,
-                            &failing_trace.arena,
-                            setup_traces
-                                .iter()
-                                .map(|(_, arena)| &arena.arena)
-                                .chain(prior_traces.iter().map(|arena| &arena.arena)),
-                            DeployedCode::default(),
-                        )
-                        .map_err(SolidityTestStackTraceError::from)
-                        .into()
-                    })
-                };
-            let revert_reason =
-                revert_decoder.maybe_decode(call_result.result.as_ref(), call_result.exit_reason);
+                    get_stack_trace(
+                        decoder,
+                        &failing_trace.arena,
+                        setup_traces
+                            .iter()
+                            .map(|(_, arena)| &arena.arena)
+                            .chain(prior_traces.iter().map(|arena| &arena.arena)),
+                        DeployedCode::default(),
+                    )
+                    .map_err(SolidityTestStackTraceError::from)
+                    .into()
+                })
+            };
+            let revert_reason = revert_decoder.maybe_decode(result.as_ref(), exit_reason);
             return Ok(ReplayResult {
                 counterexample_sequence,
                 stack_trace_result,
                 revert_reason,
             });
         }
+
+        // This call is not the failing one, so its arena can only ever serve
+        // as a code source. Strip it now rather than when the next push
+        // displaces it. Then no arena in the collection is step-laden while
+        // the next call runs.
+        execution_traces.strip_last_steps();
     }
 
     // Replay invariant to collect logs and traces.
@@ -254,7 +271,11 @@ pub fn replay_run<
             call_result: after_invariant_result,
             success: after_invariant_success,
         } = call_after_invariant_function(&executor, invariant_contract.address)?;
-        execution_traces.push(after_invariant_result.call_trace_arena.clone().unwrap());
+        execution_traces.push(
+            after_invariant_result
+                .call_trace_arena
+                .expect("tracing is on"),
+        );
         after_invariant_indeterminism = after_invariant_result.indeterminism_reasons;
         if !after_invariant_success {
             after_invariant_failure = Some(Failure {
@@ -297,9 +318,9 @@ pub fn replay_run<
                     .map(SolidityTestStackTraceResult::from)
                     .or_else(|| {
                         contract_decoder.map(|decoder| {
-                            let (failing_trace, prior_traces) = execution_traces
-                                .split_last()
-                                .expect("the invariant call arena was pushed above");
+                            let (failing_trace, prior_traces) = execution_traces.split_last().expect(
+                                "the failing call's arena was pushed above: afterInvariant() when it ran, otherwise invariant()",
+                            );
 
                             get_stack_trace(
                                 decoder,
@@ -338,7 +359,7 @@ pub struct ReplayErrorArgs<
     TransactionErrorT: TransactionErrorTrait,
     ChainContextT: ChainContextTr,
 > {
-    pub execution_traces: &'a mut Vec<SparsedTraceArena>,
+    pub execution_traces: &'a mut ExecutionTraces,
     pub executor: Executor<
         BlockT,
         TxT,

--- a/crates/foundry/evm/evm/src/executors/invariant/replay.rs
+++ b/crates/foundry/evm/evm/src/executors/invariant/replay.rs
@@ -155,12 +155,17 @@ pub fn replay_run<
             U256::ZERO,
         )?;
         logs.extend(call_result.logs);
-        execution_traces.push(call_result.traces.clone().expect("enabled tracing"));
+        execution_traces.push(
+            call_result
+                .call_trace_arena
+                .clone()
+                .expect("enabled tracing"),
+        );
         HitMaps::merge_opt(coverage, call_result.line_coverage);
 
         // Identify newly generated contracts, if they exist.
         ided_contracts.extend(load_contracts(
-            call_result.traces.iter().map(|a| &a.arena),
+            call_result.call_trace_arena.iter().map(|a| &a.arena),
             known_contracts,
         ));
 
@@ -170,7 +175,7 @@ pub fn replay_run<
             tx.call_details.target,
             &tx.call_details.calldata,
             &ided_contracts,
-            call_result.traces,
+            call_result.call_trace_arena,
             /* indeterminism_reason */ None,
         ));
 
@@ -230,7 +235,7 @@ pub fn replay_run<
             .into(),
     )?;
 
-    execution_traces.push(invariant_result.traces.expect("tracing is on"));
+    execution_traces.push(invariant_result.call_trace_arena.expect("tracing is on"));
     logs.extend(invariant_result.logs);
     deprecated_cheatcodes.extend(
         invariant_result
@@ -249,7 +254,7 @@ pub fn replay_run<
             call_result: after_invariant_result,
             success: after_invariant_success,
         } = call_after_invariant_function(&executor, invariant_contract.address)?;
-        execution_traces.push(after_invariant_result.traces.clone().unwrap());
+        execution_traces.push(after_invariant_result.call_trace_arena.clone().unwrap());
         after_invariant_indeterminism = after_invariant_result.indeterminism_reasons;
         if !after_invariant_success {
             after_invariant_failure = Some(Failure {

--- a/crates/foundry/evm/evm/src/executors/invariant/result.rs
+++ b/crates/foundry/evm/evm/src/executors/invariant/result.rs
@@ -256,7 +256,7 @@ pub(crate) fn can_continue<
 
     // Assert invariants if the call did not revert and the handlers did not fail.
     if !call_result.reverted && handlers_succeeded {
-        if let Some(traces) = call_result.traces {
+        if let Some(traces) = call_result.call_trace_arena {
             invariant_run.run_traces.push(traces);
         }
 

--- a/crates/foundry/evm/evm/src/executors/mod.rs
+++ b/crates/foundry/evm/evm/src/executors/mod.rs
@@ -1306,8 +1306,8 @@ pub struct RawCallResult<
     pub logs: Vec<Log>,
     /// The labels assigned to addresses during the call
     pub labels: AddressHashMap<String>,
-    /// The traces of the call
-    pub traces: Option<SparsedTraceArena>,
+    /// The call trace arena of the call
+    pub call_trace_arena: Option<SparsedTraceArena>,
     /// The line coverage info collected during the call
     pub line_coverage: Option<HitMaps>,
     /// The edge coverage info collected during the call
@@ -1364,7 +1364,7 @@ impl<
             stipend: 0,
             logs: Vec::new(),
             labels: HashMap::default(),
-            traces: None,
+            call_trace_arena: None,
             line_coverage: None,
             edge_coverage: None,
             state_changeset: HashMap::default(),
@@ -1753,7 +1753,7 @@ fn convert_executed_result<
     let InspectorData {
         mut logs,
         labels,
-        traces,
+        call_trace_arena,
         line_coverage,
         edge_coverage,
         cheatcodes,
@@ -1774,7 +1774,7 @@ fn convert_executed_result<
         stipend: gas.initial_total_gas(),
         logs,
         labels,
-        traces,
+        call_trace_arena,
         line_coverage,
         edge_coverage,
         state_changeset,

--- a/crates/foundry/evm/evm/src/inspectors/stack.rs
+++ b/crates/foundry/evm/evm/src/inspectors/stack.rs
@@ -247,7 +247,7 @@ pub struct InspectorData<
 > {
     pub logs: Vec<Log>,
     pub labels: AddressHashMap<String>,
-    pub traces: Option<SparsedTraceArena>,
+    pub call_trace_arena: Option<SparsedTraceArena>,
     pub line_coverage: Option<HitMaps>,
     pub edge_coverage: Option<Vec<u8>>,
     pub cheatcodes: Option<
@@ -557,7 +557,7 @@ impl<
                 },
         } = self;
 
-        let traces = tracer
+        let call_trace_arena = tracer
             .map(foundry_evm_traces::TracingInspector::into_traces)
             .map(|arena| {
                 let ignored = cheatcodes
@@ -589,7 +589,7 @@ impl<
                 .as_ref()
                 .map(|cheatcodes| cheatcodes.labels.clone())
                 .unwrap_or_default(),
-            traces,
+            call_trace_arena,
             line_coverage: line_coverage.map(foundry_evm_coverage::LineCoverageCollector::finish),
             edge_coverage: edge_coverage.map(EdgeCovInspector::into_hitcount),
             cheatcodes,

--- a/crates/foundry/evm/fuzz/src/lib.rs
+++ b/crates/foundry/evm/fuzz/src/lib.rs
@@ -219,12 +219,12 @@ pub struct FuzzTestResult {
     /// Labeled addresses
     pub labeled_addresses: AddressHashMap<String>,
 
-    /// Exemplary traces for a fuzz run of the test function
+    /// Exemplary call trace arena for a fuzz run of the test function
     ///
     /// **Note** We only store a single trace of a successful fuzz call,
     /// otherwise we would get `num(fuzz_cases)` traces, one for each run,
     /// which is neither helpful nor performant.
-    pub traces: Option<SparsedTraceArena>,
+    pub call_trace_arena: Option<SparsedTraceArena>,
 
     /// Additional traces used for gas report construction.
     /// Those traces should not be displayed.

--- a/crates/foundry/evm/traces/Cargo.toml
+++ b/crates/foundry/evm/traces/Cargo.toml
@@ -22,6 +22,7 @@ alloy-primitives = { workspace = true, features = [
     "rlp",
 ] }
 alloy-sol-types.workspace = true
+derive-where.workspace = true
 revm.workspace = true
 revm-inspectors.workspace = true
 

--- a/crates/foundry/evm/traces/src/lib.rs
+++ b/crates/foundry/evm/traces/src/lib.rs
@@ -15,6 +15,7 @@ use std::{
 };
 
 use alloy_primitives::map::HashMap;
+use derive_where::derive_where;
 use revm_inspectors::tracing::types::DecodedTraceStep;
 pub use revm_inspectors::tracing::{
     types::{
@@ -31,7 +32,7 @@ use serde::{Deserialize, Serialize};
 /// Identifiers figure out what ABIs and labels belong to all the addresses of
 /// the trace.
 pub mod identifier;
-use identifier::LocalTraceIdentifier;
+use identifier::{LocalTraceIdentifier, TraceIdentifier};
 
 pub mod abi;
 pub mod decoder;
@@ -39,11 +40,137 @@ pub use decoder::{CallTraceDecoder, CallTraceDecoderBuilder};
 use foundry_evm_core::contracts::{ContractsByAddress, ContractsByArtifact};
 
 /// A suite's setup-phase trace arenas, including deployments and `setUp()`,
-/// in execution order. When setup failed, the last arena is the failing call;
-/// the setup stack-trace computation relies on that.
-pub type SetupTraces = Vec<SetupTrace>;
+/// in execution order.
+///
+/// The setup stack-trace computation only names the last arena as the failing
+/// call, so the earlier ones never need their steps. When setup failed, that
+/// last arena is the failing call.
+pub type SetupTraces = TraceArenas<SetupTrace>;
 
+/// A setup trace arena paired with the kind of setup call that recorded it.
 pub type SetupTrace = (SetupTraceKind, SparsedTraceArena);
+
+/// The arenas a test's execution has recorded so far, in execution order.
+///
+/// Only the last arena may be named as the failing trace of a stack-trace
+/// computation; every earlier arena may only serve as a code source, which is
+/// walked for its CREATE nodes alone.
+pub type ExecutionTraces = TraceArenas<SparsedTraceArena>;
+
+/// An element of [`TraceArenas`]: a trace arena, possibly paired with
+/// metadata.
+pub trait HasTraceArena {
+    /// The carried arena.
+    fn trace_arena_mut(&mut self) -> &mut SparsedTraceArena;
+}
+
+impl HasTraceArena for SparsedTraceArena {
+    fn trace_arena_mut(&mut self) -> &mut SparsedTraceArena {
+        self
+    }
+}
+
+impl HasTraceArena for SetupTrace {
+    fn trace_arena_mut(&mut self) -> &mut SparsedTraceArena {
+        &mut self.1
+    }
+}
+
+/// Trace arenas in execution order.
+///
+/// At most the last element's arena carries recorded EVM steps, because
+/// [`push`](Self::push) — the only way to grow the collection — strips them
+/// from the arena it displaces. That bounds the memory peak while a test is
+/// still running, not just between tests. The collection derefs to a slice
+/// for reading; the mutating methods decode arenas in place or strip steps,
+/// so none of them can reintroduce steps or reorder the arenas.
+#[derive(Clone, Debug, Serialize)]
+#[derive_where(Default)]
+#[serde(transparent)]
+pub struct TraceArenas<T>(Vec<T>);
+
+impl<T: HasTraceArena> TraceArenas<T> {
+    /// Appends an element, stripping the recorded EVM steps from the arena
+    /// that was previously last (see [`SparsedTraceArena::strip_steps`]).
+    ///
+    /// The strip is unconditional, even when the whole collection is freed
+    /// once the test finishes. The in-test peak is worth the walk.
+    pub fn push(&mut self, item: T) {
+        self.strip_last_steps();
+        self.0.push(item);
+    }
+
+    /// Identifies the contracts in every arena and decodes the arenas in
+    /// place. Decoding writes labels and decoded call data; it cannot
+    /// reintroduce recorded steps.
+    pub async fn identify_and_decode(
+        &mut self,
+        decoder: &mut CallTraceDecoder,
+        identifier: &mut impl TraceIdentifier,
+    ) {
+        for item in &mut self.0 {
+            let arena = item.trace_arena_mut();
+            decoder.identify(arena, identifier);
+            decode_trace_arena(&mut arena.arena, decoder).await;
+        }
+    }
+
+    /// Strips the recorded EVM steps from the last arena, if any — the strip
+    /// [`push`](Self::push) would otherwise do when that arena is displaced.
+    pub fn strip_last_steps(&mut self) {
+        if let Some(last) = self.0.last_mut() {
+            last.trace_arena_mut().strip_steps();
+        }
+    }
+
+    /// Strips the recorded EVM steps from every arena, including the last.
+    ///
+    /// Must only be called once a stack trace can no longer be requested for
+    /// any of them.
+    pub fn strip_steps(&mut self) {
+        for item in &mut self.0 {
+            item.trace_arena_mut().strip_steps();
+        }
+    }
+}
+
+impl<T> Deref for TraceArenas<T> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> IntoIterator for TraceArenas<T> {
+    type Item = T;
+    type IntoIter = std::vec::IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a TraceArenas<T> {
+    type Item = &'a T;
+    type IntoIter = std::slice::Iter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl<T: HasTraceArena> FromIterator<T> for TraceArenas<T> {
+    /// Collects through [`push`](Self::push), so every arena but the last is
+    /// stripped of its steps.
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        let mut traces = Self::default();
+        for item in iter {
+            traces.push(item);
+        }
+        traces
+    }
+}
 
 /// Trace arena keeping track of ignored trace items.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -392,6 +519,19 @@ mod tests {
         ignored.insert((1, 0), (3, 0));
 
         SparsedTraceArena { arena, ignored }
+    }
+
+    #[test]
+    fn push_strips_steps_of_the_displaced_arena_only() {
+        let mut traces = ExecutionTraces::default();
+
+        traces.push(paused_arena());
+        assert!(!traces[0].nodes()[0].trace.steps.is_empty());
+
+        traces.push(paused_arena());
+        assert!(traces[0].nodes()[0].trace.steps.is_empty());
+        assert!(traces[0].ignored.is_empty());
+        assert!(!traces[1].nodes()[0].trace.steps.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Problem / context

Arenas kept their recorded steps until the test finished and `TraceRetentionPolicy` stripped them. A test that records several arenas — a `beforeTestSetup` chain, an invariant replay sequence — therefore held all of them step-laden at once. Only the last arena of a collection is ever the failing trace of a stack-trace computation; the earlier ones are walked for their CREATE nodes alone.

## Solution

Introduce a `TraceArenas<T>` newtype that can only grow through `push`, which strips the steps of the arena it displaces. At most one step-laden arena is then alive per collection, and the invariant lives in the type rather than in a convention on a `Vec`. Mutable access is limited to methods that cannot reintroduce steps: `identify_and_decode` for the decoding pass, and the stripping methods. This bounds the transient peak within a test, not just the peak between tests. `ExecutionTraces` and `TestSetup::traces` (`SetupTraces`) are both aliases of it, since `get_stack_trace` and `get_setup_stack_trace` each only name the last arena of their collection. In the invariant replay, a call that turns out not to be the failing one is stripped as soon as that is known.

The replay also stops handing each call's arena to `BaseCounterExample::traces`, which nothing reads (#1702 established that). The arena moves into `execution_traces` instead of being cloned into it, and a dead clone of the `afterInvariant()` arena is dropped. The counterexample's copies were the step-laden originals and would have outlived the strip.

A preparatory commit renames the single-arena `traces` fields (`RawCallResult`, `InspectorData`, `CaseOutcome`, `FailedInvariantCaseData`, `FuzzTestResult`) to `call_trace_arena`, so call sites no longer read as if they carried several arenas.

## Validation

- Unit tests pin the newtype's behavior: pushing strips the displaced arena only, and `strip_steps` on a sparse arena matches resolve-then-drop.
- Measured on top of #1703 for an earlier revision of this change (peak RSS, one run per configuration): solady `-vvv` 5.0 → 4.8 GiB, `-vvvv` 4.4 → 4.3 GiB. The benchmark repos have no failing invariants and no `beforeTestSetup`, so the strip is a no-op there; the deltas are measurement spread.

## Notes for reviewer

- Stacked on #1703; part of the Solidity test runner memory-reduction series. Two commits: the field rename, then the newtypes.
