### PR TITLE
feat: expose native secp256k1 public key derivation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3160,6 +3160,7 @@ dependencies = [
  "edr_utils_sync",
  "foundry-cheatcodes",
  "foundry-compilers",
+ "k256",
  "mimalloc",
  "napi",
  "napi-build",

--- a/crates/edr_napi/Cargo.toml
+++ b/crates/edr_napi/Cargo.toml
@@ -42,6 +42,7 @@ edr_signer.workspace = true
 edr_solidity.workspace = true
 edr_tracing.workspace = true
 edr_utils_sync.workspace = true
+k256.workspace = true
 mimalloc = { version = "0.1.39", default-features = false, features = [
     "local_dynamic_tls",
 ] }

--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -1535,6 +1535,15 @@ export interface RevertResult {
   output: Uint8Array
 }
 
+/**
+ * Derives the secp256k1 public key of the provided secret key, returning it
+ * in uncompressed SEC1 form: 65 bytes, `0x04 || X || Y`.
+ *
+ * Throws if the input isn't a valid secret key: exactly 32 bytes encoding a
+ * big-endian scalar in `[1, n)`, where `n` is the curve order.
+ */
+export declare function secp256k1PublicKeyFromSecretKey(secretKey: Uint8Array): Uint8Array
+
 export const SHANGHAI: string
 
 export type SolidityStackTrace =

--- a/crates/edr_napi/index.js
+++ b/crates/edr_napi/index.js
@@ -780,6 +780,7 @@ module.exports.precompileP256Verify = nativeBinding.precompileP256Verify
 module.exports.printStackTrace = nativeBinding.printStackTrace
 module.exports.RECEIVE_FUNCTION_NAME = nativeBinding.RECEIVE_FUNCTION_NAME
 module.exports.REGOLITH = nativeBinding.REGOLITH
+module.exports.secp256k1PublicKeyFromSecretKey = nativeBinding.secp256k1PublicKeyFromSecretKey
 module.exports.SHANGHAI = nativeBinding.SHANGHAI
 module.exports.SpecId = nativeBinding.SpecId
 module.exports.SPURIOUS_DRAGON = nativeBinding.SPURIOUS_DRAGON

--- a/crates/edr_napi/src/lib.rs
+++ b/crates/edr_napi/src/lib.rs
@@ -44,6 +44,8 @@ pub mod result;
 /// Types relating to benchmark scenarios.
 #[cfg(feature = "scenarios")]
 pub mod scenarios;
+/// Native secp256k1 operations.
+pub mod secp256k1;
 mod serde;
 /// Solidity test runner.
 pub mod solidity_tests;

--- a/crates/edr_napi/src/secp256k1.rs
+++ b/crates/edr_napi/src/secp256k1.rs
@@ -1,0 +1,32 @@
+use k256::{
+    elliptic_curve::{ops::MulByGenerator, sec1::ToEncodedPoint},
+    NonZeroScalar, ProjectivePoint,
+};
+use napi::bindgen_prelude::Uint8Array;
+use napi_derive::napi;
+
+/// Derives the secp256k1 public key of the provided secret key, returning it
+/// in uncompressed SEC1 form: 65 bytes, `0x04 || X || Y`.
+///
+/// Throws if the input isn't a valid secret key: exactly 32 bytes encoding a
+/// big-endian scalar in `[1, n)`, where `n` is the curve order.
+// The `js_name` avoids the `secp256K1` that the automatic camel-casing of
+// `secp256k1_` would produce.
+#[napi(js_name = "secp256k1PublicKeyFromSecretKey")]
+pub fn secp256k1_public_key_from_secret_key(secret_key: Uint8Array) -> napi::Result<Uint8Array> {
+    let scalar = NonZeroScalar::try_from(secret_key.as_ref()).map_err(|_error| {
+        napi::Error::new(
+            napi::Status::InvalidArg,
+            "Expected a 32-byte big-endian scalar in [1, n)",
+        )
+    })?;
+
+    // `mul_by_generator` uses the fixed-base precomputed table, unlike
+    // `SecretKey::public_key`, which performs a generic variable-base
+    // multiplication.
+    let public_key = ProjectivePoint::mul_by_generator(&*scalar).to_affine();
+
+    Ok(Uint8Array::new(
+        public_key.to_encoded_point(false).as_bytes().to_vec(),
+    ))
+}

--- a/crates/edr_napi/test/secp256k1.ts
+++ b/crates/edr_napi/test/secp256k1.ts
@@ -1,0 +1,115 @@
+import { assert } from "chai";
+import { SigningKey } from "ethers";
+import { randomBytes } from "crypto";
+
+import { secp256k1PublicKeyFromSecretKey } from "..";
+
+const CURVE_ORDER = BigInt(
+  "0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141"
+);
+
+function toHex(bytes: Uint8Array): string {
+  return `0x${Buffer.from(bytes).toString("hex")}`;
+}
+
+function secretKeyOf(scalar: bigint): Uint8Array {
+  return Uint8Array.from(
+    Buffer.from(scalar.toString(16).padStart(64, "0"), "hex")
+  );
+}
+
+const KNOWN_SECRET_KEY =
+  "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+const KNOWN_PUBLIC_KEY =
+  "0x048318535b54105d4a7aae60c08fc45f9687181b4fdfc625bd1a753fa7397fed75" +
+  "3547f11ca8696646f2f3acb08e31016afac23e630c5d11f59f61fef57b0d2aa5";
+
+describe("secp256k1PublicKeyFromSecretKey", function () {
+  it("derives the well-known public key of a known secret key", function () {
+    assert.strictEqual(
+      toHex(
+        secp256k1PublicKeyFromSecretKey(Buffer.from(KNOWN_SECRET_KEY, "hex"))
+      ),
+      KNOWN_PUBLIC_KEY
+    );
+  });
+
+  it("returns a 65-byte uncompressed point", function () {
+    const publicKey = secp256k1PublicKeyFromSecretKey(
+      secretKeyOf(BigInt(1337))
+    );
+
+    assert.instanceOf(publicKey, Uint8Array);
+    assert.strictEqual(publicKey.length, 65);
+    assert.strictEqual(publicKey[0], 0x04);
+  });
+
+  it("accepts the ends of the valid range", function () {
+    for (const scalar of [BigInt(1), CURVE_ORDER - BigInt(1)]) {
+      const secretKey = secretKeyOf(scalar);
+
+      assert.strictEqual(
+        toHex(secp256k1PublicKeyFromSecretKey(secretKey)),
+        new SigningKey(secretKey).publicKey
+      );
+    }
+  });
+
+  it("rejects secret keys outside the valid range", function () {
+    for (const scalar of [
+      BigInt(0),
+      CURVE_ORDER,
+      CURVE_ORDER + BigInt(1),
+      BigInt(2) ** BigInt(256) - BigInt(1),
+    ]) {
+      assert.throws(() =>
+        secp256k1PublicKeyFromSecretKey(secretKeyOf(scalar))
+      );
+    }
+  });
+
+  it("rejects inputs that aren't 32 bytes", function () {
+    for (const length of [0, 1, 31, 33, 64, 65]) {
+      assert.throws(
+        () => secp256k1PublicKeyFromSecretKey(new Uint8Array(length).fill(1)),
+        undefined,
+        undefined,
+        `a ${length}-byte input should be rejected`
+      );
+    }
+  });
+
+  it("accepts a view into a pooled Buffer", function () {
+    const pool = Buffer.alloc(96);
+    const pooled = pool.subarray(8, 40);
+    Buffer.from(KNOWN_SECRET_KEY, "hex").copy(pooled);
+    assert.notStrictEqual(pooled.byteOffset, 0);
+
+    assert.strictEqual(
+      toHex(secp256k1PublicKeyFromSecretKey(pooled)),
+      KNOWN_PUBLIC_KEY
+    );
+  });
+
+  // A mismatch with the JS implementation would produce wrong addresses, so
+  // this covers a wide range of random keys.
+  it("fuzz: matches the JS implementation for random secret keys", function () {
+    for (let i = 0; i < 500; i++) {
+      const secretKey = randomBytes(32);
+
+      let expected;
+      try {
+        expected = new SigningKey(secretKey).publicKey;
+      } catch {
+        // Outside [1, n), which the cases above cover explicitly.
+        continue;
+      }
+
+      assert.strictEqual(
+        toHex(secp256k1PublicKeyFromSecretKey(secretKey)),
+        expected,
+        `mismatch for ${toHex(secretKey)}`
+      );
+    }
+  });
+});

--- a/crates/edr_napi/test/secp256k1.ts
+++ b/crates/edr_napi/test/secp256k1.ts
@@ -62,9 +62,7 @@ describe("secp256k1PublicKeyFromSecretKey", function () {
       CURVE_ORDER + BigInt(1),
       BigInt(2) ** BigInt(256) - BigInt(1),
     ]) {
-      assert.throws(() =>
-        secp256k1PublicKeyFromSecretKey(secretKeyOf(scalar))
-      );
+      assert.throws(() => secp256k1PublicKeyFromSecretKey(secretKeyOf(scalar)));
     }
   });
 


### PR DESCRIPTION
Expose secp256k1 EDR implementation so hardhat can use it to override the ether default one