### PR TITLE
refactor: drop the never-consumed `BaseCounterExample::traces`

### DIFF
--- a/crates/edr_solidity_tests/src/result.rs
+++ b/crates/edr_solidity_tests/src/result.rs
@@ -387,9 +387,6 @@ pub struct TestResult<HaltReasonT> {
     pub reason: Option<String>,
 
     /// Minimal reproduction test case for failing test.
-    ///
-    /// Its trace arenas are freed once the test has finished — nothing
-    /// consumes them.
     pub counterexample: Option<CounterExample>,
 
     /// Any captured & parsed as strings logs along the test's execution which
@@ -524,13 +521,14 @@ impl<HaltReasonT> From<TestResult<HaltReasonT>> for TestRunOutcome<HaltReasonT> 
 }
 
 impl<HaltReasonT> TestResult<HaltReasonT> {
-    /// Frees every trace arena that no longer has a consumer, as decided by
-    /// `policy`, and strips the recorded EVM steps from the arenas it keeps.
+    /// Frees the execution traces when they no longer have a consumer, as
+    /// decided by `policy`, and strips the recorded EVM steps from arenas it
+    /// keeps.
     pub(crate) fn free_unconsumed_traces(&mut self, policy: TraceRetentionPolicy) {
         let Self {
             status,
             reason: _,
-            counterexample,
+            counterexample: _,
             logs: _,
             decoded_logs: _,
             kind: _,
@@ -550,17 +548,6 @@ impl<HaltReasonT> TestResult<HaltReasonT> {
             Retain::CallsOnly => {
                 execution_traces.strip_steps();
             }
-        }
-
-        // Counterexample arenas have no consumer at all once the test has
-        // finished: they are neither decoded nor exposed over napi.
-        let counterexamples: &mut [BaseCounterExample] = match counterexample {
-            Some(CounterExample::Single(counterexample)) => std::slice::from_mut(counterexample),
-            Some(CounterExample::Sequence(_, counterexamples)) => counterexamples,
-            None => &mut [],
-        };
-        for counterexample in counterexamples {
-            counterexample.traces = None;
         }
     }
 

--- a/crates/edr_solidity_tests/src/runner.rs
+++ b/crates/edr_solidity_tests/src/runner.rs
@@ -1143,9 +1143,6 @@ impl<
                                 .expect("args have valid abi encoding"),
                         ),
                         &args,
-                        // Counterexample arenas are never consumed; the
-                        // failing arena lives on in `execution_traces`.
-                        None,
                         raw_call_result.indeterminism_reasons.clone(),
                     )));
                 let elapsed = start.elapsed();

--- a/crates/edr_solidity_tests/src/trace_retention.rs
+++ b/crates/edr_solidity_tests/src/trace_retention.rs
@@ -107,15 +107,12 @@ impl TraceRetentionPolicy {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{map::HashMap, Bytes};
+    use alloy_primitives::map::HashMap;
     use edr_chain_spec::EvmHaltReason;
     use foundry_evm::traces::{CallTraceArena, SparsedTraceArena};
 
     use super::*;
-    use crate::{
-        fuzz::{BaseCounterExample, CounterExample},
-        result::TestResult,
-    };
+    use crate::result::TestResult;
 
     #[test]
     fn retains_arenas_only_for_results_that_surface_call_traces() {
@@ -155,33 +152,27 @@ mod tests {
     }
 
     #[test]
-    fn frees_counterexample_arenas_without_consumers() {
+    fn frees_or_strips_execution_traces_per_policy() {
         let arena = || SparsedTraceArena {
             arena: CallTraceArena::default(),
             ignored: HashMap::default(),
         };
-        let counterexample =
-            || BaseCounterExample::from_fuzz_call(Bytes::new(), &[], Some(arena()), None);
 
-        let mut result = TestResult::<EvmHaltReason> {
+        // `All` keeps the call traces.
+        let mut kept = TestResult::<EvmHaltReason> {
             execution_traces: [arena()].into_iter().collect(),
-            counterexample: Some(CounterExample::Sequence(
-                2,
-                vec![counterexample(), counterexample()],
-            )),
             ..TestResult::default()
         };
+        kept.free_unconsumed_traces(TraceRetentionPolicy::new(IncludeTraces::All, false));
+        assert_eq!(kept.execution_traces.len(), 1);
 
-        // `All` keeps the call traces, but the counterexample arenas have no
-        // consumer.
-        result.free_unconsumed_traces(TraceRetentionPolicy::new(IncludeTraces::All, false));
-
-        assert_eq!(result.execution_traces.len(), 1);
-        let Some(CounterExample::Sequence(_, counterexamples)) = &result.counterexample else {
-            panic!("counterexample kind changed");
+        // `Failing` frees a passing test's call traces.
+        let mut freed = TestResult::<EvmHaltReason> {
+            status: TestStatus::Success,
+            execution_traces: [arena()].into_iter().collect(),
+            ..TestResult::default()
         };
-        assert!(counterexamples
-            .iter()
-            .all(|counterexample| counterexample.traces.is_none()));
+        freed.free_unconsumed_traces(TraceRetentionPolicy::new(IncludeTraces::Failing, false));
+        assert!(freed.execution_traces.is_empty());
     }
 }

--- a/crates/foundry/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/foundry/evm/evm/src/executors/fuzz/mod.rs
@@ -272,9 +272,9 @@ impl<
         let last_run_traces = if run_result.is_ok() {
             traces.pop()
         } else {
-            // Nothing reads `BaseCounterExample::traces`, so the failing
-            // arena can move into `FuzzTestResult::traces` rather than be
-            // cloned for both.
+            // The failing run's arena never reaches `traces`: it is held by
+            // the counterexample's call result, so that is where the failing
+            // trace comes from.
             call.traces
         };
 
@@ -325,8 +325,6 @@ impl<
                         Some(CounterExample::Single(BaseCounterExample::from_fuzz_call(
                             calldata,
                             &args,
-                            // Nothing consumes counterexample arenas; see above.
-                            None,
                             call.indeterminism_reasons,
                         )));
                 }

--- a/crates/foundry/evm/evm/src/executors/invariant/replay.rs
+++ b/crates/foundry/evm/evm/src/executors/invariant/replay.rs
@@ -180,10 +180,7 @@ pub fn replay_run<
             tx.call_details.target,
             &tx.call_details.calldata,
             &ided_contracts,
-            // Counterexample arenas are never consumed; the failing arena
-            // lives on in `execution_traces`.
-            None,
-            /* indeterminism_reason */ None,
+            /* indeterminism_reasons */ None,
         ));
 
         // If this call failed, but didn't revert, this is terminal for sure.

--- a/crates/foundry/evm/fuzz/src/lib.rs
+++ b/crates/foundry/evm/fuzz/src/lib.rs
@@ -63,9 +63,6 @@ pub struct BaseCounterExample {
     pub args: Option<String>,
     /// Unformatted args used to call the function.
     pub raw_args: Option<String>,
-    /// Counter example traces.
-    #[serde(skip)]
-    pub traces: Option<SparsedTraceArena>,
     /// If re-executing the counter example is not guaranteed to yield the same
     /// results, this field contains the reason why.
     pub indeterminism_reasons: Option<IndeterminismReasons>,
@@ -79,7 +76,6 @@ impl BaseCounterExample {
         addr: Address,
         bytes: &Bytes,
         contracts: &ContractsByAddress,
-        traces: Option<SparsedTraceArena>,
         indeterminism_reasons: Option<IndeterminismReasons>,
     ) -> Self {
         if let Some((name, abi)) = &contracts.get(&addr) {
@@ -109,7 +105,6 @@ impl BaseCounterExample {
                                 .format(", ")
                                 .to_string(),
                         ),
-                        traces,
                         indeterminism_reasons,
                     };
                 }
@@ -125,7 +120,6 @@ impl BaseCounterExample {
             signature: None,
             args: None,
             raw_args: None,
-            traces,
             indeterminism_reasons,
         }
     }
@@ -134,7 +128,6 @@ impl BaseCounterExample {
     pub fn from_fuzz_call(
         bytes: Bytes,
         args: &[DynSolValue],
-        traces: Option<SparsedTraceArena>,
         indeterminism_reasons: Option<IndeterminismReasons>,
     ) -> Self {
         Self {
@@ -154,7 +147,6 @@ impl BaseCounterExample {
                     .format(", ")
                     .to_string(),
             ),
-            traces,
             indeterminism_reasons,
         }
     }


### PR DESCRIPTION
## Problem / context

`BaseCounterExample::traces` has been dead weight since #1702: every caller passes `None` and nothing ever reads the field. It is `#[serde(skip)]`, so persisted invariant failures don't carry it, and the napi conversion doesn't expose it.

## Solution

Remove the field and the constructor parameters, along with the retention loop in `TestResult::free_unconsumed_traces` that nulled a field that was already `None`. "Counterexample arenas are never consumed" is now a fact of the type rather than a post-hoc clear.

## Validation

- `cargo clippy --workspace --all-targets -- -D warnings` and the `edr_solidity_tests` integration suite (135 tests) pass.
- No serialized format changes: the field was `#[serde(skip)]`.

## Notes for reviewer

- Stacked on #1708; part of the Solidity test runner memory-reduction series.
- Pure removal; no behavior change.
