### PR TITLE
fix(ci): cancel benchmarks of merged PRs

### DIFF
--- a/.github/workflows/edr-benchmark.yml
+++ b/.github/workflows/edr-benchmark.yml
@@ -24,13 +24,18 @@ defaults:
     working-directory: js/benchmark
 
 concurrency:
-  # Key PR runs on the PR number rather than the ref, so the run created by the
-  # `closed` event groups with the runs from opened/synchronize and cancels
-  # them. Pushes to main and manual dispatches have no PR number and fall back
-  # to the ref.
+  # Key PR runs on the PR number rather than the ref. For a `closed` event
+  # `github.ref` is only `refs/pull/N/merge` when the PR was closed without
+  # merging; when it was merged, `github.ref` is the base branch (e.g.
+  # `refs/heads/main`), so keying on the ref would not group the `closed` run
+  # with the PR's earlier runs. Pushes to main and manual dispatches have no PR
+  # number and fall back to the ref.
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  # Don't cancel in progress jobs in main
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  # Never cancel in-progress runs on main. PR runs are always cancellable,
+  # including the `closed` run of a merged PR, whose `github.ref` is the base
+  # branch: with `cancel-in-progress: false` GitHub would park that run behind
+  # the in-progress benchmark instead of cancelling it.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.ref != 'refs/heads/main' }}
 
 jobs:
   benchmarks-test:


### PR DESCRIPTION
## Problem

#1723 made closing a PR cancel its in-progress benchmark by adding a `closed`
run that takes over the PR's concurrency group. It works when a PR is closed
without merging, but not when it is merged, which is the common case.

GitHub documents that for a `closed` event `github.ref` is
`refs/pull/N/merge` if the PR was closed unmerged, but the **base branch**
(`refs/heads/main`) if it was merged. The workflow's
`cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}` therefore
evaluated to `false` on the `closed` run of a merged PR. With
cancel-in-progress false, GitHub parks the new run behind the in-progress one
instead of cancelling it.

This is visible in the merge of #1723 itself:

| Run | Event | What happened |
|---|---|---|
| #5024 | PR `synchronize` | Ran to completion at 08:30:57, never cancelled |
| #5025 | `push` to main (08:12:50) | Waited for the runner until 08:30:58 |
| #5026 | PR `closed` (08:12:52) | Parked behind #5024, released and skipped at 08:30:58 |

## Fix

```yaml
cancel-in-progress: ${{ github.event_name == 'pull_request' || github.ref != 'refs/heads/main' }}
```

The closed run is still a pull_request event regardless of the ref it
reports, so this makes it cancellable on both the merged and unmerged paths.
Pushes to main have event_name == 'push' and ref == 'refs/heads/main', so
they remain protected, and they live in a separate concurrency group anyway.
Dispatches on non-main branches behave as before.

The comments on group and cancel-in-progress are updated to explain the
merged-PR ref behavior, since that is also the actual reason the group has to
be keyed on the PR number.