### PR TITLE
fix: keep the stack trace of a reverting `afterInvariant()`

### DIFF
--- a/.changeset/after-invariant-stack-trace.md
+++ b/.changeset/after-invariant-stack-trace.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Fixed the missing stack trace for an invariant test whose `afterInvariant()` reverts. The replay used to look for the revert reason in the passing `invariant()` call, so the runner discarded the failure's stack trace as unreproducible.

--- a/crates/edr_solidity_tests/src/runner.rs
+++ b/crates/edr_solidity_tests/src/runner.rs
@@ -1392,10 +1392,18 @@ impl<
                             }
 
                             // If we can't get a revert reason for the second time, we couldn't
-                            // replay the failure, so keep the original revert reason
-                            // and discard the stack trace as it may be misleading.
+                            // replay the failure, so keep the original revert reason.
                             if reason.is_some() && revert_reason.is_none() {
-                                tracing::warn!(?invariant_contract.invariant_function, "Failed to compute stack trace");
+                                if matches!(
+                                    &stack_trace_result,
+                                    Some(SolidityTestStackTraceResult::UnsafeToReplay { .. })
+                                ) {
+                                    // Indeterminism explains a failure that did not reproduce
+                                    self.result.stack_trace_result = stack_trace_result;
+                                } else {
+                                    // Discard the stack trace as it may be misleading.
+                                    tracing::warn!(?invariant_contract.invariant_function, "Failed to compute stack trace");
+                                }
                             } else {
                                 self.result.stack_trace_result = stack_trace_result;
                                 self.result.reason = revert_reason;

--- a/crates/edr_solidity_tests/tests/it/repros.rs
+++ b/crates/edr_solidity_tests/tests/it/repros.rs
@@ -779,6 +779,29 @@ async fn always_mode_produces_stack_trace_for_failing_test() {
         "expected UnsafeToReplay naming envOr, got {impure_stack_trace:?}"
     );
 
+    // The mirror case: the impure cheatcode runs in the passing `invariant()`
+    // and `afterInvariant()` reverts without one. `afterInvariant()` only ran
+    // because `invariant()` passed, so this failure is unsafe to replay too.
+    let impure_invariant_suite = suite_results
+        .get("via-ir/repros/StackTraceAlwaysMode.t.sol:AlwaysStackTraceImpureInvariantTest")
+        .expect("the AlwaysStackTraceImpureInvariant suite should have run");
+    let impure_invariant_result = impure_invariant_suite
+        .test_results
+        .get("invariantAlwaysHolds()")
+        .expect("the impure invariant test should have run");
+    let impure_invariant_stack_trace = impure_invariant_result
+        .stack_trace_result
+        .as_ref()
+        .expect("a stack trace result should be present");
+    assert!(
+        matches!(
+            impure_invariant_stack_trace,
+            SolidityTestStackTraceResult::UnsafeToReplay { impure_cheatcodes, .. }
+                if impure_cheatcodes.iter().any(|sig| sig.contains("envOr"))
+        ),
+        "expected UnsafeToReplay naming envOr, got {impure_invariant_stack_trace:?}"
+    );
+
     // An invariant that is already broken in the initial state fails the
     // campaign's initial check (`invariant_fuzz` returns an error before any
     // fuzzed calls); that path must produce a stack trace too.

--- a/crates/edr_solidity_tests/tests/it/repros.rs
+++ b/crates/edr_solidity_tests/tests/it/repros.rs
@@ -756,6 +756,29 @@ async fn always_mode_produces_stack_trace_for_failing_test() {
     // counterexample sequence; the stack trace alone is the point here.
     assert_execution_error_stack_trace(after_invariant_suite, "invariantAlwaysHolds()");
 
+    // An impure cheatcode inside `afterInvariant()` taints the replay, so the
+    // result must say the failure is unsafe to replay rather than carry a
+    // stack trace computed from an indeterministic re-execution.
+    let impure_suite = suite_results
+        .get("via-ir/repros/StackTraceAlwaysMode.t.sol:AlwaysStackTraceImpureAfterInvariantTest")
+        .expect("the AlwaysStackTraceImpureAfterInvariant suite should have run");
+    let impure_result = impure_suite
+        .test_results
+        .get("invariantAlwaysHolds()")
+        .expect("the impure afterInvariant invariant test should have run");
+    let impure_stack_trace = impure_result
+        .stack_trace_result
+        .as_ref()
+        .expect("a stack trace result should be present");
+    assert!(
+        matches!(
+            impure_stack_trace,
+            SolidityTestStackTraceResult::UnsafeToReplay { impure_cheatcodes, .. }
+                if impure_cheatcodes.iter().any(|sig| sig.contains("envOr"))
+        ),
+        "expected UnsafeToReplay naming envOr, got {impure_stack_trace:?}"
+    );
+
     // An invariant that is already broken in the initial state fails the
     // campaign's initial check (`invariant_fuzz` returns an error before any
     // fuzzed calls); that path must produce a stack trace too.

--- a/crates/edr_solidity_tests/tests/it/repros.rs
+++ b/crates/edr_solidity_tests/tests/it/repros.rs
@@ -835,6 +835,39 @@ async fn always_mode_produces_stack_trace_for_failing_test() {
         "expected UnsafeToReplay naming envOr, got {flaky_stack_trace:?}"
     );
 
+    // A replay that fails in a different phase than the campaign did: the
+    // campaign failed in `invariant()`, while the replay reaches the
+    // always-reverting `afterInvariant()`. That unrelated revert must not
+    // replace the original reason, and the divergence must be reported as
+    // unsafe to replay.
+    let cross_phase_suite = suite_results
+        .get("via-ir/repros/StackTraceAlwaysMode.t.sol:AlwaysStackTraceCrossPhaseTest")
+        .expect("the AlwaysStackTraceCrossPhase suite should have run");
+    let cross_phase_result = cross_phase_suite
+        .test_results
+        .get("invariantFlaky()")
+        .expect("the cross-phase invariant test should have run");
+    assert!(
+        cross_phase_result
+            .reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("flaky invariant")),
+        "expected the original revert reason to be kept, got {:?}",
+        cross_phase_result.reason
+    );
+    let cross_phase_stack_trace = cross_phase_result
+        .stack_trace_result
+        .as_ref()
+        .expect("a stack trace result should be present");
+    assert!(
+        matches!(
+            cross_phase_stack_trace,
+            SolidityTestStackTraceResult::UnsafeToReplay { impure_cheatcodes, .. }
+                if impure_cheatcodes.iter().any(|sig| sig.contains("envOr"))
+        ),
+        "expected UnsafeToReplay naming envOr, got {cross_phase_stack_trace:?}"
+    );
+
     // An invariant that is already broken in the initial state fails the
     // campaign's initial check (`invariant_fuzz` returns an error before any
     // fuzzed calls); that path must produce a stack trace too.

--- a/crates/edr_solidity_tests/tests/it/repros.rs
+++ b/crates/edr_solidity_tests/tests/it/repros.rs
@@ -802,6 +802,39 @@ async fn always_mode_produces_stack_trace_for_failing_test() {
         "expected UnsafeToReplay naming envOr, got {impure_invariant_stack_trace:?}"
     );
 
+    // A failure that does not reproduce on replay: `afterInvariant()` reverts
+    // only on its first execution (see the fixture). The replay observes the
+    // impure `envOr` read that explains the divergence, so the result must be
+    // `UnsafeToReplay` and keep the original revert reason. It must not be
+    // discarded with the "no revert reason on replay" heuristic.
+    let flaky_suite = suite_results
+        .get("via-ir/repros/StackTraceAlwaysMode.t.sol:AlwaysStackTraceFlakyAfterInvariantTest")
+        .expect("the AlwaysStackTraceFlakyAfterInvariant suite should have run");
+    let flaky_result = flaky_suite
+        .test_results
+        .get("invariantAlwaysHolds()")
+        .expect("the flaky afterInvariant invariant test should have run");
+    assert!(
+        flaky_result
+            .reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("flaky boom")),
+        "expected the original revert reason to be kept, got {:?}",
+        flaky_result.reason
+    );
+    let flaky_stack_trace = flaky_result
+        .stack_trace_result
+        .as_ref()
+        .expect("a stack trace result should be present");
+    assert!(
+        matches!(
+            flaky_stack_trace,
+            SolidityTestStackTraceResult::UnsafeToReplay { impure_cheatcodes, .. }
+                if impure_cheatcodes.iter().any(|sig| sig.contains("envOr"))
+        ),
+        "expected UnsafeToReplay naming envOr, got {flaky_stack_trace:?}"
+    );
+
     // An invariant that is already broken in the initial state fails the
     // campaign's initial check (`invariant_fuzz` returns an error before any
     // fuzzed calls); that path must produce a stack trace too.

--- a/crates/edr_solidity_tests/tests/it/repros.rs
+++ b/crates/edr_solidity_tests/tests/it/repros.rs
@@ -745,6 +745,17 @@ async fn always_mode_produces_stack_trace_for_failing_test() {
         "expected a counterexample call sequence"
     );
 
+    // When `afterInvariant()` is what fails, the replay must decode the
+    // revert reason from it rather than from the (passing) `invariant()`
+    // call, or the runner treats the failure as unreproduced and discards
+    // the stack trace it computed.
+    let after_invariant_suite = suite_results
+        .get("via-ir/repros/StackTraceAlwaysMode.t.sol:AlwaysStackTraceAfterInvariantTest")
+        .expect("the AlwaysStackTraceAfterInvariant suite should have run");
+    // The failure does not depend on the fuzzed calls, so shrinking leaves no
+    // counterexample sequence; the stack trace alone is the point here.
+    assert_execution_error_stack_trace(after_invariant_suite, "invariantAlwaysHolds()");
+
     // An invariant that is already broken in the initial state fails the
     // campaign's initial check (`invariant_fuzz` returns an error before any
     // fuzzed calls); that path must produce a stack trace too.

--- a/crates/edr_solidity_tests/tests/testdata/via-ir/repros/StackTraceAlwaysMode.t.sol
+++ b/crates/edr_solidity_tests/tests/testdata/via-ir/repros/StackTraceAlwaysMode.t.sol
@@ -162,3 +162,27 @@ contract AlwaysStackTraceImpureAfterInvariantTest is DSTest {
         reverter.boom();
     }
 }
+
+// Covers the indeterministic `invariant()` before a failing
+// `afterInvariant()`: the impure `envOr` call makes it uncertain that
+// `invariant()` passes again on a re-execution. `afterInvariant()` only ran
+// because it passed, so the failure must be reported as unsafe to replay.
+contract AlwaysStackTraceImpureInvariantTest is DSTest {
+    Vm constant vm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+
+    Counter counter;
+    Reverter reverter;
+
+    function setUp() public {
+        counter = new Counter();
+        reverter = new Reverter();
+    }
+
+    function invariantAlwaysHolds() public view {
+        vm.envOr("EDR_NONEXISTENT_ENV_VAR", uint256(0));
+    }
+
+    function afterInvariant() public view {
+        reverter.boom();
+    }
+}

--- a/crates/edr_solidity_tests/tests/testdata/via-ir/repros/StackTraceAlwaysMode.t.sol
+++ b/crates/edr_solidity_tests/tests/testdata/via-ir/repros/StackTraceAlwaysMode.t.sol
@@ -213,3 +213,41 @@ contract AlwaysStackTraceFlakyAfterInvariantTest is DSTest {
         require(seen == 1, "flaky boom");
     }
 }
+
+// Covers a replay failure in a different phase than the campaign's. The
+// campaign fails in `invariant()` the first time it observes a fuzzed call,
+// so its failure phase is `invariant()`. Every later execution passes, so
+// the replay's `invariant()` succeeds and the always-reverting
+// `afterInvariant()` runs. That revert is not the campaign's failure. The
+// result must keep the original reason and report the replay as unsafe
+// instead of adopting the unrelated revert.
+contract AlwaysStackTraceCrossPhaseTest is DSTest {
+    Vm constant vm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+
+    Counter counter;
+    Reverter reverter;
+
+    function setUp() public {
+        counter = new Counter();
+        reverter = new Reverter();
+        // Overwrite whatever value the process environment holds, so a prior
+        // campaign in this process or a caller-set variable cannot change
+        // which execution reverts below.
+        vm.setEnv("EDR_CROSS_PHASE_INVARIANT", "0");
+    }
+
+    // Passes while no fuzzed call has run. The first execution that observes
+    // one reverts and arms the variable, so every later execution — shrinking
+    // and the replay — passes again.
+    function invariantFlaky() public {
+        uint256 seen = vm.envOr("EDR_CROSS_PHASE_INVARIANT", uint256(0));
+        if (counter.count() > 0) {
+            vm.setEnv("EDR_CROSS_PHASE_INVARIANT", "1");
+            require(seen == 1, "flaky invariant");
+        }
+    }
+
+    function afterInvariant() public view {
+        reverter.boom();
+    }
+}

--- a/crates/edr_solidity_tests/tests/testdata/via-ir/repros/StackTraceAlwaysMode.t.sol
+++ b/crates/edr_solidity_tests/tests/testdata/via-ir/repros/StackTraceAlwaysMode.t.sol
@@ -140,3 +140,25 @@ contract Rejecter {
         vm.assume(false);
     }
 }
+
+// Covers the indeterministic `afterInvariant()` replay: the impure `envOr`
+// call taints the re-execution, so the failure must be reported as unsafe
+// to replay instead of with a concrete stack trace.
+contract AlwaysStackTraceImpureAfterInvariantTest is DSTest {
+    Vm constant vm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+
+    Counter counter;
+    Reverter reverter;
+
+    function setUp() public {
+        counter = new Counter();
+        reverter = new Reverter();
+    }
+
+    function invariantAlwaysHolds() public view {}
+
+    function afterInvariant() public view {
+        vm.envOr("EDR_NONEXISTENT_ENV_VAR", uint256(0));
+        reverter.boom();
+    }
+}

--- a/crates/edr_solidity_tests/tests/testdata/via-ir/repros/StackTraceAlwaysMode.t.sol
+++ b/crates/edr_solidity_tests/tests/testdata/via-ir/repros/StackTraceAlwaysMode.t.sol
@@ -64,6 +64,27 @@ contract Counter {
     }
 }
 
+// Covers the `afterInvariant()` stack-trace path: the invariant holds, so
+// the campaign only fails once `afterInvariant()` reverts, and on replay
+// both the fuzzed sequence and `invariant()` succeed — leaving the revert
+// reason of the reproduced failure only in `afterInvariant()`'s result.
+// `Counter` gives the campaign a fuzzable target.
+contract AlwaysStackTraceAfterInvariantTest is DSTest {
+    Counter counter;
+    Reverter reverter;
+
+    function setUp() public {
+        counter = new Counter();
+        reverter = new Reverter();
+    }
+
+    function invariantAlwaysHolds() public view {}
+
+    function afterInvariant() public view {
+        reverter.boom();
+    }
+}
+
 // Covers the failing-`setUp()` stack-trace path (issue #1605). The suite
 // needs at least one test function, or `run_tests` skips setup entirely.
 contract AlwaysStackTraceFailingSetupTest is DSTest {

--- a/crates/edr_solidity_tests/tests/testdata/via-ir/repros/StackTraceAlwaysMode.t.sol
+++ b/crates/edr_solidity_tests/tests/testdata/via-ir/repros/StackTraceAlwaysMode.t.sol
@@ -186,3 +186,30 @@ contract AlwaysStackTraceImpureInvariantTest is DSTest {
         reverter.boom();
     }
 }
+
+// Covers the `afterInvariant()` failure that does not reproduce on replay.
+// The first execution reads an unset variable and reverts; the same call sets
+// the variable, so every later execution passes. The campaign therefore
+// fails, while the replay succeeds. Only the impure `envOr` read explains
+// the divergence, so the failure must be reported as unsafe to replay.
+contract AlwaysStackTraceFlakyAfterInvariantTest is DSTest {
+    Vm constant vm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+
+    Counter counter;
+
+    function setUp() public {
+        counter = new Counter();
+        // Overwrite whatever value the process environment holds, so a prior
+        // campaign in this process or a caller-set variable cannot mask the
+        // first-call revert below.
+        vm.setEnv("EDR_FLAKY_AFTER_INVARIANT", "0");
+    }
+
+    function invariantAlwaysHolds() public view {}
+
+    function afterInvariant() public {
+        uint256 seen = vm.envOr("EDR_FLAKY_AFTER_INVARIANT", uint256(0));
+        vm.setEnv("EDR_FLAKY_AFTER_INVARIANT", "1");
+        require(seen == 1, "flaky boom");
+    }
+}

--- a/crates/foundry/evm/evm/src/executors/invariant/replay.rs
+++ b/crates/foundry/evm/evm/src/executors/invariant/replay.rs
@@ -112,12 +112,11 @@ pub fn replay_run<
         ChainContextT,
     >,
 ) -> Result<ReplayResult<HaltReasonT>> {
-    /// What a reverting call returned. The revert reason and the
-    /// replay-safety verdict are decoded from these fields.
+    /// What a reverting call returned. The revert reason is decoded from
+    /// these fields.
     struct Failure {
         output: Bytes,
         exit_reason: Option<InstructionResult>,
-        indeterminism_reasons: Option<IndeterminismReasons>,
     }
 
     let ReplayRunArgs {
@@ -244,47 +243,47 @@ pub fn replay_run<
     // what failed, the revert reason must be decoded from it rather than from
     // the passing `invariant()` call.
     let mut after_invariant_failure: Option<Failure> = None;
+    let mut after_invariant_indeterminism: Option<IndeterminismReasons> = None;
     if invariant_contract.call_after_invariant && invariant_success {
         let CallAfterInvariantResult {
             call_result: after_invariant_result,
             success: after_invariant_success,
         } = call_after_invariant_function(&executor, invariant_contract.address)?;
         execution_traces.push(after_invariant_result.traces.clone().unwrap());
+        after_invariant_indeterminism = after_invariant_result.indeterminism_reasons;
         if !after_invariant_success {
             after_invariant_failure = Some(Failure {
                 output: after_invariant_result.result,
                 exit_reason: after_invariant_result.exit_reason,
-                indeterminism_reasons: after_invariant_result.indeterminism_reasons,
             });
         }
         logs.extend(after_invariant_result.logs);
     }
 
+    // Replay safety covers every call the replay executed, whichever one
+    // failed. The sequence's persisted impurity is included in both tail
+    // results. `invariant()` and `afterInvariant()` run on copy-on-write
+    // backends, so each result only carries its own impurity and the two
+    // must be merged. A failure that did not reproduce can also be explained
+    // by impurity observed anywhere in the replay.
+    let indeterminism_reasons = match (
+        invariant_result.indeterminism_reasons,
+        after_invariant_indeterminism,
+    ) {
+        (Some(mut reasons), other) => {
+            reasons.merge(other);
+            Some(reasons)
+        }
+        (None, other) => other,
+    };
+
     let Failure {
         output: failing_output,
         exit_reason: failing_exit_reason,
-        indeterminism_reasons,
-    } = match after_invariant_failure {
-        // `invariant()` executed on a copy-on-write backend, so its own
-        // indeterminism never reaches `afterInvariant()`'s call result.
-        // `afterInvariant()` only ran because `invariant()` passed, so that
-        // indeterminism taints this failure too and must be merged in.
-        Some(mut failure) => {
-            failure.indeterminism_reasons = match failure.indeterminism_reasons {
-                Some(mut reasons) => {
-                    reasons.merge(invariant_result.indeterminism_reasons);
-                    Some(reasons)
-                }
-                None => invariant_result.indeterminism_reasons,
-            };
-            failure
-        }
-        None => Failure {
-            output: invariant_result.result,
-            exit_reason: invariant_result.exit_reason,
-            indeterminism_reasons: invariant_result.indeterminism_reasons,
-        },
-    };
+    } = after_invariant_failure.unwrap_or_else(|| Failure {
+        output: invariant_result.result,
+        exit_reason: invariant_result.exit_reason,
+    });
 
     let stack_trace_result: Option<SolidityTestStackTraceResult<HaltReasonT>> =
         generate_stack_trace

--- a/crates/foundry/evm/evm/src/executors/invariant/replay.rs
+++ b/crates/foundry/evm/evm/src/executors/invariant/replay.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use alloy_dyn_abi::JsonAbiExt;
-use alloy_primitives::Log;
+use alloy_primitives::{Bytes, Log};
 use derive_where::derive_where;
 use edr_decoder_revert::RevertDecoder;
 use edr_solidity::{
@@ -111,6 +111,13 @@ pub fn replay_run<
         ChainContextT,
     >,
 ) -> Result<ReplayResult<HaltReasonT>> {
+    /// What a reverting call returned. The revert reason is decoded from
+    /// these fields.
+    struct Failure {
+        output: Bytes,
+        exit_reason: Option<InstructionResult>,
+    }
+
     let ReplayRunArgs {
         execution_traces,
         mut executor,
@@ -231,13 +238,22 @@ pub fn replay_run<
             .map_or_else(Default::default, |cheats| cheats.deprecated.clone()),
     );
 
-    // Collect after invariant logs and traces.
+    // Collect after invariant logs and traces. When `afterInvariant()` is
+    // what failed, the revert reason must be decoded from it rather than from
+    // the passing `invariant()` call.
+    let mut after_invariant_failure: Option<Failure> = None;
     if invariant_contract.call_after_invariant && invariant_success {
         let CallAfterInvariantResult {
             call_result: after_invariant_result,
-            success: _,
+            success: after_invariant_success,
         } = call_after_invariant_function(&executor, invariant_contract.address)?;
         execution_traces.push(after_invariant_result.traces.clone().unwrap());
+        if !after_invariant_success {
+            after_invariant_failure = Some(Failure {
+                output: after_invariant_result.result,
+                exit_reason: after_invariant_result.exit_reason,
+            });
+        }
         logs.extend(after_invariant_result.logs);
     }
 
@@ -269,10 +285,14 @@ pub fn replay_run<
             })
             .flatten();
 
-    let revert_reason = revert_decoder.maybe_decode(
-        invariant_result.result.as_ref(),
-        invariant_result.exit_reason,
-    );
+    let (failing_output, failing_exit_reason) = match &after_invariant_failure {
+        Some(Failure {
+            output,
+            exit_reason,
+        }) => (output, *exit_reason),
+        None => (&invariant_result.result, invariant_result.exit_reason),
+    };
+    let revert_reason = revert_decoder.maybe_decode(failing_output.as_ref(), failing_exit_reason);
 
     Ok(ReplayResult {
         counterexample_sequence,

--- a/crates/foundry/evm/evm/src/executors/invariant/replay.rs
+++ b/crates/foundry/evm/evm/src/executors/invariant/replay.rs
@@ -260,17 +260,31 @@ pub fn replay_run<
         logs.extend(after_invariant_result.logs);
     }
 
-    // The backend accumulates indeterminism across calls, so the failing
-    // call's reasons include everything the replay executed before it.
     let Failure {
         output: failing_output,
         exit_reason: failing_exit_reason,
         indeterminism_reasons,
-    } = after_invariant_failure.unwrap_or_else(|| Failure {
-        output: invariant_result.result,
-        exit_reason: invariant_result.exit_reason,
-        indeterminism_reasons: invariant_result.indeterminism_reasons,
-    });
+    } = match after_invariant_failure {
+        // `invariant()` executed on a copy-on-write backend, so its own
+        // indeterminism never reaches `afterInvariant()`'s call result.
+        // `afterInvariant()` only ran because `invariant()` passed, so that
+        // indeterminism taints this failure too and must be merged in.
+        Some(mut failure) => {
+            failure.indeterminism_reasons = match failure.indeterminism_reasons {
+                Some(mut reasons) => {
+                    reasons.merge(invariant_result.indeterminism_reasons);
+                    Some(reasons)
+                }
+                None => invariant_result.indeterminism_reasons,
+            };
+            failure
+        }
+        None => Failure {
+            output: invariant_result.result,
+            exit_reason: invariant_result.exit_reason,
+            indeterminism_reasons: invariant_result.indeterminism_reasons,
+        },
+    };
 
     let stack_trace_result: Option<SolidityTestStackTraceResult<HaltReasonT>> =
         generate_stack_trace

--- a/crates/foundry/evm/evm/src/executors/invariant/replay.rs
+++ b/crates/foundry/evm/evm/src/executors/invariant/replay.rs
@@ -10,6 +10,7 @@ use edr_solidity::{
 };
 use eyre::Result;
 use foundry_evm_core::{
+    backend::IndeterminismReasons,
     contracts::{ContractsByAddress, ContractsByArtifact},
     evm_context::{
         BlockEnvTr, ChainContextTr, EvmBuilderTrait, HardforkTr, TransactionEnvTr,
@@ -111,11 +112,12 @@ pub fn replay_run<
         ChainContextT,
     >,
 ) -> Result<ReplayResult<HaltReasonT>> {
-    /// What a reverting call returned. The revert reason is decoded from
-    /// these fields.
+    /// What a reverting call returned. The revert reason and the
+    /// replay-safety verdict are decoded from these fields.
     struct Failure {
         output: Bytes,
         exit_reason: Option<InstructionResult>,
+        indeterminism_reasons: Option<IndeterminismReasons>,
     }
 
     let ReplayRunArgs {
@@ -252,16 +254,28 @@ pub fn replay_run<
             after_invariant_failure = Some(Failure {
                 output: after_invariant_result.result,
                 exit_reason: after_invariant_result.exit_reason,
+                indeterminism_reasons: after_invariant_result.indeterminism_reasons,
             });
         }
         logs.extend(after_invariant_result.logs);
     }
 
+    // The backend accumulates indeterminism across calls, so the failing
+    // call's reasons include everything the replay executed before it.
+    let Failure {
+        output: failing_output,
+        exit_reason: failing_exit_reason,
+        indeterminism_reasons,
+    } = after_invariant_failure.unwrap_or_else(|| Failure {
+        output: invariant_result.result,
+        exit_reason: invariant_result.exit_reason,
+        indeterminism_reasons: invariant_result.indeterminism_reasons,
+    });
+
     let stack_trace_result: Option<SolidityTestStackTraceResult<HaltReasonT>> =
         generate_stack_trace
             .then(|| {
-                invariant_result
-                    .indeterminism_reasons
+                indeterminism_reasons
                     .map(SolidityTestStackTraceResult::from)
                     .or_else(|| {
                         contract_decoder.map(|decoder| {
@@ -285,13 +299,6 @@ pub fn replay_run<
             })
             .flatten();
 
-    let (failing_output, failing_exit_reason) = match &after_invariant_failure {
-        Some(Failure {
-            output,
-            exit_reason,
-        }) => (output, *exit_reason),
-        None => (&invariant_result.result, invariant_result.exit_reason),
-    };
     let revert_reason = revert_decoder.maybe_decode(failing_output.as_ref(), failing_exit_reason);
 
     Ok(ReplayResult {


### PR DESCRIPTION
## Problem / context

When the replayed sequence and `invariant()` both succeed and `afterInvariant()` is what reverts, `replay_run` computed the stack trace from `afterInvariant()`'s arena but decoded the revert reason from `invariant()`'s call result, which had succeeded. The runner treats a replay without a revert reason as a failure it could not reproduce and discards the stack trace. `afterInvariant()` failures therefore never carried one.

## Solution

Decode the reason from the call that actually failed: `afterInvariant()`'s result when it ran and reverted, `invariant()`'s otherwise.

Review surfaced two more gaps on the same path. First, the replay-safety verdict also came from `invariant()`'s result only, so an impure cheatcode executed inside a failing `afterInvariant()` was missed and a concrete stack trace was reported where `UnsafeToReplay` belongs. The failing call's indeterminism reasons now travel with its output and exit reason. Second, the mirror case: `invariant()` and `afterInvariant()` each run on a copy-on-write backend, so a passing `invariant()`'s impurity never reaches `afterInvariant()`'s result. `afterInvariant()` only ran because `invariant()` passed, so the two calls' reasons are merged. Third, a failure that does not reproduce on replay: a successful `afterInvariant()` replay dropped its observed impurity, and the runner discarded the whole stack-trace result for lack of a replayed revert reason. The merged reasons now cover every executed call, and an `UnsafeToReplay` verdict survives that discard with the original revert reason kept.

## Validation

- The first commit adds the reproduction: fixture `AlwaysStackTraceAfterInvariantTest`, whose invariant always holds and whose `afterInvariant()` always reverts. At that commit the assertion fails with "stack trace should be computed". The second commit's fix makes it pass.
- The third and fourth commits repeat that structure for the first replay-safety gap: `AlwaysStackTraceImpureAfterInvariantTest` calls `envOr` in its reverting `afterInvariant()`, fails with a concrete stack trace at the test commit, and reports `UnsafeToReplay` naming `envOr` after the fix.
- The fifth and sixth commits do the same for the mirror case: `AlwaysStackTraceImpureInvariantTest` calls `envOr` in its passing `invariant()` and reverts in a pure `afterInvariant()`.
- The seventh and eighth commits cover the non-reproducing failure: `AlwaysStackTraceFlakyAfterInvariantTest`'s `afterInvariant()` reverts only on its first execution, so the campaign fails while the replay passes. Without the fix the runner reports no stack-trace result at all.
- The ninth commit pins a replay that fails in a different phase than the campaign (`AlwaysStackTraceCrossPhaseTest`). Existing behavior already handles it, so this commit is test-only: the divergence's impurity short-circuits to `UnsafeToReplay`, and `TestResult::invariant_result` restores the campaign's original reason after replay handling.
- `cargo clippy --workspace --all-targets -- -D warnings`, `cargo +nightly fmt --check` and the `edr_solidity_tests` integration suite pass.

## Notes for reviewer

- Based directly on `main`; the bug exists there independently of the memory-reduction series, where this fix was first written.
- The selected arena was already correct (the last one replayed); only the reason decoding was wrong.
