### PR TITLE
perf: share setup trace arenas across a suite's napi test results

### DIFF
--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -154,12 +154,12 @@ export declare class TestResult {
    */
   stackTrace(): StackTrace | UnexpectedError | HeuristicFailed | UnsafeToReplay | null
   /**
-   * Constructs the execution traces for the test. Returns an empty array if
+   * Constructs the call traces for the test. Returns an empty array if
    * traces for this test were not requested according to
-   * [`crate::solidity_tests::config::SolidityTestRunnerConfigArgs::include_traces`]. Otherwise, returns
-   * an array of the root calls of the trace, which always includes the test
-   * call itself and may also include the setup call if there is one
-   * (identified by the function name `setUp`).
+   * [`crate::solidity_tests::config::SolidityTestRunnerConfigArgs::include_traces`].
+   * Otherwise, returns an array of the root calls of the trace, which
+   * always includes the test call itself and may also include the suite's
+   * setup call if there is one (identified by the function name `setUp`).
    */
   callTraces(): Array<CallTrace>
 }

--- a/crates/edr_napi/src/solidity_tests/test_results.rs
+++ b/crates/edr_napi/src/solidity_tests/test_results.rs
@@ -7,7 +7,7 @@ use std::{
 use edr_solidity_tests::{
     constants::CHEATCODE_ADDRESS,
     executors::stack_trace::SolidityTestStackTraceResult,
-    traces::{self, CallTraceArena, SparsedTraceArena},
+    traces::{self, CallTraceArena, ExecutionTraces, SparsedTraceArena},
 };
 use napi::{
     bindgen_prelude::{BigInt, Either3, Either4, Uint8Array},
@@ -81,22 +81,45 @@ impl SuiteResult {
         suite_result: edr_solidity_tests::result::SuiteResult<String>,
         include_traces: IncludeTraces,
     ) -> Self {
+        let edr_solidity_tests::result::SuiteResult {
+            duration,
+            setup_traces,
+            test_results,
+            warnings,
+        } = suite_result;
+
+        // Every included test result surfaces the same setup traces, so
+        // materialize them once per suite instead of cloning them into each
+        // result. Deployment traces are internal — contract identification,
+        // stack traces, the gas report — and are never surfaced.
+        let setup_trace_arenas: Arc<[SparsedTraceArena]> =
+            if matches!(include_traces, IncludeTraces::None) {
+                // No result will surface them.
+                Arc::default()
+            } else {
+                setup_traces
+                    .into_iter()
+                    .filter(|(kind, _)| !kind.is_deployment())
+                    .map(|(_, mut arena)| {
+                        // Resolve `pauseTracing`/`resumeTracing` ranges once
+                        // here; otherwise `call_traces` clones the shared
+                        // arena for every test result.
+                        arena.resolve_in_place();
+                        arena
+                    })
+                    .collect()
+            };
+
         Self {
             id: id.into(),
-            duration_ns: BigInt::from(suite_result.duration.as_nanos()),
-            test_results: suite_result
-                .test_results
+            duration_ns: BigInt::from(duration.as_nanos()),
+            test_results: test_results
                 .into_iter()
                 .map(|(name, test_result)| {
-                    TestResult::new(
-                        name,
-                        test_result,
-                        &suite_result.setup_traces,
-                        include_traces,
-                    )
+                    TestResult::new(name, test_result, &setup_trace_arenas, include_traces)
                 })
                 .collect(),
-            warnings: suite_result.warnings,
+            warnings,
         }
     }
 }
@@ -115,7 +138,15 @@ pub struct TestResult {
     value_snapshot_groups: Option<Vec<ValueSnapshotGroup>>,
 
     stack_trace_result: Option<Arc<SolidityTestStackTraceResult<String>>>,
-    call_trace_arenas: Vec<SparsedTraceArena>,
+    /// The suite's surfaced setup trace arenas — deployment traces excluded —
+    /// shared between its test results. Their `pauseTracing`/`resumeTracing`
+    /// ranges are resolved up front, so `call_traces` never clones them.
+    /// Empty when traces for this test were not requested, or when the suite
+    /// has no traced `setUp()`.
+    setup_trace_arenas: Arc<[SparsedTraceArena]>,
+    /// This test's own execution trace arenas. Empty when traces for this
+    /// test were not requested.
+    execution_trace_arenas: ExecutionTraces,
 }
 
 /// The stack trace result
@@ -279,16 +310,17 @@ impl TestResult {
         })
     }
 
-    /// Constructs the execution traces for the test. Returns an empty array if
+    /// Constructs the call traces for the test. Returns an empty array if
     /// traces for this test were not requested according to
-    /// [`crate::solidity_tests::config::SolidityTestRunnerConfigArgs::include_traces`]. Otherwise, returns
-    /// an array of the root calls of the trace, which always includes the test
-    /// call itself and may also include the setup call if there is one
-    /// (identified by the function name `setUp`).
+    /// [`crate::solidity_tests::config::SolidityTestRunnerConfigArgs::include_traces`].
+    /// Otherwise, returns an array of the root calls of the trace, which
+    /// always includes the test call itself and may also include the suite's
+    /// setup call if there is one (identified by the function name `setUp`).
     #[napi]
     pub fn call_traces(&self) -> Vec<CallTrace> {
-        self.call_trace_arenas
+        self.setup_trace_arenas
             .iter()
+            .chain(self.execution_trace_arenas.iter())
             .map(|arena| CallTrace::from_arena_node(&arena.resolve_arena(), 0))
             .collect()
     }
@@ -298,11 +330,18 @@ impl TestResult {
     fn new(
         name: String,
         test_result: edr_solidity_tests::result::TestResult<String>,
-        setup_traces: &edr_solidity_tests::traces::SetupTraces,
+        setup_trace_arenas: &Arc<[SparsedTraceArena]>,
         include_traces: IncludeTraces,
     ) -> Self {
         let include_trace = edr_solidity::config::IncludeTraces::from(include_traces)
             .should_include(|| test_result.status.is_failure());
+        // Bound together so the two halves of `call_traces` cannot diverge.
+        // `Arc::<[_]>::default()` avoids allocating an empty slice per result.
+        let (setup_trace_arenas, execution_trace_arenas) = if include_trace {
+            (Arc::clone(setup_trace_arenas), test_result.execution_traces)
+        } else {
+            Default::default()
+        };
 
         Self {
             name,
@@ -386,16 +425,8 @@ impl TestResult {
                     .collect(),
             ),
             stack_trace_result: test_result.stack_trace_result.map(Arc::new),
-            call_trace_arenas: if include_trace {
-                setup_traces
-                    .iter()
-                    .filter(|(k, _)| *k != traces::SetupTraceKind::Deployment)
-                    .map(|(_, arena)| arena.clone())
-                    .chain(test_result.execution_traces)
-                    .collect()
-            } else {
-                Vec::new()
-            },
+            setup_trace_arenas,
+            execution_trace_arenas,
         }
     }
 }

--- a/crates/edr_napi/src/solidity_tests/test_results.rs
+++ b/crates/edr_napi/src/solidity_tests/test_results.rs
@@ -301,8 +301,8 @@ impl TestResult {
         setup_traces: &edr_solidity_tests::traces::SetupTraces,
         include_traces: IncludeTraces,
     ) -> Self {
-        let include_trace = include_traces == IncludeTraces::All
-            || (include_traces == IncludeTraces::Failing && test_result.status.is_failure());
+        let include_trace = edr_solidity::config::IncludeTraces::from(include_traces)
+            .should_include(|| test_result.status.is_failure());
 
         Self {
             name,

--- a/crates/edr_solidity_tests/src/lib.rs
+++ b/crates/edr_solidity_tests/src/lib.rs
@@ -24,6 +24,7 @@ pub use foundry_evm::executors::stack_trace::SolidityTestStackTraceError;
 
 mod error;
 mod test_filter;
+mod trace_retention;
 
 pub use foundry_evm::*;
 pub use test_filter::{TestFilter, TestFilterConfig};

--- a/crates/edr_solidity_tests/src/multi_runner.rs
+++ b/crates/edr_solidity_tests/src/multi_runner.rs
@@ -42,7 +42,7 @@ use crate::{
     error::TestRunnerError,
     fuzz::{invariant::InvariantConfig, FuzzConfig},
     inline_config::{self, InlineConfigRoot, SharedInlineConfigProvider},
-    result::SuiteResult,
+    result::{SuiteResult, SuiteRunOutcome, TestRunOutcome},
     runner::{ContractRunnerArtifacts, ContractRunnerOptions},
     ContractRunner, SolidityTestRunnerConfig, SolidityTestRunnerConfigError, TestFilter,
     TestFunctionConfigOverride,
@@ -447,22 +447,33 @@ impl<
                     invariant_config: &self.invariant_config,
                     test_function_overrides: &inline_overrides,
                     generate_gas_report: self.generate_gas_report,
+                    include_traces: self.include_traces,
                 },
                 span,
             );
-        let mut r = runner.run_tests(filter, handle)?;
+        let SuiteRunOutcome {
+            duration,
+            mut setup_traces,
+            test_outcomes,
+            warnings,
+        } = runner.run_tests(filter, handle)?;
 
         let mut gas_report = self
             .generate_gas_report
             .then(crate::gas_report::GasReport::default);
 
-        if self.include_traces != IncludeTraces::None {
+        let test_results = if self.include_traces == IncludeTraces::None {
+            test_outcomes
+                .into_iter()
+                .map(|(signature, outcome)| (signature, outcome.result))
+                .collect()
+        } else {
             let mut decoder = CallTraceDecoderBuilder::new().build();
             let mut trace_identifier = TraceIdentifiers::new().with_local(&self.known_contracts);
 
             // Setup traces are shared across all tests in the suite, so decode and analyze
             // them only once.
-            for (_, arena) in &mut r.setup_traces {
+            for (_, arena) in &mut setup_traces {
                 decoder.identify(arena, &mut trace_identifier);
                 tokio::task::block_in_place(|| {
                     handle.block_on(decode_trace_arena(arena, &decoder));
@@ -472,64 +483,76 @@ impl<
             if let Some(gas_report) = gas_report.as_mut() {
                 tokio::task::block_in_place(|| {
                     handle.block_on(
-                        gas_report.analyze(r.setup_traces.iter().map(|(_, a)| &a.arena), &decoder),
+                        gas_report.analyze(setup_traces.iter().map(|(_, a)| &a.arena), &decoder),
                     );
                 });
             }
 
-            for result in r.test_results.values_mut() {
-                if result.status.is_success() && self.include_traces != IncludeTraces::All {
-                    continue;
-                }
+            test_outcomes
+                .into_iter()
+                .map(|(signature, outcome)| {
+                    let TestRunOutcome {
+                        mut result,
+                        gas_report_samples,
+                    } = outcome;
 
-                decoder.clear_addresses();
-                decoder.labels.extend(
-                    result
-                        .labeled_addresses
-                        .iter()
-                        .map(|(k, v)| (*k, v.clone())),
-                );
-
-                // Re-execute setup traces to collect identities of deployed contracts.
-                for (_, arena) in &mut r.setup_traces {
-                    decoder.identify(arena, &mut trace_identifier);
-                }
-
-                for arena in &mut result.execution_traces {
-                    decoder.identify(arena, &mut trace_identifier);
-                    tokio::task::block_in_place(|| {
-                        handle.block_on(decode_trace_arena(arena, &decoder));
-                    });
-                }
-
-                if let Some(gas_report) = gas_report.as_mut() {
-                    tokio::task::block_in_place(|| {
-                        handle.block_on(gas_report.analyze(
-                            result.execution_traces.iter().map(|arena| &arena.arena),
-                            &decoder,
-                        ));
-                    });
-
-                    for trace in &result.gas_report_traces {
+                    if self
+                        .include_traces
+                        .should_include(|| result.status.is_failure())
+                    {
                         decoder.clear_addresses();
+                        decoder.labels.extend(
+                            result
+                                .labeled_addresses
+                                .iter()
+                                .map(|(k, v)| (*k, v.clone())),
+                        );
 
                         // Re-execute setup traces to collect identities of deployed contracts.
-                        for (_, arena) in &r.setup_traces {
+                        for (_, arena) in &setup_traces {
                             decoder.identify(arena, &mut trace_identifier);
                         }
 
-                        for arena in trace {
+                        for arena in &mut result.execution_traces {
                             decoder.identify(arena, &mut trace_identifier);
                             tokio::task::block_in_place(|| {
-                                handle.block_on(gas_report.analyze([arena], &decoder));
+                                handle.block_on(decode_trace_arena(arena, &decoder));
                             });
                         }
+
+                        if let Some(gas_report) = gas_report.as_mut() {
+                            tokio::task::block_in_place(|| {
+                                handle.block_on(gas_report.analyze(
+                                    result.execution_traces.iter().map(|arena| &arena.arena),
+                                    &decoder,
+                                ));
+                            });
+
+                            for trace in gas_report_samples.into_iter().flatten() {
+                                decoder.clear_addresses();
+
+                                // Re-execute setup traces to collect identities of deployed
+                                // contracts.
+                                for (_, arena) in &setup_traces {
+                                    decoder.identify(arena, &mut trace_identifier);
+                                }
+
+                                for arena in trace {
+                                    decoder.identify(&arena, &mut trace_identifier);
+                                    tokio::task::block_in_place(|| {
+                                        handle.block_on(gas_report.analyze([&arena], &decoder));
+                                    });
+                                }
+                            }
+                        }
                     }
-                }
-                // Clear memory.
-                result.gas_report_traces.clear();
-            }
-        }
+
+                    (signature, result)
+                })
+                .collect()
+        };
+
+        let r = SuiteResult::new(duration, setup_traces, test_results, warnings);
         debug!(duration=?r.duration, "executed all tests in contract");
 
         Ok((r, gas_report))

--- a/crates/edr_solidity_tests/src/multi_runner.rs
+++ b/crates/edr_solidity_tests/src/multi_runner.rs
@@ -196,7 +196,7 @@ impl<
             project_root,
             cheats_config_options,
             fuzz,
-            invariant,
+            mut invariant,
             enable_fuzz_fixtures,
             enable_table_tests,
             local_predeploys,
@@ -234,6 +234,9 @@ impl<
             include_traces = IncludeTraces::All;
             // Enable EVM isolation for more accurate gas measurements
             evm_opts.isolate = true;
+        } else {
+            // Nothing consumes gas-report samples, so don't collect them.
+            invariant.gas_report_samples = 0;
         }
 
         Ok(Self {

--- a/crates/edr_solidity_tests/src/result.rs
+++ b/crates/edr_solidity_tests/src/result.rs
@@ -21,7 +21,10 @@ use foundry_evm::{
         invariant::InvariantFuzzError, stack_trace::SolidityTestStackTraceResult, RawCallResult,
     },
     fuzz::{CounterExample, FuzzFixtures},
-    traces::{CallTraceArena, CallTraceDecoder, SetupTraceKind, SetupTraces, SparsedTraceArena},
+    traces::{
+        strip_arena_steps, CallTraceArena, CallTraceDecoder, SetupTraceKind, SetupTraces,
+        SparsedTraceArena,
+    },
 };
 use serde::{Deserialize, Serialize};
 use yansi::Paint;
@@ -408,7 +411,9 @@ pub struct TestResult<HaltReasonT> {
     ///
     /// Emptied by `Self::free_unconsumed_traces` once the test has
     /// finished, unless trace decoding, the gas report or the napi conversion
-    /// will still consume them.
+    /// will still consume them. The arenas that are kept have their recorded
+    /// EVM steps stripped: only the call tree, the logs and their ordering
+    /// survive.
     #[serde(skip)]
     pub execution_traces: Vec<SparsedTraceArena>,
 
@@ -475,9 +480,15 @@ pub struct SuiteRunOutcome<HaltReasonT> {
 
 impl<HaltReasonT> TestRunOutcome<HaltReasonT> {
     /// Frees every trace arena that no longer has a consumer, as decided by
-    /// `policy`.
+    /// `policy`, and strips the recorded EVM steps from the arenas it keeps.
     pub(crate) fn free_unconsumed_traces(&mut self, policy: TraceRetentionPolicy) {
         self.result.free_unconsumed_traces(policy);
+
+        // The gas report reads the call tree only; without one the samples
+        // are `None`.
+        for arena in self.gas_report_samples.iter_mut().flatten().flatten() {
+            strip_arena_steps(arena);
+        }
     }
 }
 
@@ -509,7 +520,7 @@ impl<HaltReasonT> From<TestResult<HaltReasonT>> for TestRunOutcome<HaltReasonT> 
 
 impl<HaltReasonT> TestResult<HaltReasonT> {
     /// Frees every trace arena that no longer has a consumer, as decided by
-    /// `policy`.
+    /// `policy`, and strips the recorded EVM steps from the arenas it keeps.
     pub(crate) fn free_unconsumed_traces(&mut self, policy: TraceRetentionPolicy) {
         let Self {
             status,
@@ -531,7 +542,11 @@ impl<HaltReasonT> TestResult<HaltReasonT> {
             Retain::Nothing => {
                 *execution_traces = Vec::new();
             }
-            Retain::CallsOnly => {}
+            Retain::CallsOnly => {
+                for arena in execution_traces.iter_mut() {
+                    arena.strip_steps();
+                }
+            }
         }
 
         // Counterexample arenas have no consumer at all once the test has

--- a/crates/edr_solidity_tests/src/result.rs
+++ b/crates/edr_solidity_tests/src/result.rs
@@ -31,6 +31,7 @@ use crate::{
     decode::decode_console_logs,
     fuzz::{BaseCounterExample, FuzzTestResult, FuzzedCases},
     gas_report::GasReport,
+    trace_retention::{Retain, TraceRetentionPolicy},
 };
 
 /// The aggregated result of a test run.
@@ -380,7 +381,10 @@ pub struct TestResult<HaltReasonT> {
     /// expected to fail.
     pub reason: Option<String>,
 
-    /// Minimal reproduction test case for failing test
+    /// Minimal reproduction test case for failing test.
+    ///
+    /// Its trace arenas are freed once the test has finished — nothing
+    /// consumes them.
     pub counterexample: Option<CounterExample>,
 
     /// Any captured & parsed as strings logs along the test's execution which
@@ -401,12 +405,12 @@ pub struct TestResult<HaltReasonT> {
     /// that arena off; it walks the earlier ones only for the contracts they
     /// deployed. Can be empty even for a failing test — see
     /// [`Self::stack_trace_result`].
+    ///
+    /// Emptied by `Self::free_unconsumed_traces` once the test has
+    /// finished, unless trace decoding, the gas report or the napi conversion
+    /// will still consume them.
     #[serde(skip)]
     pub execution_traces: Vec<SparsedTraceArena>,
-
-    /// Additional traces to use for gas report.
-    #[serde(skip)]
-    pub gas_report_traces: Vec<Vec<CallTraceArena>>,
 
     /// Raw coverage info
     #[serde(skip)]
@@ -439,7 +443,109 @@ pub struct TestResult<HaltReasonT> {
     pub deprecated_cheatcodes: HashMap<&'static str, Option<&'static str>>,
 }
 
+/// A finished test's result together with the trace arenas sampled for the
+/// gas report.
+///
+/// The samples live beside the result instead of on it because they have
+/// exactly one consumer: the gas-report pass in
+/// `MultiContractRunner::run_test_suite` takes them by value. `TestResult`
+/// therefore never carries arenas that would need freeing after that pass.
+pub struct TestRunOutcome<HaltReasonT> {
+    /// The test's result, as surfaced to the caller.
+    pub result: TestResult<HaltReasonT>,
+    /// The trace arenas sampled for the gas report, one collection per
+    /// sampled run. `None` when no gas report was requested.
+    pub gas_report_samples: Option<Vec<Vec<CallTraceArena>>>,
+}
+
+/// A suite's run: the per-test outcomes plus everything else that goes into
+/// its [`SuiteResult`], which the caller assembles once it has consumed each
+/// outcome's gas-report samples. The samples stay on their outcome, so no
+/// bookkeeping beside the outcomes can orphan them.
+pub struct SuiteRunOutcome<HaltReasonT> {
+    /// Wall clock time it took to run the suite.
+    pub duration: Duration,
+    /// Traces from the suite's setup phase.
+    pub setup_traces: SetupTraces,
+    /// Each test's outcome: `test fn signature -> outcome`.
+    pub test_outcomes: BTreeMap<String, TestRunOutcome<HaltReasonT>>,
+    /// Generated warnings.
+    pub warnings: Vec<String>,
+}
+
+impl<HaltReasonT> TestRunOutcome<HaltReasonT> {
+    /// Frees every trace arena that no longer has a consumer, as decided by
+    /// `policy`.
+    pub(crate) fn free_unconsumed_traces(&mut self, policy: TraceRetentionPolicy) {
+        self.result.free_unconsumed_traces(policy);
+    }
+}
+
+impl<HaltReasonT: HaltReasonTrait> SuiteRunOutcome<HaltReasonT> {
+    /// Wraps a suite result whose tests produced no gas-report samples.
+    pub fn without_samples(suite_result: SuiteResult<HaltReasonT>) -> Self {
+        Self {
+            duration: suite_result.duration,
+            setup_traces: suite_result.setup_traces,
+            test_outcomes: suite_result
+                .test_results
+                .into_iter()
+                .map(|(signature, result)| (signature, TestRunOutcome::from(result)))
+                .collect(),
+            warnings: suite_result.warnings,
+        }
+    }
+}
+
+impl<HaltReasonT> From<TestResult<HaltReasonT>> for TestRunOutcome<HaltReasonT> {
+    /// Wraps a result that produced no gas-report samples.
+    fn from(result: TestResult<HaltReasonT>) -> Self {
+        Self {
+            result,
+            gas_report_samples: None,
+        }
+    }
+}
+
 impl<HaltReasonT> TestResult<HaltReasonT> {
+    /// Frees every trace arena that no longer has a consumer, as decided by
+    /// `policy`.
+    pub(crate) fn free_unconsumed_traces(&mut self, policy: TraceRetentionPolicy) {
+        let Self {
+            status,
+            reason: _,
+            counterexample,
+            logs: _,
+            decoded_logs: _,
+            kind: _,
+            execution_traces,
+            line_coverage: _,
+            labeled_addresses: _,
+            duration: _,
+            value_snapshots: _,
+            stack_trace_result: _,
+            deprecated_cheatcodes: _,
+        } = self;
+
+        match policy.retain_after(*status) {
+            Retain::Nothing => {
+                *execution_traces = Vec::new();
+            }
+            Retain::CallsOnly => {}
+        }
+
+        // Counterexample arenas have no consumer at all once the test has
+        // finished: they are neither decoded nor exposed over napi.
+        let counterexamples: &mut [BaseCounterExample] = match counterexample {
+            Some(CounterExample::Single(counterexample)) => std::slice::from_mut(counterexample),
+            Some(CounterExample::Sequence(_, counterexamples)) => counterexamples,
+            None => &mut [],
+        };
+        for counterexample in counterexamples {
+            counterexample.traces = None;
+        }
+    }
+
     pub fn map_halt_reason<
         ConversionFnT: Copy + Fn(HaltReasonT) -> NewHaltReasonT,
         NewHaltReasonT,
@@ -455,7 +561,6 @@ impl<HaltReasonT> TestResult<HaltReasonT> {
             decoded_logs: self.decoded_logs,
             kind: self.kind,
             execution_traces: self.execution_traces,
-            gas_report_traces: self.gas_report_traces,
             line_coverage: self.line_coverage,
             labeled_addresses: self.labeled_addresses,
             duration: self.duration,
@@ -604,7 +709,6 @@ impl<HaltReasonT: HaltReasonTrait> TestResult<HaltReasonT> {
         };
         self.reason = reason;
         self.duration = duration;
-        self.gas_report_traces = Vec::new();
 
         if let Some(cheatcodes) = raw_call_result.cheatcodes {
             self.value_snapshots = cheatcodes.gas_snapshots;
@@ -639,11 +743,6 @@ impl<HaltReasonT: HaltReasonTrait> TestResult<HaltReasonT> {
         self.reason = result.reason;
         self.counterexample = result.counterexample;
         self.duration = duration;
-        self.gas_report_traces = result
-            .gas_report_traces
-            .into_iter()
-            .map(|t| vec![t])
-            .collect();
         self.deprecated_cheatcodes = result.deprecated_cheatcodes;
     }
 
@@ -709,7 +808,6 @@ impl<HaltReasonT: HaltReasonTrait> TestResult<HaltReasonT> {
     #[expect(clippy::too_many_arguments)]
     pub fn invariant_result(
         &mut self,
-        gas_report_traces: Vec<Vec<CallTraceArena>>,
         success: bool,
         reason: Option<String>,
         counterexample: Option<CounterExample>,
@@ -732,7 +830,6 @@ impl<HaltReasonT: HaltReasonTrait> TestResult<HaltReasonT> {
         };
         self.reason = reason;
         self.counterexample = counterexample;
-        self.gas_report_traces = gas_report_traces;
         self.duration = duration;
     }
 

--- a/crates/edr_solidity_tests/src/result.rs
+++ b/crates/edr_solidity_tests/src/result.rs
@@ -22,8 +22,8 @@ use foundry_evm::{
     },
     fuzz::{CounterExample, FuzzFixtures},
     traces::{
-        strip_arena_steps, CallTraceArena, CallTraceDecoder, SetupTraceKind, SetupTraces,
-        SparsedTraceArena,
+        push_setup_trace_stripping_prior_steps, strip_arena_steps, CallTraceArena,
+        CallTraceDecoder, ExecutionTraces, SetupTraceKind, SetupTraces,
     },
 };
 use serde::{Deserialize, Serialize};
@@ -414,8 +414,11 @@ pub struct TestResult<HaltReasonT> {
     /// will still consume them. The arenas that are kept have their recorded
     /// EVM steps stripped: only the call tree, the logs and their ordering
     /// survive.
+    ///
+    /// While the test runs, at most the last arena carries recorded steps —
+    /// see [`ExecutionTraces`].
     #[serde(skip)]
-    pub execution_traces: Vec<SparsedTraceArena>,
+    pub execution_traces: ExecutionTraces,
 
     /// Raw coverage info
     #[serde(skip)]
@@ -540,12 +543,10 @@ impl<HaltReasonT> TestResult<HaltReasonT> {
 
         match policy.retain_after(*status) {
             Retain::Nothing => {
-                *execution_traces = Vec::new();
+                *execution_traces = ExecutionTraces::default();
             }
             Retain::CallsOnly => {
-                for arena in execution_traces.iter_mut() {
-                    arena.strip_steps();
-                }
+                execution_traces.strip_steps();
             }
         }
 
@@ -715,7 +716,9 @@ impl<HaltReasonT: HaltReasonTrait> TestResult<HaltReasonT> {
         self.logs.extend(raw_call_result.logs);
         self.decoded_logs = decode_console_logs(&self.logs);
         self.labeled_addresses.extend(raw_call_result.labels);
-        self.execution_traces.extend(raw_call_result.traces);
+        if let Some(arena) = raw_call_result.traces {
+            self.execution_traces.push(arena);
+        }
         self.merge_coverages(raw_call_result.line_coverage);
 
         self.status = match success {
@@ -745,7 +748,9 @@ impl<HaltReasonT: HaltReasonTrait> TestResult<HaltReasonT> {
         self.logs.extend(result.logs);
         self.decoded_logs = decode_console_logs(&self.logs);
         self.labeled_addresses.extend(result.labeled_addresses);
-        self.execution_traces.extend(result.traces);
+        if let Some(arena) = result.traces {
+            self.execution_traces.push(arena);
+        }
         self.merge_coverages(result.line_coverage);
 
         self.status = if result.skipped {
@@ -811,7 +816,9 @@ impl<HaltReasonT: HaltReasonTrait> TestResult<HaltReasonT> {
             metrics: HashMap::default(),
             failed_corpus_replays: 0,
         };
-        self.execution_traces.extend(e.take_traces());
+        if let Some(arena) = e.take_traces() {
+            self.execution_traces.push(arena);
+        }
         self.status = TestStatus::Failure;
         self.reason = Some(format!(
             "failed to set up invariant testing environment: {e}"
@@ -881,7 +888,9 @@ impl<HaltReasonT: HaltReasonTrait> TestResult<HaltReasonT> {
         self.logs.extend(call_result.logs);
         self.decoded_logs = decode_console_logs(&self.logs);
         self.labeled_addresses.extend(call_result.labels);
-        self.execution_traces.extend(call_result.traces);
+        if let Some(arena) = call_result.traces {
+            self.execution_traces.push(arena);
+        }
         self.merge_coverages(call_result.line_coverage);
     }
 
@@ -1028,7 +1037,8 @@ pub struct TestSetup<HaltReasonT> {
     pub logs: Vec<Log>,
     /// Addresses labeled during setup.
     pub labels: AddressHashMap<String>,
-    /// Call traces of the setup.
+    /// Call traces of the setup. Only the last arena carries recorded EVM
+    /// steps — append through [`push_setup_trace_stripping_prior_steps`].
     pub traces: SetupTraces,
     /// Coverage info during setup.
     pub coverage: Option<HitMaps>,
@@ -1092,8 +1102,12 @@ impl<HaltReasonT: HaltReasonTrait> TestSetup<HaltReasonT> {
     ) {
         self.logs.extend(raw.logs);
         self.labels.extend(raw.labels);
-        self.traces
-            .extend(raw.traces.map(|traces| (trace_kind, traces)));
+        if let Some(traces) = raw.traces {
+            // Only the last setup arena can be named as the failing trace (by
+            // `get_setup_stack_trace`), so a step-recorded setup re-run keeps
+            // one step-laden arena instead of one per setup call.
+            push_setup_trace_stripping_prior_steps(&mut self.traces, trace_kind, traces);
+        }
         if let Some(indeterminism_reasons) = self.indeterminism_reasons.as_mut() {
             indeterminism_reasons.merge(raw.indeterminism_reasons);
         } else {

--- a/crates/edr_solidity_tests/src/runner.rs
+++ b/crates/edr_solidity_tests/src/runner.rs
@@ -17,6 +17,7 @@ use edr_artifact::ArtifactId;
 use edr_chain_spec::{EvmHaltReason, HaltReasonTrait};
 use edr_decoder_revert::RevertDecoder;
 use edr_solidity::{
+    config::IncludeTraces,
     contract_decoder::SyncNestedTraceDecoder,
     solidity_stack_trace::{get_stack_trace, DeployedCode, StackTraceEntry},
 };
@@ -44,7 +45,9 @@ use foundry_evm::{
         invariant::{CallDetails, InvariantContract},
         CounterExample, FuzzFixtures,
     },
-    traces::{load_contracts, SetupTraceKind, SetupTraces, SparsedTraceArena, TracingMode},
+    traces::{
+        load_contracts, CallTraceArena, SetupTraceKind, SetupTraces, SparsedTraceArena, TracingMode,
+    },
 };
 use itertools::Itertools;
 use proptest::test_runner::{FailurePersistence, RngAlgorithm, TestError, TestRng, TestRunner};
@@ -56,8 +59,9 @@ use crate::{
     error::TestRunnerError,
     fuzz::{invariant::BasicTxDetails, BaseCounterExample, FuzzConfig},
     multi_runner::TestContract,
-    result::{SuiteResult, TestResult, TestSetup},
+    result::{SuiteResult, SuiteRunOutcome, TestResult, TestRunOutcome, TestSetup, TestStatus},
     revm::context::result::HaltReason,
+    trace_retention::TraceRetentionPolicy,
     TestFilter, TestFunctionConfigOverride,
 };
 
@@ -109,6 +113,8 @@ pub struct ContractRunner<
     /// Whether gas reports are being generated. When enabled, isolation cannot
     /// be disabled by function-level overrides.
     generate_gas_report: bool,
+    /// Which trace arenas to retain once a test has finished.
+    trace_retention: TraceRetentionPolicy,
 
     #[allow(clippy::type_complexity)]
     _phantom: PhantomData<fn() -> (EvmBuilderT, HaltReasonT, TransactionErrorT)>,
@@ -134,6 +140,8 @@ pub struct ContractRunnerOptions<'a> {
     /// Whether gas reports are being generated. When enabled, isolation cannot
     /// be disabled by function-level overrides.
     pub generate_gas_report: bool,
+    /// Which test results carry call traces to the caller.
+    pub include_traces: IncludeTraces,
 }
 
 /// Contract artifact related arguments to the contract runner.
@@ -197,6 +205,7 @@ impl<
             invariant_config,
             test_function_overrides,
             generate_gas_report,
+            include_traces,
         } = options;
 
         Self {
@@ -217,6 +226,7 @@ impl<
             span,
             test_function_overrides,
             generate_gas_report,
+            trace_retention: TraceRetentionPolicy::new(include_traces, generate_gas_report),
             _phantom: PhantomData,
         }
     }
@@ -517,7 +527,7 @@ impl<
         self,
         filter: &dyn TestFilter,
         tokio_handle: &tokio::runtime::Handle,
-    ) -> Result<SuiteResult<HaltReasonT>, TestRunnerError> {
+    ) -> Result<SuiteRunOutcome<HaltReasonT>, TestRunnerError> {
         // Forge doesn't include building the executor in the test time, so we're
         // excluding it as well.
         let mut executor = self.executor_builder.clone().build()?;
@@ -552,7 +562,7 @@ impl<
         // There are multiple setUp function, so we return a single test result for
         // `setUp`
         if setup_fns.len() > 1 {
-            return Ok(SuiteResult::new(
+            return Ok(SuiteRunOutcome::without_samples(SuiteResult::new(
                 start.elapsed(),
                 Vec::new(),
                 [(
@@ -561,7 +571,7 @@ impl<
                 )]
                 .into(),
                 warnings,
-            ));
+            )));
         }
 
         // Check if `afterInvariant` function with valid signature declared.
@@ -573,7 +583,7 @@ impl<
             .collect();
         if after_invariant_fns.len() > 1 {
             // Return a single test result failure if multiple functions declared.
-            return Ok(SuiteResult::new(
+            return Ok(SuiteRunOutcome::without_samples(SuiteResult::new(
                 start.elapsed(),
                 Vec::new(),
                 [(
@@ -582,7 +592,7 @@ impl<
                 )]
                 .into(),
                 warnings,
-            ));
+            )));
         }
         let call_after_invariant = after_invariant_fns.first().is_some_and(|after_invariant_fn| {
             let match_sig = after_invariant_fn.name == "afterInvariant";
@@ -614,12 +624,12 @@ impl<
 
         // Avoid set-up if there are no test functions to run
         if functions.is_empty() {
-            return Ok(SuiteResult::new(
+            return Ok(SuiteRunOutcome::without_samples(SuiteResult::new(
                 start.elapsed(),
                 Vec::new(),
                 BTreeMap::new(),
                 warnings,
-            ));
+            )));
         }
 
         // Invariant testing requires tracing to figure out what contracts were created.
@@ -673,12 +683,15 @@ impl<
             } else {
                 "constructor()".to_string()
             };
-            return Ok(SuiteResult::new(
+            // `setup_failure_result` does not read the traces, so move rather
+            // than clone them.
+            let setup_traces = std::mem::take(&mut setup.traces);
+            return Ok(SuiteRunOutcome::without_samples(SuiteResult::new(
                 elapsed,
-                setup.traces.clone(),
+                setup_traces,
                 [(fail_msg, TestResult::setup_failure_result(setup))].into(),
                 warnings,
-            ));
+            )));
         }
 
         let identified_contracts = has_invariants.then(|| {
@@ -698,15 +711,15 @@ impl<
             let test_results = test_fail_functions
                 .map(|func| (func.signature(), fail()))
                 .collect();
-            return Ok(SuiteResult::new(
+            return Ok(SuiteRunOutcome::without_samples(SuiteResult::new(
                 start.elapsed(),
                 setup.traces,
                 test_results,
                 warnings,
-            ));
+            )));
         }
 
-        let test_results = functions
+        let test_outcomes = functions
             .par_iter()
             .map(|&func| {
                 let _tokio_guard = tokio_handle.enter();
@@ -727,26 +740,38 @@ impl<
                 )
                 .entered();
 
-                let res = FunctionRunner::new(&self, &executor, &setup).run(
+                let mut outcome = FunctionRunner::new(&self, &executor, &setup).run(
                     func,
                     kind,
                     call_after_invariant,
                     identified_contracts.as_ref(),
                 );
 
-                (sig, res)
+                // Stack-trace generation has just run. Nothing reads the
+                // freed traces after it.
+                outcome.free_unconsumed_traces(self.trace_retention);
+
+                (sig, outcome)
             })
             .collect::<BTreeMap<_, _>>();
 
         let duration = start.elapsed();
-        let suite_result = SuiteResult::new(duration, setup.traces, test_results, warnings);
+        let passed = test_outcomes
+            .values()
+            .filter(|outcome| outcome.result.status == TestStatus::Success)
+            .count();
         info!(
-            duration=?suite_result.duration,
+            duration=?duration,
             "done. {}/{} successful",
-            suite_result.passed(),
-            suite_result.test_results.len()
+            passed,
+            test_outcomes.len()
         );
-        Ok(suite_result)
+        Ok(SuiteRunOutcome {
+            duration,
+            setup_traces: setup.traces,
+            test_outcomes,
+            warnings,
+        })
     }
 }
 
@@ -791,6 +816,9 @@ struct FunctionRunner<
     setup: &'a TestSetup<HaltReasonT>,
     /// The test result. Returned after running the test.
     result: TestResult<HaltReasonT>,
+    /// The trace arenas the test sampled for the gas report; `None` when no
+    /// gas report was requested. Returned beside the result.
+    gas_report_samples: Option<Vec<Vec<CallTraceArena>>>,
 }
 
 impl<
@@ -845,6 +873,15 @@ impl<
             cr,
             setup,
             result: TestResult::new(setup),
+            gas_report_samples: None,
+        }
+    }
+
+    /// Finishes the run, pairing the result with the gas-report samples.
+    fn outcome(self) -> TestRunOutcome<HaltReasonT> {
+        TestRunOutcome {
+            result: self.result,
+            gas_report_samples: self.gas_report_samples,
         }
     }
 
@@ -854,14 +891,14 @@ impl<
         kind: TestFunctionKind,
         call_after_invariant: bool,
         identified_contracts: Option<&ContractsByAddress>,
-    ) -> TestResult<HaltReasonT> {
+    ) -> TestRunOutcome<HaltReasonT> {
         // Apply executor config overrides.
         if let Err(err) = self
             .cr
             .apply_executor_overrides(func, self.executor.to_mut())
         {
             self.result.single_fail(Some(err), Instant::now().elapsed());
-            return self.result;
+            return self.outcome();
         }
 
         match kind {
@@ -891,12 +928,12 @@ impl<
     /// modified state). State modifications of before test txes and unit
     /// test function call are discarded after test ends, similar to
     /// `eth_call`.
-    fn run_unit_test(mut self, func: &Function) -> TestResult<HaltReasonT> {
+    fn run_unit_test(mut self, func: &Function) -> TestRunOutcome<HaltReasonT> {
         let start: Instant = Instant::now();
 
         // Prepare unit test execution.
         if self.prepare_test(func, start).is_err() {
-            return self.result;
+            return self.outcome();
         }
 
         // Run current unit test.
@@ -912,12 +949,12 @@ impl<
             Err(EvmError::Execution(err)) => (err.raw, Some(err.reason)),
             Err(EvmError::Skip(reason)) => {
                 self.result.single_skip(reason);
-                return self.result;
+                return self.outcome();
             }
             Err(err) => {
                 self.result
                     .single_fail(Some(err.to_string()), start.elapsed());
-                return self.result;
+                return self.outcome();
             }
         };
 
@@ -959,7 +996,7 @@ impl<
             None
         };
 
-        self.result
+        self.outcome()
     }
 
     /// Runs a table test.
@@ -970,7 +1007,7 @@ impl<
     /// - `uint256[] public fixtureAmount = [2, 5]`
     /// - `bool[] public fixtureSwap = [true, false]` The `table_test` is then
     ///   called with the pair of args `(2, true)` and `(5, false)`.
-    fn run_table_test(mut self, func: &Function) -> TestResult<HaltReasonT> {
+    fn run_table_test(mut self, func: &Function) -> TestRunOutcome<HaltReasonT> {
         let start = Instant::now();
 
         if !self.cr.enable_table_tests {
@@ -978,12 +1015,12 @@ impl<
                 Some("Table tests are not supported".into()),
                 start.elapsed(),
             );
-            return self.result;
+            return self.outcome();
         };
 
         // Prepare unit test execution.
         if self.prepare_test(func, start).is_err() {
-            return self.result;
+            return self.outcome();
         }
 
         // Extract and validate fixtures for the first table test parameter.
@@ -992,7 +1029,7 @@ impl<
                 Some("Table test should have at least one parameter".into()),
                 start.elapsed(),
             );
-            return self.result;
+            return self.outcome();
         };
 
         let Some(first_param_fixtures) =
@@ -1002,7 +1039,7 @@ impl<
                 Some("Table test should have fixtures defined".into()),
                 start.elapsed(),
             );
-            return self.result;
+            return self.outcome();
         };
 
         if first_param_fixtures.is_empty() {
@@ -1010,7 +1047,7 @@ impl<
                 Some("Table test should have at least one fixture".into()),
                 start.elapsed(),
             );
-            return self.result;
+            return self.outcome();
         }
 
         let fixtures_len = first_param_fixtures.len();
@@ -1024,7 +1061,7 @@ impl<
                     Some(format!("No fixture defined for param {param_name}")),
                     start.elapsed(),
                 );
-                return self.result;
+                return self.outcome();
             };
 
             if fixtures.len() != fixtures_len {
@@ -1036,7 +1073,7 @@ impl<
                     )),
                     start.elapsed(),
                 );
-                return self.result;
+                return self.outcome();
             }
 
             table_fixtures.push(&fixtures[..]);
@@ -1060,12 +1097,12 @@ impl<
                 Err(EvmError::Execution(err)) => (err.raw, Some(err.reason)),
                 Err(EvmError::Skip(reason)) => {
                     self.result.single_skip(reason);
-                    return self.result;
+                    return self.outcome();
                 }
                 Err(err) => {
                     self.result
                         .single_fail(Some(err.to_string()), start.elapsed());
-                    return self.result;
+                    return self.outcome();
                 }
             };
 
@@ -1081,7 +1118,9 @@ impl<
                                 .expect("args have valid abi encoding"),
                         ),
                         &args,
-                        raw_call_result.traces.clone(),
+                        // Counterexample arenas are never consumed; the
+                        // failing arena lives on in `execution_traces`.
+                        None,
                         raw_call_result.indeterminism_reasons.clone(),
                     )));
                 let elapsed = start.elapsed();
@@ -1114,7 +1153,7 @@ impl<
                     };
                 self.result.stack_trace_result = Some(stack_trace_result);
 
-                return self.result;
+                return self.outcome();
             }
 
             // If it's the last iteration and all other runs succeeded, then use last call
@@ -1122,11 +1161,11 @@ impl<
             if i == fixtures_len - 1 {
                 self.result
                     .single_result(true, None, raw_call_result, start.elapsed());
-                return self.result;
+                return self.outcome();
             }
         }
 
-        self.result
+        self.outcome()
     }
 
     fn run_invariant_test(
@@ -1135,7 +1174,7 @@ impl<
         call_after_invariant: bool,
         identified_contracts: &ContractsByAddress,
         test_bytecode: &Bytes,
-    ) -> TestResult<HaltReasonT> {
+    ) -> TestRunOutcome<HaltReasonT> {
         let start = Instant::now();
 
         // First, run the test normally to see if it needs to be skipped.
@@ -1148,7 +1187,7 @@ impl<
             Some(self.cr.revert_decoder),
         ) {
             self.result.invariant_skip(reason, start.elapsed());
-            return self.result;
+            return self.outcome();
         };
 
         let mut invariant_config = self.cr.invariant_config.clone();
@@ -1272,7 +1311,7 @@ impl<
                     stack_trace_result,
                     start.elapsed(),
                 );
-                return self.result;
+                return self.outcome();
             }
         }
 
@@ -1320,7 +1359,7 @@ impl<
                 };
                 self.result.stack_trace_result = stack_trace_result;
 
-                return self.result;
+                return self.outcome();
             }
         };
         // Merge coverage collected during invariant run with test setup coverage.
@@ -1435,8 +1474,12 @@ impl<
             }
         }
 
+        self.gas_report_samples = self
+            .cr
+            .trace_retention
+            .retains_gas_report_samples()
+            .then_some(invariant_result.gas_report_traces);
         self.result.invariant_result(
-            invariant_result.gas_report_traces,
             success,
             reason,
             counterexample,
@@ -1446,7 +1489,7 @@ impl<
             invariant_result.failed_corpus_replays,
             start.elapsed(),
         );
-        self.result
+        self.outcome()
     }
 
     /// Runs a fuzzed test.
@@ -1458,12 +1501,12 @@ impl<
     /// to the EVM database (therefore the fuzz test will use the modified
     /// state). State modifications of before test txes and fuzz test are
     /// discarded after test ends, similar to `eth_call`.
-    fn run_fuzz_test(mut self, func: &Function) -> TestResult<HaltReasonT> {
+    fn run_fuzz_test(mut self, func: &Function) -> TestRunOutcome<HaltReasonT> {
         let start = Instant::now();
 
         // Prepare fuzz test execution.
         if self.prepare_test(func, start).is_err() {
-            return self.result;
+            return self.outcome();
         }
 
         let mut fuzz_config = self.cr.fuzz_config.clone();
@@ -1508,13 +1551,23 @@ impl<
             self.cr.sender,
             fuzz_config,
         );
-        let result = fuzzed_executor.fuzz(
+        let mut result = fuzzed_executor.fuzz(
             func,
             &self.setup.fuzz_fixtures,
             &self.setup.deployed_libs,
             self.setup.address,
             self.cr.revert_decoder,
         );
+        self.gas_report_samples = self
+            .cr
+            .trace_retention
+            .retains_gas_report_samples()
+            .then(|| {
+                std::mem::take(&mut result.gas_report_traces)
+                    .into_iter()
+                    .map(|traces| vec![traces])
+                    .collect()
+            });
         self.result.fuzz_result(result, start.elapsed());
 
         self.result.stack_trace_result = if let Some(CounterExample::Single(counter_example)) =
@@ -1557,7 +1610,12 @@ impl<
             None
         };
 
-        self.result
+        // `Self::outcome` cannot consume `self` here: `self.executor` was
+        // moved into `fuzzed_executor` at the start of the run.
+        TestRunOutcome {
+            result: self.result,
+            gas_report_samples: self.gas_report_samples,
+        }
     }
 
     /// Prepares single unit test and fuzz test execution:

--- a/crates/edr_solidity_tests/src/runner.rs
+++ b/crates/edr_solidity_tests/src/runner.rs
@@ -1302,6 +1302,9 @@ impl<
                     contract_decoder: Some(&*self.cr.contract_decoder),
                     revert_decoder: self.cr.revert_decoder,
                     fail_on_revert: self.cr.invariant_config.fail_on_revert,
+                    // Inert here: `generate_stack_trace` is true, and
+                    // stack-trace generation keeps the arenas either way.
+                    retain_traces: self.cr.trace_retention.retains(TestStatus::Failure),
                 })
                 .map_or(None, |result| result.stack_trace_result);
                 self.result.invariant_replay_fail(
@@ -1393,6 +1396,9 @@ impl<
                         generate_stack_trace: true,
                         contract_decoder: Some(&*self.cr.contract_decoder),
                         revert_decoder: self.cr.revert_decoder,
+                        // Inert here: `generate_stack_trace` is true, and
+                        // stack-trace generation keeps the arenas either way.
+                        retain_traces: self.cr.trace_retention.retains(TestStatus::Failure),
                     }) {
                         Ok(ReplayResult {
                             counterexample_sequence,
@@ -1468,6 +1474,10 @@ impl<
                     contract_decoder: Some(&*self.cr.contract_decoder),
                     revert_decoder: self.cr.revert_decoder,
                     fail_on_revert: self.cr.invariant_config.fail_on_revert,
+                    // The campaign passed, so these arenas are only consumed
+                    // if a passing test's are — as call traces or by the gas
+                    // report.
+                    retain_traces: self.cr.trace_retention.retains(TestStatus::Success),
                 }) {
                     error!(%err, "Failed to replay last invariant run");
                 }

--- a/crates/edr_solidity_tests/src/trace_retention.rs
+++ b/crates/edr_solidity_tests/src/trace_retention.rs
@@ -62,6 +62,22 @@ impl TraceRetentionPolicy {
         }
     }
 
+    /// Whether a finished test with the given status still has a consumer for
+    /// its arenas — i.e. whether
+    /// [`TestResult::free_unconsumed_traces`](crate::result::TestResult::free_unconsumed_traces)
+    /// would keep them.
+    ///
+    /// Lets producers skip accumulating arenas that would only be freed
+    /// again. Callers must pass the status the finished result will have, or
+    /// a result could lose call traces it should have carried.
+    #[must_use]
+    pub(crate) fn retains(self, status: TestStatus) -> bool {
+        match self.retain_after(status) {
+            Retain::Nothing => false,
+            Retain::CallsOnly => true,
+        }
+    }
+
     /// Returns whether the gas-report samples a test produced still have a
     /// consumer: the gas-report pass in `MultiContractRunner::run_test_suite`.
     pub(crate) fn retains_gas_report_samples(self) -> bool {
@@ -96,7 +112,7 @@ mod tests {
         for (include_traces, status, retained) in cases {
             let policy = TraceRetentionPolicy::new(include_traces, false);
             assert_eq!(
-                matches!(policy.retain_after(status), Retain::CallsOnly),
+                policy.retains(status),
                 retained,
                 "{include_traces:?} {status:?}"
             );
@@ -104,7 +120,7 @@ mod tests {
             // A gas report consumes every test's call traces.
             let policy = TraceRetentionPolicy::new(include_traces, true);
             assert!(
-                matches!(policy.retain_after(status), Retain::CallsOnly),
+                policy.retains(status),
                 "{include_traces:?} {status:?} with a gas report"
             );
         }

--- a/crates/edr_solidity_tests/src/trace_retention.rs
+++ b/crates/edr_solidity_tests/src/trace_retention.rs
@@ -120,7 +120,7 @@ mod tests {
             || BaseCounterExample::from_fuzz_call(Bytes::new(), &[], Some(arena()), None);
 
         let mut result = TestResult::<EvmHaltReason> {
-            execution_traces: vec![arena()],
+            execution_traces: [arena()].into_iter().collect(),
             counterexample: Some(CounterExample::Sequence(
                 2,
                 vec![counterexample(), counterexample()],

--- a/crates/edr_solidity_tests/src/trace_retention.rs
+++ b/crates/edr_solidity_tests/src/trace_retention.rs
@@ -1,13 +1,14 @@
-//! Policy for freeing the trace arenas a finished test no longer needs.
+//! Policy for freeing the trace data a finished test no longer needs.
 //!
 //! Arenas are recorded according to
 //! [`TracingMode`](foundry_evm::traces::TracingMode) and consumed by
 //! stack-trace generation while the test runs. Whether anything consumes them
 //! *after* the test has finished depends on `include_traces` — which results
-//! carry call traces to the caller — and `generate_gas_report`. Without this
-//! policy the unconsumed arenas would stay resident until the whole suite
-//! completes, which with EVM step recording enabled is the difference between
-//! megabytes and gigabytes.
+//! carry call traces to the caller — and `generate_gas_report`. Even a
+//! retained arena only needs its call tree, never the recorded EVM steps.
+//! Without this policy the unconsumed arenas would stay resident until the
+//! whole suite completes, which with step recording enabled is the difference
+//! between megabytes and gigabytes.
 
 use edr_solidity::config::IncludeTraces;
 
@@ -18,8 +19,9 @@ use crate::result::TestStatus;
 pub(crate) enum Retain {
     /// Nothing consumes the arenas: free them.
     Nothing,
-    /// The call traces are still consumed — by trace decoding, the gas
-    /// report and the napi conversion — so the arenas must be kept.
+    /// Only the call tree is still consumed — by trace decoding, the gas
+    /// report and the napi conversion — so the arenas are kept, but their
+    /// recorded EVM steps are dropped.
     CallsOnly,
 }
 

--- a/crates/edr_solidity_tests/src/trace_retention.rs
+++ b/crates/edr_solidity_tests/src/trace_retention.rs
@@ -1,0 +1,141 @@
+//! Policy for freeing the trace arenas a finished test no longer needs.
+//!
+//! Arenas are recorded according to
+//! [`TracingMode`](foundry_evm::traces::TracingMode) and consumed by
+//! stack-trace generation while the test runs. Whether anything consumes them
+//! *after* the test has finished depends on `include_traces` — which results
+//! carry call traces to the caller — and `generate_gas_report`. Without this
+//! policy the unconsumed arenas would stay resident until the whole suite
+//! completes, which with EVM step recording enabled is the difference between
+//! megabytes and gigabytes.
+
+use edr_solidity::config::IncludeTraces;
+
+use crate::result::TestStatus;
+
+/// What a finished test's recorded arenas are still needed for.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum Retain {
+    /// Nothing consumes the arenas: free them.
+    Nothing,
+    /// The call traces are still consumed — by trace decoding, the gas
+    /// report and the napi conversion — so the arenas must be kept.
+    CallsOnly,
+}
+
+/// Decides which trace arenas to retain once a test has finished and its
+/// stack trace (if any) has been computed.
+///
+/// Derived from the test runner's `include_traces` and `generate_gas_report`
+/// settings in `MultiContractRunner::run_test_suite`.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct TraceRetentionPolicy {
+    /// Which results carry call traces to the caller.
+    include_traces: IncludeTraces,
+    /// Whether a gas report is being generated, which consumes every test's
+    /// call traces.
+    generate_gas_report: bool,
+}
+
+impl TraceRetentionPolicy {
+    /// Creates a policy from the test runner's trace-related settings.
+    pub(crate) fn new(include_traces: IncludeTraces, generate_gas_report: bool) -> Self {
+        Self {
+            include_traces,
+            generate_gas_report,
+        }
+    }
+
+    /// Returns what the arenas of a finished test with the given status are
+    /// still needed for.
+    pub(crate) fn retain_after(self, status: TestStatus) -> Retain {
+        // The gas report consumes every test's call traces.
+        // `MultiContractRunner::new` already forces `include_traces` to `All`
+        // when one is requested; checking here keeps the policy right on its
+        // own.
+        if self.generate_gas_report || self.include_traces.should_include(|| status.is_failure()) {
+            Retain::CallsOnly
+        } else {
+            Retain::Nothing
+        }
+    }
+
+    /// Returns whether the gas-report samples a test produced still have a
+    /// consumer: the gas-report pass in `MultiContractRunner::run_test_suite`.
+    pub(crate) fn retains_gas_report_samples(self) -> bool {
+        self.generate_gas_report
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{map::HashMap, Bytes};
+    use edr_chain_spec::EvmHaltReason;
+    use foundry_evm::traces::{CallTraceArena, SparsedTraceArena};
+
+    use super::*;
+    use crate::{
+        fuzz::{BaseCounterExample, CounterExample},
+        result::TestResult,
+    };
+
+    #[test]
+    fn retains_arenas_only_for_results_that_surface_call_traces() {
+        let cases = [
+            (IncludeTraces::None, TestStatus::Failure, false),
+            (IncludeTraces::None, TestStatus::Success, false),
+            (IncludeTraces::Failing, TestStatus::Failure, true),
+            (IncludeTraces::Failing, TestStatus::Success, false),
+            // Skipped tests follow the same rule as passing ones.
+            (IncludeTraces::Failing, TestStatus::Skipped, false),
+            (IncludeTraces::All, TestStatus::Success, true),
+            (IncludeTraces::All, TestStatus::Skipped, true),
+        ];
+        for (include_traces, status, retained) in cases {
+            let policy = TraceRetentionPolicy::new(include_traces, false);
+            assert_eq!(
+                matches!(policy.retain_after(status), Retain::CallsOnly),
+                retained,
+                "{include_traces:?} {status:?}"
+            );
+
+            // A gas report consumes every test's call traces.
+            let policy = TraceRetentionPolicy::new(include_traces, true);
+            assert!(
+                matches!(policy.retain_after(status), Retain::CallsOnly),
+                "{include_traces:?} {status:?} with a gas report"
+            );
+        }
+    }
+
+    #[test]
+    fn frees_counterexample_arenas_without_consumers() {
+        let arena = || SparsedTraceArena {
+            arena: CallTraceArena::default(),
+            ignored: HashMap::default(),
+        };
+        let counterexample =
+            || BaseCounterExample::from_fuzz_call(Bytes::new(), &[], Some(arena()), None);
+
+        let mut result = TestResult::<EvmHaltReason> {
+            execution_traces: vec![arena()],
+            counterexample: Some(CounterExample::Sequence(
+                2,
+                vec![counterexample(), counterexample()],
+            )),
+            ..TestResult::default()
+        };
+
+        // `All` keeps the call traces, but the counterexample arenas have no
+        // consumer.
+        result.free_unconsumed_traces(TraceRetentionPolicy::new(IncludeTraces::All, false));
+
+        assert_eq!(result.execution_traces.len(), 1);
+        let Some(CounterExample::Sequence(_, counterexamples)) = &result.counterexample else {
+            panic!("counterexample kind changed");
+        };
+        assert!(counterexamples
+            .iter()
+            .all(|counterexample| counterexample.traces.is_none()));
+    }
+}

--- a/crates/edr_solidity_tests/tests/it/invariant.rs
+++ b/crates/edr_solidity_tests/tests/it/invariant.rs
@@ -1328,3 +1328,44 @@ async fn test_invariant_function_override_timeout() {
         )]),
     );
 }
+
+// The gas-report sample budget bounds how many runs' traces are collected: a
+// run past the budget records no traces at all instead of recording and then
+// dropping them. The report sees the sampled runs' calls plus the replayed
+// last run's.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_invariant_gas_report_samples_bound_collected_run_traces() {
+    const RUNS: u32 = 4;
+    const DEPTH: u32 = 3;
+    for (gas_report_samples, sampled_runs) in [(2, 2), (8, RUNS)] {
+        let filter = SolidityTestFilter::new(
+            ".*",
+            ".*",
+            ".*fuzz/invariant/common/InvariantGasReportSamples.t.sol",
+        );
+        let mut config = TEST_DATA_DEFAULT.config_with_mock_rpc();
+        config.generate_gas_report = true;
+        config.invariant.runs = RUNS;
+        config.invariant.depth = DEPTH;
+        config.invariant.gas_report_samples = gas_report_samples;
+
+        let runner = TEST_DATA_DEFAULT.runner_with_fuzz_persistence(config).await;
+        let test_result = runner.test_collect(filter).await.test_result;
+        let bump_calls = test_result
+            .gas_report
+            .as_ref()
+            .expect("a gas report was requested")
+            .contracts
+            .get("default/fuzz/invariant/common/InvariantGasReportSamples.t.sol:Bumper")
+            .expect("the handler should be in the gas report")
+            .functions
+            .get("bump()")
+            .map_or(0, Vec::len);
+
+        assert_eq!(
+            bump_calls,
+            ((sampled_runs + 1) * DEPTH) as usize,
+            "calls reported with a budget of {gas_report_samples}"
+        );
+    }
+}

--- a/crates/edr_solidity_tests/tests/it/invariant.rs
+++ b/crates/edr_solidity_tests/tests/it/invariant.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeMap;
 
 use alloy_primitives::U256;
 use edr_gas_report::GasReportExecutionStatus;
+use edr_solidity::config::IncludeTraces;
 use edr_solidity_tests::{fuzz::CounterExample, result::TestKind};
 
 use crate::helpers::{
@@ -959,6 +960,56 @@ async fn test_invariant_after_invariant() {
                     ("invariant_success()", true, None, None, None),
                 ],
             )]));
+}
+
+/// Gating the replay's arena pushes must not lose the call traces that
+/// `IncludeTraces::All` surfaces for a passing invariant test; at the other
+/// settings the policy frees them either way.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_passing_invariant_replay_traces_follow_include_traces() {
+    const DEPTH: u32 = 5;
+
+    for (include_traces, expect_traces) in [
+        (IncludeTraces::All, true),
+        (IncludeTraces::Failing, false),
+        (IncludeTraces::None, false),
+    ] {
+        let mut config = TEST_DATA_DEFAULT.config_with_mock_rpc();
+        config.include_traces = include_traces;
+        config.invariant = TestInvariantConfig {
+            runs: 1,
+            depth: DEPTH,
+            ..TestInvariantConfig::default()
+        }
+        .into();
+        let runner = TEST_DATA_DEFAULT.runner_with_config(config).await;
+
+        let filter = SolidityTestFilter::new(
+            "success",
+            ".*",
+            ".*fuzz/invariant/common/InvariantAfterInvariant.t.sol",
+        );
+        let results = runner.test_collect(filter).await.suite_results;
+        let result = results
+            .values()
+            .flat_map(|suite| suite.test_results.values())
+            .next()
+            .expect("`invariant_success()` should have run");
+        assert!(result.status.is_success(), "{include_traces:?}");
+
+        let expected_len = if expect_traces {
+            // One arena per replayed call, plus `invariant()` and
+            // `afterInvariant()`.
+            DEPTH as usize + 2
+        } else {
+            0
+        };
+        assert_eq!(
+            result.execution_traces.len(),
+            expected_len,
+            "{include_traces:?}"
+        );
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/edr_solidity_tests/tests/it/repros.rs
+++ b/crates/edr_solidity_tests/tests/it/repros.rs
@@ -849,6 +849,70 @@ async fn on_failure_mode_produces_stack_trace_for_failing_setup() {
     assert_execution_error_stack_trace(suite, "setUp()");
 }
 
+// Once a failing test's stack trace has been computed, its arenas are freed
+// unless something will still consume them.
+#[tokio::test(flavor = "multi_thread")]
+async fn always_mode_frees_arenas_nothing_consumes() {
+    for (include_traces, expect_retained) in [
+        // Nothing surfaces call traces: the arenas go, the stack trace stays.
+        (IncludeTraces::None, false),
+        // The failing test's call traces are surfaced.
+        (IncludeTraces::Failing, true),
+    ] {
+        let mut config = runner_config(None, &TEST_DATA_VIA_IR, false).await;
+        config.collect_stack_traces = CollectStackTraces::Always;
+        config.include_traces = include_traces;
+
+        let contract_decoder = contract_decoder(TEST_DATA_VIA_IR.build_info_path());
+        let runner = TEST_DATA_VIA_IR
+            .runner_with_contract_decoder(config, contract_decoder)
+            .await;
+        let filter = SolidityTestFilter::new(
+            ".*",
+            "AlwaysStackTraceTest",
+            ".*repros/StackTraceAlwaysMode.t.sol",
+        );
+        let suite_results = runner.test_collect(filter).await.suite_results;
+        let suite = suite_results
+            .get("via-ir/repros/StackTraceAlwaysMode.t.sol:AlwaysStackTraceTest")
+            .expect("the AlwaysStackTrace suite should have run");
+
+        let result = assert_execution_error_stack_trace(suite, "testRevertHasStackTrace()");
+        assert_eq!(
+            !result.execution_traces.is_empty(),
+            expect_retained,
+            "arenas retained at {include_traces:?}"
+        );
+    }
+}
+
+// A passing test's arenas are recorded in `Always` mode too; they are freed
+// unless every result surfaces its call traces.
+#[tokio::test(flavor = "multi_thread")]
+async fn always_mode_frees_passing_tests_arenas_unless_all_are_included() {
+    for (include_traces, expect_retained) in
+        [(IncludeTraces::Failing, false), (IncludeTraces::All, true)]
+    {
+        let mut config = runner_config(None, &TEST_DATA_DEFAULT, false).await;
+        config.collect_stack_traces = CollectStackTraces::Always;
+        config.include_traces = include_traces;
+
+        let runner = TEST_DATA_DEFAULT.runner_with_fuzz_persistence(config).await;
+        let suite_results = runner.test_collect(repro_filter(3347)).await.suite_results;
+        let suite = suite_results
+            .get("default/repros/Issue3347.t.sol:Issue3347Test")
+            .expect("the Issue3347 suite should have run");
+
+        for (name, result) in &suite.test_results {
+            assert_eq!(result.status, TestStatus::Success, "{name}");
+            assert_eq!(
+                !result.execution_traces.is_empty(),
+                expect_retained,
+                "{name}: arenas retained at {include_traces:?}"
+            );
+        }
+    }
+}
 /// One 32-byte zero hash as a hex literal.
 const ZERO_HASH: &str = "0x0000000000000000000000000000000000000000000000000000000000000000";
 

--- a/crates/edr_solidity_tests/tests/it/repros.rs
+++ b/crates/edr_solidity_tests/tests/it/repros.rs
@@ -21,7 +21,7 @@ use foundry_evm::{
         TransactionErrorTrait,
     },
     executors::stack_trace::SolidityTestStackTraceResult,
-    traces::{CallKind, CallTraceDecoder, DecodedCallData},
+    traces::{CallKind, CallTraceDecoder, DecodedCallData, SparsedTraceArena, TraceMemberOrder},
 };
 
 use crate::helpers::{
@@ -883,7 +883,25 @@ async fn always_mode_frees_arenas_nothing_consumes() {
             expect_retained,
             "arenas retained at {include_traces:?}"
         );
+        if expect_retained {
+            assert!(
+                result.execution_traces.iter().all(steps_stripped),
+                "steps stripped from the retained arenas at {include_traces:?}"
+            );
+        }
     }
+}
+
+/// Whether `arena` keeps its call tree but none of the recorded EVM steps —
+/// neither the step records nor their entries in each node's ordering.
+fn steps_stripped(arena: &SparsedTraceArena) -> bool {
+    arena.nodes().iter().all(|node| {
+        node.trace.steps.is_empty()
+            && !node
+                .ordering
+                .iter()
+                .any(|item| matches!(item, TraceMemberOrder::Step(_)))
+    })
 }
 
 // A passing test's arenas are recorded in `Always` mode too; they are freed
@@ -909,6 +927,11 @@ async fn always_mode_frees_passing_tests_arenas_unless_all_are_included() {
                 !result.execution_traces.is_empty(),
                 expect_retained,
                 "{name}: arenas retained at {include_traces:?}"
+            );
+            // Retained arenas keep their call tree but not the recorded steps.
+            assert!(
+                result.execution_traces.iter().all(steps_stripped),
+                "{name}: steps stripped from retained arenas"
             );
         }
     }

--- a/crates/edr_solidity_tests/tests/it/repros.rs
+++ b/crates/edr_solidity_tests/tests/it/repros.rs
@@ -904,6 +904,42 @@ fn steps_stripped(arena: &SparsedTraceArena) -> bool {
     })
 }
 
+// A failing invariant test whose call traces nobody surfaces still gets its
+// stack trace: the replay keeps the arenas for stack-trace generation even
+// though the retention policy will free them afterwards.
+#[tokio::test(flavor = "multi_thread")]
+async fn always_mode_computes_invariant_stack_trace_without_call_traces() {
+    let mut config = runner_config(None, &TEST_DATA_VIA_IR, false).await;
+    config.collect_stack_traces = CollectStackTraces::Always;
+    config.include_traces = IncludeTraces::None;
+    config.invariant.runs = 10;
+    config.invariant.depth = 10;
+
+    let contract_decoder = contract_decoder(TEST_DATA_VIA_IR.build_info_path());
+    let runner = TEST_DATA_VIA_IR
+        .runner_with_contract_decoder(config, contract_decoder)
+        .await;
+    let filter = SolidityTestFilter::new(
+        ".*",
+        "AlwaysStackTraceInvariantTest",
+        ".*repros/StackTraceAlwaysMode.t.sol",
+    );
+    let suite_results = runner.test_collect(filter).await.suite_results;
+    let suite = suite_results
+        .get("via-ir/repros/StackTraceAlwaysMode.t.sol:AlwaysStackTraceInvariantTest")
+        .expect("the AlwaysStackTraceInvariant suite should have run");
+
+    let result = assert_execution_error_stack_trace(suite, "invariantCountIsZero()");
+    assert!(
+        result.counterexample.is_some(),
+        "expected a replayed counterexample call sequence"
+    );
+    assert!(
+        result.execution_traces.is_empty(),
+        "no call traces are surfaced at IncludeTraces::None"
+    );
+}
+
 // A passing test's arenas are recorded in `Always` mode too; they are freed
 // unless every result surfaces its call traces.
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/edr_solidity_tests/tests/testdata/default/fuzz/invariant/common/InvariantGasReportSamples.t.sol
+++ b/crates/edr_solidity_tests/tests/testdata/default/fuzz/invariant/common/InvariantGasReportSamples.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.18;
+
+import "ds-test/test.sol";
+
+// Fixture for `test_invariant_gas_report_samples_bound_collected_run_traces`:
+// the handler never reverts, so every run performs exactly `depth` calls and
+// the number of calls the gas report sees is a function of the sample budget.
+contract GasReportSamplesTest is DSTest {
+    Bumper bumper;
+
+    function setUp() public {
+        bumper = new Bumper();
+    }
+
+    function invariant_alwaysHolds() public {}
+}
+
+contract Bumper {
+    uint256 public count;
+
+    function bump() public {
+        count += 1;
+    }
+}

--- a/crates/foundry/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/foundry/evm/evm/src/executors/fuzz/mod.rs
@@ -272,7 +272,10 @@ impl<
         let last_run_traces = if run_result.is_ok() {
             traces.pop()
         } else {
-            call.traces.clone()
+            // Nothing reads `BaseCounterExample::traces`, so the failing
+            // arena can move into `FuzzTestResult::traces` rather than be
+            // cloned for both.
+            call.traces
         };
 
         let mut result = FuzzTestResult {
@@ -322,7 +325,8 @@ impl<
                         Some(CounterExample::Single(BaseCounterExample::from_fuzz_call(
                             calldata,
                             &args,
-                            call.traces,
+                            // Nothing consumes counterexample arenas; see above.
+                            None,
                             call.indeterminism_reasons,
                         )));
                 }

--- a/crates/foundry/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/foundry/evm/evm/src/executors/invariant/mod.rs
@@ -328,6 +328,16 @@ impl<
         }
     }
 
+    /// Whether the gas report still needs samples, i.e. whether a run's traces
+    /// are worth collecting, given the configured `gas_report_samples` budget.
+    ///
+    /// [`InvariantTestData::gas_report_traces`] only grows in
+    /// [`end_run`](Self::end_run), so the answer is constant for the duration
+    /// of a run.
+    pub(crate) fn needs_gas_report_samples(&self, gas_samples: usize) -> bool {
+        self.execution_data.borrow().gas_report_traces.len() < gas_samples
+    }
+
     /// End invariant test run by collecting results, cleaning collected
     /// artifacts and reverting created fuzz state.
     pub fn end_run(
@@ -347,8 +357,12 @@ impl<
         self.targeted_contracts
             .clear_created_contracts(run.created_contracts);
 
+        // `needs_gas_report_samples` borrows `execution_data` itself, so it
+        // cannot run while the mutable borrow below is held.
+        let needs_gas_report_samples = self.needs_gas_report_samples(gas_samples);
+
         let mut invariant_data = self.execution_data.borrow_mut();
-        if invariant_data.gas_report_traces.len() < gas_samples {
+        if needs_gas_report_samples {
             invariant_data.gas_report_traces.push(
                 run.run_traces
                     .into_iter()
@@ -391,7 +405,8 @@ pub struct InvariantTestRun<
     pub fuzz_runs: Vec<FuzzCase>,
     // Contracts created during current invariant run.
     pub created_contracts: Vec<Address>,
-    // Traces of each call of the invariant run call sequence.
+    // Traces of each call of the invariant run call sequence, collected only
+    // while the gas report still needs samples.
     pub run_traces: Vec<SparsedTraceArena>,
     // Current depth of invariant run.
     pub depth: u32,

--- a/crates/foundry/evm/evm/src/executors/invariant/replay.rs
+++ b/crates/foundry/evm/evm/src/executors/invariant/replay.rs
@@ -21,7 +21,7 @@ use foundry_evm_fuzz::{
     invariant::{BasicTxDetails, InvariantContract},
     BaseCounterExample,
 };
-use foundry_evm_traces::{load_contracts, SetupTraces, SparsedTraceArena, TracingMode};
+use foundry_evm_traces::{load_contracts, ExecutionTraces, SetupTraces, TracingMode};
 use parking_lot::RwLock;
 use proptest::test_runner::TestError;
 use revm::{
@@ -51,7 +51,7 @@ pub struct ReplayRunArgs<
     TransactionErrorT: TransactionErrorTrait,
     ChainContextT: ChainContextTr,
 > {
-    pub execution_traces: &'a mut Vec<SparsedTraceArena>,
+    pub execution_traces: &'a mut ExecutionTraces,
     pub executor: Executor<
         BlockT,
         TxT,
@@ -140,14 +140,13 @@ pub fn replay_run<
 
     // Replay each call from the sequence, collect logs, traces and coverage.
     for tx in inputs.iter() {
-        let call_result = executor.transact_raw(
+        let mut call_result = executor.transact_raw(
             tx.sender,
             tx.call_details.target,
             tx.call_details.calldata.clone(),
             U256::ZERO,
         )?;
         logs.extend(call_result.logs);
-        execution_traces.push(call_result.traces.clone().expect("enabled tracing"));
         HitMaps::merge_opt(coverage, call_result.line_coverage);
 
         // Identify newly generated contracts, if they exist.
@@ -156,13 +155,17 @@ pub fn replay_run<
             known_contracts,
         ));
 
+        execution_traces.push(call_result.traces.take().expect("enabled tracing"));
+
         // Create counter example to be used in failed case.
         counterexample_sequence.push(BaseCounterExample::from_invariant_call(
             tx.sender,
             tx.call_details.target,
             &tx.call_details.calldata,
             &ided_contracts,
-            call_result.traces,
+            // Counterexample arenas are never consumed; the failing arena
+            // lives on in `execution_traces`.
+            None,
             /* indeterminism_reason */ None,
         ));
 
@@ -203,6 +206,12 @@ pub fn replay_run<
                 revert_reason,
             });
         }
+
+        // This call is not the failing one, so its arena can only ever serve
+        // as a code source: strip it now rather than when the next push
+        // displaces it, so no arena in the collection is step-laden while the
+        // next call runs.
+        execution_traces.strip_last_steps();
     }
 
     // Replay invariant to collect logs and traces.
@@ -237,7 +246,7 @@ pub fn replay_run<
             call_result: after_invariant_result,
             success: _,
         } = call_after_invariant_function(&executor, invariant_contract.address)?;
-        execution_traces.push(after_invariant_result.traces.clone().unwrap());
+        execution_traces.push(after_invariant_result.traces.expect("tracing is on"));
         logs.extend(after_invariant_result.logs);
     }
 
@@ -249,9 +258,14 @@ pub fn replay_run<
                     .map(SolidityTestStackTraceResult::from)
                     .or_else(|| {
                         contract_decoder.map(|decoder| {
+                            // The failing call is always the last one
+                            // replayed — `afterInvariant()` when it ran,
+                            // otherwise `invariant()` — so its arena is the
+                            // one just pushed, and the only one still
+                            // carrying steps.
                             let (failing_trace, prior_traces) = execution_traces
                                 .split_last()
-                                .expect("the invariant call arena was pushed above");
+                                .expect("the invariant or afterInvariant arena was pushed above");
 
                             get_stack_trace(
                                 decoder,
@@ -293,7 +307,7 @@ pub struct ReplayErrorArgs<
     TransactionErrorT: TransactionErrorTrait,
     ChainContextT: ChainContextTr,
 > {
-    pub execution_traces: &'a mut Vec<SparsedTraceArena>,
+    pub execution_traces: &'a mut ExecutionTraces,
     pub executor: Executor<
         BlockT,
         TxT,

--- a/crates/foundry/evm/evm/src/executors/invariant/replay.rs
+++ b/crates/foundry/evm/evm/src/executors/invariant/replay.rs
@@ -69,11 +69,19 @@ pub struct ReplayRunArgs<
     pub line_coverage: &'a mut Option<HitMaps>,
     pub deprecated_cheatcodes: &'a mut HashMap<&'static str, Option<&'static str>>,
     pub inputs: &'a [BasicTxDetails],
+    /// Whether to compute a stack trace for the replayed failure. When false,
+    /// [`ReplayResult::stack_trace_result`] is always `None`.
     pub generate_stack_trace: bool,
     /// Must be provided if `generate_stack_trace` is true
     pub contract_decoder: Option<&'a NestedTraceDecoderT>,
     pub revert_decoder: &'a RevertDecoder,
     pub fail_on_revert: bool,
+    /// Whether the caller still consumes the replayed arenas and so wants
+    /// them accumulated in [`Self::execution_traces`]. When false — and no
+    /// stack trace needs them — they are dropped with the call results they
+    /// came from. Only consulted when `generate_stack_trace` is false:
+    /// stack-trace generation keeps the arenas regardless.
+    pub retain_traces: bool,
 }
 
 /// Results of a replay
@@ -126,15 +134,20 @@ pub fn replay_run<
         contract_decoder,
         revert_decoder,
         fail_on_revert,
+        retain_traces,
     } = args;
-
-    // We want traces for a failed case.
 
     executor.set_tracing(if generate_stack_trace && executor.safe_to_re_execute() {
         TracingMode::WithSteps
     } else {
         TracingMode::WithoutSteps
     });
+
+    // Stack-trace generation needs the accumulated arenas — the last as the
+    // failing trace, the earlier ones as code sources — so keep them even
+    // when the caller won't consume them afterwards; the caller's retention
+    // policy frees them once the test finishes.
+    let keep_traces = retain_traces || generate_stack_trace;
 
     let mut counterexample_sequence = vec![];
 
@@ -155,7 +168,9 @@ pub fn replay_run<
             known_contracts,
         ));
 
-        execution_traces.push(call_result.traces.take().expect("enabled tracing"));
+        if keep_traces {
+            execution_traces.push(call_result.traces.take().expect("enabled tracing"));
+        }
 
         // Create counter example to be used in failed case.
         counterexample_sequence.push(BaseCounterExample::from_invariant_call(
@@ -176,28 +191,31 @@ pub fn replay_run<
             .is_some_and(InstructionResult::is_ok)
             && (fail_on_revert || !call_result.reverted)
         {
-            let stack_trace_result =
-                if let Some(indeterminism_reasons) = call_result.indeterminism_reasons {
-                    Some(indeterminism_reasons.into())
-                } else {
-                    contract_decoder.map(|decoder| {
-                        let (failing_trace, prior_traces) = execution_traces
-                            .split_last()
-                            .expect("an arena was pushed for this call above");
+            let stack_trace_result = if !generate_stack_trace {
+                // The caller wants no stack trace; without `keep_traces` the
+                // arenas it would need were never accumulated.
+                None
+            } else if let Some(indeterminism_reasons) = call_result.indeterminism_reasons {
+                Some(indeterminism_reasons.into())
+            } else {
+                contract_decoder.map(|decoder| {
+                    let (failing_trace, prior_traces) = execution_traces
+                        .split_last()
+                        .expect("`generate_stack_trace` implies `keep_traces`");
 
-                        get_stack_trace(
-                            decoder,
-                            &failing_trace.arena,
-                            setup_traces
-                                .iter()
-                                .map(|(_, arena)| &arena.arena)
-                                .chain(prior_traces.iter().map(|arena| &arena.arena)),
-                            DeployedCode::default(),
-                        )
-                        .map_err(SolidityTestStackTraceError::from)
-                        .into()
-                    })
-                };
+                    get_stack_trace(
+                        decoder,
+                        &failing_trace.arena,
+                        setup_traces
+                            .iter()
+                            .map(|(_, arena)| &arena.arena)
+                            .chain(prior_traces.iter().map(|arena| &arena.arena)),
+                        DeployedCode::default(),
+                    )
+                    .map_err(SolidityTestStackTraceError::from)
+                    .into()
+                })
+            };
             let revert_reason =
                 revert_decoder.maybe_decode(call_result.result.as_ref(), call_result.exit_reason);
             return Ok(ReplayResult {
@@ -209,9 +227,11 @@ pub fn replay_run<
 
         // This call is not the failing one, so its arena can only ever serve
         // as a code source: strip it now rather than when the next push
-        // displaces it, so no arena in the collection is step-laden while the
-        // next call runs.
-        execution_traces.strip_last_steps();
+        // displaces it, so the tracer's in-flight arena is the only
+        // step-laden one.
+        if keep_traces {
+            execution_traces.strip_last_steps();
+        }
     }
 
     // Replay invariant to collect logs and traces.
@@ -231,7 +251,9 @@ pub fn replay_run<
             .into(),
     )?;
 
-    execution_traces.push(invariant_result.traces.expect("tracing is on"));
+    if keep_traces {
+        execution_traces.push(invariant_result.traces.expect("tracing is on"));
+    }
     logs.extend(invariant_result.logs);
     deprecated_cheatcodes.extend(
         invariant_result
@@ -246,7 +268,9 @@ pub fn replay_run<
             call_result: after_invariant_result,
             success: _,
         } = call_after_invariant_function(&executor, invariant_contract.address)?;
-        execution_traces.push(after_invariant_result.traces.expect("tracing is on"));
+        if keep_traces {
+            execution_traces.push(after_invariant_result.traces.expect("tracing is on"));
+        }
         logs.extend(after_invariant_result.logs);
     }
 
@@ -265,7 +289,7 @@ pub fn replay_run<
                             // carrying steps.
                             let (failing_trace, prior_traces) = execution_traces
                                 .split_last()
-                                .expect("the invariant or afterInvariant arena was pushed above");
+                                .expect("`generate_stack_trace` implies `keep_traces`");
 
                             get_stack_trace(
                                 decoder,
@@ -295,7 +319,7 @@ pub fn replay_run<
     })
 }
 
-/// Arguments to `replay_run`.
+/// Arguments to `replay_error`.
 pub struct ReplayErrorArgs<
     'a,
     NestedTraceDecoderT,
@@ -329,6 +353,8 @@ pub struct ReplayErrorArgs<
     /// Must be provided if `generate_stack_trace` is true
     pub contract_decoder: Option<&'a NestedTraceDecoderT>,
     pub revert_decoder: &'a RevertDecoder,
+    /// See [`ReplayRunArgs::retain_traces`].
+    pub retain_traces: bool,
 }
 
 /// Replays the error case, shrinks the failing sequence and collects all
@@ -370,6 +396,7 @@ pub fn replay_error<
         generate_stack_trace,
         contract_decoder,
         revert_decoder,
+        retain_traces,
     } = args;
 
     match failed_case.test_error {
@@ -403,6 +430,7 @@ pub fn replay_error<
                 contract_decoder,
                 fail_on_revert: failed_case.fail_on_revert,
                 revert_decoder,
+                retain_traces,
             })
         }
     }

--- a/crates/foundry/evm/evm/src/executors/invariant/result.rs
+++ b/crates/foundry/evm/evm/src/executors/invariant/result.rs
@@ -256,7 +256,15 @@ pub(crate) fn can_continue<
 
     // Assert invariants if the call did not revert and the handlers did not fail.
     if !call_result.reverted && handlers_succeeded {
-        if let Some(traces) = call_result.traces {
+        // Run traces are only ever consumed as gas-report samples, and
+        // `InvariantTest::end_run` drops a finished run's traces unless the
+        // gas report still needs samples. That condition is constant for the
+        // duration of a run, so applying it here keeps exactly the same
+        // samples while avoiding the accumulation of up to `depth` arenas per
+        // run that nothing would read.
+        if let Some(traces) = call_result.traces
+            && invariant_test.needs_gas_report_samples(invariant_config.gas_report_samples as usize)
+        {
             invariant_run.run_traces.push(traces);
         }
 

--- a/crates/foundry/evm/traces/src/lib.rs
+++ b/crates/foundry/evm/traces/src/lib.rs
@@ -39,10 +39,13 @@ pub use decoder::{CallTraceDecoder, CallTraceDecoderBuilder};
 use foundry_evm_core::contracts::{ContractsByAddress, ContractsByArtifact};
 
 /// A suite's setup-phase trace arenas, including deployments and `setUp()`,
-/// in execution order. When setup failed, the last arena is the failing call;
-/// the setup stack-trace computation relies on that.
+/// in execution order — appended through
+/// [`push_setup_trace_stripping_prior_steps`], so only the last one carries
+/// recorded EVM steps. When setup failed, that last arena is the failing
+/// call; the setup stack-trace computation relies on both properties.
 pub type SetupTraces = Vec<SetupTrace>;
 
+/// A setup trace arena paired with the kind of setup call that recorded it.
 pub type SetupTrace = (SetupTraceKind, SparsedTraceArena);
 
 /// Trace arena keeping track of ignored trace items.
@@ -97,6 +100,111 @@ impl SparsedTraceArena {
         self.resolve_in_place();
         strip_arena_steps(&mut self.arena);
     }
+}
+
+/// The arenas a test's execution has recorded so far, in execution order.
+///
+/// Only the last arena carries recorded EVM steps, because [`push`](Self::push)
+/// — the only way to grow the collection — strips them from the arena it
+/// displaces; that bounds the peak while a test is still running, not just
+/// between tests. Only that last arena may therefore be named as the failing
+/// trace of a stack-trace computation; every earlier arena may only serve as a
+/// code source, which is walked for its CREATE nodes alone. The collection
+/// derefs to a slice for reading; mutable access —
+/// [`iter_mut`](Self::iter_mut), iterating `&mut`, and the step-stripping
+/// methods — hands out the arenas one by one, so it cannot reorder them, and
+/// callers use it only to decode and label them in place.
+#[derive(Clone, Debug, Default)]
+pub struct ExecutionTraces(Vec<SparsedTraceArena>);
+
+impl ExecutionTraces {
+    /// Appends `arena`, stripping the recorded EVM steps from the arena that
+    /// was previously last (see [`SparsedTraceArena::strip_steps`]).
+    ///
+    /// The strip is unconditional: an arena is stripped when displaced even if
+    /// the whole collection is freed once the test finishes — the in-test peak
+    /// is worth the walk.
+    pub fn push(&mut self, arena: SparsedTraceArena) {
+        self.strip_last_steps();
+        self.0.push(arena);
+    }
+
+    /// Returns an iterator over the arenas, for decoding and labelling them in
+    /// place — mutations that cannot reintroduce recorded steps.
+    pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, SparsedTraceArena> {
+        self.0.iter_mut()
+    }
+
+    /// Strips the recorded EVM steps from the last arena, if any — the strip
+    /// [`push`](Self::push) would otherwise do when that arena is displaced.
+    pub fn strip_last_steps(&mut self) {
+        if let Some(last) = self.0.last_mut() {
+            last.strip_steps();
+        }
+    }
+
+    /// Strips the recorded EVM steps from every arena, including the last.
+    ///
+    /// Must only be called once a stack trace can no longer be requested for
+    /// any of them.
+    pub fn strip_steps(&mut self) {
+        for arena in &mut self.0 {
+            arena.strip_steps();
+        }
+    }
+}
+
+impl Deref for ExecutionTraces {
+    type Target = [SparsedTraceArena];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl IntoIterator for ExecutionTraces {
+    type Item = SparsedTraceArena;
+    type IntoIter = std::vec::IntoIter<SparsedTraceArena>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a mut ExecutionTraces {
+    type Item = &'a mut SparsedTraceArena;
+    type IntoIter = std::slice::IterMut<'a, SparsedTraceArena>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter_mut()
+    }
+}
+
+impl FromIterator<SparsedTraceArena> for ExecutionTraces {
+    /// Collects through [`push`](Self::push), so every arena but the last is
+    /// stripped of its steps.
+    fn from_iter<I: IntoIterator<Item = SparsedTraceArena>>(iter: I) -> Self {
+        let mut traces = Self::default();
+        for arena in iter {
+            traces.push(arena);
+        }
+        traces
+    }
+}
+
+/// Appends a setup trace to `traces`, stripping the recorded EVM steps from
+/// the arena that was previously last — the [`SetupTraces`] counterpart of
+/// [`ExecutionTraces::push`], with the same contract: only the last setup
+/// arena may be named as the failing trace.
+pub fn push_setup_trace_stripping_prior_steps(
+    traces: &mut SetupTraces,
+    kind: SetupTraceKind,
+    arena: SparsedTraceArena,
+) {
+    if let Some((_, previous)) = traces.last_mut() {
+        previous.strip_steps();
+    }
+    traces.push((kind, arena));
 }
 
 impl Deref for SparsedTraceArena {
@@ -391,6 +499,19 @@ mod tests {
         ignored.insert((1, 0), (3, 0));
 
         SparsedTraceArena { arena, ignored }
+    }
+
+    #[test]
+    fn push_strips_steps_of_the_displaced_arena_only() {
+        let mut traces = ExecutionTraces::default();
+
+        traces.push(paused_arena());
+        assert!(!traces[0].nodes()[0].trace.steps.is_empty());
+
+        traces.push(paused_arena());
+        assert!(traces[0].nodes()[0].trace.steps.is_empty());
+        assert!(traces[0].ignored.is_empty());
+        assert!(!traces[1].nodes()[0].trace.steps.is_empty());
     }
 
     #[test]

--- a/crates/foundry/evm/traces/src/lib.rs
+++ b/crates/foundry/evm/traces/src/lib.rs
@@ -73,9 +73,10 @@ impl SparsedTraceArena {
         }
     }
 
-    /// Removes the ignored trace items from the arena itself, so that it no
-    /// longer needs resolving.
-    fn resolve_in_place(&mut self) {
+    /// Removes the ignored trace items from the arena itself, so that
+    /// [`resolve_arena`](Self::resolve_arena) no longer needs to clone it.
+    /// The arena is no longer sparse afterwards; a no-op when it never was.
+    pub fn resolve_in_place(&mut self) {
         if !self.ignored.is_empty() {
             clear_node(self.arena.nodes_mut(), 0, &self.ignored, &mut None);
             self.ignored = HashMap::default();

--- a/crates/foundry/evm/traces/src/lib.rs
+++ b/crates/foundry/evm/traces/src/lib.rs
@@ -64,106 +64,38 @@ impl SparsedTraceArena {
         if self.ignored.is_empty() {
             Cow::Borrowed(&self.arena)
         } else {
-            fn clear_node(
-                nodes: &mut [CallTraceNode],
-                node_idx: usize,
-                ignored: &HashMap<(usize, usize), (usize, usize)>,
-                cur_ignore_end: &mut Option<(usize, usize)>,
-            ) {
-                // Prepend an additional None item to the ordering to handle the beginning of
-                // the trace.
-                let node = nodes
-                    .get(node_idx)
-                    .expect("node_idx should be within nodes bounds");
-                let items = std::iter::once(None)
-                    .chain(node.ordering.clone().into_iter().map(Some))
-                    .enumerate();
-
-                let mut internal_calls = Vec::new();
-                let mut items_to_remove = BTreeSet::new();
-                for (item_idx, item) in items {
-                    if let Some(end_node) = ignored.get(&(node_idx, item_idx)) {
-                        *cur_ignore_end = Some(*end_node);
-                    }
-
-                    let mut remove = cur_ignore_end.is_some() & item.is_some();
-
-                    match item {
-                        // we only remove calls if they did not start/pause tracing
-                        Some(TraceMemberOrder::Call(child_idx)) => {
-                            let node = nodes
-                                .get(node_idx)
-                                .expect("node_idx should be within nodes bounds");
-                            let &child_node_idx = node
-                                .children
-                                .get(child_idx)
-                                .expect("child_idx should be within children bounds");
-                            clear_node(nodes, child_node_idx, ignored, cur_ignore_end);
-                            remove &= cur_ignore_end.is_some();
-                        }
-                        // we only remove decoded internal calls if they did not start/pause tracing
-                        Some(TraceMemberOrder::Step(step_idx)) => {
-                            // If this is an internal call beginning, track it in `internal_calls`
-                            let node = nodes
-                                .get(node_idx)
-                                .expect("node_idx should be within nodes bounds");
-                            let step = node
-                                .trace
-                                .steps
-                                .get(step_idx)
-                                .expect("step_idx should be within steps bounds");
-                            if let Some(decoded) = &step.decoded
-                                && let DecodedTraceStep::InternalCall(_, end_step_idx) = &**decoded
-                            {
-                                internal_calls.push((item_idx, remove, *end_step_idx));
-                                // we decide if we should remove it later
-                                remove = false;
-                            }
-                            // Handle ends of internal calls
-                            internal_calls.retain(|(start_item_idx, remove_start, end_idx)| {
-                                if *end_idx != step_idx {
-                                    return true;
-                                }
-                                // only remove start if end should be removed as well
-                                if *remove_start && remove {
-                                    items_to_remove.insert(*start_item_idx);
-                                } else {
-                                    remove = false;
-                                }
-
-                                false
-                            });
-                        }
-                        _ => {}
-                    }
-
-                    if remove {
-                        items_to_remove.insert(item_idx);
-                    }
-
-                    if let Some((end_node, end_step_idx)) = cur_ignore_end
-                        && node_idx == *end_node
-                        && item_idx == *end_step_idx
-                    {
-                        *cur_ignore_end = None;
-                    }
-                }
-
-                for (offset, item_idx) in items_to_remove.into_iter().enumerate() {
-                    let ordering = &mut nodes
-                        .get_mut(node_idx)
-                        .expect("node_idx should be within nodes bounds")
-                        .ordering;
-                    ordering.remove(item_idx - offset - 1);
-                }
-            }
-
             let mut arena = self.arena.clone();
-
             clear_node(arena.nodes_mut(), 0, &self.ignored, &mut None);
-
             Cow::Owned(arena)
         }
+    }
+
+    /// Removes the ignored trace items from the arena itself, so that it no
+    /// longer needs resolving.
+    fn resolve_in_place(&mut self) {
+        if !self.ignored.is_empty() {
+            clear_node(self.arena.nodes_mut(), 0, &self.ignored, &mut None);
+            self.ignored = HashMap::default();
+        }
+    }
+
+    /// Discards the recorded EVM steps, keeping the rest of the call tree:
+    /// its nodes, their logs and their ordering. With step recording enabled
+    /// the steps are by far the largest part of an arena — one entry per
+    /// executed opcode — while in the Solidity test runner their only
+    /// consumer is stack-trace generation.
+    ///
+    /// Must only be called once a stack trace can no longer be requested for
+    /// this arena.
+    ///
+    /// Ignored ranges (from the `pauseTracing`/`resumeTracing` cheatcodes) are
+    /// resolved first: they are keyed by position in each node's `ordering`,
+    /// which dropping the step entries would shift. Afterwards the arena is
+    /// no longer sparse and [`resolve_arena`](Self::resolve_arena) borrows it
+    /// as is.
+    pub fn strip_steps(&mut self) {
+        self.resolve_in_place();
+        strip_arena_steps(&mut self.arena);
     }
 }
 
@@ -212,6 +144,129 @@ impl TracingMode {
             record_logs: true,
             record_immediate_bytes: false,
         })
+    }
+}
+
+/// Removes the trace items covered by `ignored` from the sub-tree rooted at
+/// `node_idx`, recursing into the children it visits. `cur_ignore_end` carries
+/// the end of the range currently being skipped across that recursion, so a
+/// range may start in one node and end in another.
+fn clear_node(
+    nodes: &mut [CallTraceNode],
+    node_idx: usize,
+    ignored: &HashMap<(usize, usize), (usize, usize)>,
+    cur_ignore_end: &mut Option<(usize, usize)>,
+) {
+    // Take the ordering out for the duration rather than cloning it: with step
+    // recording enabled it holds one entry per executed opcode. The loop reads
+    // this node's `children` and `steps` through `nodes` but never its
+    // `ordering`, and only recurses into children — distinct indices — so
+    // nothing observes the gap.
+    let mut ordering = std::mem::take(
+        &mut nodes
+            .get_mut(node_idx)
+            .expect("node_idx should be within nodes bounds")
+            .ordering,
+    );
+    // Prepend an additional None item to the ordering to handle the beginning of
+    // the trace.
+    let items = std::iter::once(None)
+        .chain(ordering.iter().copied().map(Some))
+        .enumerate();
+
+    let mut internal_calls = Vec::new();
+    let mut items_to_remove = BTreeSet::new();
+    for (item_idx, item) in items {
+        if let Some(end_node) = ignored.get(&(node_idx, item_idx)) {
+            *cur_ignore_end = Some(*end_node);
+        }
+
+        let mut remove = cur_ignore_end.is_some() & item.is_some();
+
+        match item {
+            // we only remove calls if they did not start/pause tracing
+            Some(TraceMemberOrder::Call(child_idx)) => {
+                let node = nodes
+                    .get(node_idx)
+                    .expect("node_idx should be within nodes bounds");
+                let &child_node_idx = node
+                    .children
+                    .get(child_idx)
+                    .expect("child_idx should be within children bounds");
+                clear_node(nodes, child_node_idx, ignored, cur_ignore_end);
+                remove &= cur_ignore_end.is_some();
+            }
+            // we only remove decoded internal calls if they did not start/pause tracing
+            Some(TraceMemberOrder::Step(step_idx)) => {
+                // If this is an internal call beginning, track it in `internal_calls`
+                let node = nodes
+                    .get(node_idx)
+                    .expect("node_idx should be within nodes bounds");
+                let step = node
+                    .trace
+                    .steps
+                    .get(step_idx)
+                    .expect("step_idx should be within steps bounds");
+                if let Some(decoded) = &step.decoded
+                    && let DecodedTraceStep::InternalCall(_, end_step_idx) = &**decoded
+                {
+                    internal_calls.push((item_idx, remove, *end_step_idx));
+                    // we decide if we should remove it later
+                    remove = false;
+                }
+                // Handle ends of internal calls
+                internal_calls.retain(|(start_item_idx, remove_start, end_idx)| {
+                    if *end_idx != step_idx {
+                        return true;
+                    }
+                    // only remove start if end should be removed as well
+                    if *remove_start && remove {
+                        items_to_remove.insert(*start_item_idx);
+                    } else {
+                        remove = false;
+                    }
+
+                    false
+                });
+            }
+            _ => {}
+        }
+
+        if remove {
+            items_to_remove.insert(item_idx);
+        }
+
+        if let Some((end_node, end_step_idx)) = cur_ignore_end
+            && node_idx == *end_node
+            && item_idx == *end_step_idx
+        {
+            *cur_ignore_end = None;
+        }
+    }
+
+    for (offset, item_idx) in items_to_remove.into_iter().enumerate() {
+        ordering.remove(item_idx - offset - 1);
+    }
+    nodes
+        .get_mut(node_idx)
+        .expect("node_idx should be within nodes bounds")
+        .ordering = ordering;
+}
+
+/// Discards the recorded EVM steps of every node in `arena`, keeping the rest
+/// of the call tree: its nodes, their logs and their ordering. See
+/// [`SparsedTraceArena::strip_steps`] for when this is safe.
+///
+/// Must not be applied to the arena of a still-sparse [`SparsedTraceArena`]:
+/// its ignored ranges are keyed by position in `ordering`, which this shifts.
+/// Use [`SparsedTraceArena::strip_steps`] there instead.
+pub fn strip_arena_steps(arena: &mut CallTraceArena) {
+    for node in arena.nodes_mut() {
+        node.trace.steps = Vec::new();
+        node.ordering
+            .retain(|item| !matches!(item, TraceMemberOrder::Step(_)));
+        // `retain` keeps the capacity, which grew with one entry per step.
+        node.ordering.shrink_to_fit();
     }
 }
 
@@ -271,4 +326,97 @@ pub fn load_contracts<'a>(
         }
     }
     contracts
+}
+
+#[cfg(test)]
+mod tests {
+    use revm::bytecode::opcode::OpCode;
+
+    use super::*;
+
+    /// Returns a minimal recorded step; only its presence in a node matters.
+    fn step() -> CallTraceStep {
+        CallTraceStep {
+            pc: 0,
+            op: OpCode::STOP,
+            stack: None,
+            push_stack: None,
+            memory: None,
+            returndata: alloy_primitives::Bytes::default(),
+            gas_remaining: 0,
+            gas_refund_counter: 0,
+            gas_used: 0,
+            gas_cost: 0,
+            storage_change: None,
+            status: None,
+            immediate_bytes: None,
+            decoded: None,
+        }
+    }
+
+    /// Root node with a `pauseTracing` child (node 1), a `resumeTracing` child
+    /// (node 3) and a call in between (node 2) that should be ignored, with
+    /// steps interleaved the way the tracing inspector records them.
+    fn paused_arena() -> SparsedTraceArena {
+        use TraceMemberOrder::{Call, Log, Step};
+
+        let mut arena = CallTraceArena::default();
+        let nodes = arena.nodes_mut();
+        nodes[0].children = vec![1, 2, 3];
+        nodes[0].logs = vec![CallLog::default(), CallLog::default()];
+        nodes[0].trace.steps = (0..5).map(|_| step()).collect();
+        nodes[0].ordering = vec![
+            Step(0),
+            Log(0),
+            Step(1),
+            Call(0),
+            Step(2),
+            Call(1),
+            Log(1),
+            Step(3),
+            Call(2),
+            Step(4),
+        ];
+        for idx in 1..=3 {
+            nodes.push(CallTraceNode {
+                parent: Some(0),
+                idx,
+                ..CallTraceNode::default()
+            });
+        }
+
+        // Recorded by the cheatcodes as the position in the cheatcode call's
+        // own (still empty) ordering.
+        let mut ignored = HashMap::default();
+        ignored.insert((1, 0), (3, 0));
+
+        SparsedTraceArena { arena, ignored }
+    }
+
+    #[test]
+    fn strip_steps_matches_resolving_then_dropping_steps() {
+        let mut arena = paused_arena();
+
+        let expected: Vec<Vec<TraceMemberOrder>> = arena
+            .resolve_arena()
+            .nodes()
+            .iter()
+            .map(|node| {
+                node.ordering
+                    .iter()
+                    .filter(|item| !matches!(item, TraceMemberOrder::Step(_)))
+                    .copied()
+                    .collect()
+            })
+            .collect();
+
+        arena.strip_steps();
+
+        assert!(arena.ignored.is_empty());
+        assert!(matches!(arena.resolve_arena(), Cow::Borrowed(_)));
+        for (node, expected) in arena.nodes().iter().zip(expected) {
+            assert!(node.trace.steps.is_empty());
+            assert_eq!(node.ordering, expected);
+        }
+    }
 }

--- a/js/integration-tests/solidity-tests/test-contracts/CallTracesFailingOnlySetup.t.sol
+++ b/js/integration-tests/solidity-tests/test-contracts/CallTracesFailingOnlySetup.t.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.0;
+
+import {Test} from "forge-std/src/Test.sol";
+
+contract CallTracesFailingOnlySetup is Test {
+    uint256 public initialValue;
+
+    function setUp() public {
+        initialValue = 42;
+    }
+
+    function testSuccessfulTest() public view {
+        require(initialValue == 42, "Setup not called properly");
+    }
+
+    function testIntentionallyFailingTest() public pure {
+        revert("This test intentionally fails");
+    }
+}

--- a/js/integration-tests/solidity-tests/test-contracts/CallTracesSetup.t.sol
+++ b/js/integration-tests/solidity-tests/test-contracts/CallTracesSetup.t.sol
@@ -16,6 +16,13 @@ contract CallTracesSetup is Test {
         emit TestEvent("test after setup", initialValue);
     }
 
+    // A second test, so that the suite's setup traces are shared between
+    // several test results.
+    function testAlsoAfterSetup() public {
+        require(initialValue == 42, "Setup not called properly");
+        emit TestEvent("second test after setup", initialValue);
+    }
+
     event SetupEvent(string message, uint256 value);
     event TestEvent(string message, uint256 value);
 }

--- a/js/integration-tests/solidity-tests/test/call_traces.ts
+++ b/js/integration-tests/solidity-tests/test/call_traces.ts
@@ -28,7 +28,7 @@ describe("Call traces - IncludeTraces.All", () => {
       isCheatcode: false,
       gasUsed: trace[0].gasUsed, // avoid coupling test to specific gas costs
       value: 0n,
-      address: '0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496',
+      address: "0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496",
       contract: "CallTraces",
       inputs: {
         name: "testNoChildren",
@@ -164,7 +164,7 @@ describe("Call traces - IncludeTraces.All", () => {
     assert.equal(child.kind, CallKind.Call);
     assert.deepEqual(child.inputs, {
       arguments: ["0xdeadbeef"],
-      name: "fallback"
+      name: "fallback",
     });
   });
 
@@ -398,6 +398,31 @@ describe("Call traces - IncludeTraces.Failing", () => {
   });
 });
 
+describe("Call traces - IncludeTraces.Failing with setUp", () => {
+  let testCallTraces: Map<string, CallTrace[]>;
+
+  before(async () => {
+    const testContext = await TestContext.setup();
+    const runResult = await testContext.runTestsWithStats(
+      "CallTracesFailingOnlySetup",
+      { includeTraces: IncludeTraces.Failing }
+    );
+    testCallTraces = runResult.callTraces;
+  });
+
+  it("should not capture setUp traces for successful tests", async function () {
+    const trace = testCallTraces.get("testSuccessfulTest()");
+    assert.deepEqual(trace, []);
+  });
+
+  it("should capture setUp and test traces for failing tests", async function () {
+    const trace = testCallTraces.get("testIntentionallyFailingTest()");
+    assert.equal(trace?.length, 2);
+    assert.deepEqual(trace[0].inputs, { name: "setUp", arguments: [] });
+    assert.equal(trace[1].success, false);
+  });
+});
+
 describe("Call traces - CallTracesSetup", () => {
   let testCallTraces: Map<string, CallTrace[]>;
 
@@ -427,6 +452,24 @@ describe("Call traces - CallTracesSetup", () => {
       name: "testAfterSetup",
       arguments: [],
     });
+  });
+
+  it("should include setUp function in the traces of every test", async function () {
+    for (const testName of ["testAfterSetup()", "testAlsoAfterSetup()"]) {
+      const trace = testCallTraces.get(testName);
+      assert.equal(trace?.length, 2, testName);
+      assert.deepEqual(trace[0].inputs, { name: "setUp", arguments: [] });
+      assert.deepEqual(trace[1].inputs, {
+        name: testName.slice(0, -2),
+        arguments: [],
+      });
+    }
+
+    // Every test's setUp trace is the same trace, resolved the same way.
+    assert.deepEqual(
+      testCallTraces.get("testAfterSetup()")?.[0],
+      testCallTraces.get("testAlsoAfterSetup()")?.[0]
+    );
   });
 });
 


### PR DESCRIPTION
## Problem / context

The napi conversion cloned the suite's `setUp()` trace arenas into every included test result. A suite of N tests at `IncludeTraces::All` therefore held N copies of them.

## Solution

Build the surfaced subset once per suite — moving it out of the suite result rather than cloning it — and share it as an `Arc<[SparsedTraceArena]>`. `TestResult::call_traces` returns the same traces in the same order. Excluded results, and every result at `IncludeTraces::None` where the subset isn't even built, share a static empty slice, so the `Arc<[_]>` switch costs them nothing.

The `pauseTracing`/`resumeTracing` ranges of the shared arenas are resolved once per suite. `call_traces` used to resolve each arena on the fly, which cloned it whenever such ranges were present — once per test result of the suite.

## Validation

- The napi test `call_traces.ts` gains assertions that each result still returns the setup traces, in order, at every `IncludeCallTraces` level.
- `setUp()` is traced `WithoutSteps`, so the dropped copies are step-free call trees (roughly 1 KB and a handful of allocations per setup node per test). Measured on top of #1706: within run-to-run noise everywhere, as expected; the saving grows with tests per suite × `setUp()` size.
- `cargo clippy --workspace --all-targets -- -D warnings`, the `edr_solidity_tests` integration suite (135 tests) and the napi test suite pass.

## Notes for reviewer

- Stacked on #1706; part of the Solidity test runner memory-reduction series.
- `index.d.ts` changes only by the reworded `callTraces` doc; two untouched lines of `call_traces.ts` picked up prettier fixes.
