### PR TITLE
ci: build the linux gnu bindings on bookworm

### DIFF
--- a/.changeset/bookworm-glibc-floor.md
+++ b/.changeset/bookworm-glibc-floor.md
@@ -2,6 +2,4 @@
 "@nomicfoundation/edr": minor
 ---
 
-Raised the minimum glibc of the prebuilt Linux gnu binaries (`@nomicfoundation/edr-linux-x64-gnu`, `@nomicfoundation/edr-linux-arm64-gnu`) from 2.30 to 2.34. They are now built on Debian 12 (bookworm) instead of Debian 11 (bullseye), which reached end of life on 2026-08-31.
-
-Ubuntu 20.04 and Debian 11 can no longer load these binaries and will fail at require time with `GLIBC_2.34 not found`. Ubuntu 22.04, Debian 12, RHEL 9, Amazon Linux 2023 and later are unaffected, as are the musl builds.
+Raised the minimum glibc of the prebuilt Linux gnu binaries (`@nomicfoundation/edr-linux-x64-gnu`, `@nomicfoundation/edr-linux-arm64-gnu`) from 2.30 to 2.34.

--- a/.changeset/bookworm-glibc-floor.md
+++ b/.changeset/bookworm-glibc-floor.md
@@ -1,0 +1,7 @@
+---
+"@nomicfoundation/edr": minor
+---
+
+Raised the minimum glibc of the prebuilt Linux gnu binaries (`@nomicfoundation/edr-linux-x64-gnu`, `@nomicfoundation/edr-linux-arm64-gnu`) from 2.30 to 2.34. They are now built on Debian 12 (bookworm) instead of Debian 11 (bullseye), which reached end of life on 2026-08-31.
+
+Ubuntu 20.04 and Debian 11 can no longer load these binaries and will fail at require time with `GLIBC_2.34 not found`. Ubuntu 22.04, Debian 12, RHEL 9, Amazon Linux 2023 and later are unaffected, as are the musl builds.

--- a/.changeset/bookworm-glibc-floor.md
+++ b/.changeset/bookworm-glibc-floor.md
@@ -2,4 +2,4 @@
 "@nomicfoundation/edr": minor
 ---
 
-Raised the minimum glibc of the prebuilt Linux gnu binaries (`@nomicfoundation/edr-linux-x64-gnu`, `@nomicfoundation/edr-linux-arm64-gnu`) from 2.30 to 2.34.
+Raised the minimum supported version of glibc for the prebuilt Linux gnu binaries (`@nomicfoundation/edr-linux-x64-gnu`, `@nomicfoundation/edr-linux-arm64-gnu`) from 2.30 to 2.34.

--- a/.github/actions/select-node-image/action.yml
+++ b/.github/actions/select-node-image/action.yml
@@ -3,7 +3,7 @@ description: Resolves the node Docker image for a job. Normal runs use the GHCR 
 
 inputs:
   tag:
-    description: node image tag, e.g. 24-bullseye-slim or 22-alpine
+    description: node image tag, e.g. 24-bookworm-slim or 22-alpine
     required: true
   release-tag:
     description: check_commit's release tag; non-empty marks a release run

--- a/.github/workflows/edr-npm-release.yml
+++ b/.github/workflows/edr-npm-release.yml
@@ -58,14 +58,19 @@ jobs:
           # select-node-image action (GHCR mirror normally, Docker Hub on
           # releases). New or changed tags must be added to the mirror
           # workflow's tag list in the same PR.
+          #
+          # The gnu image sets the glibc floor of the published binaries:
+          # bookworm puts it at 2.34, up from 2.30 on bullseye, which went
+          # away when Debian 11 hit EOL on 2026-08-31 and its security pool
+          # was purged out from under `apt-get install`.
           - host: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
-            docker_tag: 24-bullseye-slim
+            docker_tag: 24-bookworm-slim
             flavor: gnu
 
           - host: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
-            docker_tag: 24-bullseye-slim
+            docker_tag: 24-bookworm-slim
             flavor: gnu
 
           - host: ubuntu-24.04

--- a/.github/workflows/mirror-docker-images.yml
+++ b/.github/workflows/mirror-docker-images.yml
@@ -50,7 +50,7 @@ jobs:
           # Keep in sync with the node versions and container images in
           # edr-npm-release.yml; a tag missing here fails CI with "manifest
           # unknown" on the mirror pull.
-          TAGS=(22 22-alpine 24 24-alpine 24-bullseye-slim 26 26-alpine)
+          TAGS=(22 22-alpine 24 24-alpine 24-bookworm-slim 26 26-alpine)
 
           OWNER=${GITHUB_REPOSITORY_OWNER,,} # ghcr.io requires lowercase
           for tag in "${TAGS[@]}"; do


### PR DESCRIPTION
CI is currently broken for GNU, e.g. see https://github.com/NomicFoundation/edr/actions/runs/33944918632/job/101249182787?pr=1734. This is due to an end of life of the image, and the associated package being pulled. We need to bump `node:24-bullseye-slim`. Downside is this also bumps `glibc` (from 2.30 to 2.34) which makes it harder for EDR users with an older operating system to use it. I've gone for the `node:24-bookworm-slim` as this still allows the within support window Ubuntu 22.04 to be used directly (`glibc 2.35`). 

Verified `glibc` version locally by pulling down the built artefacts:

```
$ gh run download 33965347869 \
    -n bindings-x86_64-unknown-linux-gnu \
    -n bindings-aarch64-unknown-linux-gnu -D floor

$ for f in floor/*/*.node; do
    printf '%s: ' "$f"
    objdump -T "$f" | grep -oE 'GLIBC_[0-9.]+' | sort -uV | tail -1
  done
floor/bindings-aarch64-unknown-linux-gnu/edr.linux-arm64-gnu.node: GLIBC_2.34
floor/bindings-x86_64-unknown-linux-gnu/edr.linux-x64-gnu.node: GLIBC_2.34
```

# Claude summary
Both gnu legs of `EDR NPM release` have failed on every run since 2026-09-04
21:52 UTC, `main` included. This is not a flake.

Debian 11 reached EOL on 2026-08-31 and `debian-security` was purged of every
deb11 binary, but the `bullseye-security` indices are still published. So
`apt-get update` succeeds, apt resolves package versions that no longer have
files behind them, and the install in `node:24-bullseye-slim` dies:

```
E: Failed to fetch .../libperl5.32_5.32.1-4+deb11u5_amd64.deb   404  Not Found
E: Failed to fetch .../libc-dev-bin_2.31-13+deb11u14_amd64.deb  404  Not Found
E: Failed to fetch .../linux-libc-dev_5.10.262-1_amd64.deb      404  Not Found
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

Confirmed against the live mirror: `pool/updates/main/p/perl/` now holds 27
`.deb` files, **zero** of them deb11. `archive.debian.org/debian-security/dists/`
only goes up to `buster`, so bullseye has not landed on the archive yet and there
is no URL to redirect at. The `bullseye/main` suite still resolves, which is why
most of the package list downloads fine before the security-suite entries 404.

The alpine/musl legs use `apk` and are unaffected.

## What this changes

`node:24-bullseye-slim` → `node:24-bookworm-slim` on both gnu matrix entries, the
mirror tag list, and the `select-node-image` input description.

**This raises the glibc floor of the published binaries from 2.30 to 2.34.** That
comes from glibc 2.34 folding `libpthread` and `libdl` into `libc`: 18 of the
symbols EDR references bind at `GLIBC_2.34` there — 15 `pthread_*` plus
`dlopen`, `dlsym` and `dladdr`. Nothing it references binds higher —
`arc4random` and the other 2.35/2.36 additions are unused.

Resolved by taking all 171 undefined glibc symbols in the published
`edr-linux-x64-gnu@0.20.0` binary and looking up each one's default version in
bookworm's own `libc6_2.36-9+deb12u7`:

| | glibc | before (2.30) | after (2.34) |
|---|---|---|---|
| RHEL/Rocky 8, Amazon Linux 2 | 2.28, 2.26 | ✗ already unsupported | ✗ |
| **Ubuntu 20.04, Debian 11** | **2.31** | **✓** | **✗ dropped** |
| RHEL 9, Amazon Linux 2023 | 2.34 | ✓ | ✓ |
| Ubuntu 22.04 | 2.35 | ✓ | ✓ |
| Debian 12, Ubuntu 24.04 | 2.36+ | ✓ | ✓ |

So the blast radius is Ubuntu 20.04 (standard support ended mid-2025) and Debian
11 — the distro whose EOL caused this outage. Ubuntu 22.04 is unaffected. Node
itself already requires 2.28, and `engines` is `node >= 22`, so consumers below
that band were largely out of reach anyway.

Changeset is `minor` rather than `patch`: dropping a platform is the sort of
thing someone needs to read in the changelog, not discover from
`GLIBC_2.34 not found` at require time.

## Verifying

Measured on run 33965347869's artifacts rather than trusting the analysis above,
since a newer gcc/libstdc++ can change *which* symbols get referenced. Both
arches top out at `GLIBC_2.34`, and the 18 symbols binding there are exactly the
predicted set — nothing new appeared. Command and output are in the section
above.

`mirror-docker-images.yml` mirrors the new tag on this PR via its
`pull_request` paths trigger, but it runs concurrently with the build job, so
`manifest unknown` on the mirror pull is possible on a first run. It did not
happen here; if it does, re-run once the mirror job is green.

## Not in scope

Every build leg still constructs its toolchain from scratch (`apt`/`apk` + rustup
+ two `npm i -g`), which is what put Debian's archive on the critical path in the
first place. Baking node + rust + pnpm + sfw into GHCR-hosted builder images
would make distro EOL a scheduled image rebuild instead of an outage, and would
make the glibc floor a property of a checked-in Dockerfile rather than of a tag
string in a matrix entry. Worth doing separately; there are real questions about
how a baked image squares with release runs deliberately bypassing the mirror.

Nothing in CI currently notices the glibc floor moving. Asserting it against a
committed expected value is a few lines in the build job and would turn a silent
platform drop into a failing check — happy to add it here or fold it into the
builder-image work.

