### PR TITLE
fix: reclaim a provider's OS thread when it becomes unreachable

### DIFF
--- a/.changeset/provider-thread-gc-pressure.md
+++ b/.changeset/provider-thread-gc-pressure.md
@@ -1,0 +1,7 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Fixed provider threads accumulating until the process ran out of them. Each provider owns a dedicated OS thread, which V8 could not see, so an unreachable provider was never collected and its thread never joined. On macOS, whose per-process thread limit is far below Linux's, a suite creating hundreds of providers exhausted it.
+
+`createProvider` now rejects when the OS refuses a thread, instead of panicking and leaving its promise pending forever.

--- a/crates/edr_napi/src/context.rs
+++ b/crates/edr_napi/src/context.rs
@@ -21,7 +21,7 @@ use crate::{
     config::{resolve_configs, ConfigResolution, ProviderConfig, TracingConfigWithBuffers},
     contract_decoder::ContractDecoder,
     logger::LoggerConfig,
-    provider::{factory::SyncProviderFactory, Provider, ProviderFactory},
+    provider::{factory::SyncProviderFactory, GcProvider, Provider, ProviderFactory},
     solidity_tests::{
         artifact::{Artifact, ArtifactId},
         config::SolidityTestRunnerConfigArgs,
@@ -139,14 +139,14 @@ impl EdrContext {
                     Arc::clone(&contract_decoder),
                 )
                 .map(|provider| {
-                    Provider::new(
+                    GcProvider::from(Provider::new(
                         provider,
                         runtime,
                         contract_decoder,
                         dropped_provider_sender,
                         #[cfg(feature = "scenarios")]
                         scenario_file,
-                    )
+                    ))
                 });
 
             deferred.resolve(|_env| result);
@@ -390,11 +390,13 @@ impl EdrContext {
 impl EdrContext {
     /// Creates a mock provider, which always returns the given response.
     /// For testing purposes.
-    #[napi(async_runtime)]
+    // `GcProvider` only carries the value to JavaScript, which receives a
+    // `Provider`.
+    #[napi(async_runtime, ts_return_type = "Provider")]
     pub fn create_mock_provider(
         &self,
         mocked_response: serde_json::Value,
-    ) -> napi::Result<Provider> {
+    ) -> napi::Result<GcProvider> {
         use crate::mock::MockProvider;
 
         let runtime = runtime::Handle::current();
@@ -404,16 +406,14 @@ impl EdrContext {
             context.provider_deallocator.sender()
         };
 
-        let provider = Provider::new(
+        Ok(GcProvider::from(Provider::new(
             Arc::new(MockProvider::new(mocked_response)),
             runtime,
             Arc::default(),
             dropped_provider_sender,
             #[cfg(feature = "scenarios")]
             None,
-        );
-
-        Ok(provider)
+        )))
     }
 
     /// Creates a provider with a mock timer.
@@ -462,7 +462,7 @@ impl EdrContext {
             // Using a closure to limit the scope, allowing us to use `?` for error
             // handling. This is necessary because the result of the closure is used
             // to resolve the deferred promise.
-            let create_provider = move || -> napi::Result<Provider> {
+            let create_provider = move || -> napi::Result<GcProvider> {
                 use crate::subscription::subscriber_callback_for_chain_spec;
 
                 let logger = Logger::<GenericChainSpec, Arc<edr_provider::time::MockTime>>::new(
@@ -491,14 +491,14 @@ impl EdrContext {
                 )
                 .map_err(|error| napi::Error::from_reason(error.to_string()))?;
 
-                Ok(Provider::new(
+                Ok(GcProvider::from(Provider::new(
                     Arc::new(provider),
                     runtime,
                     contract_decoder,
                     dropped_provider_sender,
                     #[cfg(feature = "scenarios")]
                     None,
-                ))
+                )))
             };
 
             let result = create_provider();

--- a/crates/edr_napi/src/gc.rs
+++ b/crates/edr_napi/src/gc.rs
@@ -1,14 +1,42 @@
 use napi::{bindgen_prelude::ToNapiValue, sys, Env};
 
-/// Wraps a value so that handing it to JavaScript reports `EXTERNAL_MEMORY`
-/// bytes to V8.
+/// Declares how much external memory a type's JavaScript object stands for.
 ///
-/// # `T`'s finalizer must release the same amount
+/// Implemented by `gc_tracked!`, which also emits the finalizer releasing
+/// [`Self::EXTERNAL_MEMORY`] again. Implementing it by hand gets the report
+/// without that release.
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` is not declared with `gc_tracked!`",
+    label = "not declared with `gc_tracked!`",
+    note = "invoke `gc_tracked!`, which declares the alias, the amount and the finalizer together"
+)]
+pub trait HasExternalMemory {
+    /// Bytes reported to V8 while the JavaScript object is alive.
+    const EXTERNAL_MEMORY: i64;
+}
+
+/// Blanket-implemented for every type that has its own [`Drop`], so
+/// `gc_tracked!`'s matching implementation collides with it.
 ///
-/// The wrapper exists only for the conversion. JavaScript receives `T`'s own
-/// object, so `T`'s [`ObjectFinalize`] implementation is the only place that
-/// can call [`Env::adjust_external_memory`] with `-EXTERNAL_MEMORY`. Nothing
-/// checks that it does, so keep the two sites with the constant they share.
+/// The collision is the diagnostic: a type reaching `gc_tracked!` with a
+/// hand-written `Drop` gets an `E0119` naming this trait, whose name says
+/// where that implementation belongs instead.
+// Never a bound, so the collision is the only thing this trait is for.
+#[expect(dead_code)]
+pub trait MoveTheDropImplIntoGcTracked {}
+
+// The `drop_bounds` lint targets exactly this bound, which is the detector
+// here.
+#[expect(drop_bounds)]
+impl<T: Drop> MoveTheDropImplIntoGcTracked for T {}
+
+/// Wraps a value so that handing it to JavaScript reports
+/// [`HasExternalMemory::EXTERNAL_MEMORY`] bytes to V8.
+///
+/// `gc_tracked!` is the only thing that implements [`HasExternalMemory`], and
+/// it emits the finalizer that releases the same constant. The report and its
+/// release are therefore declared together, and neither can name a different
+/// amount.
 ///
 /// # Why report at all
 ///
@@ -18,25 +46,87 @@ use napi::{bindgen_prelude::ToNapiValue, sys, Env};
 /// If an exact size is not known, a heuristic suffices: telling Node the
 /// order of magnitude of the external allocation matters more than being
 /// precise.
-///
-/// [`ObjectFinalize`]: napi::bindgen_prelude::ObjectFinalize
 #[repr(transparent)]
-pub struct GcTracked<T, const EXTERNAL_MEMORY: i64>(T);
+pub struct GcTracked<T: HasExternalMemory>(T);
 
-impl<T, const EXTERNAL_MEMORY: i64> From<T> for GcTracked<T, EXTERNAL_MEMORY> {
+impl<T: HasExternalMemory> From<T> for GcTracked<T> {
     fn from(value: T) -> Self {
         Self(value)
     }
 }
 
-impl<T: ToNapiValue, const EXTERNAL_MEMORY: i64> ToNapiValue for GcTracked<T, EXTERNAL_MEMORY> {
+impl<T: ToNapiValue + HasExternalMemory> ToNapiValue for GcTracked<T> {
     unsafe fn to_napi_value(env: sys::napi_env, val: Self) -> napi::Result<sys::napi_value> {
         // Reported before the conversion, because only a JS object gets a
         // finalizer to release it. A conversion that fails afterwards leaves an
         // over-report, which makes V8 more eager rather than less.
-        Env::from_raw(env).adjust_external_memory(EXTERNAL_MEMORY)?;
+        Env::from_raw(env).adjust_external_memory(T::EXTERNAL_MEMORY)?;
 
         // SAFETY: `env` is valid, as this function's own contract requires.
         unsafe { T::to_napi_value(env, val.0) }
     }
 }
+
+/// Declares a [`GcTracked`] alias for a type, along with the amount its
+/// JavaScript object reports and the finalizer that releases it.
+///
+/// `GcTracked` in the alias is a literal token rather than a path, so it needs
+/// no import. `fn drop` takes `self` by value, and `mut self` is not
+/// supported.
+///
+/// ```text
+/// gc_tracked! {
+///     /// A `Provider` on its way to JavaScript.
+///     pub(crate) type GcProvider = GcTracked<Provider>;
+///
+///     /// What the JavaScript object stands for.
+///     const EXTERNAL_MEMORY: i64 = 2 * 1024 * 1024;
+///
+///     fn drop(self) {
+///         // whatever `Drop` would have done
+///     }
+/// }
+/// ```
+macro_rules! gc_tracked {
+    (
+        $(#[$alias_meta:meta])*
+        $alias_vis:vis type $alias:ident = GcTracked<$ty:ty>;
+
+        $(#[$memory_meta:meta])*
+        const EXTERNAL_MEMORY: i64 = $external_memory:expr;
+
+        fn drop($self:ident) $body:block
+    ) => {
+        $(#[$alias_meta])*
+        $alias_vis type $alias = $crate::gc::GcTracked<$ty>;
+
+        impl $crate::gc::HasExternalMemory for $ty {
+            $(#[$memory_meta])*
+            const EXTERNAL_MEMORY: i64 = $external_memory;
+        }
+
+        impl $crate::gc::MoveTheDropImplIntoGcTracked for $ty {}
+
+        impl $ty {
+            fn __gc_tracked_drop($self) $body
+        }
+
+        impl ::napi::bindgen_prelude::ObjectFinalize for $ty {
+            fn finalize($self, env: ::napi::Env) -> ::napi::Result<()> {
+                // Runs first, so returning below cannot drop the value on the
+                // JS thread.
+                Self::__gc_tracked_drop($self);
+
+                // Releases what the conversion to JavaScript reported. Only a
+                // JS object reaches this finalizer, so the amounts pair up.
+                env.adjust_external_memory(
+                    -<Self as $crate::gc::HasExternalMemory>::EXTERNAL_MEMORY,
+                )?;
+
+                Ok(())
+            }
+        }
+    };
+}
+
+pub(crate) use gc_tracked;

--- a/crates/edr_napi/src/gc.rs
+++ b/crates/edr_napi/src/gc.rs
@@ -1,0 +1,42 @@
+use napi::{bindgen_prelude::ToNapiValue, sys, Env};
+
+/// Wraps a value so that handing it to JavaScript reports `EXTERNAL_MEMORY`
+/// bytes to V8.
+///
+/// # `T`'s finalizer must release the same amount
+///
+/// The wrapper exists only for the conversion. JavaScript receives `T`'s own
+/// object, so `T`'s [`ObjectFinalize`] implementation is the only place that
+/// can call [`Env::adjust_external_memory`] with `-EXTERNAL_MEMORY`. Nothing
+/// checks that it does, so keep the two sites with the constant they share.
+///
+/// # Why report at all
+///
+/// V8 schedules collection from the pressure it can see, and a JS wrapper
+/// around an expensive Rust resource is a handful of bytes. Reporting the
+/// resource's weight is what makes an unreachable wrapper worth collecting.
+/// If an exact size is not known, a heuristic suffices: telling Node the
+/// order of magnitude of the external allocation matters more than being
+/// precise.
+///
+/// [`ObjectFinalize`]: napi::bindgen_prelude::ObjectFinalize
+#[repr(transparent)]
+pub struct GcTracked<T, const EXTERNAL_MEMORY: i64>(T);
+
+impl<T, const EXTERNAL_MEMORY: i64> From<T> for GcTracked<T, EXTERNAL_MEMORY> {
+    fn from(value: T) -> Self {
+        Self(value)
+    }
+}
+
+impl<T: ToNapiValue, const EXTERNAL_MEMORY: i64> ToNapiValue for GcTracked<T, EXTERNAL_MEMORY> {
+    unsafe fn to_napi_value(env: sys::napi_env, val: Self) -> napi::Result<sys::napi_value> {
+        // Reported before the conversion, because only a JS object gets a
+        // finalizer to release it. A conversion that fails afterwards leaves an
+        // over-report, which makes V8 more eager rather than less.
+        Env::from_raw(env).adjust_external_memory(EXTERNAL_MEMORY)?;
+
+        // SAFETY: `env` is valid, as this function's own contract requires.
+        unsafe { T::to_napi_value(env, val.0) }
+    }
+}

--- a/crates/edr_napi/src/lib.rs
+++ b/crates/edr_napi/src/lib.rs
@@ -22,8 +22,7 @@ pub mod context;
 pub mod contract_decoder;
 mod debug_trace;
 pub mod gas_report;
-/// Reporting Rust-owned resources to the JavaScript garbage collector.
-pub mod gc;
+mod gc;
 /// Types and functions related to code coverage instrumentation.
 pub mod instrument;
 /// Native Keccak-256 hashing.

--- a/crates/edr_napi/src/lib.rs
+++ b/crates/edr_napi/src/lib.rs
@@ -22,6 +22,8 @@ pub mod context;
 pub mod contract_decoder;
 mod debug_trace;
 pub mod gas_report;
+/// Reporting Rust-owned resources to the JavaScript garbage collector.
+pub mod gc;
 /// Types and functions related to code coverage instrumentation.
 pub mod instrument;
 /// Native Keccak-256 hashing.

--- a/crates/edr_napi/src/provider.rs
+++ b/crates/edr_napi/src/provider.rs
@@ -9,7 +9,7 @@ use edr_solidity::artifacts::{
     solc::extract_solc_contract_metadata, solx::extract_solx_contract_metadata, to_compiler_type,
 };
 use napi::{
-    bindgen_prelude::{FnArgs, Function, Object, ObjectFinalize, Promise, Uint8Array},
+    bindgen_prelude::{FnArgs, Function, Object, Promise, Uint8Array},
     tokio::runtime,
     Env, Status,
 };
@@ -20,22 +20,8 @@ pub use self::factory::ProviderFactory;
 use self::response::Response;
 use crate::{
     async_deallocator::AsyncDeallocatorSender, call_override::CallOverrideCallback,
-    contract_decoder::ContractDecoder, gc::GcTracked,
+    contract_decoder::ContractDecoder, gc::gc_tracked,
 };
-
-/// Bytes reported to V8 for the OS thread that a provider owns.
-///
-/// This is the standard library's default stack reservation, which
-/// [`edr_utils_sync::CancellableThread`] does not override. `RUST_MIN_STACK`
-/// does, in which case the figure is wrong but still the right order of
-/// magnitude.
-///
-/// [`GcProvider`] reports it and [`ObjectFinalize::finalize`] releases it, so
-/// the two must stay the same amount.
-pub const THREAD_EXTERNAL_MEMORY: i64 = 2 * 1024 * 1024;
-
-/// A [`Provider`] on its way to JavaScript, reporting its OS thread to V8.
-pub type GcProvider = GcTracked<Provider, THREAD_EXTERNAL_MEMORY>;
 
 /// A JSON-RPC provider for Ethereum.
 #[napi(custom_finalize)]
@@ -53,7 +39,7 @@ impl Provider {
     ///
     /// Hand the result to JavaScript as a [`GcProvider`], so V8 learns of the
     /// OS thread it now owns.
-    pub fn new(
+    pub(crate) fn new(
         provider: Arc<dyn SyncProvider>,
         runtime: runtime::Handle,
         contract_decoder: Arc<RwLock<edr_solidity::contract_decoder::ContractDecoder>>,
@@ -282,23 +268,26 @@ impl Provider {
     }
 }
 
-impl ObjectFinalize for Provider {
-    fn finalize(self, env: Env) -> napi::Result<()> {
+gc_tracked! {
+    /// A [`Provider`] on its way to JavaScript, reporting its OS thread to V8.
+    pub(crate) type GcProvider = GcTracked<Provider>;
+
+    /// The standard library's default thread stack reservation, which
+    /// [`edr_utils_sync::CancellableThread`] does not override.
+    /// `RUST_MIN_STACK` does, in which case the figure is wrong but still the
+    /// right order of magnitude.
+    const EXTERNAL_MEMORY: i64 = 2 * 1024 * 1024;
+
+    fn drop(self) {
         let Self {
             provider,
             dropped_provider_sender,
             ..
         } = self;
 
-        // Releases what `GcProvider` reported. Only a JS object reaches this
-        // finalizer, so the two amounts always pair up.
-        env.adjust_external_memory(-THREAD_EXTERNAL_MEMORY)?;
-
         // Off-loads deallocation to a background thread to avoid blocking the
         // JS thread (the provider may be running thread-safe functions on a
         // background thread; dropping it here would deadlock).
         dropped_provider_sender.deallocate(provider);
-
-        Ok(())
     }
 }

--- a/crates/edr_napi/src/provider.rs
+++ b/crates/edr_napi/src/provider.rs
@@ -20,8 +20,22 @@ pub use self::factory::ProviderFactory;
 use self::response::Response;
 use crate::{
     async_deallocator::AsyncDeallocatorSender, call_override::CallOverrideCallback,
-    contract_decoder::ContractDecoder,
+    contract_decoder::ContractDecoder, gc::GcTracked,
 };
+
+/// Bytes reported to V8 for the OS thread that a provider owns.
+///
+/// This is the standard library's default stack reservation, which
+/// [`edr_utils_sync::CancellableThread`] does not override. `RUST_MIN_STACK`
+/// does, in which case the figure is wrong but still the right order of
+/// magnitude.
+///
+/// [`GcProvider`] reports it and [`ObjectFinalize::finalize`] releases it, so
+/// the two must stay the same amount.
+pub const THREAD_EXTERNAL_MEMORY: i64 = 2 * 1024 * 1024;
+
+/// A [`Provider`] on its way to JavaScript, reporting its OS thread to V8.
+pub type GcProvider = GcTracked<Provider, THREAD_EXTERNAL_MEMORY>;
 
 /// A JSON-RPC provider for Ethereum.
 #[napi(custom_finalize)]
@@ -36,6 +50,9 @@ pub struct Provider {
 
 impl Provider {
     /// Constructs a new instance.
+    ///
+    /// Hand the result to JavaScript as a [`GcProvider`], so V8 learns of the
+    /// OS thread it now owns.
     pub fn new(
         provider: Arc<dyn SyncProvider>,
         runtime: runtime::Handle,
@@ -266,12 +283,16 @@ impl Provider {
 }
 
 impl ObjectFinalize for Provider {
-    fn finalize(self, _env: Env) -> napi::Result<()> {
+    fn finalize(self, env: Env) -> napi::Result<()> {
         let Self {
             provider,
             dropped_provider_sender,
             ..
         } = self;
+
+        // Releases what `GcProvider` reported. Only a JS object reaches this
+        // finalizer, so the two amounts always pair up.
+        env.adjust_external_memory(-THREAD_EXTERNAL_MEMORY)?;
 
         // Off-loads deallocation to a background thread to avoid blocking the
         // JS thread (the provider may be running thread-safe functions on a

--- a/crates/edr_provider/src/error.rs
+++ b/crates/edr_provider/src/error.rs
@@ -110,6 +110,9 @@ pub enum CreationError<GenesisBlockCreationErrorT, HardforkT> {
     /// An error that occured while querying the remote state.
     #[error(transparent)]
     RpcClient(#[from] RpcClientError),
+    /// The OS refused to start the thread that owns the provider's state.
+    #[error("Failed to spawn the provider thread: {0}")]
+    ThreadSpawn(#[source] std::io::Error),
 }
 
 /// Helper type for a chain-specific [`ProviderError`].

--- a/crates/edr_provider/src/provider.rs
+++ b/crates/edr_provider/src/provider.rs
@@ -11,7 +11,7 @@ use tokio::runtime;
 use crate::{
     config::ProviderConfig,
     data::ProviderData,
-    error::{CreationErrorForChainSpec, ProviderError, ProviderErrorForChainSpec},
+    error::{CreationError, CreationErrorForChainSpec, ProviderError, ProviderErrorForChainSpec},
     event_loop::{self, Message, OnResponse},
     logger::SyncLogger,
     mock::SyncCallOverride,
@@ -148,7 +148,7 @@ impl<
             CancellableThread::spawn("edr-provider".to_owned(), move |cancellation_receiver| {
                 event_loop::run(data, request_receiver, cancellation_receiver);
             })
-            .expect("failed to spawn the provider thread");
+            .map_err(CreationError::ThreadSpawn)?;
 
         Ok(Self {
             request_sender,

--- a/hardhat-tests/test/internal/hardhat-network/provider/modules/evm.ts
+++ b/hardhat-tests/test/internal/hardhat-network/provider/modules/evm.ts
@@ -947,7 +947,9 @@ describe("Evm module", function () {
             });
 
             it("should allow disabling interval mining", async function () {
-              const interval = 100;
+              // Generous, because the assertions below depend on a block
+              // arriving within `0.7 * interval` of when it is due.
+              const interval = 250;
               const initialBlock = await getBlockNumber();
               await this.provider.send("evm_setIntervalMining", [interval]);
 
@@ -967,7 +969,9 @@ describe("Evm module", function () {
             });
 
             it("should mine block with transaction after the interval", async function () {
-              const interval = 100;
+              // Generous, because the assertion below depends on a block
+              // arriving within `0.7 * interval` of when it is due.
+              const interval = 250;
               const txHash = await this.provider.send("eth_sendTransaction", [
                 {
                   from: DEFAULT_ACCOUNTS_ADDRESSES[1],

--- a/patches/hardhat@2.28.4.patch
+++ b/patches/hardhat@2.28.4.patch
@@ -21,10 +21,16 @@ index 9d31ee4326d66725b85b5ce45de79ba29c252deb..ea82219d526e39c64215c5cf2aa4b6fb
 +{"version":3,"file":"provider.d.ts","sourceRoot":"","sources":["../../../src/internal/hardhat-network/provider/provider.ts"],"names":[],"mappings":";AAAA,OAAO,KAAK,EACV,SAAS,EAGT,eAAe,EAEf,0BAA0B,EAC1B,gBAAgB,EACjB,MAAM,gBAAgB,CAAC;AAExB,OAAO,KAAK,EACV,UAAU,EAKV,wBAAwB,EAKzB,MAAM,sBAAsB,CAAC;AAK9B,OAAO,EAAE,YAAY,EAAE,MAAM,QAAQ,CAAC;AAoCtC,OAAO,EACL,UAAU,EACV,cAAc,EACd,oBAAoB,EACpB,YAAY,EACb,MAAM,cAAc,CAAC;AAUtB,OAAO,EAAE,YAAY,EAA8B,MAAM,kBAAkB,CAAC;AAO5E,eAAO,MAAM,gBAAgB,+CAA+C,CAAC;AAI7E,wBAAsB,mBAAmB,IAAI,OAAO,CAAC,UAAU,CAAC,CAgB/D;AAED,UAAU,4BAA4B;IACpC,QAAQ,EAAE,MAAM,CAAC;IACjB,OAAO,EAAE,MAAM,CAAC;IAChB,SAAS,EAAE,MAAM,CAAC;IAClB,aAAa,EAAE,MAAM,CAAC;IACtB,WAAW,EAAE,MAAM,CAAC;IACpB,QAAQ,EAAE,OAAO,CAAC;IAClB,cAAc,EAAE,oBAAoB,CAAC;IACrC,YAAY,EAAE,YAAY,CAAC;IAC3B,MAAM,EAAE,0BAA0B,CAAC;IACnC,eAAe,EAAE,cAAc,EAAE,CAAC;IAClC,0BAA0B,EAAE,OAAO,CAAC;IACpC,0BAA0B,EAAE,OAAO,CAAC;IACpC,mBAAmB,EAAE,OAAO,CAAC;IAC7B,4BAA4B,EAAE,OAAO,CAAC;IAEtC,oBAAoB,CAAC,EAAE,MAAM,CAAC;IAC9B,WAAW,CAAC,EAAE,IAAI,CAAC;IACnB,QAAQ,CAAC,EAAE,MAAM,CAAC;IAClB,UAAU,CAAC,EAAE,UAAU,CAAC;IACxB,aAAa,CAAC,EAAE,MAAM,CAAC;IACvB,sBAAsB,EAAE,OAAO,CAAC;IAChC,aAAa,EAAE,OAAO,CAAC;CACxB;AAWD,qBAAa,kBACX,SAAQ,YACR,YAAW,eAAe;IAQxB,OAAO,CAAC,SAAS;IACjB,OAAO,CAAC,QAAQ,CAAC,eAAe;IAChC,OAAO,CAAC,QAAQ,CAAC,aAAa;IAE9B,OAAO,CAAC,KAAK;IAGb,OAAO,CAAC,QAAQ,CAAC,mBAAmB;IAIpC,OAAO,CAAC,QAAQ,CAAC,wBAAwB;IACzC,OAAO,CAAC,QAAQ,CAAC,iBAAiB;IAClC,OAAO,CAAC,QAAQ,CAAC,uBAAuB;IACxC,OAAO,CAAC,QAAQ,CAAC,6BAA6B;IAC9C,OAAO,CAAC,QAAQ,CAAC,yBAAyB;IArB5C,OAAO,CAAC,kBAAkB,CAAK;IAG/B,OAAO,CAAC,qBAAqB,CAAC,CAAuB;IAErD,OAAO;WAqBa,MAAM,CACxB,MAAM,EAAE,4BAA4B,EACpC,YAAY,EAAE,YAAY,EAC1B,aAAa,CAAC,EAAE,wBAAwB,GACvC,OAAO,CAAC,kBAAkB,CAAC;IAsLjB,OAAO,CAAC,IAAI,EAAE,gBAAgB,GAAG,OAAO,CAAC,OAAO,CAAC;YAyJhD,qBAAqB;YAerB,MAAM;YA0EN,wBAAwB;YAexB,kBAAkB;IAIhC,OAAO,CAAC,iBAAiB;IASzB,OAAO,CAAC,4BAA4B;IAOpC,OAAO,CAAC,6BAA6B;CAWtC;AAQD,wBAAsB,4BAA4B,CAChD,4BAA4B,EAAE,4BAA4B,EAC1D,YAAY,EAAE,YAAY,EAC1B,SAAS,CAAC,EAAE,SAAS,GACpB,OAAO,CAAC,eAAe,CAAC,CAY1B"}
 \ No newline at end of file
 diff --git a/internal/hardhat-network/provider/provider.js b/internal/hardhat-network/provider/provider.js
-index 8f6a795176e0ccb5e78a96143be1dab4b8d78593..39f5ddf52aa97aa565416fbf5ee902e104b0a600 100644
+index 8f6a795176e0ccb5e78a96143be1dab4b8d78593..e64fdf0b1679599573290486b8f67b1d8e51268d 100644
 --- a/internal/hardhat-network/provider/provider.js
 +++ b/internal/hardhat-network/provider/provider.js
-@@ -70,9 +70,10 @@ class EdrProviderWrapper extends events_1.EventEmitter {
+@@ -64,15 +64,14 @@ async function getGlobalEdrContext() {
+     return _globalEdrContext;
+ }
+ exports.getGlobalEdrContext = getGlobalEdrContext;
+-class EdrProviderEventAdapter extends events_1.EventEmitter {
+-}
+ class EdrProviderWrapper extends events_1.EventEmitter {
      constructor(_provider, _providerConfig, _loggerConfig, 
      // we add this for backwards-compatibility with plugins like solidity-coverage
      _node, _subscriptionConfig, 
@@ -38,7 +44,7 @@ index 8f6a795176e0ccb5e78a96143be1dab4b8d78593..39f5ddf52aa97aa565416fbf5ee902e1
          super();
          this._provider = _provider;
          this._providerConfig = _providerConfig;
-@@ -82,6 +83,8 @@ class EdrProviderWrapper extends events_1.EventEmitter {
+@@ -82,6 +81,8 @@ class EdrProviderWrapper extends events_1.EventEmitter {
          this._originalGenesisAccounts = _originalGenesisAccounts;
          this._originalCacheDir = _originalCacheDir;
          this._originalChainOverrides = _originalChainOverrides;
@@ -47,7 +53,7 @@ index 8f6a795176e0ccb5e78a96143be1dab4b8d78593..39f5ddf52aa97aa565416fbf5ee902e1
          this._failedStackTraces = 0;
      }
      static async create(config, loggerConfig, tracingConfig) {
-@@ -100,9 +103,13 @@ class EdrProviderWrapper extends events_1.EventEmitter {
+@@ -100,9 +101,13 @@ class EdrProviderWrapper extends events_1.EventEmitter {
              };
          });
          const cacheDir = config.forkCachePath;
@@ -63,23 +69,28 @@ index 8f6a795176e0ccb5e78a96143be1dab4b8d78593..39f5ddf52aa97aa565416fbf5ee902e1
                  blockNumber: config.forkConfig.blockNumber !== undefined
                      ? BigInt(config.forkConfig.blockNumber)
                      : undefined,
-@@ -112,9 +119,12 @@ class EdrProviderWrapper extends events_1.EventEmitter {
+@@ -112,17 +117,22 @@ class EdrProviderWrapper extends events_1.EventEmitter {
                  url: config.forkConfig.jsonRpcUrl,
              };
          }
 -        const initialDate = config.initialDate !== undefined
 -            ? BigInt(Math.floor(config.initialDate.getTime() / 1000))
 -            : undefined;
+-        // To accommodate construction ordering, we need an adapter to forward events
+-        // from the EdrProvider callback to the wrapper's listener
+-        const eventAdapter = new EdrProviderEventAdapter();
 +        else {
 +            network = {
 +                genesisBlockGasLimit,
 +                genesisBlockTime,
 +            };
 +        }
-         // To accommodate construction ordering, we need an adapter to forward events
-         // from the EdrProvider callback to the wrapper's listener
-         const eventAdapter = new EdrProviderEventAdapter();
-@@ -122,7 +132,7 @@ class EdrProviderWrapper extends events_1.EventEmitter {
++        // EDR holds `subscriptionCallback` through a threadsafe function, which V8
++        // cannot see through. A strong reference to the wrapper from that callback
++        // would root the wrapper, and with it the provider whose OS thread is only
++        // released once the provider is finalized.
++        let wrapperWeakRef;
+         const printLineFn = loggerConfig.printLineFn ?? logger_1.printLine;
          const replaceLastLineFn = loggerConfig.replaceLastLineFn ?? logger_1.replaceLastLine;
          const hardforkName = (0, hardforks_1.getHardforkName)(config.hardfork);
          const edrHardfork = (0, convertToEdr_1.ethereumsjsHardforkToEdrSpecId)(hardforkName);
@@ -117,16 +128,30 @@ index 8f6a795176e0ccb5e78a96143be1dab4b8d78593..39f5ddf52aa97aa565416fbf5ee902e1
              networkId: BigInt(config.networkId),
              observability: {},
              ownedAccounts,
-@@ -194,7 +204,7 @@ class EdrProviderWrapper extends events_1.EventEmitter {
+@@ -184,7 +194,7 @@ class EdrProviderWrapper extends events_1.EventEmitter {
+         };
+         const edrSubscriptionConfig = {
+             subscriptionCallback: (event) => {
+-                eventAdapter.emit("ethEvent", event);
++                wrapperWeakRef?.deref()?._ethEventListener(event);
+             },
+         };
+         const edrTracingConfig = tracingConfig ?? {};
+@@ -194,9 +204,10 @@ class EdrProviderWrapper extends events_1.EventEmitter {
          const minimalEthereumJsNode = {
              _vm: (0, minimal_vm_1.getMinimalEthereumJsVm)(provider),
          };
 -        const wrapper = new EdrProviderWrapper(provider, edrProviderConfig, edrLoggerConfig, minimalEthereumJsNode, edrSubscriptionConfig, config.genesisAccounts, cacheDir, chainOverrides);
+-        // Pass through all events from the provider
+-        eventAdapter.addListener("ethEvent", wrapper._ethEventListener.bind(wrapper));
 +        const wrapper = new EdrProviderWrapper(provider, edrProviderConfig, edrLoggerConfig, minimalEthereumJsNode, edrSubscriptionConfig, config.genesisAccounts, cacheDir, chainOverrides, genesisBlockGasLimit, genesisBlockTime);
-         // Pass through all events from the provider
-         eventAdapter.addListener("ethEvent", wrapper._ethEventListener.bind(wrapper));
++        // Assigned after construction, which is why the callback above reaches the
++        // wrapper through a binding rather than capturing it.
++        wrapperWeakRef = new WeakRef(wrapper);
          return wrapper;
-@@ -231,60 +241,75 @@ class EdrProviderWrapper extends events_1.EventEmitter {
+     }
+     async request(args) {
+@@ -231,60 +242,75 @@ class EdrProviderWrapper extends events_1.EventEmitter {
          else {
              response = responseObject.data;
          }
@@ -248,7 +273,7 @@ index 8f6a795176e0ccb5e78a96143be1dab4b8d78593..39f5ddf52aa97aa565416fbf5ee902e1
                  if (response.error.code === errors_1.InvalidArgumentsError.CODE) {
                      error = new errors_1.InvalidArgumentsError(response.error.message);
                  }
-@@ -304,10 +329,6 @@ class EdrProviderWrapper extends events_1.EventEmitter {
+@@ -304,10 +330,6 @@ class EdrProviderWrapper extends events_1.EventEmitter {
          if (args.method === "web3_clientVersion") {
              return clientVersion(response.result);
          }
@@ -259,7 +284,7 @@ index 8f6a795176e0ccb5e78a96143be1dab4b8d78593..39f5ddf52aa97aa565416fbf5ee902e1
          else {
              return response.result;
          }
-@@ -328,14 +349,16 @@ class EdrProviderWrapper extends events_1.EventEmitter {
+@@ -328,14 +350,16 @@ class EdrProviderWrapper extends events_1.EventEmitter {
          const [genesisState, ownedAccounts] = _genesisStateAndOwnedAccounts(forkConfig !== undefined, this._providerConfig.hardfork, this._originalGenesisAccounts);
          this._providerConfig.genesisState = genesisState;
          this._providerConfig.ownedAccounts = ownedAccounts;
@@ -283,7 +308,7 @@ index 8f6a795176e0ccb5e78a96143be1dab4b8d78593..39f5ddf52aa97aa565416fbf5ee902e1
                  blockNumber: forkConfig.blockNumber !== undefined
                      ? BigInt(forkConfig.blockNumber)
                      : undefined,
-@@ -346,7 +369,16 @@ class EdrProviderWrapper extends events_1.EventEmitter {
+@@ -346,7 +370,16 @@ class EdrProviderWrapper extends events_1.EventEmitter {
              };
          }
          else {
@@ -411,7 +436,7 @@ index f83df9fdce13dcce820f520b556ec9dce9537ff8..b97968227b38b48845d60e4a93e8dd21
 +{"version":3,"file":"convertToEdr.js","sourceRoot":"","sources":["../../../../src/internal/hardhat-network/provider/utils/convertToEdr.ts"],"names":[],"mappings":";;;AAUA,8CAoB8B;AAC9B,2CAA2C;AAE3C,wDAAiE;AACjE,uDAAuD;AASvD,+EAA+E;AAE/E,SAAgB,8BAA8B,CAAC,QAAsB;IACnE,QAAQ,QAAQ,EAAE;QAChB,KAAK,wBAAY,CAAC,QAAQ;YACxB,OAAO,cAAQ,CAAC;QAClB,KAAK,wBAAY,CAAC,SAAS;YACzB,OAAO,eAAS,CAAC;QACnB,KAAK,wBAAY,CAAC,GAAG;YACnB,OAAO,cAAQ,CAAC;QAClB,KAAK,wBAAY,CAAC,iBAAiB;YACjC,OAAO,eAAS,CAAC;QACnB,KAAK,wBAAY,CAAC,eAAe;YAC/B,OAAO,qBAAe,CAAC;QACzB,KAAK,wBAAY,CAAC,SAAS;YACzB,OAAO,eAAS,CAAC;QACnB,KAAK,wBAAY,CAAC,cAAc;YAC9B,OAAO,oBAAc,CAAC;QACxB,KAAK,wBAAY,CAAC,UAAU;YAC1B,OAAO,gBAAU,CAAC;QACpB,KAAK,wBAAY,CAAC,QAAQ;YACxB,OAAO,cAAQ,CAAC;QAClB,KAAK,wBAAY,CAAC,YAAY;YAC5B,OAAO,kBAAY,CAAC;QACtB,KAAK,wBAAY,CAAC,MAAM;YACtB,OAAO,YAAM,CAAC;QAChB,KAAK,wBAAY,CAAC,MAAM;YACtB,OAAO,YAAM,CAAC;QAChB,KAAK,wBAAY,CAAC,aAAa;YAC7B,OAAO,mBAAa,CAAC;QACvB,KAAK,wBAAY,CAAC,YAAY;YAC5B,OAAO,kBAAY,CAAC;QACtB,KAAK,wBAAY,CAAC,KAAK;YACrB,OAAO,WAAK,CAAC;QACf,KAAK,wBAAY,CAAC,QAAQ;YACxB,OAAO,cAAQ,CAAC;QAClB,KAAK,wBAAY,CAAC,MAAM;YACtB,OAAO,YAAM,CAAC;QAChB,KAAK,wBAAY,CAAC,MAAM;YACtB,OAAO,YAAM,CAAC;QAChB,KAAK,wBAAY,CAAC,KAAK;YACrB,OAAO,WAAK,CAAC;QACf;YACE,MAAM,gBAAgB,GAAU,QAAQ,CAAC;YACzC,MAAM,IAAI,KAAK,CACb,0BAA0B,QAAkB,0BAA0B,CACvE,CAAC;KACL;AACH,CAAC;AA9CD,wEA8CC;AAED,SAAgB,2BAA2B,CAAC,MAAc;IACxD,MAAM,EAAE,MAAM,EAAE,GAAG,IAAA,6BAAmB,EACpC,sBAAsB,CACkB,CAAC;IAE3C,QAAQ,MAAM,EAAE;QACd,KAAK,MAAM,CAAC,QAAQ;YAClB,OAAO,wBAAY,CAAC,QAAQ,CAAC;QAC/B,KAAK,MAAM,CAAC,SAAS;YACnB,OAAO,wBAAY,CAAC,SAAS,CAAC;QAChC,KAAK,MAAM,CAAC,OAAO;YACjB,OAAO,wBAAY,CAAC,GAAG,CAAC;QAC1B,KAAK,MAAM,CAAC,SAAS;YACnB,OAAO,wBAAY,CAAC,iBAAiB,CAAC;QACxC,KAAK,MAAM,CAAC,cAAc;YACxB,OAAO,wBAAY,CAAC,eAAe,CAAC;QACtC,KAAK,MAAM,CAAC,SAAS;YACnB,OAAO,wBAAY,CAAC,SAAS,CAAC;QAChC,KAAK,MAAM,CAAC,cAAc;YACxB,OAAO,wBAAY,CAAC,cAAc,CAAC;QACrC,KAAK,MAAM,CAAC,UAAU;YACpB,OAAO,wBAAY,CAAC,UAAU,CAAC;QACjC,KAAK,MAAM,CAAC,QAAQ;YAClB,OAAO,wBAAY,CAAC,QAAQ,CAAC;QAC/B,KAAK,MAAM,CAAC,WAAW;YACrB,OAAO,wBAAY,CAAC,YAAY,CAAC;QACnC,KAAK,MAAM,CAAC,MAAM;YAChB,OAAO,wBAAY,CAAC,MAAM,CAAC;QAC7B,KAAK,MAAM,CAAC,MAAM;YAChB,OAAO,wBAAY,CAAC,MAAM,CAAC;QAC7B,KAAK,MAAM,CAAC,YAAY;YACtB,OAAO,wBAAY,CAAC,aAAa,CAAC;QACpC,KAAK,MAAM,CAAC,WAAW;YACrB,OAAO,wBAAY,CAAC,YAAY,CAAC;QACnC,KAAK,MAAM,CAAC,KAAK;YACf,OAAO,wBAAY,CAAC,KAAK,CAAC;QAC5B,KAAK,MAAM,CAAC,QAAQ;YAClB,OAAO,wBAAY,CAAC,QAAQ,CAAC;QAC/B,KAAK,MAAM,CAAC,MAAM;YAChB,OAAO,wBAAY,CAAC,MAAM,CAAC;QAC7B,KAAK,MAAM,CAAC,MAAM;YAChB,OAAO,wBAAY,CAAC,MAAM,CAAC;QAC7B,KAAK,MAAM,CAAC,KAAK;YACf,OAAO,wBAAY,CAAC,KAAK,CAAC;QAE5B;YACE,MAAM,IAAI,KAAK,CAAC,oBAAoB,MAAM,0BAA0B,CAAC,CAAC;KACzE;AACH,CAAC;AAhDD,kEAgDC;AAED,SAAgB,mCAAmC,CACjD,MAA4B;IAE5B,IAAI,OAAO,MAAM,KAAK,QAAQ,EAAE;QAC9B,+BAA+B;QAC/B,IAAI,MAAM,KAAK,CAAC,EAAE;YAChB,OAAO,SAAS,CAAC;SAClB;aAAM;YACL,OAAO,MAAM,CAAC,MAAM,CAAC,CAAC;SACvB;KACF;SAAM;QACL,OAAO;YACL,GAAG,EAAE,MAAM,CAAC,MAAM,CAAC,CAAC,CAAC,CAAC;YACtB,GAAG,EAAE,MAAM,CAAC,MAAM,CAAC,CAAC,CAAC,CAAC;SACvB,CAAC;KACH;AACH,CAAC;AAhBD,kFAgBC;AAED,SAAgB,uCAAuC,CACrD,YAA0B;IAE1B,MAAM,EAAE,YAAY,EAAE,GAAG,IAAA,6BAAmB,EAC1C,sBAAsB,CACkB,CAAC;IAE3C,QAAQ,YAAY,EAAE;QACpB,KAAK,MAAM;YACT,OAAO,YAAY,CAAC,IAAI,CAAC;QAC3B,KAAK,UAAU;YACb,OAAO,YAAY,CAAC,QAAQ,CAAC;KAChC;AACH,CAAC;AAbD,0FAaC;AAED,SAAgB,sCAAsC,CACpD,IAAiB;IAEjB,MAAM,sBAAsB,GAA2B;QACrD,EAAE,EAAE,MAAM,CAAC,IAAI,CAAC,EAAE,CAAC;QACnB,KAAK,EAAE,IAAI,CAAC,KAAK;QACjB,MAAM,EAAE;YACN,IAAI,EAAE,IAAI,CAAC,MAAM;SAClB;QACD,KAAK,EAAE,IAAI,CAAC,KAAK;KAClB,CAAC;IAEF,IAAI,IAAI,CAAC,MAAM,KAAK,SAAS,EAAE;QAC7B,sBAAsB,CAAC,MAAM,GAAG,IAAI,CAAC,MAAM,CAAC;KAC7C;IAED,OAAO,sBAAsB,CAAC;AAChC,CAAC;AAjBD,wFAiBC;AAED,SAAgB,yCAAyC,CACvD,oBAA0C;IAE1C,MAAM,EAAE,MAAM,EAAE,eAAe,EAAE,GAAG,oBAAoB,CAAC,eAAe,CAAC;IAEzE,8BAA8B;IAC9B,MAAM,OAAO,GAAG,MAAM,IAAI,MAAM,CAAC;IAEjC,MAAM,gBAAgB,GAAqB;QACzC,UAAU,EAAE;YACV,gBAAgB,EAAE,MAAM,CAAC,OAAO;YAChC,OAAO;SACR;KACF,CAAC;IAEF,gDAAgD;IAChD,IAAI,QAAQ,IAAI,MAAM,EAAE;QACtB,gBAAgB,CAAC,UAAU,CAAC,MAAM,GAAG,MAAM,CAAC,MAAM,CAAC;KACpD;IACD,IAAI,QAAQ,IAAI,MAAM,EAAE;QACtB,MAAM,EAAE,MAAM,EAAE,GAAG,MAAM,CAAC;QAC1B,IAAI,MAAM,YAAY,UAAU,EAAE;YAChC,gBAAgB,CAAC,UAAU,CAAC,MAAM,GAAG,MAAM,CAAC,IAAI,CAAC,MAAM,CAAC,CAAC;SAC1D;aAAM;YACL,gBAAgB,CAAC,UAAU,CAAC,MAAM,GAAG,MAAM,CAAC,IAAI,CAAC,MAAM,CAAC,WAAW,CAAC,CAAC;SACtE;KACF;IAED,IAAI,eAAe,KAAK,SAAS,EAAE;QACjC,gBAAgB,CAAC,UAAU,CAAC,eAAe,GAAG,IAAI,cAAO,CAAC,eAAe,CAAC,CAAC;KAC5E;IAED,OAAO,gBAAgB,CAAC;AAC1B,CAAC;AAjCD,8FAiCC;AAED,SAAgB,iCAAiC,CAC/C,OAAuB;IAEvB,OAAO;QACL,EAAE,EAAE,OAAO,CAAC,EAAE,KAAK,SAAS,CAAC,CAAC,CAAC,IAAI,cAAO,CAAC,OAAO,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,SAAS;QAClE,WAAW,EACT,OAAO,CAAC,WAAW,KAAK,SAAS;YAC/B,CAAC,CAAC,IAAI,cAAO,CAAC,OAAO,CAAC,WAAW,CAAC;YAClC,CAAC,CAAC,SAAS;QACf,IAAI,EAAE,OAAO,CAAC,IAAI;QAClB,KAAK,EAAE,OAAO,CAAC,KAAK;QACpB,MAAM,EAAE,IAAI,cAAO,CAAC,OAAO,CAAC,MAAM,CAAC;QACnC,QAAQ,EAAE,OAAO,CAAC,QAAQ;QAC1B,YAAY,EAAE,OAAO,CAAC,YAAY;KACnC,CAAC;AACJ,CAAC;AAfD,8EAeC;AAED,SAAgB,gBAAgB,CAAC,KAEhC;IACC,IAAI,WAAqC,CAAC;IAC1C,IAAI,KAAK,KAAK,SAAS,EAAE;QACvB,WAAW,GAAG,EAAE,CAAC;QAEjB,KAAK,MAAM,CAAC,IAAI,EAAE,KAAK,CAAC,IAAI,MAAM,CAAC,OAAO,CAAC,KAAK,CAAC,EAAE;YACjD,WAAW,CAAC,IAAI,CAAC;gBACf,IAAI;gBACJ,KAAK;aACN,CAAC,CAAC;SACJ;KACF;IAED,OAAO,WAAW,CAAC;AACrB,CAAC;AAhBD,4CAgBC"}
 \ No newline at end of file
 diff --git a/src/internal/hardhat-network/provider/provider.ts b/src/internal/hardhat-network/provider/provider.ts
-index 7e4276a589668b96c16243f547c0a2caecdb0d46..4636477ae060c71beadf065749aaa9382ccda358 100644
+index 7e4276a589668b96c16243f547c0a2caecdb0d46..68a7a2e343ad8170455f994743e22afca0a8662f 100644
 --- a/src/internal/hardhat-network/provider/provider.ts
 +++ b/src/internal/hardhat-network/provider/provider.ts
 @@ -67,7 +67,6 @@ import {
@@ -422,7 +447,16 @@ index 7e4276a589668b96c16243f547c0a2caecdb0d46..4636477ae060c71beadf065749aaa938
    edrTracingMessageResultToMinimalEVMResult,
    edrTracingMessageToMinimalMessage,
    edrTracingStepToMinimalInterpreterStep,
-@@ -157,11 +156,14 @@ export class EdrProviderWrapper
+@@ -130,8 +129,6 @@ interface HardhatNetworkProviderConfig {
+   enableRip7212: boolean;
+ }
+ 
+-class EdrProviderEventAdapter extends EventEmitter {}
+-
+ type CallOverrideCallback = (
+   address: Buffer,
+   data: Buffer
+@@ -157,11 +154,14 @@ export class EdrProviderWrapper
        _vm: MinimalEthereumJsVm;
      },
      private readonly _subscriptionConfig: SubscriptionConfig,
@@ -440,7 +474,7 @@ index 7e4276a589668b96c16243f547c0a2caecdb0d46..4636477ae060c71beadf065749aaa938
    ) {
      super();
    }
-@@ -200,9 +202,15 @@ export class EdrProviderWrapper
+@@ -200,9 +200,15 @@ export class EdrProviderWrapper
  
      const cacheDir = config.forkCachePath;
  
@@ -458,7 +492,7 @@ index 7e4276a589668b96c16243f547c0a2caecdb0d46..4636477ae060c71beadf065749aaa938
          blockNumber:
            config.forkConfig.blockNumber !== undefined
              ? BigInt(config.forkConfig.blockNumber)
-@@ -212,13 +220,13 @@ export class EdrProviderWrapper
+@@ -212,16 +218,18 @@ export class EdrProviderWrapper
          httpHeaders: httpHeadersToEdr(config.forkConfig.httpHeaders),
          url: config.forkConfig.jsonRpcUrl,
        };
@@ -474,9 +508,17 @@ index 7e4276a589668b96c16243f547c0a2caecdb0d46..4636477ae060c71beadf065749aaa938
 -        ? BigInt(Math.floor(config.initialDate.getTime() / 1000))
 -        : undefined;
 -
-     // To accommodate construction ordering, we need an adapter to forward events
-     // from the EdrProvider callback to the wrapper's listener
-     const eventAdapter = new EdrProviderEventAdapter();
+-    // To accommodate construction ordering, we need an adapter to forward events
+-    // from the EdrProvider callback to the wrapper's listener
+-    const eventAdapter = new EdrProviderEventAdapter();
++    // EDR holds `subscriptionCallback` through a threadsafe function, which V8
++    // cannot see through. A strong reference to the wrapper from that callback
++    // would root the wrapper, and with it the provider whose OS thread is only
++    // released once the provider is finalized.
++    let wrapperWeakRef: WeakRef<EdrProviderWrapper> | undefined;
+ 
+     const printLineFn = loggerConfig.printLineFn ?? printLine;
+     const replaceLastLineFn = loggerConfig.replaceLastLineFn ?? replaceLastLine;
 @@ -230,7 +238,7 @@ export class EdrProviderWrapper
      const edrHardfork = ethereumsjsHardforkToEdrSpecId(hardforkName);
  
@@ -516,7 +558,16 @@ index 7e4276a589668b96c16243f547c0a2caecdb0d46..4636477ae060c71beadf065749aaa938
        networkId: BigInt(config.networkId),
        observability: {},
        ownedAccounts,
-@@ -332,7 +340,9 @@ export class EdrProviderWrapper
+@@ -303,7 +311,7 @@ export class EdrProviderWrapper
+ 
+     const edrSubscriptionConfig = {
+       subscriptionCallback: (event: SubscriptionEvent) => {
+-        eventAdapter.emit("ethEvent", event);
++        wrapperWeakRef?.deref()?._ethEventListener(event);
+       },
+     };
+ 
+@@ -332,14 +340,14 @@ export class EdrProviderWrapper
        edrSubscriptionConfig,
        config.genesisAccounts,
        cacheDir,
@@ -526,8 +577,18 @@ index 7e4276a589668b96c16243f547c0a2caecdb0d46..4636477ae060c71beadf065749aaa938
 +      genesisBlockTime
      );
  
-     // Pass through all events from the provider
-@@ -387,75 +397,88 @@ export class EdrProviderWrapper
+-    // Pass through all events from the provider
+-    eventAdapter.addListener(
+-      "ethEvent",
+-      wrapper._ethEventListener.bind(wrapper)
+-    );
++    // Assigned after construction, which is why the callback above reaches the
++    // wrapper through a binding rather than capturing it.
++    wrapperWeakRef = new WeakRef(wrapper);
+ 
+     return wrapper;
+   }
+@@ -387,75 +395,88 @@ export class EdrProviderWrapper
        response = responseObject.data;
      }
  
@@ -675,7 +736,7 @@ index 7e4276a589668b96c16243f547c0a2caecdb0d46..4636477ae060c71beadf065749aaa938
          if (response.error.code === InvalidArgumentsError.CODE) {
            error = new InvalidArgumentsError(response.error.message);
          } else {
-@@ -479,11 +502,6 @@ export class EdrProviderWrapper
+@@ -479,11 +500,6 @@ export class EdrProviderWrapper
      // e.g. `HardhatNetwork/2.19.0/@nomicfoundation/edr/0.2.0-dev`
      if (args.method === "web3_clientVersion") {
        return clientVersion(response.result);
@@ -687,7 +748,7 @@ index 7e4276a589668b96c16243f547c0a2caecdb0d46..4636477ae060c71beadf065749aaa938
      } else {
        return response.result;
      }
-@@ -519,18 +537,19 @@ export class EdrProviderWrapper
+@@ -519,18 +535,19 @@ export class EdrProviderWrapper
      this._providerConfig.genesisState = genesisState;
      this._providerConfig.ownedAccounts = ownedAccounts;
  
@@ -716,7 +777,7 @@ index 7e4276a589668b96c16243f547c0a2caecdb0d46..4636477ae060c71beadf065749aaa938
          blockNumber:
            forkConfig.blockNumber !== undefined
              ? BigInt(forkConfig.blockNumber)
-@@ -541,7 +560,18 @@ export class EdrProviderWrapper
+@@ -541,7 +558,18 @@ export class EdrProviderWrapper
          url: forkConfig.jsonRpcUrl,
        };
      } else {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   hardhat>@nomicfoundation/edr: workspace:*
 
 patchedDependencies:
-  hardhat@2.28.4: e673aa2222bae6d08ea4b76561adbbf94ee393d74412eaea64f8837258809600
+  hardhat@2.28.4: 6dceec35886863596ca7335e7d202f9ef56f5044429843cfcee9a82ac182775b
   hardhat@3.4.5: 0de38ef817bceff74a51505ab96d0c87085e888d660f71a437d879da576ba805
 
 importers:
@@ -215,7 +215,7 @@ importers:
         version: 7.0.1
       hardhat:
         specifier: 2.28.4
-        version: 2.28.4(patch_hash=e673aa2222bae6d08ea4b76561adbbf94ee393d74412eaea64f8837258809600)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3))(typescript@5.8.3)
+        version: 2.28.4(patch_hash=6dceec35886863596ca7335e7d202f9ef56f5044429843cfcee9a82ac182775b)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3))(typescript@5.8.3)
       mocha:
         specifier: ^11.1.0
         version: 11.8.0
@@ -297,7 +297,7 @@ importers:
         version: 3.4.5(patch_hash=0de38ef817bceff74a51505ab96d0c87085e888d660f71a437d879da576ba805)
       hardhat2:
         specifier: npm:hardhat@2.28.4
-        version: hardhat@2.28.4(patch_hash=e673aa2222bae6d08ea4b76561adbbf94ee393d74412eaea64f8837258809600)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3))(typescript@5.8.3)
+        version: hardhat@2.28.4(patch_hash=6dceec35886863596ca7335e7d202f9ef56f5044429843cfcee9a82ac182775b)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3))(typescript@5.8.3)
       lodash:
         specifier: ^4.17.11
         version: 4.18.1
@@ -6224,7 +6224,7 @@ snapshots:
 
   graphemer@1.4.0: {}
 
-  hardhat@2.28.4(patch_hash=e673aa2222bae6d08ea4b76561adbbf94ee393d74412eaea64f8837258809600)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3))(typescript@5.8.3):
+  hardhat@2.28.4(patch_hash=6dceec35886863596ca7335e7d202f9ef56f5044429843cfcee9a82ac182775b)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3))(typescript@5.8.3):
     dependencies:
       '@ethereumjs/util': 9.1.0
       '@ethersproject/abi': 5.8.0


### PR DESCRIPTION
## Problem

#1486 gave every provider a dedicated OS thread, joined only when the JS `Provider` wrapper is garbage-collected and its finalizer runs. The wrapper is a handful of bytes on the JS heap, so V8 sees no reason to collect it, and the threads accumulate for the life of the process.

macOS caps threads per process far below Linux, so it hits the wall first. In [this Hardhat test job](https://github.com/NomicFoundation/edr/actions/runs/33519467687/job/99929773105?pr=1670) the suite created 1,998 providers before `pthread_create` started returning `EAGAIN`:

```
thread 'tokio-rt-worker' panicked at crates/edr_provider/src/provider.rs:151:14:
failed to spawn the provider thread: Os { code: 35, kind: WouldBlock,
                                          message: "Resource temporarily unavailable" }
```

A second defect turned that into a job timeout. `Provider::new` used `.expect` on the spawn, and it runs inside the `spawn_blocking` closure that owns `create_provider`'s deferred. napi-rs has no `Drop` for `JsDeferred`, so unwinding left the JavaScript promise pending forever. Each affected stack-trace test then sat out its full 120s timeout — the panics in the log are exactly 120s apart — and the job was cancelled after 16 of them.

A third defect was doing most of the damage, and only became visible once the hang was gone. Hardhat 2 handed EDR a `subscriptionCallback` that reached the wrapper through an event adapter, and the wrapper holds the provider. EDR keeps that callback alive through a threadsafe function — a strong reference V8 cannot see through — so the closure was a GC root and the provider stayed **reachable**, not merely un-pressured. No amount of external-memory reporting collects a reachable object, which is why the GC change alone did not move the wall: 2,006 providers instead of 1,998.

## Fix

**`fix(edr_provider): reject rather than hang when a thread is refused`** — adds `CreationError::ThreadSpawn` and propagates the `io::Error`. `CreationError` already reaches JS as a rejection, so `createProvider` now fails with a real message in milliseconds instead of hanging.

**`fix(edr_napi): let V8 collect providers that pin an OS thread`** — reports the thread's 2 MiB stack reservation as external memory, which is the pressure signal V8 was missing. A `GcTracked<T>` newtype reports it while converting the value for JavaScript, so only a value that became a JS object — and therefore has a finalizer to release it again — is ever counted. Reporting from a constructor cannot make that guarantee: a later failure would leave the finalizer subtracting an amount that was never added.

**`refactor(edr_napi): declare the report and its release together`** — the report and its release still had to be written by hand in two places, which is the asymmetry Copilot flagged in review. A `gc_tracked!` macro now emits the alias, the amount and the finalizer from one declaration:

```rust
gc_tracked! {
    /// A [`Provider`] on its way to JavaScript, reporting its OS thread to V8.
    pub(crate) type GcProvider = GcTracked<Provider>;

    /// The standard library's default thread stack reservation, which
    /// `CancellableThread` does not override.
    const EXTERNAL_MEMORY: i64 = 2 * 1024 * 1024;

    fn drop(self) {
        // whatever `Drop` would have done
    }
}
```

The amount lives on a `HasExternalMemory` trait rather than a const generic, so no second alias can name a figure the finalizer does not release. Two diagnostics come along: a marker blanket-implemented for `T: Drop` turns a hand-written `Drop` into an `E0119` naming where that body belongs, and `on_unimplemented` turns an undeclared type into ``  `X` is not declared with `gc_tracked!` `` rather than an unsatisfied trait bound.

**`fix(hardhat-tests): break Hardhat 2's provider reference cycle`** — patches a `WeakRef` into Hardhat 2 so the subscription callback no longer roots the wrapper, which also removes the event adapter that existed only to work around the construction ordering. Hardhat 3 already does exactly this in `edr-provider.ts`, so this follows its precedent rather than inventing one. The same change is needed on Hardhat's `v2` branch — the patch only covers the vendored suite until that lands. ([HH2 branch](https://github.com/Wodann/hardhat/tree/fix/edr-provider-reference-cycle))

**`test(hardhat-tests): widen the interval-mining timing margin`** that caused [these CI failures](https://github.com/NomicFoundation/edr/actions/runs/33624762704/job/100229797128?pr=1720) — the `evm_setIntervalMining` "using sleep" tests configured a 100 ms interval and slept 170 ms, leaving 70 ms between a block being due and the assertion. macOS missed it in 5 of 6 cases. The bound is two-sided — the sleep has to fall between one and two intervals — so the absolute margin grows only with the interval, not the multiplier; at 250 ms the block has 175 ms of slack, for about 2 s of extra suite time.

## Thread counts

Creating providers back to back on Linux with a debug build, sampling `/proc/self/status`. Through **patched Hardhat 2 against the locally built EDR** — the configuration that fails in CI — over 300 providers:

| | live threads after 300 providers | peak |
|---|---|---|
| before | **333**, one per provider, never reclaimed | 333 |
| after | 34 | 68 |

And with EDR driven directly, isolating the GC change from the cycle, over 400 providers:

| | live threads after 400 providers | peak |
|---|---|---|
| before | **433**, one per provider, never reclaimed | 433 |
| after | 39–67 | 79–83 |

Before each fix, growth is strictly linear and nothing is ever released. After it, the count is flat and settles back down. Three runs each; the peak varied by 4 threads.

Note that the second table only exercises the collectible case: its subscription callback captures nothing, so it never forms the cycle. Give that harness a Hardhat-shaped callback and it returns to 433 threads with the GC change in place, which is what the first table's fix addresses.

Reporting more than 2 MiB was tested and rejected: 8 MiB halves the peak but nearly triples GC count, and 32 MiB is no better than 8 MiB on threads while tripling it again. The returns are sublinear, the GC cost grows with the real heap, and 2 MiB is the only figure that is actually true.

## CI outcome

On the macOS job, in order: cancelled at the 30-minute mark → 957 failing → 5 failing (2,800 passing, 167 pending) → expected green. The last five were the timing-sensitive interval-mining tests, unrelated to the leak; the job was green before #1486 and every run since was cancelled, so they had never been visible.

## Validation

- Both harnesses above, run against builds with and without each change, and again after every refactor of the reporting mechanism.
- Subscription delivery after the `WeakRef` change: `eth_subscribe` plus `evm_mine` through the built Hardhat 2 package still delivers the notification. Hardhat 2 has no provider tests of its own, so that coverage lives here.
- Both diagnostics exercised by hand: adding a `Drop` impl to `Provider`, and wrapping a type the macro never declared.