### PR TITLE
perf(edr_napi): report a response's payload to V8

### DIFF
--- a/crates/edr_napi/src/gc.rs
+++ b/crates/edr_napi/src/gc.rs
@@ -2,9 +2,15 @@ use napi::{bindgen_prelude::ToNapiValue, sys, Env};
 
 /// Declares how much external memory a type's JavaScript object stands for.
 ///
-/// Implemented by `gc_tracked!`, which also emits the finalizer releasing
-/// [`Self::EXTERNAL_MEMORY`] again. Implementing it by hand gets the report
-/// without that release.
+/// Implemented by `gc_tracked!`, which also emits the finalizer releasing the
+/// same amount. Implementing it by hand gets the report without that release.
+///
+/// Must return the same value for the lifetime of the JavaScript object. A
+/// type whose answer varies has to store it, so both ends read one field.
+///
+/// The function should run in constant time, as it can be called on a hot
+/// code path! The figure is only a heuristic for the order of magnitude of
+/// the externally allocated memory.
 #[diagnostic::on_unimplemented(
     message = "`{Self}` is not declared with `gc_tracked!`",
     label = "not declared with `gc_tracked!`",
@@ -12,7 +18,7 @@ use napi::{bindgen_prelude::ToNapiValue, sys, Env};
 )]
 pub trait HasExternalMemory {
     /// Bytes reported to V8 while the JavaScript object is alive.
-    const EXTERNAL_MEMORY: i64;
+    fn external_memory(&self) -> i64;
 }
 
 /// Blanket-implemented for every type that has its own [`Drop`], so
@@ -31,12 +37,12 @@ pub trait MoveTheDropImplIntoGcTracked {}
 impl<T: Drop> MoveTheDropImplIntoGcTracked for T {}
 
 /// Wraps a value so that handing it to JavaScript reports
-/// [`HasExternalMemory::EXTERNAL_MEMORY`] bytes to V8.
+/// [`HasExternalMemory::external_memory`] bytes to V8.
 ///
 /// `gc_tracked!` is the only thing that implements [`HasExternalMemory`], and
-/// it emits the finalizer that releases the same constant. The report and its
+/// it emits the finalizer that releases the same amount. The report and its
 /// release are therefore declared together, and neither can name a different
-/// amount.
+/// figure.
 ///
 /// # Why report at all
 ///
@@ -60,7 +66,7 @@ impl<T: ToNapiValue + HasExternalMemory> ToNapiValue for GcTracked<T> {
         // Reported before the conversion, because only a JS object gets a
         // finalizer to release it. A conversion that fails afterwards leaves an
         // over-report, which makes V8 more eager rather than less.
-        Env::from_raw(env).adjust_external_memory(T::EXTERNAL_MEMORY)?;
+        Env::from_raw(env).adjust_external_memory(val.0.external_memory())?;
 
         // SAFETY: `env` is valid, as this function's own contract requires.
         unsafe { T::to_napi_value(env, val.0) }
@@ -71,8 +77,10 @@ impl<T: ToNapiValue + HasExternalMemory> ToNapiValue for GcTracked<T> {
 /// JavaScript object reports and the finalizer that releases it.
 ///
 /// `GcTracked` in the alias is a literal token rather than a path, so it needs
-/// no import. `fn drop` takes `self` by value, and `mut self` is not
-/// supported.
+/// no import. Both functions take `self` by the name written here, and
+/// `mut self` is not supported.
+///
+/// `external_memory` should run in constant time; see [`HasExternalMemory`].
 ///
 /// ```text
 /// gc_tracked! {
@@ -80,7 +88,9 @@ impl<T: ToNapiValue + HasExternalMemory> ToNapiValue for GcTracked<T> {
 ///     pub(crate) type GcProvider = GcTracked<Provider>;
 ///
 ///     /// What the JavaScript object stands for.
-///     const EXTERNAL_MEMORY: i64 = 2 * 1024 * 1024;
+///     fn external_memory(&self) -> i64 {
+///         2 * 1024 * 1024
+///     }
 ///
 ///     fn drop(self) {
 ///         // whatever `Drop` would have done
@@ -93,7 +103,7 @@ macro_rules! gc_tracked {
         $alias_vis:vis type $alias:ident = GcTracked<$ty:ty>;
 
         $(#[$memory_meta:meta])*
-        const EXTERNAL_MEMORY: i64 = $external_memory:expr;
+        fn external_memory(&$memory_self:ident) -> i64 $memory_body:block
 
         fn drop($self:ident) $body:block
     ) => {
@@ -102,7 +112,7 @@ macro_rules! gc_tracked {
 
         impl $crate::gc::HasExternalMemory for $ty {
             $(#[$memory_meta])*
-            const EXTERNAL_MEMORY: i64 = $external_memory;
+            fn external_memory(&$memory_self) -> i64 $memory_body
         }
 
         impl $crate::gc::MoveTheDropImplIntoGcTracked for $ty {}
@@ -113,15 +123,16 @@ macro_rules! gc_tracked {
 
         impl ::napi::bindgen_prelude::ObjectFinalize for $ty {
             fn finalize($self, env: ::napi::Env) -> ::napi::Result<()> {
-                // Runs first, so returning below cannot drop the value on the
-                // JS thread.
+                let external_memory =
+                    <Self as $crate::gc::HasExternalMemory>::external_memory(&$self);
+
+                // Runs before the report is released, so returning below cannot
+                // drop the value on the JS thread.
                 Self::__gc_tracked_drop($self);
 
                 // Releases what the conversion to JavaScript reported. Only a
                 // JS object reaches this finalizer, so the amounts pair up.
-                env.adjust_external_memory(
-                    -<Self as $crate::gc::HasExternalMemory>::EXTERNAL_MEMORY,
-                )?;
+                env.adjust_external_memory(-external_memory)?;
 
                 Ok(())
             }

--- a/crates/edr_napi/src/provider.rs
+++ b/crates/edr_napi/src/provider.rs
@@ -2,7 +2,10 @@
 pub mod factory;
 mod response;
 
-use std::sync::Arc;
+use std::sync::{
+    atomic::{self, AtomicI64},
+    Arc,
+};
 
 use edr_napi_core::provider::SyncProvider;
 use edr_solidity::artifacts::{
@@ -17,7 +20,7 @@ use napi_derive::napi;
 use parking_lot::RwLock;
 
 pub use self::factory::ProviderFactory;
-use self::response::Response;
+use self::response::{call_trace_external_mem_size, GcResponse, Response};
 use crate::{
     async_deallocator::AsyncDeallocatorSender, call_override::CallOverrideCallback,
     contract_decoder::ContractDecoder, gc::gc_tracked,
@@ -30,6 +33,9 @@ pub struct Provider {
     provider: Arc<dyn SyncProvider>,
     runtime: runtime::Handle,
     dropped_provider_sender: AsyncDeallocatorSender<Arc<dyn SyncProvider>>,
+    /// What a response carrying call trace arenas reports to V8. Follows
+    /// `verbose_raw_tracing`, which [`Self::set_verbose_tracing`] toggles.
+    call_trace_external_mem_size: AtomicI64,
     #[cfg(feature = "scenarios")]
     scenario_file: Option<Arc<napi::tokio::sync::Mutex<napi::tokio::fs::File>>>,
 }
@@ -53,6 +59,9 @@ impl Provider {
             provider,
             runtime,
             dropped_provider_sender,
+            // `verbose_raw_tracing` is not exposed in the provider config, so
+            // it starts disabled.
+            call_trace_external_mem_size: AtomicI64::new(call_trace_external_mem_size(false)),
             #[cfg(feature = "scenarios")]
             scenario_file: scenario_file.map(Arc::new),
         }
@@ -166,12 +175,24 @@ impl Provider {
     ) -> napi::Result<Object<'env>> {
         let (deferred, promise) = env.create_deferred()?;
 
+        // Relaxed because the figure publishes nothing: a response created
+        // alongside `set_verbose_tracing` may read either value, and reports
+        // and releases whichever it read.
+        let call_trace_external_mem_size = self
+            .call_trace_external_mem_size
+            .load(atomic::Ordering::Relaxed);
+
         let enqueue_request =
             move |provider: &dyn SyncProvider, request: napi::Result<String>| match request {
                 Ok(request) => provider.enqueue_request(
                     request,
                     Box::new(move |result| match result {
-                        Ok(response) => deferred.resolve(move |_env| Ok(Response::from(response))),
+                        Ok(response) => deferred.resolve(move |_env| {
+                            Ok(GcResponse::from(Response::new(
+                                response,
+                                call_trace_external_mem_size,
+                            )))
+                        }),
                         Err(error) => deferred.reject(error),
                     }),
                 ),
@@ -259,6 +280,12 @@ impl Provider {
     /// `false` to disable this.
     #[napi(catch_unwind)]
     pub async fn set_verbose_tracing(&self, verbose_tracing: bool) -> napi::Result<()> {
+        // Responses made from here on report the figure for this setting.
+        self.call_trace_external_mem_size.store(
+            call_trace_external_mem_size(verbose_tracing),
+            atomic::Ordering::Relaxed,
+        );
+
         let provider = self.provider.clone();
 
         self.runtime
@@ -276,7 +303,9 @@ gc_tracked! {
     /// [`edr_utils_sync::CancellableThread`] does not override.
     /// `RUST_MIN_STACK` does, in which case the figure is wrong but still the
     /// right order of magnitude.
-    const EXTERNAL_MEMORY: i64 = 2 * 1024 * 1024;
+    fn external_memory(&self) -> i64 {
+        2 * 1024 * 1024
+    }
 
     fn drop(self) {
         let Self {

--- a/crates/edr_napi/src/provider.rs
+++ b/crates/edr_napi/src/provider.rs
@@ -33,8 +33,9 @@ pub struct Provider {
     provider: Arc<dyn SyncProvider>,
     runtime: runtime::Handle,
     dropped_provider_sender: AsyncDeallocatorSender<Arc<dyn SyncProvider>>,
-    /// What a response carrying call trace arenas reports to V8. Follows
-    /// `verbose_raw_tracing`, which [`Self::set_verbose_tracing`] toggles.
+    /// What a response reports to V8 for each call trace arena it carries.
+    /// Follows `verbose_raw_tracing`, which [`Self::set_verbose_tracing`]
+    /// toggles.
     call_trace_external_mem_size: AtomicI64,
     #[cfg(feature = "scenarios")]
     scenario_file: Option<Arc<napi::tokio::sync::Mutex<napi::tokio::fs::File>>>,

--- a/crates/edr_napi/src/provider/response.rs
+++ b/crates/edr_napi/src/provider/response.rs
@@ -11,8 +11,7 @@ use crate::{
     },
 };
 
-/// Bytes reported for a response whose call trace arenas were recorded without
-/// stack snapshots.
+/// Bytes reported for one recorded call trace arena, without stack snapshots.
 ///
 /// A `CallTraceStep` is 192 bytes, so this is a trace of roughly 5,400 steps.
 /// A complex contract call runs many more, which is the intended direction:
@@ -20,8 +19,8 @@ use crate::{
 /// only forgoes some of the benefit.
 const CALL_TRACE_EXTERNAL_MEM_SIZE: i64 = 1024 * 1024;
 
-/// Bytes reported for a response whose call trace steps also carry stack
-/// snapshots, as `verbose_raw_tracing` records them.
+/// Bytes reported for one recorded call trace arena whose steps also carry
+/// stack snapshots, as `verbose_raw_tracing` records them.
 ///
 /// A snapshot is a `Box<[U256]>`, so a step costs roughly 448 bytes rather than
 /// 192. PR #1301 measured 4.9x more retained memory in this configuration, so
@@ -38,10 +37,10 @@ const STACK_TRACE_EXTERNAL_MEM_SIZE: i64 = 4 * 1024;
 /// tree costs several times its serialized length, so this is a floor.
 const VALUE_DATA_EXTERNAL_MEM_SIZE: i64 = 256 * 1024 * 1024;
 
-/// Bytes a response reports for the call trace arenas it carries.
+/// Bytes a response reports for each call trace arena it carries.
 ///
 /// Recording stack snapshots takes a step from roughly 192 bytes to 448, so a
-/// verbosely traced response stands for several times as much.
+/// verbosely recorded arena stands for several times as much.
 pub(crate) const fn call_trace_external_mem_size(verbose_tracing: bool) -> i64 {
     if verbose_tracing {
         VERBOSE_CALL_TRACE_EXTERNAL_MEM_SIZE
@@ -61,9 +60,9 @@ pub struct Response {
 impl Response {
     /// Constructs a new instance.
     ///
-    /// `call_trace_external_mem_size` is what the provider reports for a
-    /// response carrying call trace arenas, which depends on whether it records
-    /// stack snapshots.
+    /// `call_trace_external_mem_size` is what the provider reports for each
+    /// call trace arena the response carries, which depends on whether it
+    /// records stack snapshots.
     pub(crate) fn new(
         inner: edr_napi_core::spec::Response,
         call_trace_external_mem_size: i64,
@@ -77,9 +76,8 @@ impl Response {
             external_memory += STACK_TRACE_EXTERNAL_MEM_SIZE;
         }
 
-        if !inner.call_trace_arenas.is_empty() {
-            external_memory += call_trace_external_mem_size;
-        }
+        let arena_count = i64::try_from(inner.call_trace_arenas.len()).unwrap_or(i64::MAX);
+        external_memory += call_trace_external_mem_size.saturating_mul(arena_count);
 
         Self {
             inner,
@@ -216,6 +214,19 @@ mod tests {
         let response = Response::new(inner, call_trace_external_mem_size(true));
 
         assert_eq!(response.external_memory, call_trace_external_mem_size(true));
+    }
+
+    #[test]
+    fn external_memory_scales_with_the_arena_count() {
+        let mut inner = response(Either::A(String::new()));
+        inner.call_trace_arenas = vec![CallTraceArena::default(); 3];
+
+        let response = Response::new(inner, call_trace_external_mem_size(false));
+
+        assert_eq!(
+            response.external_memory,
+            3 * call_trace_external_mem_size(false)
+        );
     }
 
     /// Pins the ratio the figures were derived from: PR #1301 measured 4.9x

--- a/crates/edr_napi/src/provider/response.rs
+++ b/crates/edr_napi/src/provider/response.rs
@@ -3,6 +3,7 @@ use napi::{bindgen_prelude::Either3, Either};
 use napi_derive::napi;
 
 use crate::{
+    gc::gc_tracked,
     solidity_tests::test_results::{CallTrace, HeuristicFailed, StackTrace, UnexpectedError},
     trace::solidity_stack_trace::{
         solidity_stack_trace_error_to_napi, solidity_stack_trace_heuristic_failed_to_napi,
@@ -10,14 +11,94 @@ use crate::{
     },
 };
 
-#[napi]
-pub struct Response {
-    inner: edr_napi_core::spec::Response,
+/// Bytes reported for a response whose call trace arenas were recorded without
+/// stack snapshots.
+///
+/// A `CallTraceStep` is 192 bytes, so this is a trace of roughly 5,400 steps.
+/// A complex contract call runs many more, which is the intended direction:
+/// over-reporting costs a collection on every request, while under-reporting
+/// only forgoes some of the benefit.
+const CALL_TRACE_EXTERNAL_MEM_SIZE: i64 = 1024 * 1024;
+
+/// Bytes reported for a response whose call trace steps also carry stack
+/// snapshots, as `verbose_raw_tracing` records them.
+///
+/// A snapshot is a `Box<[U256]>`, so a step costs roughly 448 bytes rather than
+/// 192. PR #1301 measured 4.9x more retained memory in this configuration, so
+/// 4x stays on the low side of the only figures available.
+const VERBOSE_CALL_TRACE_EXTERNAL_MEM_SIZE: i64 = 4 * 1024 * 1024;
+
+/// Bytes reported for a stack trace, which is a handful of frames of strings.
+const STACK_TRACE_EXTERNAL_MEM_SIZE: i64 = 4 * 1024;
+
+/// Bytes reported when the envelope was too large to marshal as a string.
+///
+/// That only happens above the 250 MB limit in
+/// [`edr_napi_core::spec::marshal_response_data`], and a `serde_json::Value`
+/// tree costs several times its serialized length, so this is a floor.
+const VALUE_DATA_EXTERNAL_MEM_SIZE: i64 = 256 * 1024 * 1024;
+
+/// Bytes a response reports for the call trace arenas it carries.
+///
+/// Recording stack snapshots takes a step from roughly 192 bytes to 448, so a
+/// verbosely traced response stands for several times as much.
+pub(crate) const fn call_trace_external_mem_size(verbose_tracing: bool) -> i64 {
+    if verbose_tracing {
+        VERBOSE_CALL_TRACE_EXTERNAL_MEM_SIZE
+    } else {
+        CALL_TRACE_EXTERNAL_MEM_SIZE
+    }
 }
 
-impl From<edr_napi_core::spec::Response> for Response {
-    fn from(value: edr_napi_core::spec::Response) -> Self {
-        Self { inner: value }
+#[napi(custom_finalize)]
+pub struct Response {
+    inner: edr_napi_core::spec::Response,
+    /// Reported to V8 on the way in and released on finalize, so it is stored
+    /// rather than recomputed.
+    external_memory: i64,
+}
+
+impl Response {
+    /// Constructs a new instance.
+    ///
+    /// `call_trace_external_mem_size` is what the provider reports for a
+    /// response carrying call trace arenas, which depends on whether it records
+    /// stack snapshots.
+    pub(crate) fn new(
+        inner: edr_napi_core::spec::Response,
+        call_trace_external_mem_size: i64,
+    ) -> Self {
+        let mut external_memory = match &inner.data {
+            Either::A(envelope) => i64::try_from(envelope.len()).unwrap_or(i64::MAX),
+            Either::B(_value) => VALUE_DATA_EXTERNAL_MEM_SIZE,
+        };
+
+        if inner.stack_trace_result.is_some() {
+            external_memory += STACK_TRACE_EXTERNAL_MEM_SIZE;
+        }
+
+        if !inner.call_trace_arenas.is_empty() {
+            external_memory += call_trace_external_mem_size;
+        }
+
+        Self {
+            inner,
+            external_memory,
+        }
+    }
+}
+
+gc_tracked! {
+    /// A [`Response`] on its way to JavaScript, reporting what it holds to V8.
+    pub(crate) type GcResponse = GcTracked<Response>;
+
+    /// Computed once by [`Response::new`].
+    fn external_memory(&self) -> i64 {
+        self.external_memory
+    }
+
+    fn drop(self) {
+        // Nothing beyond dropping the response itself.
     }
 }
 
@@ -72,4 +153,90 @@ impl Response {
     //         .map(|trace| RawTrace::from(trace.clone()))
     //         .collect()
     // }
+}
+
+#[cfg(test)]
+mod tests {
+    use edr_solidity_tests::traces::CallTraceArena;
+
+    use super::*;
+
+    fn response(data: edr_napi_core::spec::ResponseData) -> edr_napi_core::spec::Response {
+        edr_napi_core::spec::Response {
+            data,
+            stack_trace_result: None,
+            call_trace_arenas: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn external_memory_of_an_untraced_response_is_its_envelope() {
+        let envelope = "a".repeat(2_048);
+        let response = Response::new(
+            response(Either::A(envelope.clone())),
+            call_trace_external_mem_size(false),
+        );
+
+        assert_eq!(response.external_memory, envelope.len() as i64);
+    }
+
+    #[test]
+    fn external_memory_counts_a_stack_trace() {
+        let mut inner = response(Either::A("a".repeat(2_048)));
+        inner.stack_trace_result = Some(StackTraceCreationResult::HeuristicFailed);
+
+        let response = Response::new(inner, call_trace_external_mem_size(false));
+
+        assert_eq!(
+            response.external_memory,
+            2_048 + STACK_TRACE_EXTERNAL_MEM_SIZE
+        );
+    }
+
+    /// Whether traces were requested is not the question, so the arenas being
+    /// present is what the figure keys on.
+    #[test]
+    fn external_memory_counts_recorded_arenas() {
+        let mut inner = response(Either::A("a".repeat(2_048)));
+        inner.call_trace_arenas = vec![CallTraceArena::default()];
+
+        let response = Response::new(inner, call_trace_external_mem_size(false));
+
+        assert_eq!(
+            response.external_memory,
+            2_048 + call_trace_external_mem_size(false)
+        );
+    }
+
+    #[test]
+    fn external_memory_uses_the_verbose_figure_when_given_it() {
+        let mut inner = response(Either::A(String::new()));
+        inner.call_trace_arenas = vec![CallTraceArena::default()];
+
+        let response = Response::new(inner, call_trace_external_mem_size(true));
+
+        assert_eq!(response.external_memory, call_trace_external_mem_size(true));
+    }
+
+    /// Pins the ratio the figures were derived from: PR #1301 measured 4.9x
+    /// more retained memory with stack snapshots, so 4x stays on the low side.
+    #[test]
+    fn recording_stack_snapshots_reports_four_times_as_much() {
+        assert_eq!(
+            call_trace_external_mem_size(true),
+            4 * call_trace_external_mem_size(false)
+        );
+    }
+
+    /// The `Value` arm is only reachable above the marshalling limit, so its
+    /// figure is a floor rather than an estimate of the envelope.
+    #[test]
+    fn external_memory_of_an_oversized_response_is_the_value_floor() {
+        let response = Response::new(
+            response(Either::B(serde_json::Value::Null)),
+            call_trace_external_mem_size(false),
+        );
+
+        assert_eq!(response.external_memory, VALUE_DATA_EXTERNAL_MEM_SIZE);
+    }
 }


### PR DESCRIPTION
A `Response` holds the JSON-RPC envelope and, when tracing is enabled, the call trace arenas. [PR #1301's analysis](https://github.com/NomicFoundation/edr/pull/1301#issuecomment-4915995062) measured peak RSS going from 445 MB to 1.5 GB with arenas retained, and attributed +1.0s of the slowdown to V8 working against the larger resident set.

None of that weight is visible to V8. The JS wrapper is a handful of bytes, so an unreachable response looks cheap and V8 has no reason to collect it — the same blind spot #1720 fixed for provider threads.

## What changed

`GcTracked`'s amount moves from an associated const to a `HasExternalMemory::external_memory` method, because a response's weight is not a property of its type. `Response` computes its figure once in `Response::new` and stores it. `Provider` keeps the call-trace figure in an `AtomicI64` that follows `verbose_raw_tracing`.

## Design constraints

**The rate is the binding constraint.** `Provider` is created a handful of times per process; `Response` is created once per JSON-RPC request. Measured while building #1720, 2 MiB per provider produced a collection roughly every 32 providers, so V8 behaves as though it wants a hint per ~64 MiB of reported growth. Applying that rate to responses:

| reported per response | collection hint every |
|---|---|
| 16 MiB | ~4 requests |
| 4 MiB | ~16 requests |
| 1 MiB | ~64 requests |
| ~2 KB | ~32,000 requests |

**The payload is bimodal, so no single constant works.** On the common Hardhat path `data` is ~2 KB with no arenas; with tracing on the arenas are tens of MB. Sized for traces a constant wrecks the common path; sized for the common path it does nothing for traces.

**The report and its release must not drift.** An associated const guaranteed that by construction. A method only guarantees it if the value's answer never changes — so the figure is *stored* rather than recomputed, and both ends read one immutable field. That is the whole reason `Response` carries it as a field.

**It has to be O(1), with no arena traversal.** The figure comes from provider configuration, which is known before any request runs, so nothing walks a trace. The trait documents the constant-time expectation for future implementors.

**`IncludeTraces::Failing` is bimodal within one provider** — most responses carry no arenas, failures carry full ones. Keying on `call_trace_arenas.is_empty()` rather than on the configured `IncludeTraces` makes `Failing` exact instead of a compromise, and `is_empty()` is O(1).

**The atomic is `Relaxed` because it publishes nothing.** Stronger orderings exist to make other writes visible alongside the atomic one, and there are none. A response created concurrently with `setVerboseTracing` may read either figure, and both are sound: whichever it reads is what it stores and later releases.

## The figures

Deliberately **uncalibrated**. Memory work is in flight, and a figure calibrated against today's allocations would overshoot once those PRs land. Being wrong is not symmetric — over-reporting costs a collection on every request, under-reporting only forgoes some of the benefit — so these lean low.

They are derived rather than guessed. Measured with `size_of` against `revm-inspectors` 0.41.4: `CallTraceStep` = 192 B, `CallTraceNode` = 384 B, `CallLog` = 104 B. The step size independently confirms #1301's "~200-byte `CallTraceStep`".

| case | figure | derivation |
|---|---|---|
| untraced | `data.len()` | exact for the envelope, and O(1) |
| stack trace present | +4 KiB | a handful of frames of strings |
| envelope too large to marshal as a string | 256 MiB | only reachable above the 250 MB limit, and a `Value` tree costs several times its serialized length, so a floor |
| call traces recorded | +1 MiB | 192 B/step × ~5,400 steps |
| …with stack snapshots | +4 MiB | ~448 B/step (192 flat plus a `Box<[U256]>`) × ~9,300 steps |

Two checks on the traced figures. The **4× ratio is corroborated from the other direction**: #1301 measured +1.05 GB of retained arenas with `StackSnapshotType::Top` against +5.15 GB with `Full`, a ratio of 4.9 — so 4× under-reports the verbose case against the only real data available, and a unit test pins the ratio so the two constants can't drift apart. And **1 MiB is a small trace**: a complex contract call runs tens of thousands of opcodes, so a seaport-sized transaction is plausibly 5–10× that.

The one aggressive cadence is traced-verbose at ~16 requests per hint. That would be indefensible on the common path, but verbose tracing already costs orders of magnitude more per request than a collection, and its failure mode without this change is the OOM #1301 hit at 5.6 GB.

## Validation

- Six unit tests on the figure computation: envelope length, the stack-trace term, the arena discriminator, the verbose figure, the `Value` floor, and the 4× ratio.

## Follow-up

#1562 off-loads response deallocation to a dedicated thread. Until it lands, reporting external memory makes finalizers run earlier and more often, so *more* arena teardown happens on the JS thread — the ~0.5s #1301 measured — in exchange for lower peak RSS. The common path is unaffected, since untraced responses report ~2 KB. Worth watching on the benchmark rather than blocking on.
