### PR TITLE
fix(edr_solidity): accept 64-bit optimizer.runs in compiler input

### DIFF
--- a/.changeset/optimizer-runs-u64.md
+++ b/.changeset/optimizer-runs-u64.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Fixed build-info parsing rejecting compiler input whose `optimizer.runs` exceeds 32 bits. Projects using vanity runs values such as `444444444444` (aave-v4's historical setting) failed the whole build-info parse — disabling stack traces — even though solc accepts the value; the field is now read as 64-bit, matching solc and foundry-compilers.

--- a/crates/edr_solidity/src/artifacts.rs
+++ b/crates/edr_solidity/src/artifacts.rs
@@ -364,8 +364,6 @@ pub struct CompilerSettings {
 /// Specifies the optimizer settings.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct OptimizerSettings {
-    // 64-bit like solc and foundry-compilers: real projects ship vanity
-    // values such as aave-v4's 444444444444, which overflow u32.
     runs: Option<u64>,
     enabled: Option<bool>,
     details: Option<OptimizerDetails>,

--- a/crates/edr_solidity/src/artifacts.rs
+++ b/crates/edr_solidity/src/artifacts.rs
@@ -364,7 +364,9 @@ pub struct CompilerSettings {
 /// Specifies the optimizer settings.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct OptimizerSettings {
-    runs: Option<u32>,
+    // 64-bit like solc and foundry-compilers: real projects ship vanity
+    // values such as aave-v4's 444444444444, which overflow u32.
+    runs: Option<u64>,
     enabled: Option<bool>,
     details: Option<OptimizerDetails>,
 }
@@ -598,5 +600,28 @@ mod tests {
 
         assert_eq!(to_compiler_type(None), CompilerType::Solc);
         assert_eq!(to_compiler_type(Some("not-a-compiler")), CompilerType::Solc);
+    }
+
+    /// aave-v4 shipped `optimizer.runs: 444444444444` (a widespread
+    /// vanity-runs convention); solc and foundry-compilers both treat the
+    /// field as 64-bit, so build-info parsing must not reject or clamp it.
+    #[test]
+    fn optimizer_runs_wider_than_u32_round_trips() {
+        let raw = serde_json::json!({
+            "language": "Solidity",
+            "sources": {},
+            "settings": {
+                "optimizer": { "enabled": true, "runs": 444_444_444_444_u64 },
+                "outputSelection": {},
+            },
+        });
+
+        let input: CompilerInput =
+            serde_json::from_value(raw).expect("64-bit optimizer.runs must deserialize");
+        let round_tripped = serde_json::to_value(&input).expect("serializes");
+        assert_eq!(
+            round_tripped["settings"]["optimizer"]["runs"],
+            serde_json::json!(444_444_444_444_u64)
+        );
     }
 }


### PR DESCRIPTION
Change `runs` in the `solc` `OptimizerSettings` to support `U64`, to support Aave's value, and potentially other projects. 

# Claude summary
## Why

`edr_solidity`'s `OptimizerSettings.runs` was `Option<u32>`, but real projects ship vanity runs values wider than that: aave-v4's config historically used `optimizer.runs: 444444444444` (4.4×10¹¹; the current upstream reduced it to `44444444`, apparently to accommodate tooling with exactly this kind of limit). solc accepts the value — it treats runs as 64-bit, as does `foundry-compilers` (`Optimizer { runs: Option<usize> }` in our own dependency tree) — so build-info containing it is legitimate compiler input.

The impact was disproportionate: the serde error propagates out of `BuildInfoBuffers::parse`, failing the **entire build-info parse** — and with it stack traces — on both the solc and slang-solx paths, over a field the contract decoder never reads.

Found while building a DWARF decode benchmark corpus from aave-v4's real hardhat-slang-solx build-info (#1718): the bench setup hit `invalid value: integer '444444444444', expected u32`.

## What

- `runs: Option<u32>` → `Option<u64>`, matching solc and foundry-compilers. The field is deserialized but never read, so nothing downstream changes.
- Regression test deserializes a minimal `CompilerInput` with `runs: 444444444444` and round-trips it through serialization, so a silent clamp would also fail it. Proven red on the pre-fix code.
- Changeset: patch.
