### PR TITLE
ci(bench): include verbosity variants in the default benchmark filter

### DIFF
--- a/.github/scripts/resolve-regression-trigger.test.ts
+++ b/.github/scripts/resolve-regression-trigger.test.ts
@@ -218,7 +218,7 @@ test("push → baseline run against Hardhat main", async () => {
     // Baseline runs all projects (`*`), but only the default test-execution
     // benchmarks — EDR doesn't affect compilation, so compile ones are skipped.
     scenario_filter: "*",
-    benchmark_filter: "test solidity,test mocha,test vitest",
+    benchmark_filter: "test solidity*,test mocha*,test vitest*",
   });
 });
 
@@ -271,7 +271,7 @@ test("workflow_dispatch → forwards explicit filters; benchmark uses the defaul
   // No benchmark-filter given → default test-execution benchmarks.
   assert.equal(
     withoutFilter.captured.outputs.benchmark_filter,
-    "test solidity,test mocha,test vitest"
+    "test solidity*,test mocha*,test vitest*"
   );
 });
 
@@ -325,7 +325,7 @@ test("issue_comment → same-repo PR with green CI runs and parses hardhat-ref",
   // default test-execution benchmarks (no benchmarks= in body)
   assert.equal(
     captured.outputs.benchmark_filter,
-    "test solidity,test mocha,test vitest"
+    "test solidity*,test mocha*,test vitest*"
   );
   assert.equal(captured.comments.length, 1);
   assert.match(firstComment(captured), /Starting regression benchmark/);

--- a/.github/scripts/resolve-regression-trigger.ts
+++ b/.github/scripts/resolve-regression-trigger.ts
@@ -25,11 +25,12 @@ const CI_POLL_INTERVAL_MS = 30 * 1000; // 30 seconds
 // --benchmarks unconditionally; `*` matches everything.
 //
 // Scenarios default to all. Benchmarks default to just the test-execution
-// entries — EDR affects EVM execution, not Solidity compilation, so we skip the
+// entries (the trailing `*` picks up verbosity variants like `test solidity
+// -vvv`) — EDR affects EVM execution, not Solidity compilation, so we skip the
 // expensive compile ones to save CI time. Override per run via the workflow
 // inputs / `scenarios=`/`benchmarks=` comment args; pass `*` for the full suite.
 const DEFAULT_SCENARIO_FILTER = "*";
-const DEFAULT_BENCHMARK_FILTER = "test solidity,test mocha,test vitest";
+const DEFAULT_BENCHMARK_FILTER = "test solidity*,test mocha*,test vitest*";
 
 // Optional Hardhat compatibility pin (see hardhat-compat-pin.ts for the file
 // format). While the pinned Hardhat PR is open, runs that don't name an

--- a/.github/workflows/hh3-regression-benchmark.yml
+++ b/.github/workflows/hh3-regression-benchmark.yml
@@ -40,10 +40,10 @@ on:
         type: string
         default: "*"
       benchmark-filter:
-        description: "Glob(s) selecting which benchmarks to run within each project, by name — a command or step name, i.e. the part after `<project> /` in a report (e.g. `test solidity`, `cold compile`, `*compile*`). Comma-separated. Defaults to `test solidity,test mocha,test vitest` (EDR affects test execution, not compilation); pass `*` to run the full suite. Forwarded to `bench:regression --benchmarks`."
+        description: "Glob(s) selecting which benchmarks to run within each project, by name — a command or step name, i.e. the part after `<project> /` in a report (e.g. `test solidity`, `cold compile`, `*compile*`). Comma-separated. Defaults to `test solidity*,test mocha*,test vitest*` — test execution including verbosity variants like `test solidity -vvv` (EDR affects test execution, not compilation); pass `*` to run the full suite. Forwarded to `bench:regression --benchmarks`."
         required: false
         type: string
-        default: "test solidity,test mocha,test vitest"
+        default: "test solidity*,test mocha*,test vitest*"
   # ChatOps: comment `/bench` on a same-repo PR, optionally with
   # `hardhat-ref=<branch|sha|PR>` (defaults to `main`, or the compat pin if
   # one is active on the PR head), `scenarios="<glob>[,<glob>...]"` and/or


### PR DESCRIPTION
The default benchmark filter matched only the exact names `test solidity`, `test mocha` and `test vitest`. This excluded the verbosity variants such as `test solidity -vvv` and `test solidity -vvvv`, that were merged in https://github.com/NomicFoundation/hardhat/pull/8593. A trailing `*` on each glob now includes them.