### PR TITLE
chore(devcontainer): stop forwarding INFURA_URL into the container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,8 +20,7 @@
     }
   },
   "containerEnv": {
-    "ALCHEMY_URL": "${localEnv:ALCHEMY_URL}",
-    "INFURA_URL": "${localEnv:INFURA_URL}"
+    "ALCHEMY_URL": "${localEnv:ALCHEMY_URL}"
   },
   "customizations": {
     "vscode": {


### PR DESCRIPTION
#1585 removed Infura from the hardhat-tests forked-provider matrix, so nothing in the repo reads `INFURA_URL` any more. The devcontainer still forwarded it from the host via `containerEnv`; this drops that line, leaving `ALCHEMY_URL` as the only remote-provider variable, matching what the book's testing chapter documents.

Follow-up outside the repo: delete the `INFURA_URL` repository secret (still present as of 2026-09-03).
