### PR TITLE
feat(solidity-tests): scope inline config directives by test profile

### DIFF
--- a/.changeset/olive-pugs-shave.md
+++ b/.changeset/olive-pugs-shave.md
@@ -1,0 +1,7 @@
+---
+"@nomicfoundation/edr": minor
+---
+
+Added profile support to Solidity test inline configuration. `SolidityTestRunnerConfigArgs` now accepts `testProfile` and `declaredTestProfiles`. Unprefixed directives apply to every profile, while profile-prefixed directives apply only when that profile is selected and override unprefixed directives with the same key. Undeclared profile prefixes are rejected.
+
+BREAKING CHANGE: Renamed the `InlineConfigUnsupportedProfile` inline config problem to `InlineConfigUndeclaredProfile`. The replacement also includes the declared profile names in `declaredProfiles`.

--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -959,7 +959,7 @@ export interface InlineConfigDirectiveLocation {
  * consumers can map each problem onto their own error types.
  */
 export type InlineConfigDirectiveProblem =
-  InlineConfigInvalidSyntax | InlineConfigUnsupportedProfile | InlineConfigInvalidKey | InlineConfigInvalidKeyForTestType | InlineConfigInvalidValue | InlineConfigDuplicateKey
+  InlineConfigInvalidSyntax | InlineConfigUndeclaredProfile | InlineConfigInvalidKey | InlineConfigInvalidKeyForTestType | InlineConfigInvalidValue | InlineConfigDuplicateKey
 
 /**
  * The same key was specified more than once for the same function or
@@ -1066,12 +1066,14 @@ export interface InlineConfigSourceFileNotFound {
 export type InlineConfigSourceProblem =
   InlineConfigInvalidSolcVersion | InlineConfigSourceFileNotFound | InlineConfigDirectiveLocation
 
-/** A profile other than `default` was used. */
-export interface InlineConfigUnsupportedProfile {
+/** A directive named a profile the project does not declare. */
+export interface InlineConfigUndeclaredProfile {
   /** Enum tag for JS. */
-  kind: "InlineConfigUnsupportedProfile"
-  /** The unsupported profile name. */
+  kind: "InlineConfigUndeclaredProfile"
+  /** The undeclared profile name, exactly as written. */
   profile: string
+  /** The profiles the project declares, sorted. */
+  declaredProfiles: Array<string>
 }
 
 export interface InstrumentationMetadata {
@@ -1792,6 +1794,23 @@ export interface SolidityTestRunnerConfigArgs {
    * do.
    */
   importMappings?: Record<string, string>
+  /**
+   * The Solidity test profile this run was started with.
+   *
+   * An inline-config directive prefixed with a profile name
+   * (`forge-config: ci.fuzz.runs = 8`) applies only under that profile; an
+   * unprefixed one applies under every profile, and the prefixed one wins
+   * where both set the same key. Defaults to `default`.
+   */
+  testProfile?: string
+  /**
+   * Every Solidity test profile the project declares.
+   *
+   * A prefix naming a profile that is not declared is an error, so a
+   * mistyped one fails whichever profile is selected. `default` is always
+   * declared. Defaults to `["default"]`.
+   */
+  declaredTestProfiles?: Array<string>
 }
 
 export interface SourceReference {

--- a/crates/edr_napi/src/solidity_tests/config.rs
+++ b/crates/edr_napi/src/solidity_tests/config.rs
@@ -5,6 +5,7 @@ use edr_primitives::hex;
 use edr_solidity_tests::{
     executors::invariant::InvariantConfig,
     fuzz::FuzzConfig,
+    inline_config::DEFAULT_PROFILE,
     inspectors::cheatcodes::{CheatsConfigOptions, ExecutionContextConfig},
     TestFilterConfig,
 };
@@ -223,6 +224,19 @@ pub struct SolidityTestRunnerConfigArgs<'env> {
     /// file and need no entry here; only non-relative paths (package imports)
     /// do.
     pub import_mappings: Option<HashMap<String, String>>,
+    /// The Solidity test profile this run was started with.
+    ///
+    /// An inline-config directive prefixed with a profile name
+    /// (`forge-config: ci.fuzz.runs = 8`) applies only under that profile; an
+    /// unprefixed one applies under every profile, and the prefixed one wins
+    /// where both set the same key. Defaults to `default`.
+    pub test_profile: Option<String>,
+    /// Every Solidity test profile the project declares.
+    ///
+    /// A prefix naming a profile that is not declared is an error, so a
+    /// mistyped one fails whichever profile is selected. `default` is always
+    /// declared. Defaults to `["default"]`.
+    pub declared_test_profiles: Option<Vec<String>>,
 }
 
 impl SolidityTestRunnerConfigArgs<'_> {
@@ -274,6 +288,8 @@ impl SolidityTestRunnerConfigArgs<'_> {
             eip712_canonical_types,
             test_source_paths,
             import_mappings,
+            test_profile,
+            declared_test_profiles,
         } = self;
 
         let test_source_paths = test_source_paths.map_or_else(HashMap::new, |paths| {
@@ -289,6 +305,10 @@ impl SolidityTestRunnerConfigArgs<'_> {
                 .map(|(import_path, path)| (import_path, PathBuf::from(path)))
                 .collect()
         });
+
+        let test_profile = test_profile.unwrap_or_else(|| DEFAULT_PROFILE.to_owned());
+        let declared_test_profiles =
+            declared_test_profiles.unwrap_or_else(|| vec![DEFAULT_PROFILE.to_owned()]);
 
         let test_pattern = TestFilterConfig {
             test_pattern: test_pattern
@@ -417,6 +437,8 @@ impl SolidityTestRunnerConfigArgs<'_> {
             generate_gas_report,
             test_source_paths,
             import_mappings,
+            test_profile,
+            declared_test_profiles,
         };
 
         Ok(config)

--- a/crates/edr_napi/src/solidity_tests/inline_config.rs
+++ b/crates/edr_napi/src/solidity_tests/inline_config.rs
@@ -21,14 +21,16 @@ pub struct InlineConfigInvalidSyntax {
     pub directive: String,
 }
 
-/// A profile other than `default` was used.
+/// A directive named a profile the project does not declare.
 #[napi(object)]
-pub struct InlineConfigUnsupportedProfile {
+pub struct InlineConfigUndeclaredProfile {
     /// Enum tag for JS.
-    #[napi(ts_type = "\"InlineConfigUnsupportedProfile\"")]
+    #[napi(ts_type = "\"InlineConfigUndeclaredProfile\"")]
     pub kind: String,
-    /// The unsupported profile name.
+    /// The undeclared profile name, exactly as written.
     pub profile: String,
+    /// The profiles the project declares, sorted.
+    pub declared_profiles: Vec<String>,
 }
 
 /// An unknown configuration key was used.
@@ -133,7 +135,7 @@ pub type InlineConfigSourceProblem = Either3<
 #[napi]
 pub type InlineConfigDirectiveProblem = Either6<
     InlineConfigInvalidSyntax,
-    InlineConfigUnsupportedProfile,
+    InlineConfigUndeclaredProfile,
     InlineConfigInvalidKey,
     InlineConfigInvalidKeyForTestType,
     InlineConfigInvalidValue,
@@ -216,10 +218,11 @@ fn to_directive_problem(error: &CoreInlineConfigError) -> InlineConfigDirectiveP
             kind: "InlineConfigInvalidSyntax".to_owned(),
             directive: line.clone(),
         }),
-        CoreInlineConfigError::UnsupportedProfile { profile } => {
-            Either6::B(InlineConfigUnsupportedProfile {
-                kind: "InlineConfigUnsupportedProfile".to_owned(),
+        CoreInlineConfigError::UndeclaredProfile { profile, declared } => {
+            Either6::B(InlineConfigUndeclaredProfile {
+                kind: "InlineConfigUndeclaredProfile".to_owned(),
                 profile: profile.clone(),
+                declared_profiles: declared.clone(),
             })
         }
         CoreInlineConfigError::InvalidKey { key } => Either6::C(InlineConfigInvalidKey {

--- a/crates/edr_napi_core/src/solidity/config.rs
+++ b/crates/edr_napi_core/src/solidity/config.rs
@@ -7,7 +7,7 @@ use edr_solidity_tests::{
     backend::Predeploy,
     evm_context::HardforkTr,
     fuzz::{invariant::InvariantConfig, FuzzConfig},
-    inline_config::ImportResolver,
+    inline_config::{ImportResolver, InlineConfigProfiles},
     inspectors::cheatcodes::CheatsConfigOptions,
     opts::effective_transaction_gas_cap,
     CollectStackTraces, SolidityTestRunnerConfig, SyncOnCollectedCoverageCallback,
@@ -205,6 +205,14 @@ pub struct TestRunnerConfig {
     /// (`./`, `../`) are resolved against the importing file and need no entry
     /// here.
     pub import_mappings: HashMap<String, PathBuf>,
+    /// The Solidity test profile the run was started with. Inline-config
+    /// directives prefixed with a profile name apply only when that profile is
+    /// the selected one.
+    pub test_profile: String,
+    /// Every Solidity test profile the project declares. A profile-prefixed
+    /// inline-config directive naming an undeclared profile is an error,
+    /// whichever profile is selected.
+    pub declared_test_profiles: Vec<String>,
 }
 
 fn parse_hardfork<HardforkT>(hardfork: String) -> napi::Result<HardforkT>
@@ -265,6 +273,8 @@ impl TestRunnerConfig {
             generate_gas_report,
             test_source_paths,
             import_mappings,
+            test_profile,
+            declared_test_profiles,
         } = self;
 
         let mut evm_opts = SolidityTestRunnerConfig::default_evm_opts();
@@ -365,6 +375,10 @@ impl TestRunnerConfig {
 
         let import_resolver = ImportResolver::new(import_mappings);
 
+        let inline_config_profiles =
+            InlineConfigProfiles::new(test_profile, declared_test_profiles)
+                .map_err(|error| napi::Error::new(napi::Status::InvalidArg, error.to_string()))?;
+
         Ok(SolidityTestRunnerConfig {
             project_root,
             collect_stack_traces,
@@ -383,12 +397,15 @@ impl TestRunnerConfig {
             generate_gas_report,
             test_source_paths,
             import_resolver,
+            inline_config_profiles,
         })
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use edr_solidity_tests::inline_config::DEFAULT_PROFILE;
+
     use super::*;
 
     fn default_config() -> TestRunnerConfig {
@@ -429,6 +446,8 @@ mod tests {
             generate_gas_report: None,
             test_source_paths: HashMap::new(),
             import_mappings: HashMap::new(),
+            test_profile: DEFAULT_PROFILE.to_owned(),
+            declared_test_profiles: vec![DEFAULT_PROFILE.to_owned()],
         }
     }
 

--- a/crates/edr_solidity_tests/src/config.rs
+++ b/crates/edr_solidity_tests/src/config.rs
@@ -12,7 +12,7 @@ use foundry_evm::{
 
 use crate::{
     fork::CreateFork,
-    inline_config::{ImportResolver, InlineConfigErrors},
+    inline_config::{ImportResolver, InlineConfigErrors, InlineConfigProfiles},
     opts::{effective_transaction_gas_cap, Env as EvmEnv, EvmOpts},
 };
 
@@ -72,6 +72,10 @@ pub struct SolidityTestRunnerConfig<HardforkT: HardforkTr> {
     /// Resolves the imports of test sources when parsing their inline
     /// configuration (`forge-config:`/`hardhat-config:` NatSpec directives).
     pub import_resolver: ImportResolver,
+    /// The profile the run was started with and every profile the project
+    /// declares, used to scope inline-config directives. Defaults to the single
+    /// `default` profile.
+    pub inline_config_profiles: InlineConfigProfiles,
 }
 
 impl<HardforkT: HardforkTr> SolidityTestRunnerConfig<HardforkT> {

--- a/crates/edr_solidity_tests/src/inline_config.rs
+++ b/crates/edr_solidity_tests/src/inline_config.rs
@@ -19,6 +19,18 @@
 //!
 //! Both the `forge-config:` and `hardhat-config:` prefixes are recognized.
 //!
+//! A directive may be scoped to a test profile by prefixing its key with the
+//! profile's name. A prefixed directive applies only under that profile, an
+//! unprefixed one under every profile, and where both set the same key the
+//! prefixed one wins, whatever order they appear in. A prefix must name a
+//! declared profile — see [`InlineConfigProfiles`].
+//!
+//! ```solidity
+//! /// forge-config: fuzz.runs = 3       // under every profile
+//! /// forge-config: ci.fuzz.runs = 500  // only under `ci`
+//! function testFoo(uint256 x) public { /* ... */ }
+//! ```
+//!
 //! The work flows through the submodules as a pipeline:
 //!
 //! ```text
@@ -28,12 +40,16 @@
 //!   - overrides  compose the above into a source's per-contract overrides
 //!   - provider   cache the overrides and serve them
 //! ```
+//!
+//! `profiles` carries the run's selected and declared profiles through that
+//! pipeline, so `directives` can scope each one.
 
 mod directives;
 mod error;
 mod natspec;
 mod overrides;
 mod parse;
+mod profiles;
 mod provider;
 mod resolver;
 
@@ -41,9 +57,10 @@ pub(crate) use self::directives::is_test_function;
 pub use self::{
     error::{
         InlineConfigCollectError, InlineConfigError, InlineConfigErrorItem, InlineConfigErrors,
-        InlineConfigProblem,
+        InlineConfigProblem, InlineConfigProfilesError,
     },
     overrides::{ContractInlineConfig, FunctionOverride},
+    profiles::{InlineConfigProfiles, DEFAULT_PROFILE},
     provider::{CachedInlineConfigProvider, InlineConfigRoot, SharedInlineConfigProvider},
     resolver::ImportResolver,
 };

--- a/crates/edr_solidity_tests/src/inline_config/directives.rs
+++ b/crates/edr_solidity_tests/src/inline_config/directives.rs
@@ -8,8 +8,11 @@
 //! forge-config: default.fuzz.runs = 100
 //! hardhat-config: invariant.fail-on-revert = true
 //! ```
+//!
+//! A directive's key may carry a profile prefix, scoping it to that profile.
+//! See [`parse_inline_config`] for how scoping and precedence work.
 
-use super::{error::InlineConfigError, natspec::NatSpecBlock};
+use super::{error::InlineConfigError, natspec::NatSpecBlock, profiles::InlineConfigProfiles};
 use crate::config::{TestFunctionConfigOverride, TimeoutConfig};
 
 const HARDHAT_CONFIG_PREFIX: &str = "hardhat-config:";
@@ -50,9 +53,16 @@ const TOP_LEVEL_KEYS: [&str; 5] = [
     "evmVersion",
 ];
 
-/// Inline-config profiles the parser accepts as a leading dot-segment prefix.
-/// Only `default` is supported today; add new profiles here to extend support.
-const SUPPORTED_PROFILES: [&str; 1] = ["default"];
+/// The scope a directive applies under.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum DirectiveScope {
+    /// Written without a profile prefix (`fuzz.runs = 3`): applies under every
+    /// profile.
+    Bare,
+    /// Written with a profile prefix (`ci.fuzz.runs = 8`): applies only when
+    /// that profile is the selected one.
+    Profile(String),
+}
 
 /// Whether `name` is an invariant test, matching the runner's classification
 /// (`invariant*` or the `statefulFuzz*` alias).
@@ -223,9 +233,11 @@ impl Key {
 
 /// A single parsed directive, prior to validation.
 struct RawOverride {
-    /// Canonical (camelCase) key.
+    /// The profile the directive applies under.
+    scope: DirectiveScope,
+    /// Canonical (camelCase) key, with any profile prefix stripped.
     key: String,
-    /// The key exactly as written (for diagnostics).
+    /// The key exactly as written, profile prefix included (for diagnostics).
     raw_key: String,
     /// The value exactly as written.
     raw_value: String,
@@ -289,7 +301,10 @@ fn block_to_lines(block: &NatSpecBlock) -> Vec<DirectiveLine<'_>> {
 /// Parses a single candidate directive line — already stripped of comment
 /// decoration by [`block_to_lines`] — returning `None` if it is not an inline
 /// config directive.
-fn parse_line(line: &DirectiveLine<'_>) -> Result<Option<RawOverride>, LocatedDirectiveError> {
+fn parse_line(
+    line: &DirectiveLine<'_>,
+    profiles: &InlineConfigProfiles,
+) -> Result<Option<RawOverride>, LocatedDirectiveError> {
     let text = line.text;
     let located = |error: InlineConfigError| LocatedDirectiveError {
         offset: line.offset,
@@ -312,22 +327,28 @@ fn parse_line(line: &DirectiveLine<'_>) -> Result<Option<RawOverride>, LocatedDi
     let raw_key = raw_key.trim();
     let raw_value = raw_value.trim();
 
-    // Detect and strip a profile prefix (see `SUPPORTED_PROFILES`).
+    // Detect and strip a profile prefix. It is validated against the declared
+    // profiles, not the selected one, so a mistyped prefix fails on every run.
+    // Unlike the key, it is matched verbatim: profile names are user-chosen.
+    let mut scope = DirectiveScope::Bare;
     let mut key = raw_key;
     if let Some((first_segment, rest)) = raw_key.split_once('.')
         && !TOP_LEVEL_KEYS.contains(&first_segment)
     {
-        if !SUPPORTED_PROFILES.contains(&first_segment) {
-            return Err(located(InlineConfigError::UnsupportedProfile {
+        if !profiles.is_declared(first_segment) {
+            return Err(located(InlineConfigError::UndeclaredProfile {
                 profile: first_segment.to_owned(),
+                declared: profiles.declared_names(),
             }));
         }
+        scope = DirectiveScope::Profile(first_segment.to_owned());
         key = rest;
     }
 
     let key = delimiter_to_camel(&delimiter_to_camel(key, '-'), '_');
 
     Ok(Some(RawOverride {
+        scope,
         key,
         raw_key: raw_key.to_owned(),
         raw_value: raw_value.to_owned(),
@@ -366,19 +387,26 @@ fn parse_u32(value: &str, raw_key: &str) -> Result<u32, InlineConfigError> {
 }
 
 /// Parses the inline configuration attached to `target` from its leading
-/// NatSpec blocks.
+/// NatSpec blocks, resolved against `profiles`.
 ///
-/// Returns `Ok(None)` when no inline-config directive is present. On a
-/// malformed directive, the error carries the byte offset of the offending line
-/// so the caller can resolve it to a source line number.
+/// An unprefixed directive applies under every profile; a prefixed one applies
+/// only under its own, overriding the unprefixed value of the same key whatever
+/// order they were written in. Duplicates are rejected per scope, so
+/// `fuzz.runs` alongside `ci.fuzz.runs` is allowed. Every directive is
+/// validated, whichever profile it names.
+///
+/// Returns `Ok(None)` when no directive applies under the selected profile. On
+/// a malformed directive, the error carries the byte offset of the offending
+/// line so the caller can resolve it to a source line number.
 pub(super) fn parse_inline_config(
     blocks: &[NatSpecBlock],
     target: DirectiveTarget<'_>,
+    profiles: &InlineConfigProfiles,
 ) -> Result<Option<TestFunctionConfigOverride>, LocatedDirectiveError> {
     let mut raw_overrides = Vec::new();
     for block in blocks {
         for line in block_to_lines(block) {
-            if let Some(raw) = parse_line(&line)? {
+            if let Some(raw) = parse_line(&line, profiles)? {
                 raw_overrides.push(raw);
             }
         }
@@ -388,9 +416,23 @@ pub(super) fn parse_inline_config(
         return Ok(None);
     }
 
+    // Directives of unselected profiles are validated into a scratch config and
+    // discarded, so a bad key or value fails whichever profile is selected.
     let mut config = TestFunctionConfigOverride::default();
-    let mut seen = Vec::new();
+    let mut unselected = TestFunctionConfigOverride::default();
 
+    // Applied after the unprefixed ones, so they win whatever order they were
+    // written in.
+    let mut selected_profile: Vec<(&RawOverride, Key)> = Vec::new();
+
+    // Whether anything reached `config`: a function whose directives all target
+    // unselected profiles must report none, not an override that sets nothing.
+    let mut applied = false;
+
+    // The (scope, key) pairs already seen, to reject duplicates per scope.
+    let mut seen: Vec<(&DirectiveScope, Key)> = Vec::new();
+
+    // First pass: validate every directive and apply the unprefixed ones.
     for raw in &raw_overrides {
         let located = |error: InlineConfigError| LocatedDirectiveError {
             offset: raw.offset,
@@ -421,19 +463,45 @@ pub(super) fn parse_inline_config(
             }
         }
 
-        // Reject duplicate keys within one target. The same key at contract
-        // and function level is not a duplicate; the function's value wins.
-        if seen.contains(&key) {
+        // Reject duplicate keys within one target and scope. The same key at
+        // contract and function level is not a duplicate (the function's value
+        // wins), nor is the same key under two profiles.
+        if seen.contains(&(&raw.scope, key)) {
             return Err(located(InlineConfigError::DuplicateKey {
                 key: raw.raw_key.clone(),
             }));
         }
-        seen.push(key);
+        seen.push((&raw.scope, key));
 
-        key.apply(&mut config, raw).map_err(located)?;
+        // Unprefixed directives apply now; the selected profile's are replayed
+        // in the second pass.
+        let target = match &raw.scope {
+            DirectiveScope::Bare => {
+                applied = true;
+                &mut config
+            }
+            DirectiveScope::Profile(profile) => {
+                if profile.as_str() == profiles.selected() {
+                    selected_profile.push((raw, key));
+                    applied = true;
+                }
+                &mut unselected
+            }
+        };
+        key.apply(target, raw).map_err(located)?;
     }
 
-    Ok(Some(config))
+    // Second pass: the selected profile's directives override the unprefixed
+    // ones. Their values were validated above, so this cannot fail.
+    for (raw, key) in selected_profile {
+        key.apply(&mut config, raw)
+            .map_err(|error| LocatedDirectiveError {
+                offset: raw.offset,
+                error,
+            })?;
+    }
+
+    Ok(applied.then_some(config))
 }
 
 #[cfg(test)]
@@ -447,17 +515,51 @@ mod tests {
         }
     }
 
+    /// Parses `lines`, each its own NatSpec block, on `function` against
+    /// `profiles`.
+    fn parse_with(
+        profiles: &InlineConfigProfiles,
+        lines: &[&str],
+        function: &str,
+    ) -> Result<Option<TestFunctionConfigOverride>, InlineConfigError> {
+        let blocks: Vec<NatSpecBlock> = lines.iter().map(|line| block(line)).collect();
+        parse_inline_config(&blocks, DirectiveTarget::Function(function), profiles)
+            .map_err(|located| located.error)
+    }
+
+    /// Parses `text` under a project that declares only `default`.
     fn parse(
         text: &str,
         function: &str,
     ) -> Result<Option<TestFunctionConfigOverride>, InlineConfigError> {
-        parse_inline_config(&[block(text)], DirectiveTarget::Function(function))
-            .map_err(|located| located.error)
+        parse_with(&InlineConfigProfiles::default(), &[text], function)
     }
 
+    /// Parses `text` on a contract under a project that declares only
+    /// `default`.
     fn parse_contract(text: &str) -> Result<Option<TestFunctionConfigOverride>, InlineConfigError> {
-        parse_inline_config(&[block(text)], DirectiveTarget::Contract)
-            .map_err(|located| located.error)
+        parse_inline_config(
+            &[block(text)],
+            DirectiveTarget::Contract,
+            &InlineConfigProfiles::default(),
+        )
+        .map_err(|located| located.error)
+    }
+
+    /// Builds a profile context selecting `selected` out of `declared`.
+    fn profiles(selected: &str, declared: &[&str]) -> InlineConfigProfiles {
+        InlineConfigProfiles::new(selected, declared.iter().map(|&name| name.to_owned()))
+            .expect("valid profiles")
+    }
+
+    /// Unwraps a parse and returns the `fuzz.runs` it resolved to, if any.
+    fn fuzz_runs(
+        result: Result<Option<TestFunctionConfigOverride>, InlineConfigError>,
+    ) -> Option<u32> {
+        result
+            .expect("parses")
+            .and_then(|config| config.fuzz)
+            .and_then(|fuzz| fuzz.runs)
     }
 
     #[test]
@@ -535,13 +637,14 @@ mod tests {
 
     #[test]
     fn top_level_keys() {
-        let cfg = parse_inline_config(
+        let cfg = parse_with(
+            &InlineConfigProfiles::default(),
             &[
-                block("/// hardhat-config: isolate = true"),
-                block("/// hardhat-config: evmVersion = \"cancun\""),
-                block("/// hardhat-config: allow-internal-expect-revert = true"),
+                "/// hardhat-config: isolate = true",
+                "/// hardhat-config: evmVersion = \"cancun\"",
+                "/// hardhat-config: allow-internal-expect-revert = true",
             ],
-            DirectiveTarget::Function("testFoo"),
+            "testFoo",
         )
         .unwrap()
         .unwrap();
@@ -557,9 +660,239 @@ mod tests {
     }
 
     #[test]
-    fn unsupported_profile() {
-        let err = parse("/// forge-config: ci.fuzz.runs = 100", "testFoo").unwrap_err();
-        assert!(matches!(err, InlineConfigError::UnsupportedProfile { .. }));
+    fn undeclared_profile_fails_whichever_profile_is_selected() {
+        // The prefix is validated against the declared profiles, not the
+        // selected one, so a typo fails on every run.
+        for selected in ["default", "ci"] {
+            let err = parse_with(
+                &profiles(selected, &["ci"]),
+                &["/// forge-config: nope.fuzz.runs = 100"],
+                "testFoo",
+            )
+            .unwrap_err();
+
+            assert_eq!(
+                err,
+                InlineConfigError::UndeclaredProfile {
+                    profile: "nope".to_owned(),
+                    declared: vec!["ci".to_owned(), "default".to_owned()],
+                },
+                "selected: {selected}"
+            );
+            assert!(err
+                .to_string()
+                .contains("declared profiles are: ci, default"));
+        }
+    }
+
+    #[test]
+    fn unprefixed_directive_applies_under_every_profile() {
+        for selected in ["default", "ci"] {
+            let runs = fuzz_runs(parse_with(
+                &profiles(selected, &["ci"]),
+                &["/// forge-config: fuzz.runs = 3"],
+                "testFoo",
+            ));
+            assert_eq!(runs, Some(3), "selected: {selected}");
+        }
+    }
+
+    #[test]
+    fn prefixed_directive_applies_only_when_its_profile_is_selected() {
+        let directive = ["/// forge-config: ci.fuzz.runs = 8"];
+
+        assert_eq!(
+            fuzz_runs(parse_with(&profiles("ci", &["ci"]), &directive, "testFoo")),
+            Some(8)
+        );
+        // Under another profile the directive is inert, and since it is the
+        // function's only one, nothing is collected for it at all.
+        assert_eq!(
+            parse_with(&profiles("default", &["ci"]), &directive, "testFoo"),
+            Ok(None)
+        );
+    }
+
+    #[test]
+    fn default_prefix_does_not_apply_under_another_profile() {
+        // `default.` is just another profile prefix: unlike Foundry, it is not
+        // a base that every profile inherits.
+        assert_eq!(
+            parse_with(
+                &profiles("ci", &["ci"]),
+                &["/// forge-config: default.fuzz.runs = 10"],
+                "testFoo",
+            ),
+            Ok(None)
+        );
+    }
+
+    #[test]
+    fn selected_profile_overrides_unprefixed_regardless_of_order() {
+        let unprefixed_first = [
+            "/// forge-config: fuzz.runs = 3",
+            "/// forge-config: ci.fuzz.runs = 8",
+        ];
+        let prefixed_first = [
+            "/// forge-config: ci.fuzz.runs = 8",
+            "/// forge-config: fuzz.runs = 3",
+        ];
+
+        for directives in [unprefixed_first, prefixed_first] {
+            assert_eq!(
+                fuzz_runs(parse_with(&profiles("ci", &["ci"]), &directives, "testFoo")),
+                Some(8),
+                "{directives:?}"
+            );
+            // Under `default` the prefixed one is inert, leaving the
+            // unprefixed value.
+            assert_eq!(
+                fuzz_runs(parse_with(
+                    &profiles("default", &["ci"]),
+                    &directives,
+                    "testFoo"
+                )),
+                Some(3),
+                "{directives:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn duplicate_keys_are_detected_per_scope() {
+        // An unprefixed value plus a profile-specific override of the same key
+        // is the intended way to vary a setting per profile.
+        for selected in ["default", "ci"] {
+            assert!(parse_with(
+                &profiles(selected, &["ci"]),
+                &[
+                    "/// forge-config: fuzz.runs = 3",
+                    "/// forge-config: ci.fuzz.runs = 8",
+                ],
+                "testFoo",
+            )
+            .is_ok());
+        }
+
+        // Two directives sharing a scope are still a duplicate, whether that
+        // scope is selected or not.
+        for directives in [
+            [
+                "/// forge-config: fuzz.runs = 1",
+                "/// forge-config: fuzz.runs = 2",
+            ],
+            [
+                "/// forge-config: ci.fuzz.runs = 1",
+                "/// forge-config: ci.fuzz.runs = 2",
+            ],
+        ] {
+            for selected in ["default", "ci"] {
+                let err =
+                    parse_with(&profiles(selected, &["ci"]), &directives, "testFoo").unwrap_err();
+                assert!(
+                    matches!(err, InlineConfigError::DuplicateKey { .. }),
+                    "{directives:?} under {selected}: {err:?}"
+                );
+            }
+        }
+
+        // Two profiles setting the same key are not duplicates of each other.
+        assert!(parse_with(
+            &profiles("ci", &["ci", "nightly"]),
+            &[
+                "/// forge-config: ci.fuzz.runs = 1",
+                "/// forge-config: nightly.fuzz.runs = 2",
+            ],
+            "testFoo",
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn unselected_profile_directives_are_still_validated() {
+        // A directive scoped to a profile that isn't selected can't affect the
+        // run, but a mistake in it still fails the run — so a typo surfaces
+        // locally instead of only in the environment that selects it.
+        let selected = profiles("default", &["ci"]);
+
+        let err = parse_with(
+            &selected,
+            &["/// forge-config: ci.fuzz.runs = -1"],
+            "testFoo",
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, InlineConfigError::InvalidValue { .. }),
+            "{err:?}"
+        );
+
+        let err = parse_with(
+            &selected,
+            &["/// forge-config: ci.fuzz.bogus = 1"],
+            "testFoo",
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, InlineConfigError::InvalidKey { .. }),
+            "{err:?}"
+        );
+
+        let err = parse_with(
+            &selected,
+            &["/// forge-config: ci.invariant.runs = 1"],
+            "testFoo",
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, InlineConfigError::InvalidKeyForTestType { .. }),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn diagnostics_keep_the_profile_prefix() {
+        // Consumers echo `raw_key` back to the user, so it must read exactly as
+        // it was written.
+        let err = parse_with(
+            &profiles("default", &["ci"]),
+            &["/// forge-config: ci.fuzz.bogus = 1"],
+            "testFoo",
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            err,
+            InlineConfigError::InvalidKey {
+                key: "ci.fuzz.bogus".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn profile_prefix_is_matched_verbatim() {
+        // Keys are normalized from kebab/snake case, but profile names are
+        // user-chosen config keys, so they are matched as written.
+        let selected = profiles("my-ci", &["my-ci"]);
+
+        assert_eq!(
+            fuzz_runs(parse_with(
+                &selected,
+                &["/// forge-config: my-ci.fuzz.runs = 8"],
+                "testFoo"
+            )),
+            Some(8)
+        );
+
+        let err = parse_with(
+            &selected,
+            &["/// forge-config: myCi.fuzz.runs = 8"],
+            "testFoo",
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, InlineConfigError::UndeclaredProfile { .. }),
+            "{err:?}"
+        );
     }
 
     #[test]
@@ -660,15 +993,15 @@ mod tests {
 
     #[test]
     fn duplicate_key() {
-        let err = parse_inline_config(
+        let err = parse_with(
+            &InlineConfigProfiles::default(),
             &[
-                block("/// forge-config: fuzz.runs = 1"),
-                block("/// forge-config: fuzz.runs = 2"),
+                "/// forge-config: fuzz.runs = 1",
+                "/// forge-config: fuzz.runs = 2",
             ],
-            DirectiveTarget::Function("testFoo"),
+            "testFoo",
         )
-        .unwrap_err()
-        .error;
+        .unwrap_err();
         assert!(matches!(err, InlineConfigError::DuplicateKey { .. }));
     }
 
@@ -700,6 +1033,7 @@ mod tests {
                 block("/// forge-config: invariant.runs = 2"),
             ],
             DirectiveTarget::Contract,
+            &InlineConfigProfiles::default(),
         )
         .unwrap_err()
         .error;

--- a/crates/edr_solidity_tests/src/inline_config/error.rs
+++ b/crates/edr_solidity_tests/src/inline_config/error.rs
@@ -76,11 +76,16 @@ pub enum InlineConfigError {
         /// The offending directive line.
         line: String,
     },
-    /// A profile other than `default` was used.
-    #[error("unsupported profile `{profile}`; only `default` is supported")]
-    UnsupportedProfile {
-        /// The unsupported profile name.
+    /// A directive named a profile the project does not declare.
+    #[error(
+        "unknown profile `{profile}`; declared profiles are: {}",
+        declared.join(", ")
+    )]
+    UndeclaredProfile {
+        /// The undeclared profile name, exactly as written.
         profile: String,
+        /// The profiles the project declares, sorted.
+        declared: Vec<String>,
     },
     /// An unknown configuration key was used.
     #[error("invalid key `{key}`")]
@@ -113,6 +118,22 @@ pub enum InlineConfigError {
     DuplicateKey {
         /// The duplicated (raw) key.
         key: String,
+    },
+}
+
+/// Why a set of profiles could not be used to resolve inline configuration.
+#[derive(Clone, Debug, thiserror::Error, PartialEq, Eq)]
+pub enum InlineConfigProfilesError {
+    /// The selected profile is not one of the declared ones.
+    #[error(
+        "the selected Solidity test profile `{selected}` is not declared; declared profiles are: {}",
+        declared.join(", ")
+    )]
+    SelectedNotDeclared {
+        /// The selected profile.
+        selected: String,
+        /// The declared profiles, sorted.
+        declared: Vec<String>,
     },
 }
 

--- a/crates/edr_solidity_tests/src/inline_config/overrides.rs
+++ b/crates/edr_solidity_tests/src/inline_config/overrides.rs
@@ -14,6 +14,7 @@ use super::{
     error::{InlineConfigCollectError, InlineConfigErrorItem, InlineConfigProblem},
     natspec,
     parse::{locate_contracts, LocatedContract, LocatedFunction},
+    profiles::InlineConfigProfiles,
     resolver::ImportResolver,
 };
 use crate::config::TestFunctionConfigOverride;
@@ -65,9 +66,10 @@ pub(super) struct SourceCollection {
 }
 
 /// Parses the file at `root_path` (its `content`, compiled with `version`) into
-/// the inline configuration of every contract it declares. Its imports are
-/// resolved by `import_resolver` and read from disk. `source` names the file
-/// in error reports (the solc source name the caller queries by).
+/// the inline configuration of every contract it declares, resolved against
+/// `profiles`. Its imports are resolved by `import_resolver` and read from disk.
+/// `source` names the file in error reports (the solc source name the caller
+/// queries by).
 ///
 /// A failure to locate the source's contracts (an unsupported solc version)
 /// becomes the collection's single (source-level) error; otherwise every
@@ -78,6 +80,7 @@ pub(super) fn collect_source(
     content: &str,
     version: Version,
     import_resolver: &ImportResolver,
+    profiles: &InlineConfigProfiles,
 ) -> SourceCollection {
     let contracts = match locate_contracts(root_path, version, import_resolver) {
         Ok(contracts) => contracts,
@@ -95,7 +98,7 @@ pub(super) fn collect_source(
     let mut overrides = SourceOverrides::new();
     let mut errors = Vec::new();
     for located in &contracts {
-        let (contract, contract_errors) = contract_overrides(source, content, located);
+        let (contract, contract_errors) = contract_overrides(source, content, located, profiles);
         if !contract.is_empty() {
             overrides.insert(located.contract_name.clone(), contract);
         }
@@ -107,25 +110,26 @@ pub(super) fn collect_source(
 
 /// Parses the inline configuration of `contract` — the contract-level
 /// directives above its definition and the per-function directives above each
-/// of its test functions — within the already-parsed `source_text`, returning
-/// the successful overrides and the problems found (at most one per function,
-/// plus at most one for the contract's own directives), each located at its
-/// source line.
+/// of its test functions — within the already-parsed `source_text`, resolved
+/// against `profiles`, returning the successful overrides and the problems found
+/// (at most one per function, plus at most one for the contract's own
+/// directives), each located at its source line.
 fn contract_overrides(
     source: &Path,
     source_text: &str,
     contract: &LocatedContract,
+    profiles: &InlineConfigProfiles,
 ) -> (ContractInlineConfig, Vec<InlineConfigErrorItem>) {
     let mut config = ContractInlineConfig::default();
     let mut errors = Vec::new();
 
-    match collect_contract_level_directives(source_text, contract) {
+    match collect_contract_level_directives(source_text, contract, profiles) {
         Ok(parsed) => config.contract = parsed,
         Err(error) => errors.push(located_problem(source, source_text, contract, None, error)),
     }
 
     for function in &contract.functions {
-        match collect_function_level_directives(source_text, function) {
+        match collect_function_level_directives(source_text, function, profiles) {
             Ok(Some(parsed)) => config.functions.push(FunctionOverride {
                 function_name: function.function_name.clone(),
                 config: parsed,
@@ -149,12 +153,13 @@ fn contract_overrides(
 fn collect_contract_level_directives(
     source_text: &str,
     contract: &LocatedContract,
+    profiles: &InlineConfigProfiles,
 ) -> Result<Option<TestFunctionConfigOverride>, LocatedDirectiveError> {
     let blocks = natspec::collect_natspec(source_text, contract.node_start);
     if blocks.is_empty() {
         return Ok(None);
     }
-    directives::parse_inline_config(&blocks, DirectiveTarget::Contract)
+    directives::parse_inline_config(&blocks, DirectiveTarget::Contract, profiles)
 }
 
 /// Parses the per-function directives from the NatSpec above `function`,
@@ -163,6 +168,7 @@ fn collect_contract_level_directives(
 fn collect_function_level_directives(
     source_text: &str,
     function: &LocatedFunction,
+    profiles: &InlineConfigProfiles,
 ) -> Result<Option<TestFunctionConfigOverride>, LocatedDirectiveError> {
     // Only test functions carry inline configuration. The recognized prefixes
     // mirror the runner's test-function classification (`test*`, `invariant*`,
@@ -176,7 +182,11 @@ fn collect_function_level_directives(
         return Ok(None);
     }
 
-    directives::parse_inline_config(&blocks, DirectiveTarget::Function(&function.function_name))
+    directives::parse_inline_config(
+        &blocks,
+        DirectiveTarget::Function(&function.function_name),
+        profiles,
+    )
 }
 
 /// Locates a directive problem at its source line, in `contract` and (for a

--- a/crates/edr_solidity_tests/src/inline_config/profiles.rs
+++ b/crates/edr_solidity_tests/src/inline_config/profiles.rs
@@ -1,0 +1,143 @@
+//! The Solidity test profiles that inline configuration is resolved against.
+//!
+//! A directive written bare (`fuzz.runs = 3`) applies under every profile; one
+//! written with a profile prefix (`ci.fuzz.runs = 8`) applies only when that
+//! profile is the selected one. A prefix must name a profile the project
+//! declares — validated against the *declared* set rather than the selected
+//! one, so a mistyped prefix fails on every run rather than only under the
+//! profile it was meant for.
+
+use std::collections::BTreeSet;
+
+use super::error::InlineConfigProfilesError;
+
+/// The profile that is always declared, and the one selected when the caller
+/// names none.
+pub const DEFAULT_PROFILE: &str = "default";
+
+/// The profile the run was started with, together with every profile the
+/// project declares.
+///
+/// [`Default`] is the single-profile configuration (`default` declared and
+/// selected), which reproduces the behavior of a caller that knows nothing
+/// about profiles.
+///
+/// Note: a name that collides with an inline-config key category (`fuzz`,
+/// `invariant`, `isolate`, `evmVersion`, `allowInternalExpectRevert`) can never
+/// be used as a prefix, since the parser reads that segment as the key.
+/// Consumers should reject such names when validating their configuration.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InlineConfigProfiles {
+    selected: String,
+    declared: BTreeSet<String>,
+}
+
+impl Default for InlineConfigProfiles {
+    fn default() -> Self {
+        Self {
+            selected: DEFAULT_PROFILE.to_owned(),
+            declared: BTreeSet::from([DEFAULT_PROFILE.to_owned()]),
+        }
+    }
+}
+
+impl InlineConfigProfiles {
+    /// Constructs the profile context of a run. `default` is always added to
+    /// `declared`.
+    ///
+    /// Fails if the selected profile is not among the declared ones.
+    pub fn new(
+        selected: impl Into<String>,
+        declared: impl IntoIterator<Item = String>,
+    ) -> Result<Self, InlineConfigProfilesError> {
+        let selected = selected.into();
+
+        // A `BTreeSet` deduplicates and keeps the names sorted, so error
+        // messages list them deterministically.
+        let mut declared: BTreeSet<String> = declared.into_iter().collect();
+        declared.insert(DEFAULT_PROFILE.to_owned());
+
+        if !declared.contains(&selected) {
+            return Err(InlineConfigProfilesError::SelectedNotDeclared {
+                selected,
+                declared: declared.into_iter().collect(),
+            });
+        }
+
+        Ok(Self { selected, declared })
+    }
+
+    /// The profile this run was started with.
+    pub fn selected(&self) -> &str {
+        &self.selected
+    }
+
+    /// Whether `profile` is one of the project's declared profiles.
+    pub(super) fn is_declared(&self, profile: &str) -> bool {
+        self.declared.contains(profile)
+    }
+
+    /// Every declared profile, sorted, for error messages.
+    pub(super) fn declared_names(&self) -> Vec<String> {
+        self.declared.iter().cloned().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_selects_and_declares_the_default_profile() {
+        let profiles = InlineConfigProfiles::default();
+
+        assert_eq!(profiles.selected(), DEFAULT_PROFILE);
+        assert!(profiles.is_declared(DEFAULT_PROFILE));
+        assert!(!profiles.is_declared("ci"));
+        assert_eq!(profiles.declared_names(), vec![DEFAULT_PROFILE.to_owned()]);
+    }
+
+    #[test]
+    fn default_is_always_declared() {
+        // Even when the caller doesn't list it.
+        let profiles = InlineConfigProfiles::new("ci", ["ci".to_owned()]).expect("valid profiles");
+
+        assert!(profiles.is_declared(DEFAULT_PROFILE));
+        assert_eq!(
+            profiles.declared_names(),
+            vec!["ci".to_owned(), DEFAULT_PROFILE.to_owned()]
+        );
+    }
+
+    #[test]
+    fn declared_names_are_sorted_and_deduplicated() {
+        let profiles = InlineConfigProfiles::new(
+            DEFAULT_PROFILE,
+            ["nightly".to_owned(), "ci".to_owned(), "ci".to_owned()],
+        )
+        .expect("valid profiles");
+
+        assert_eq!(
+            profiles.declared_names(),
+            vec![
+                "ci".to_owned(),
+                DEFAULT_PROFILE.to_owned(),
+                "nightly".to_owned()
+            ]
+        );
+    }
+
+    #[test]
+    fn selected_must_be_declared() {
+        let error = InlineConfigProfiles::new("ci", []).expect_err("undeclared selection");
+
+        assert_eq!(
+            error,
+            InlineConfigProfilesError::SelectedNotDeclared {
+                selected: "ci".to_owned(),
+                declared: vec![DEFAULT_PROFILE.to_owned()],
+            }
+        );
+        assert!(error.to_string().contains("declared profiles are: default"));
+    }
+}

--- a/crates/edr_solidity_tests/src/inline_config/provider.rs
+++ b/crates/edr_solidity_tests/src/inline_config/provider.rs
@@ -28,6 +28,7 @@ use super::{
         InlineConfigCollectError, InlineConfigErrorItem, InlineConfigErrors, InlineConfigProblem,
     },
     overrides::{collect_source, ContractInlineConfig, SourceCollection, SourceOverrides},
+    profiles::InlineConfigProfiles,
     resolver::ImportResolver,
 };
 
@@ -64,11 +65,15 @@ pub struct CachedInlineConfigProvider {
 impl CachedInlineConfigProvider {
     /// Parses every root's inline configuration in parallel, reading each
     /// root's file — and its imports, resolved by `import_resolver` — from
-    /// disk. Sources that carry no inline-config directive are skipped. Every
-    /// problem found (a malformed directive, an unreadable root file, or an
-    /// unsupported solc version) is accumulated and surfaced by
-    /// [`validate`](Self::validate).
-    pub fn collect(roots: &[InlineConfigRoot], import_resolver: &ImportResolver) -> Self {
+    /// disk, and resolving each directive against `profiles`. Sources that
+    /// carry no inline-config directive are skipped. Every problem found (a
+    /// malformed directive, an unreadable root file, or an unsupported solc
+    /// version) is accumulated and surfaced by [`validate`](Self::validate).
+    pub fn collect(
+        roots: &[InlineConfigRoot],
+        import_resolver: &ImportResolver,
+        profiles: &InlineConfigProfiles,
+    ) -> Self {
         let parse = |root: &InlineConfigRoot| -> Option<(PathBuf, SourceCollection)> {
             let content = match std::fs::read_to_string(&root.path) {
                 Ok(content) => content,
@@ -100,6 +105,7 @@ impl CachedInlineConfigProvider {
                 &content,
                 root.version.clone(),
                 import_resolver,
+                profiles,
             );
             Some((root.source.clone(), collection))
         };
@@ -160,14 +166,19 @@ impl CachedInlineConfigProvider {
 pub struct SharedInlineConfigProvider(Arc<CachedInlineConfigProvider>);
 
 impl SharedInlineConfigProvider {
-    /// Collects every root's inline configuration, returning a shared handle to
-    /// the result. Problems found during collection are surfaced together by
-    /// [`validate`](Self::validate), which the runner calls up front to abort
-    /// the run before any test executes.
-    pub fn collect(roots: Vec<InlineConfigRoot>, import_resolver: ImportResolver) -> Self {
+    /// Collects every root's inline configuration, resolved against `profiles`,
+    /// returning a shared handle to the result. Problems found during
+    /// collection are surfaced together by [`validate`](Self::validate), which
+    /// the runner calls up front to abort the run before any test executes.
+    pub fn collect(
+        roots: Vec<InlineConfigRoot>,
+        import_resolver: ImportResolver,
+        profiles: InlineConfigProfiles,
+    ) -> Self {
         Self(Arc::new(CachedInlineConfigProvider::collect(
             &roots,
             &import_resolver,
+            &profiles,
         )))
     }
 
@@ -278,12 +289,50 @@ contract BadTest {
     #[test]
     fn cached_collects_and_queries() {
         let (root, _file) = root_with_source();
-        let provider = CachedInlineConfigProvider::collect(&[root], &ImportResolver::default());
+        let provider = CachedInlineConfigProvider::collect(
+            &[root],
+            &ImportResolver::default(),
+            &InlineConfigProfiles::default(),
+        );
 
         provider.validate().expect("no problems");
         assert_overrides(&provider.get(Path::new(SOURCE_NAME), "MyTest"));
         // A source that was never collected reports no configuration.
         assert!(provider.get(Path::new("never.sol"), "MyTest").is_empty());
+    }
+
+    /// The selected profile reaches the directive parser, so the same source
+    /// collected under two profiles yields two different configurations.
+    #[test]
+    fn collects_per_selected_profile() {
+        const PROFILED_SOURCE: &str = r#"// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract ProfiledTest {
+    /// forge-config: fuzz.runs = 5
+    /// forge-config: ci.fuzz.runs = 9
+    function testFuzz(uint256 x) public {}
+}
+"#;
+
+        for (selected, expected) in [("default", 5), ("ci", 9)] {
+            let (root, _file) = root_named("project/profiled.sol", PROFILED_SOURCE);
+            let profiles =
+                InlineConfigProfiles::new(selected, ["ci".to_owned()]).expect("valid profiles");
+
+            let provider =
+                CachedInlineConfigProvider::collect(&[root], &ImportResolver::default(), &profiles);
+
+            provider.validate().expect("no problems");
+            let config = provider.get(Path::new("project/profiled.sol"), "ProfiledTest");
+            let overrides = &config.functions;
+            assert_eq!(overrides.len(), 1, "{selected}: {overrides:#?}");
+            assert_eq!(
+                overrides[0].config.fuzz.as_ref().and_then(|fuzz| fuzz.runs),
+                Some(expected),
+                "selected: {selected}"
+            );
+        }
     }
 
     #[test]
@@ -294,7 +343,11 @@ contract BadTest {
             version: Version::new(0, 8, 0),
         };
 
-        let provider = CachedInlineConfigProvider::collect(&[root], &ImportResolver::default());
+        let provider = CachedInlineConfigProvider::collect(
+            &[root],
+            &ImportResolver::default(),
+            &InlineConfigProfiles::default(),
+        );
         let errors = provider.validate().expect_err("problems reported");
         let items = errors.items();
         assert_eq!(items.len(), 1, "{items:#?}");
@@ -316,7 +369,11 @@ contract BadTest {
     #[test]
     fn cached_accumulates_one_error_per_function() {
         let (root, _file) = malformed_root();
-        let provider = CachedInlineConfigProvider::collect(&[root], &ImportResolver::default());
+        let provider = CachedInlineConfigProvider::collect(
+            &[root],
+            &ImportResolver::default(),
+            &InlineConfigProfiles::default(),
+        );
 
         let errors = provider.validate().expect_err("problems reported");
         let items = errors.items();
@@ -387,7 +444,11 @@ contract BadContractLevel {
 }
 "#;
         let (root, _file) = root_named("project/bad_contract.sol", source);
-        let provider = CachedInlineConfigProvider::collect(&[root], &ImportResolver::default());
+        let provider = CachedInlineConfigProvider::collect(
+            &[root],
+            &ImportResolver::default(),
+            &InlineConfigProfiles::default(),
+        );
 
         let errors = provider.validate().expect_err("problems reported");
         let items = errors.items();
@@ -421,7 +482,11 @@ contract BadContractLevel {
     #[test]
     fn shared_serves_concurrent_queries() {
         let (root, _file) = root_with_source();
-        let provider = SharedInlineConfigProvider::collect(vec![root], ImportResolver::default());
+        let provider = SharedInlineConfigProvider::collect(
+            vec![root],
+            ImportResolver::default(),
+            InlineConfigProfiles::default(),
+        );
 
         provider.validate().expect("no problems");
 
@@ -441,8 +506,11 @@ contract BadContractLevel {
     fn shared_validate_reports_collection_problems() {
         let (good, _good_file) = root_with_source();
         let (bad, _bad_file) = malformed_root();
-        let provider =
-            SharedInlineConfigProvider::collect(vec![good, bad], ImportResolver::default());
+        let provider = SharedInlineConfigProvider::collect(
+            vec![good, bad],
+            ImportResolver::default(),
+            InlineConfigProfiles::default(),
+        );
 
         let errors = provider.validate().expect_err("problems reported");
         assert!(errors.to_string().contains("project/bad.sol"));

--- a/crates/edr_solidity_tests/src/multi_runner.rs
+++ b/crates/edr_solidity_tests/src/multi_runner.rs
@@ -204,6 +204,7 @@ impl<
             generate_gas_report,
             test_source_paths,
             import_resolver,
+            inline_config_profiles,
         } = config;
 
         // Collect the test sources' inline configuration up front, off the async
@@ -212,7 +213,7 @@ impl<
         // the whole run before any test executes.
         let roots = inline_config_roots(&test_source_paths, &test_contracts);
         let inline_config_provider = tokio::task::spawn_blocking(move || {
-            SharedInlineConfigProvider::collect(roots, import_resolver)
+            SharedInlineConfigProvider::collect(roots, import_resolver, inline_config_profiles)
         })
         .await
         .expect("Thread shouldn't panic");

--- a/crates/edr_solidity_tests/tests/it/fuzz.rs
+++ b/crates/edr_solidity_tests/tests/it/fuzz.rs
@@ -6,6 +6,7 @@ use alloy_primitives::{Bytes, U256};
 use edr_gas_report::GasReportExecutionStatus;
 use edr_solidity_tests::{
     fuzz::CounterExample,
+    inline_config::InlineConfigProfiles,
     result::{SuiteResult, TestKind, TestStatus},
 };
 
@@ -31,7 +32,7 @@ async fn test_fuzz() {
             .join("|"),
         )
         .exclude_paths("invariant")
-        .exclude_contracts("FuzzConfigOverrideTest");
+        .exclude_contracts("FuzzConfigOverrideTest|FuzzProfileOverrideTest");
     let runner = TEST_DATA_DEFAULT.runner().await;
     let suite_result = runner.test_collect(filter).await.suite_results;
 
@@ -459,4 +460,63 @@ async fn test_fuzz_function_overrides() {
         override_runs_result.kind,
         TestKind::Fuzz { runs: 10, .. }
     ));
+}
+
+/// A prefixed directive applies only under its own profile; an unprefixed one
+/// applies under every profile. See `fuzz/FuzzProfileOverride.t.sol`.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fuzz_profile_overrides() {
+    // The run counts each test resolves to under each selected profile. The
+    // global config sets 100 runs, so a test with no directive that applies
+    // lands there.
+    let expected_runs = [
+        (
+            "default",
+            [
+                ("testFuzz_Unprefixed", 3),
+                ("testFuzz_ProfileWinsOverUnprefixed", 3),
+                ("testFuzz_DefaultProfileOnly", 4),
+            ],
+        ),
+        (
+            "ci",
+            [
+                ("testFuzz_Unprefixed", 3),
+                ("testFuzz_ProfileWinsOverUnprefixed", 8),
+                ("testFuzz_DefaultProfileOnly", 100),
+            ],
+        ),
+    ];
+
+    for (selected, cases) in expected_runs {
+        let filter = SolidityTestFilter::new(".*", ".*", ".*fuzz/FuzzProfileOverride.t.sol");
+        let mut config = TEST_DATA_DEFAULT.config_with_mock_rpc();
+        config.fuzz.runs = 100;
+        config.fuzz.max_test_rejects = 0;
+        config.inline_config_profiles =
+            InlineConfigProfiles::new(selected, ["ci".to_owned()]).expect("valid profiles");
+
+        let runner = TEST_DATA_DEFAULT.runner_with_fuzz_persistence(config).await;
+        let results = runner.test_collect(filter).await.suite_results;
+
+        let suite_result = results
+            .get("default/fuzz/FuzzProfileOverride.t.sol:FuzzProfileOverrideTest")
+            .unwrap_or_else(|| panic!("suite ran under {selected}"));
+
+        for (function, expected) in cases {
+            let name = format!("{function}(uint256)");
+            let result = suite_result
+                .test_results
+                .get(&name)
+                .unwrap_or_else(|| panic!("{name} ran under {selected}"));
+
+            let TestKind::Fuzz { runs, .. } = result.kind else {
+                panic!(
+                    "{name} under {selected} is not a fuzz test: {:?}",
+                    result.kind
+                );
+            };
+            assert_eq!(runs, expected, "{name} under profile `{selected}`");
+        }
+    }
 }

--- a/crates/edr_solidity_tests/tests/it/helpers.rs
+++ b/crates/edr_solidity_tests/tests/it/helpers.rs
@@ -31,7 +31,7 @@ use edr_solidity::{
 };
 use edr_solidity_tests::{
     fuzz::FuzzDictionaryConfig,
-    inline_config::ImportResolver,
+    inline_config::{ImportResolver, InlineConfigProfiles, DEFAULT_PROFILE},
     multi_runner::{TestContract, TestContracts},
     revm::context::{BlockEnv, TxEnv},
     CollectStackTraces, MultiContractRunner, SolidityTestRunnerConfig,
@@ -200,6 +200,11 @@ impl ForgeTestProfile {
             // mappings (relative imports resolve, others degrade gracefully).
             test_source_paths: HashMap::new(),
             import_resolver: ImportResolver::default(),
+            // Collection covers every test source, not just the ones a run
+            // filters to, so testdata must declare every profile its sources
+            // mention: `ci`, in `fuzz/FuzzProfileOverride.t.sol`.
+            inline_config_profiles: InlineConfigProfiles::new(DEFAULT_PROFILE, ["ci".to_owned()])
+                .expect("valid profiles"),
         }
     }
 

--- a/crates/edr_solidity_tests/tests/testdata/default/fuzz/FuzzProfileOverride.t.sol
+++ b/crates/edr_solidity_tests/tests/testdata/default/fuzz/FuzzProfileOverride.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.18;
+
+import "ds-test/test.sol";
+
+contract FuzzProfileOverrideTest is DSTest {
+    // No profile prefix, so it applies under every profile (runs = 3).
+    /// forge-config: fuzz.runs = 3
+    function testFuzz_Unprefixed(uint256 a) public {
+        assertEq(a, a);
+    }
+
+    // Under `ci` the prefixed directive wins, even though it's written first.
+    /// forge-config: ci.fuzz.runs = 8
+    /// forge-config: fuzz.runs = 3
+    function testFuzz_ProfileWinsOverUnprefixed(uint256 a) public {
+        assertEq(a, a);
+    }
+
+    // Applies only under `default`; other profiles use the global config.
+    /// forge-config: default.fuzz.runs = 4
+    function testFuzz_DefaultProfileOnly(uint256 a) public {
+        assertEq(a, a);
+    }
+}

--- a/js/integration-tests/solidity-tests/test-contracts/InlineConfigProfiles.t.sol
+++ b/js/integration-tests/solidity-tests/test-contracts/InlineConfigProfiles.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.18;
+
+import {Test} from "forge-std/src/Test.sol";
+
+contract InlineConfigProfilesTest is Test {
+    // No profile prefix, so it applies under every profile (runs = 3).
+    /// hardhat-config: fuzz.runs = 3
+    function testFuzz_Unprefixed(uint256 a) public pure {
+        assertEq(a, a);
+    }
+
+    // Under `ci` the prefixed directive wins, even though it's written first.
+    /// hardhat-config: ci.fuzz.runs = 8
+    /// hardhat-config: fuzz.runs = 3
+    function testFuzz_ProfileWinsOverUnprefixed(uint256 a) public pure {
+        assertEq(a, a);
+    }
+
+    // Applies only under `default`; other profiles use the global config.
+    /// hardhat-config: default.fuzz.runs = 4
+    function testFuzz_DefaultProfileOnly(uint256 a) public pure {
+        assertEq(a, a);
+    }
+}

--- a/js/integration-tests/solidity-tests/test-contracts/InlineConfigUndeclaredProfile.t.sol
+++ b/js/integration-tests/solidity-tests/test-contracts/InlineConfigUndeclaredProfile.t.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.18;
+
+import {Test} from "forge-std/src/Test.sol";
+
+// The directive names a profile the run doesn't declare, so the inline-config
+// parser rejects it and aborts the whole run before any test executes.
+contract InlineConfigUndeclaredProfileTest is Test {
+    /// hardhat-config: nope.fuzz.runs = 1
+    function testFuzz_UndeclaredProfile(uint256 a) public pure {
+        assertEq(a, a);
+    }
+}

--- a/js/integration-tests/solidity-tests/test/fuzz.ts
+++ b/js/integration-tests/solidity-tests/test/fuzz.ts
@@ -608,4 +608,55 @@ describe("Fuzz and invariant testing", function () {
       BigInt(OVERRIDEN_RUNS * OVERRIDEN_DEPTH)
     ); // Overridden
   });
+
+  it("FuzzProfileOverrides", async function () {
+    const GLOBAL_RUNS = 100;
+
+    // The run count each test resolves to under each selected profile. See the
+    // inline directives in `InlineConfigProfiles.t.sol`.
+    const expected = {
+      default: {
+        "testFuzz_Unprefixed(uint256)": 3,
+        "testFuzz_ProfileWinsOverUnprefixed(uint256)": 3,
+        "testFuzz_DefaultProfileOnly(uint256)": 4,
+      },
+      ci: {
+        "testFuzz_Unprefixed(uint256)": 3,
+        "testFuzz_ProfileWinsOverUnprefixed(uint256)": 8,
+        // The `default.`-scoped directive doesn't apply here, so this falls
+        // back to the global configuration.
+        "testFuzz_DefaultProfileOnly(uint256)": GLOBAL_RUNS,
+      },
+    };
+
+    for (const [testProfile, runsByTest] of Object.entries(expected)) {
+      const result = await testContext.runTestsWithStats(
+        "InlineConfigProfilesTest",
+        {
+          fuzz: { runs: GLOBAL_RUNS, maxTestRejects: 0 },
+          testProfile,
+          declaredTestProfiles: ["default", "ci"],
+        }
+      );
+
+      assert.equal(result.failedTests, 0, `profile ${testProfile}`);
+      assert.equal(result.totalTests, 3, `profile ${testProfile}`);
+
+      for (const testResult of result.suiteResults[0].testResults) {
+        const expectedRuns =
+          runsByTest[testResult.name as keyof typeof runsByTest];
+        assert.notEqual(
+          expectedRuns,
+          undefined,
+          `unexpected test ${testResult.name}`
+        );
+        const fuzzKind = testResult.kind as FuzzTestKind;
+        assert.equal(
+          fuzzKind.runs,
+          BigInt(expectedRuns),
+          `${testResult.name} under profile ${testProfile}`
+        );
+      }
+    }
+  });
 });

--- a/js/integration-tests/solidity-tests/test/unit.ts
+++ b/js/integration-tests/solidity-tests/test/unit.ts
@@ -99,6 +99,43 @@ describe("Unit tests", () => {
     );
   });
 
+  it("UndeclaredInlineConfigProfile", async function () {
+    // A directive's profile prefix is validated against the declared profiles,
+    // not the selected one, so a mistyped prefix fails whichever profile the
+    // run selects.
+    for (const testProfile of ["default", "ci"]) {
+      await assert.rejects(
+        testContext.runTestsWithStats("InlineConfigUndeclaredProfileTest", {
+          testProfile,
+          declaredTestProfiles: ["default", "ci"],
+        }),
+        (error: Error & { inlineConfigErrors?: InlineConfigError[] }) => {
+          const errors = error.inlineConfigErrors;
+          if (!Array.isArray(errors) || errors.length !== 1) {
+            throw new Error(
+              `expected one structured inline config error, got ${JSON.stringify(errors)}`
+            );
+          }
+
+          const [entry] = errors;
+          if (entry.kind !== "directive") {
+            throw new Error(`expected a directive problem, got ${entry.kind}`);
+          }
+          assert.equal(entry.function, "testFuzz_UndeclaredProfile");
+          if (entry.problem.kind !== "InlineConfigUndeclaredProfile") {
+            throw new Error(
+              `expected InlineConfigUndeclaredProfile, got ${entry.problem.kind}`
+            );
+          }
+          assert.equal(entry.problem.profile, "nope");
+          // The declared profiles are reported so the message can name them.
+          assert.deepEqual(entry.problem.declaredProfiles, ["ci", "default"]);
+          return true;
+        }
+      );
+    }
+  });
+
   it("Latest global fork stack trace", async function (t) {
     if (testContext.rpcUrl === undefined) {
       return t.skip();


### PR DESCRIPTION
Adds test profile support to inline configuration, so Hardhat can offer profiles for Solidity tests.

`SolidityTestRunnerConfigArgs` gains two optional fields, `testProfile` and `declaredTestProfiles`, both defaulting to `default`. A caller that passes neither is unaffected.

A directive's key can now carry a profile prefix:

```solidity
/// forge-config: fuzz.runs = 3       // applies under every profile
/// forge-config: ci.fuzz.runs = 500  // applies only under `ci`
```

Where both set the same key, the prefixed one wins. Prefixes are validated against the *declared* profiles rather than the selected one, so a typo fails whichever profile is running.

### Behaviour changes

- A `default.`-prefixed directive is now scoped to the `default` profile instead of applying unconditionally.
- An unprefixed directive alongside a prefixed one setting the same key is no longer a duplicate-key error.
- `InlineConfigUnsupportedProfile` is renamed to `InlineConfigUndeclaredProfile` and now carries `declaredProfiles`.

The [design doc](https://app.notion.com/p/nomicfoundation/Solidity-test-profiles-3bc578cdeaf58000ba6bffbdc1ca735e) has the full rationale, including why prefixes validate against the declared set and why directives for unselected profiles are still validated.

Hardhat PR: https://github.com/NomicFoundation/hardhat/pull/8590
