### PR TITLE
perf: derive a deployed-code map instead of retaining setup arenas

### DIFF
--- a/crates/edr_provider/tests/integration/rip7212.rs
+++ b/crates/edr_provider/tests/integration/rip7212.rs
@@ -4,13 +4,15 @@ use std::sync::Arc;
 
 use edr_chain_l1::{rpc::call::L1CallRequest, L1ChainSpec};
 use edr_precompile::secp256r1::{self, P256VERIFY_BASE_GAS_FEE, P256VERIFY_BASE_GAS_FEE_OSAKA};
-use edr_primitives::{bytes, Bytes, HashMap};
+use edr_primitives::{bytes, Bytes};
 use edr_provider::{
     test_utils::create_test_config, time::CurrentTime, MethodInvocation, NoopLogger, Provider,
     ProviderRequest,
 };
 use edr_solidity::{
-    config::IncludeTraces, contract_decoder::ContractDecoder, nested_trace::NestedTrace,
+    config::IncludeTraces,
+    contract_decoder::ContractDecoder,
+    nested_trace::{CodeMap, NestedTrace},
 };
 use parking_lot::RwLock;
 use tokio::runtime;
@@ -104,8 +106,8 @@ async fn rip7212_enabled() -> anyhow::Result<()> {
     );
 
     let nested_trace = NestedTrace::<edr_chain_l1::HaltReason>::from_call_trace_arena(
-        &HashMap::default(),
-        &HashMap::default(),
+        &CodeMap::default(),
+        &CodeMap::default(),
         response
             .call_trace_arenas
             .first()
@@ -154,8 +156,8 @@ async fn rip7212_enabled_post_osaka() -> anyhow::Result<()> {
     );
 
     let nested_trace = NestedTrace::<edr_chain_l1::HaltReason>::from_call_trace_arena(
-        &HashMap::default(),
-        &HashMap::default(),
+        &CodeMap::default(),
+        &CodeMap::default(),
         response
             .call_trace_arenas
             .first()

--- a/crates/edr_solidity/src/nested_trace.rs
+++ b/crates/edr_solidity/src/nested_trace.rs
@@ -60,8 +60,8 @@ impl<HaltReasonT: HaltReasonTrait> NestedTrace<HaltReasonT> {
     ///
     /// Returns an error if the arena is empty or has an invalid root node.
     pub fn from_call_trace_arena(
-        address_to_creation_code: &HashMap<Address, &Bytes>,
-        address_to_runtime_code: &HashMap<Address, &Bytes>,
+        address_to_creation_code: &CodeMap<'_>,
+        address_to_runtime_code: &CodeMap<'_>,
         arena: &revm_inspectors::tracing::CallTraceArena,
     ) -> Result<Self, CallTraceArenaConversionError> {
         conversion::convert_from_arena(address_to_creation_code, address_to_runtime_code, arena)
@@ -83,8 +83,8 @@ impl<HaltReasonT: HaltReasonTrait> NestedTrace<HaltReasonT> {
     pub fn from_call_trace_arena_with_extracted_code(
         arena: &revm_inspectors::tracing::CallTraceArena,
     ) -> Result<Self, CallTraceArenaConversionError> {
-        let mut address_to_creation_code = HashMap::default();
-        let mut address_to_runtime_code = HashMap::default();
+        let mut address_to_creation_code = CodeMap::default();
+        let mut address_to_runtime_code = CodeMap::default();
 
         // Extract code mappings from CREATE traces
         for node in arena.nodes() {
@@ -96,6 +96,41 @@ impl<HaltReasonT: HaltReasonTrait> NestedTrace<HaltReasonT> {
         }
 
         Self::from_call_trace_arena(&address_to_creation_code, &address_to_runtime_code, arena)
+    }
+}
+
+/// A lookup from contract address to code (creation or runtime), layered over
+/// an optional pre-computed base map: entries inserted on top win over the
+/// base for the same address. Keeping the base borrowed avoids copying it
+/// into a fresh lookup table for every conversion.
+#[derive(Debug, Default)]
+pub struct CodeMap<'a> {
+    base: Option<&'a HashMap<Address, Bytes>>,
+    overlay: HashMap<Address, &'a Bytes>,
+}
+
+impl<'a> CodeMap<'a> {
+    /// Creates a lookup whose misses fall back to `base`.
+    #[must_use]
+    pub fn layered_over(base: Option<&'a HashMap<Address, Bytes>>) -> Self {
+        Self {
+            base,
+            overlay: HashMap::default(),
+        }
+    }
+
+    /// Maps `address` to `code`, overriding the base and earlier inserts.
+    pub fn insert(&mut self, address: Address, code: &'a Bytes) {
+        self.overlay.insert(address, code);
+    }
+
+    /// Returns the overlay entry for `address`, falling back to the base map.
+    #[must_use]
+    pub fn get(&self, address: &Address) -> Option<&'a Bytes> {
+        self.overlay
+            .get(address)
+            .copied()
+            .or_else(|| self.base.and_then(|base| base.get(address)))
     }
 }
 

--- a/crates/edr_solidity/src/nested_trace/conversion.rs
+++ b/crates/edr_solidity/src/nested_trace/conversion.rs
@@ -1,11 +1,13 @@
 //! Conversion from `CallTraceArena` (from revm-inspectors) to `NestedTrace`.
 
 use edr_chain_spec::{EvmHaltReason, HaltReasonTrait};
-use edr_primitives::{Address, Bytes, HashMap, U160};
+use edr_primitives::{Address, Bytes, U160};
 use revm_inspectors::tracing::{types::CallTraceStep, CallTraceArena};
 use revm_interpreter::{InternalResult, SuccessOrHalt};
 
-use super::{CallMessage, CreateMessage, EvmStep, NestedTrace, NestedTraceStep, PrecompileMessage};
+use super::{
+    CallMessage, CodeMap, CreateMessage, EvmStep, NestedTrace, NestedTraceStep, PrecompileMessage,
+};
 use crate::exit_code::ExitCode;
 
 /// Error type for converting `CallTraceArena` to `NestedTrace`.
@@ -18,8 +20,8 @@ pub enum CallTraceArenaConversionError {
 
 /// Converts a `CallTraceArena` into a `NestedTrace`.
 pub(super) fn convert_from_arena<HaltReasonT: HaltReasonTrait>(
-    address_to_creation_code: &HashMap<Address, &Bytes>,
-    address_to_runtime_code: &HashMap<Address, &Bytes>,
+    address_to_creation_code: &CodeMap<'_>,
+    address_to_runtime_code: &CodeMap<'_>,
     arena: &CallTraceArena,
 ) -> Result<NestedTrace<HaltReasonT>, CallTraceArenaConversionError> {
     // Start conversion from the root node (index 0)
@@ -31,8 +33,8 @@ pub(super) fn convert_from_arena<HaltReasonT: HaltReasonTrait>(
 }
 
 fn convert_node<HaltReasonT: HaltReasonTrait>(
-    address_to_creation_code: &HashMap<Address, &Bytes>,
-    address_to_runtime_code: &HashMap<Address, &Bytes>,
+    address_to_creation_code: &CodeMap<'_>,
+    address_to_runtime_code: &CodeMap<'_>,
     arena: &CallTraceArena,
     node_idx: usize,
 ) -> Result<NestedTrace<HaltReasonT>, CallTraceArenaConversionError> {
@@ -111,7 +113,7 @@ fn convert_node<HaltReasonT: HaltReasonTrait>(
             deployed_contract: Some(trace.output.clone()),
             code: address_to_creation_code
                 .get(&trace.address)
-                .map(|c| (*c).clone())
+                .cloned()
                 .expect("Create must have code"),
             value: trace.value,
             return_data: trace.output.clone(),
@@ -127,7 +129,7 @@ fn convert_node<HaltReasonT: HaltReasonTrait>(
         address_to_runtime_code
             .get(&trace.address)
             // Code might not exist if it's a mocked contract
-            .map_or_else(|| Bytes::from_static(&[0u8]), |c| (*c).clone())
+            .map_or_else(|| Bytes::from_static(&[0u8]), Bytes::clone)
     };
 
     Ok(NestedTrace::Call(CallMessage {

--- a/crates/edr_solidity/src/solidity_stack_trace.rs
+++ b/crates/edr_solidity/src/solidity_stack_trace.rs
@@ -7,7 +7,7 @@ use revm_inspectors::tracing::CallTraceArena;
 use crate::{
     build_model::ContractFunctionType,
     contract_decoder::{ContractDecoderError, NestedTraceDecoder},
-    nested_trace::{CallTraceArenaConversionError, NestedTrace},
+    nested_trace::{CallTraceArenaConversionError, CodeMap, NestedTrace},
     return_data::CheatcodeErrorDetails,
     solidity_tracer::{self, SolidityTracerError},
 };
@@ -260,13 +260,49 @@ impl<HaltReasonT> StackTraceCreationError<HaltReasonT> {
 }
 
 /// Code known to have been deployed to an address. A `None` field contributes
-/// no entries — the same as an empty map.
+/// no entries — the same as an empty map. See [`DeployedCodeMaps`] for the
+/// owned form.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct DeployedCode<'a> {
     /// Mapping from contract address to creation (init) code.
     pub creation: Option<&'a HashMap<Address, Bytes>>,
     /// Mapping from contract address to runtime (deployed) code.
     pub runtime: Option<&'a HashMap<Address, Bytes>>,
+}
+
+/// Owned counterpart of [`DeployedCode`]: the creation and runtime code of
+/// contracts deployed during traced execution.
+///
+/// Building this once from arenas that are repeatedly used as code sources
+/// (e.g. a test suite's setup traces) lets those arenas be dropped while
+/// stack traces can still be decoded.
+#[derive(Clone, Debug, Default)]
+pub struct DeployedCodeMaps {
+    /// Mapping from contract address to creation (init) code.
+    creation: HashMap<Address, Bytes>,
+    /// Mapping from contract address to runtime (deployed) code.
+    runtime: HashMap<Address, Bytes>,
+}
+
+impl DeployedCodeMaps {
+    /// Records the creation and runtime code of every contract created in the
+    /// arena, overwriting earlier entries for the same address — the same
+    /// precedence [`get_stack_trace`] applies to its `code_sources`.
+    pub fn record_arena(&mut self, arena: &CallTraceArena) {
+        for (address, creation, runtime) in created_contracts(arena) {
+            self.creation.insert(address, creation.clone());
+            self.runtime.insert(address, runtime.clone());
+        }
+    }
+
+    /// Borrows the maps in the form [`get_stack_trace`] takes.
+    #[must_use]
+    pub fn as_deployed_code(&self) -> DeployedCode<'_> {
+        DeployedCode {
+            creation: Some(&self.creation),
+            runtime: Some(&self.runtime),
+        }
+    }
 }
 
 /// Computes the stack trace of `failing_trace`.
@@ -297,26 +333,16 @@ pub fn get_stack_trace<
     code_sources: impl IntoIterator<Item = &'arena CallTraceArena>,
     deployed_code: DeployedCode<'arena>,
 ) -> Result<Vec<StackTraceEntry>, StackTraceCreationError<HaltReasonT>> {
-    let mut address_to_creation_code: HashMap<Address, &Bytes> = deployed_code
-        .creation
-        .map(|map| map.iter().map(|(k, v)| (*k, v)).collect())
-        .unwrap_or_default();
-
-    let mut address_to_runtime_code: HashMap<Address, &Bytes> = deployed_code
-        .runtime
-        .map(|map| map.iter().map(|(k, v)| (*k, v)).collect())
-        .unwrap_or_default();
+    let mut address_to_creation_code = CodeMap::layered_over(deployed_code.creation);
+    let mut address_to_runtime_code = CodeMap::layered_over(deployed_code.runtime);
 
     for trace in code_sources
         .into_iter()
         .chain(std::iter::once(failing_trace))
     {
-        for node in trace.nodes() {
-            let address = node.trace.address;
-            if node.trace.kind.is_any_create() {
-                address_to_creation_code.insert(address, &node.trace.data);
-                address_to_runtime_code.insert(address, &node.trace.output);
-            }
+        for (address, creation, runtime) in created_contracts(trace) {
+            address_to_creation_code.insert(address, creation);
+            address_to_runtime_code.insert(address, runtime);
         }
     }
 
@@ -328,6 +354,20 @@ pub fn get_stack_trace<
     let trace = contract_decoder.try_to_decode_nested_trace(trace)?;
     let stack_trace = solidity_tracer::get_stack_trace(trace)?;
     Ok(stack_trace)
+}
+
+/// Returns the address, creation code and runtime code of every contract
+/// created in `arena`, in arena order. Failed creates are included: the
+/// conversion panics on a create node whose creation code is missing. Their
+/// entries deliberately shadow any pre-computed base mapping for the same
+/// address — the arena executed later, so its view of the address is the
+/// current one.
+fn created_contracts(arena: &CallTraceArena) -> impl Iterator<Item = (Address, &Bytes, &Bytes)> {
+    arena
+        .nodes()
+        .iter()
+        .filter(|node| node.trace.kind.is_any_create())
+        .map(|node| (node.trace.address, &node.trace.data, &node.trace.output))
 }
 
 /// The possible outcomes from computing stack traces.

--- a/crates/edr_solidity_tests/src/result.rs
+++ b/crates/edr_solidity_tests/src/result.rs
@@ -10,6 +10,7 @@ use alloy_primitives::{map::AddressHashMap, Address, Log};
 use derive_where::derive_where;
 use edr_chain_spec::HaltReasonTrait;
 use edr_decoder_revert::cheatcodes::skip::SkipReason;
+use edr_solidity::solidity_stack_trace::DeployedCodeMaps;
 pub use foundry_evm::executors::invariant::InvariantMetrics;
 use foundry_evm::{
     coverage::HitMaps,
@@ -174,7 +175,8 @@ pub struct SuiteResult<HaltReasonT> {
     pub duration: Duration,
     /// Traces from the setup phase of the test suite. These are shared across
     /// all tests in the suite and should be printed alongside each test's
-    /// individual traces.
+    /// individual traces. Empty when setup ran untraced, or when no test
+    /// result surfaces its traces and no gas report was requested.
     pub setup_traces: SetupTraces,
     /// Individual test results: `test fn signature -> TestResult`.
     pub test_results: BTreeMap<String, TestResult<HaltReasonT>>,
@@ -1040,6 +1042,11 @@ pub struct TestSetup<HaltReasonT> {
     /// Call traces of the setup. Only the last arena carries recorded EVM
     /// steps — append through [`push_setup_trace_stripping_prior_steps`].
     pub traces: SetupTraces,
+    /// The creation and runtime code of every contract deployed during
+    /// setup, recorded from each traced setup call as it is merged in. Lets
+    /// stack traces be decoded without walking — or retaining — the setup
+    /// arenas themselves. Empty when setup ran untraced.
+    pub deployed_code: DeployedCodeMaps,
     /// Coverage info during setup.
     pub coverage: Option<HitMaps>,
     /// Addresses of external libraries deployed during setup.
@@ -1103,6 +1110,7 @@ impl<HaltReasonT: HaltReasonTrait> TestSetup<HaltReasonT> {
         self.logs.extend(raw.logs);
         self.labels.extend(raw.labels);
         if let Some(traces) = raw.traces {
+            self.deployed_code.record_arena(&traces.arena);
             // Only the last setup arena can be named as the failing trace (by
             // `get_setup_stack_trace`), so a step-recorded setup re-run keeps
             // one step-laden arena instead of one per setup call.

--- a/crates/edr_solidity_tests/src/runner.rs
+++ b/crates/edr_solidity_tests/src/runner.rs
@@ -683,9 +683,15 @@ impl<
             } else {
                 "constructor()".to_string()
             };
-            // `setup_failure_result` does not read the traces, so move rather
-            // than clone them.
-            let setup_traces = std::mem::take(&mut setup.traces);
+
+            // `setup_failure_result` does not read the traces, so only retain
+            // what is necessary.
+            let setup_traces = if self.trace_retention.retains_setup(/* any_failed */ true) {
+                std::mem::take(&mut setup.traces)
+            } else {
+                Vec::new()
+            };
+
             return Ok(SuiteRunOutcome::without_samples(SuiteResult::new(
                 elapsed,
                 setup_traces,
@@ -700,6 +706,17 @@ impl<
                 self.known_contracts,
             )
         });
+
+        // Nothing the tests run below needs the setup arenas: contract
+        // identification and `setup.deployed_code` were derived from them
+        // above. Their remaining consumers — trace decoding, the gas report
+        // and the napi conversion — all run after the suite, and what they
+        // produce is only used by results that surface their traces or by a
+        // requested gas report. Free them now if not even a failing test
+        // would.
+        if !self.trace_retention.retains_setup(/* any_failed */ true) {
+            setup.traces = Vec::new();
+        }
 
         let test_fail_functions = functions
             .iter()
@@ -760,6 +777,14 @@ impl<
             .values()
             .filter(|outcome| outcome.result.status == TestStatus::Success)
             .count();
+        let any_failed = test_outcomes
+            .values()
+            .any(|outcome| outcome.result.status.is_failure());
+        let setup_traces = if self.trace_retention.retains_setup(any_failed) {
+            setup.traces
+        } else {
+            Vec::new()
+        };
         info!(
             duration=?duration,
             "done. {}/{} successful",
@@ -768,7 +793,7 @@ impl<
         );
         Ok(SuiteRunOutcome {
             duration,
-            setup_traces: setup.traces,
+            setup_traces,
             test_outcomes,
             warnings,
         })
@@ -981,7 +1006,7 @@ impl<
 
                     collect_stack_trace(
                         &*self.cr.contract_decoder,
-                        self.setup,
+                        self.setup.deployed_code.as_deployed_code(),
                         failing_trace,
                         prior_traces,
                     )
@@ -1141,7 +1166,7 @@ impl<
 
                         collect_stack_trace(
                             &*self.cr.contract_decoder,
-                            self.setup,
+                            self.setup.deployed_code.as_deployed_code(),
                             failing_trace,
                             prior_traces,
                         )
@@ -1294,7 +1319,7 @@ impl<
                     known_contracts: self.cr.known_contracts,
                     ided_contracts: identified_contracts.clone(),
                     logs: &mut self.result.logs,
-                    setup_traces: &self.setup.traces,
+                    deployed_code: self.setup.deployed_code.as_deployed_code(),
                     line_coverage: &mut self.result.line_coverage,
                     deprecated_cheatcodes: &mut self.result.deprecated_cheatcodes,
                     inputs: &txes,
@@ -1341,7 +1366,7 @@ impl<
                     {
                         Some(collect_stack_trace(
                             &*self.cr.contract_decoder,
-                            self.setup,
+                            self.setup.deployed_code.as_deployed_code(),
                             failing_trace,
                             prior_traces,
                         ))
@@ -1390,7 +1415,7 @@ impl<
                         known_contracts: self.cr.known_contracts,
                         ided_contracts: identified_contracts.clone(),
                         logs: &mut self.result.logs,
-                        setup_traces: &self.setup.traces,
+                        deployed_code: self.setup.deployed_code.as_deployed_code(),
                         coverage: &mut None,
                         deprecated_cheatcodes: &mut self.result.deprecated_cheatcodes,
                         generate_stack_trace: true,
@@ -1466,7 +1491,7 @@ impl<
                     known_contracts: self.cr.known_contracts,
                     ided_contracts: identified_contracts.clone(),
                     logs: &mut self.result.logs,
-                    setup_traces: &self.setup.traces,
+                    deployed_code: self.setup.deployed_code.as_deployed_code(),
                     line_coverage: &mut self.result.line_coverage,
                     deprecated_cheatcodes: &mut self.result.deprecated_cheatcodes,
                     inputs: &invariant_result.last_run_inputs,
@@ -1589,7 +1614,7 @@ impl<
                 {
                     Some(collect_stack_trace(
                         &*self.cr.contract_decoder,
-                        self.setup,
+                        self.setup.deployed_code.as_deployed_code(),
                         failing_trace,
                         prior_traces,
                     ))
@@ -1700,19 +1725,25 @@ impl<
     ) -> Result<Vec<StackTraceEntry>, SolidityTestStackTraceError<HaltReasonT>> {
         let mut executor = self.cr.executor_builder.clone().build()?;
 
-        // Apply executor config overrides.
-        // Error is ignored since overrides were already validated in run().
-        let _ = self.cr.apply_executor_overrides(func, &mut executor);
-
-        // We only need light-weight tracing for setup to be able to match contract
-        // codes to contact addresses.
+        // Light-weight tracing suffices for setup: only the code of the
+        // contracts it deploys is needed, to seed stack-trace decoding. The
+        // tracer must stay on, as cheatcodes such as
+        // `vm.startDebugTraceRecording` require one.
         executor.inspector_mut().tracing(TracingMode::WithoutSteps);
-        let setup = self.cr.setup(&mut executor, needs_setup);
-        if let Some(reason) = setup.reason {
+        let mut re_run_setup = self.cr.setup(&mut executor, needs_setup);
+        // The deployed-code map has replaced the arenas as the code source,
+        // so nothing reads them again; free them ahead of the traced re-run.
+        re_run_setup.traces = Vec::new();
+        if let Some(reason) = re_run_setup.reason {
             // If this function was called, the setup succeeded during test execution, so
             // this is an unexpected failure.
             return Err(SolidityTestStackTraceError::FailingSetup(reason));
         }
+
+        // Apply executor config overrides after setup, as `FunctionRunner::run`
+        // does, so the re-run's setup matches the original's. The error is
+        // ignored: overrides were already validated in `run`.
+        let _ = self.cr.apply_executor_overrides(func, &mut executor);
 
         // Collect EVM step traces that are needed for stack trace generation.
         executor.inspector_mut().tracing(TracingMode::WithSteps);
@@ -1720,7 +1751,7 @@ impl<
         // Run unit test
         let new_trace_arena = match executor.call(
             self.cr.sender,
-            setup.address,
+            re_run_setup.address,
             func,
             args,
             U256::ZERO,
@@ -1735,8 +1766,8 @@ impl<
         get_stack_trace(
             &*self.cr.contract_decoder,
             &new_trace_arena.arena,
-            setup.traces.iter().map(|(_, arena)| &arena.arena),
-            DeployedCode::default(),
+            std::iter::empty(),
+            re_run_setup.deployed_code.as_deployed_code(),
         )
         .map_err(SolidityTestStackTraceError::Creation)
     }
@@ -1766,24 +1797,23 @@ fn get_setup_stack_trace<
 
 /// Builds the stack trace of `failing_trace`.
 ///
-/// Taken as an associated function of explicit fields rather than `&self`
-/// so it can be called from the fuzz path, where `self.executor` has
-/// already been moved out.
+/// A free function taking explicit arguments rather than `&self`, so it can
+/// be called from the fuzz path, where `self.executor` has already been
+/// moved out.
 fn collect_stack_trace<
     HaltReasonT: 'static + HaltReasonTrait + TryInto<HaltReason>,
     NestedTraceDecoderT: SyncNestedTraceDecoder<HaltReasonT>,
 >(
     contract_decoder: &NestedTraceDecoderT,
-    setup: &TestSetup<HaltReasonT>,
+    deployed_code: DeployedCode<'_>,
     failing_trace: &SparsedTraceArena,
     prior_execution_traces: &[SparsedTraceArena],
 ) -> SolidityTestStackTraceResult<HaltReasonT> {
-    let setup_arenas = setup.traces.iter().map(|(_, arena)| &arena.arena);
     get_stack_trace(
         contract_decoder,
         &failing_trace.arena,
-        setup_arenas.chain(prior_execution_traces.iter().map(|arena| &arena.arena)),
-        DeployedCode::default(),
+        prior_execution_traces.iter().map(|arena| &arena.arena),
+        deployed_code,
     )
     .map_err(SolidityTestStackTraceError::from)
     .into()
@@ -1821,19 +1851,23 @@ fn re_run_fuzz_counterexample_for_stack_traces<
 ) -> Result<Vec<StackTraceEntry>, SolidityTestStackTraceError<HaltReasonT>> {
     let mut executor = contract_runner.executor_builder.clone().build()?;
 
-    // Apply executor config overrides.
-    // Error is ignored since overrides were already validated in run().
-    let _ = contract_runner.apply_executor_overrides(func, &mut executor);
-
-    // We only need light-weight tracing for setup to be able to match contract
-    // codes to contact addresses.
+    // As in `re_run_test_for_stack_traces`: light-weight tracing of setup to
+    // learn the code of the contracts it deploys.
     executor.inspector_mut().tracing(TracingMode::WithoutSteps);
-    let setup = contract_runner.setup(&mut executor, needs_setup);
-    if let Some(reason) = setup.reason {
+    let mut re_run_setup = contract_runner.setup(&mut executor, needs_setup);
+    // The deployed-code map has replaced the arenas as the code source, so
+    // nothing reads them again; free them ahead of the traced re-run.
+    re_run_setup.traces = Vec::new();
+    if let Some(reason) = re_run_setup.reason {
         // If this function was called, the setup succeeded during test execution, so
         // this is an unexpected failure.
         return Err(SolidityTestStackTraceError::FailingSetup(reason));
     }
+
+    // Apply executor config overrides after setup, as `FunctionRunner::run`
+    // does, so the re-run's setup matches the original's. The error is
+    // ignored: overrides were already validated in `run`.
+    let _ = contract_runner.apply_executor_overrides(func, &mut executor);
 
     // Collect EVM step traces that are needed for stack trace generation.
     executor.inspector_mut().tracing(TracingMode::WithSteps);
@@ -1853,8 +1887,8 @@ fn re_run_fuzz_counterexample_for_stack_traces<
     get_stack_trace(
         &*contract_runner.contract_decoder,
         &new_trace_arena.arena,
-        setup.traces.iter().map(|(_, arena)| &arena.arena),
-        DeployedCode::default(),
+        std::iter::empty(),
+        re_run_setup.deployed_code.as_deployed_code(),
     )
     .map_err(SolidityTestStackTraceError::Creation)
 }

--- a/crates/edr_solidity_tests/src/trace_retention.rs
+++ b/crates/edr_solidity_tests/src/trace_retention.rs
@@ -1,4 +1,5 @@
-//! Policy for freeing the trace data a finished test no longer needs.
+//! Policy for freeing the trace data a finished test — or a finished
+//! suite — no longer needs.
 //!
 //! Arenas are recorded according to
 //! [`TracingMode`](foundry_evm::traces::TracingMode) and consumed by
@@ -26,7 +27,8 @@ pub(crate) enum Retain {
 }
 
 /// Decides which trace arenas to retain once a test has finished and its
-/// stack trace (if any) has been computed.
+/// stack trace (if any) has been computed, and whether a suite's setup
+/// arenas outlive its tests.
 ///
 /// Derived from the test runner's `include_traces` and `generate_gas_report`
 /// settings in `MultiContractRunner::run_test_suite`.
@@ -78,6 +80,24 @@ impl TraceRetentionPolicy {
         }
     }
 
+    /// Whether a suite's setup arenas still have a consumer once its tests
+    /// have finished, given whether any of the tests failed. Contract
+    /// identification and the deployed-code map used for stack traces are
+    /// derived from the arenas before the tests start; afterwards they are
+    /// only read by trace decoding and the napi conversion — which surface
+    /// them alongside a test result's own traces — and by the gas report,
+    /// which analyses them for gas. That is the same set of consumers a
+    /// test's own arenas have, so the setup arenas follow the rule for a
+    /// failing test if any test failed and for a passing one otherwise.
+    #[must_use]
+    pub(crate) fn retains_setup(self, any_failed: bool) -> bool {
+        self.retains(if any_failed {
+            TestStatus::Failure
+        } else {
+            TestStatus::Success
+        })
+    }
+
     /// Returns whether the gas-report samples a test produced still have a
     /// consumer: the gas-report pass in `MultiContractRunner::run_test_suite`.
     pub(crate) fn retains_gas_report_samples(self) -> bool {
@@ -115,6 +135,14 @@ mod tests {
                 policy.retains(status),
                 retained,
                 "{include_traces:?} {status:?}"
+            );
+            // Setup arenas follow the same rule, keyed on whether any test
+            // failed.
+            assert_eq!(
+                policy.retains_setup(status.is_failure()),
+                retained,
+                "{include_traces:?} setup arenas, any failed: {}",
+                status.is_failure()
             );
 
             // A gas report consumes every test's call traces.

--- a/crates/edr_solidity_tests/tests/it/repros.rs
+++ b/crates/edr_solidity_tests/tests/it/repros.rs
@@ -972,6 +972,74 @@ async fn always_mode_frees_passing_tests_arenas_unless_all_are_included() {
         }
     }
 }
+
+// A failing test in `CollectStackTraces::OnFailure` mode with
+// `IncludeTraces::None` (Hardhat's default verbosity) must produce a
+// source-level stack trace via the re-execution path. This suite has no
+// invariant tests, so nothing is traced during the original run — not even
+// setup — and the re-run has to rebuild the deployed-code mapping itself.
+#[tokio::test(flavor = "multi_thread")]
+async fn on_failure_mode_produces_stack_trace_without_traced_setup() {
+    let mut config = runner_config(None, &TEST_DATA_VIA_IR, false).await;
+    config.collect_stack_traces = CollectStackTraces::OnFailure;
+    config.include_traces = IncludeTraces::None;
+
+    // Real decoder so the stack-trace inferrer runs (mirrors `issue_1482`).
+    let contract_decoder = contract_decoder(TEST_DATA_VIA_IR.build_info_path());
+    let runner = TEST_DATA_VIA_IR
+        .runner_with_contract_decoder(config, contract_decoder)
+        .await;
+    let filter = SolidityTestFilter::new(
+        ".*",
+        "AlwaysStackTraceTest",
+        ".*repros/StackTraceAlwaysMode.t.sol",
+    );
+    let suite_results = runner.test_collect(filter).await.suite_results;
+
+    let suite = suite_results
+        .get("via-ir/repros/StackTraceAlwaysMode.t.sol:AlwaysStackTraceTest")
+        .expect("the AlwaysStackTrace suite should have run");
+
+    let unit_result = assert_execution_error_stack_trace(suite, "testRevertHasStackTrace()");
+    assert!(
+        unit_result.execution_traces.is_empty(),
+        "no call traces should be retained at `IncludeTraces::None`"
+    );
+    assert_execution_error_stack_trace(suite, "tableRevertHasStackTrace(uint256)");
+    assert_execution_error_stack_trace(suite, "testFuzzRevertHasStackTrace(uint256)");
+}
+
+// A suite's setup arenas are consumed after the run only by results that
+// surface their traces; when none will, they are freed with the suite.
+#[tokio::test(flavor = "multi_thread")]
+async fn always_mode_frees_setup_arenas_unless_a_result_surfaces_them() {
+    for (include_traces, expect_retained) in
+        [(IncludeTraces::Failing, false), (IncludeTraces::All, true)]
+    {
+        let mut config = runner_config(None, &TEST_DATA_DEFAULT, false).await;
+        config.collect_stack_traces = CollectStackTraces::Always;
+        config.include_traces = include_traces;
+
+        let runner = TEST_DATA_DEFAULT.runner_with_fuzz_persistence(config).await;
+        let suite_results = runner.test_collect(repro_filter(3190)).await.suite_results;
+        let suite = suite_results
+            .get("default/repros/Issue3190.t.sol:Issue3190Test")
+            .expect("the Issue3190 suite should have run");
+
+        assert!(
+            suite
+                .test_results
+                .values()
+                .all(|result| result.status == TestStatus::Success),
+            "every test passes, so at `Failing` nothing surfaces the setup traces"
+        );
+        assert_eq!(
+            !suite.setup_traces.is_empty(),
+            expect_retained,
+            "setup arenas retained at {include_traces:?}"
+        );
+    }
+}
 /// One 32-byte zero hash as a hex literal.
 const ZERO_HASH: &str = "0x0000000000000000000000000000000000000000000000000000000000000000";
 

--- a/crates/edr_solidity_tests/tests/it/spec.rs
+++ b/crates/edr_solidity_tests/tests/it/spec.rs
@@ -2,9 +2,15 @@
 
 use std::collections::BTreeMap;
 
-use edr_solidity_tests::revm::primitives::hardfork::SpecId;
+use edr_solidity_tests::{
+    executors::stack_trace::SolidityTestStackTraceResult, result::TestStatus,
+    revm::primitives::hardfork::SpecId, CollectStackTraces,
+};
 
-use crate::helpers::{assert_multiple, SolidityTestFilter, TestConfig, TEST_DATA_PARIS};
+use crate::helpers::{
+    assert_multiple, contract_decoder, SolidityTestFilter, TestConfig, TEST_DATA_PARIS,
+    TEST_DATA_VIA_IR,
+};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_shanghai_compat() {
@@ -52,4 +58,49 @@ async fn test_function_override_evm_version() {
             vec![("testPush0()", true, None, None, None)],
         )]),
     );
+}
+
+// The re-run that computes a failing test's stack trace must apply the test's
+// executor overrides after `setUp()`, as the original run does: here the suite
+// runs at a hardfork with PUSH0, `setUp()` needs it, and the test's inline
+// `evmVersion` directive (in `OverrideAfterSetup.t.sol`) selects Merge (Paris),
+// which predates PUSH0.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_stack_trace_re_run_applies_overrides_after_setup() {
+    let filter = SolidityTestFilter::new(".*", ".*", ".*spec/OverrideAfterSetup.t.sol");
+    let mut config = TEST_DATA_VIA_IR.config_with_mock_rpc();
+    // Only this mode re-executes the failing test for its stack trace; with
+    // `Always` the trace would come from the original run's recorded steps.
+    config.collect_stack_traces = CollectStackTraces::OnFailure;
+
+    // A real decoder, so the re-run's trace is decoded against the test
+    // contract's sources.
+    let contract_decoder = contract_decoder(TEST_DATA_VIA_IR.build_info_path());
+    let runner = TEST_DATA_VIA_IR
+        .runner_with_contract_decoder(config, contract_decoder)
+        .await;
+    let results = runner.test_collect(filter).await.suite_results;
+    let suite = results
+        .get("via-ir/spec/OverrideAfterSetup.t.sol:OverrideAfterSetup")
+        .expect("the OverrideAfterSetup suite should have run");
+
+    // Unit and fuzz tests are re-run by different functions; both must apply
+    // the override after setup.
+    for test_name in ["testRevertsAtMerge()", "testFuzzRevertsAtMerge(uint256)"] {
+        let result = suite
+            .test_results
+            .get(test_name)
+            .unwrap_or_else(|| panic!("{test_name} should have run"));
+
+        assert_eq!(result.status, TestStatus::Failure, "{test_name}");
+        assert!(
+            matches!(
+                result.stack_trace_result,
+                Some(SolidityTestStackTraceResult::Success(_))
+            ),
+            "{test_name}: expected a stack trace, got {:?} (reason: {:?})",
+            result.stack_trace_result,
+            result.reason
+        );
+    }
 }

--- a/crates/edr_solidity_tests/tests/testdata/via-ir/spec/OverrideAfterSetup.t.sol
+++ b/crates/edr_solidity_tests/tests/testdata/via-ir/spec/OverrideAfterSetup.t.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.18;
+
+import "ds-test/test.sol";
+import "cheats/Vm.sol";
+
+// Fixture for `test_stack_trace_re_run_applies_overrides_after_setup`: the
+// suite runs at a hardfork with PUSH0, which `setUp()` executes, while the
+// failing test selects Merge (Paris), which predates PUSH0, through its
+// inline `evmVersion` directive. The re-run that computes the stack trace
+// must apply that override only after `setUp()`, as the original run does,
+// or `setUp()` fails in the re-run.
+contract OverrideAfterSetup is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+
+    function setUp() public {
+        address target = address(uint160(uint256(0xc4f3)));
+        // 5F PUSH0, 5F PUSH0, F3 RETURN: returns empty data on Shanghai and
+        // above; PUSH0 is an invalid opcode before that.
+        vm.etch(target, hex"5f5ff3");
+        (bool success, ) = target.call("");
+        require(success, "PUSH0 unsupported");
+    }
+
+    /// forge-config: default.evmVersion = "Merge"
+    function testRevertsAtMerge() public pure {
+        require(false, "boom");
+    }
+
+    // The fuzz counterpart, so the fuzz counterexample re-run is covered too.
+    /// forge-config: default.evmVersion = "Merge"
+    function testFuzzRevertsAtMerge(uint256) public pure {
+        require(false, "boom");
+    }
+}

--- a/crates/foundry/evm/evm/src/executors/invariant/replay.rs
+++ b/crates/foundry/evm/evm/src/executors/invariant/replay.rs
@@ -21,7 +21,7 @@ use foundry_evm_fuzz::{
     invariant::{BasicTxDetails, InvariantContract},
     BaseCounterExample,
 };
-use foundry_evm_traces::{load_contracts, ExecutionTraces, SetupTraces, TracingMode};
+use foundry_evm_traces::{load_contracts, ExecutionTraces, TracingMode};
 use parking_lot::RwLock;
 use proptest::test_runner::TestError;
 use revm::{
@@ -65,7 +65,9 @@ pub struct ReplayRunArgs<
     pub known_contracts: &'a ContractsByArtifact,
     pub ided_contracts: ContractsByAddress,
     pub logs: &'a mut Vec<Log>,
-    pub setup_traces: &'a SetupTraces,
+    /// The code of contracts deployed during setup, for stack-trace
+    /// decoding. Only consulted when `generate_stack_trace` is true.
+    pub deployed_code: DeployedCode<'a>,
     pub line_coverage: &'a mut Option<HitMaps>,
     pub deprecated_cheatcodes: &'a mut HashMap<&'static str, Option<&'static str>>,
     pub inputs: &'a [BasicTxDetails],
@@ -126,7 +128,7 @@ pub fn replay_run<
         known_contracts,
         mut ided_contracts,
         logs,
-        setup_traces,
+        deployed_code,
         line_coverage: coverage,
         deprecated_cheatcodes,
         inputs,
@@ -206,11 +208,8 @@ pub fn replay_run<
                     get_stack_trace(
                         decoder,
                         &failing_trace.arena,
-                        setup_traces
-                            .iter()
-                            .map(|(_, arena)| &arena.arena)
-                            .chain(prior_traces.iter().map(|arena| &arena.arena)),
-                        DeployedCode::default(),
+                        prior_traces.iter().map(|arena| &arena.arena),
+                        deployed_code,
                     )
                     .map_err(SolidityTestStackTraceError::from)
                     .into()
@@ -294,11 +293,8 @@ pub fn replay_run<
                             get_stack_trace(
                                 decoder,
                                 &failing_trace.arena,
-                                setup_traces
-                                    .iter()
-                                    .map(|(_, arena)| &arena.arena)
-                                    .chain(prior_traces.iter().map(|arena| &arena.arena)),
-                                DeployedCode::default(),
+                                prior_traces.iter().map(|arena| &arena.arena),
+                                deployed_code,
                             )
                             .map_err(SolidityTestStackTraceError::from)
                             .into()
@@ -346,7 +342,8 @@ pub struct ReplayErrorArgs<
     pub known_contracts: &'a ContractsByArtifact,
     pub ided_contracts: ContractsByAddress,
     pub logs: &'a mut Vec<Log>,
-    pub setup_traces: &'a SetupTraces,
+    /// See [`ReplayRunArgs::deployed_code`].
+    pub deployed_code: DeployedCode<'a>,
     pub coverage: &'a mut Option<HitMaps>,
     pub deprecated_cheatcodes: &'a mut HashMap<&'static str, Option<&'static str>>,
     pub generate_stack_trace: bool,
@@ -390,7 +387,7 @@ pub fn replay_error<
         known_contracts,
         ided_contracts,
         logs,
-        setup_traces,
+        deployed_code,
         coverage,
         deprecated_cheatcodes,
         generate_stack_trace,
@@ -422,7 +419,7 @@ pub fn replay_error<
                 known_contracts,
                 ided_contracts,
                 logs,
-                setup_traces,
+                deployed_code,
                 line_coverage: coverage,
                 deprecated_cheatcodes,
                 inputs: &calls,


### PR DESCRIPTION
## Problem / context

Stack-trace decoding only needs the setup arenas for the creation and runtime code of the contracts deployed during setup. To keep that available, the suite retained the arenas themselves for its whole lifetime, and every failing test re-walked them as code sources.

## Solution

Capture the code into `DeployedCodeMaps` as the setup traces are recorded, and use it everywhere the setup arenas were previously walked: `collect_stack_trace` seeds `get_stack_trace` with the map, and the invariant replay paths take a `DeployedCode` instead of borrowing the setup traces. Both the map and `get_stack_trace` derive the code from the same `created_contracts` walk, so they cannot drift apart. The conversion looks contract code up through a layered `CodeMap`, so the pre-computed base stays borrowed instead of being copied into a fresh lookup table for every failing test.

With the arenas' last in-run consumer gone, a suite frees its setup arenas before running its tests when nothing could surface them afterwards, and at suite end when nothing did. The failure re-runs keep tracing setup `WithoutSteps` to rebuild the mapping for their own executor. They also now apply a test's inline `isolate`/`evmVersion` directives after setup, as `FunctionRunner::run` does, rather than before it. A directive selecting an older EVM version could otherwise make a `setUp()` that had succeeded fail in the re-run, and `isolate` could shift the re-run's deployments away from the original run's.

## Validation

- New regression tests cover the untraced-setup path, the freeing of setup arenas that no result surfaces, and the override ordering: a suite whose `setUp()` calls an etched stub that executes PUSH0, with the failing tests' directive selecting Merge (`OverrideAfterSetup.t.sol`).
- Measured on top of #1707: within run-to-run noise everywhere. The benchmark repos cannot show the saving — at `-vvvv` the arenas are retained for call traces anyway, and at `-vvv` no benchmark test fails. What it saves is one step-free set of setup arenas per suite whenever no result surfaces them.
- `cargo clippy --workspace --all-targets -- -D warnings` and the `edr_solidity_tests` integration suite (135 tests) pass.

## Notes for reviewer

- Stacked on #1707; part of the Solidity test runner memory-reduction series.
- `NestedTrace::from_call_trace_arena` now takes `&CodeMap` instead of `&HashMap<Address, &Bytes>`; that is a Rust-level API change in `edr_solidity` only, not a napi change.
- The override-ordering fix is folded in rather than split out, so this commit is self-contained for the re-run executor it introduces.
