### PR TITLE
test: add EIP-8024 new stack instruction tests (Amsterdam)

### DIFF
--- a/crates/edr_provider/tests/common/bytecode.rs
+++ b/crates/edr_provider/tests/common/bytecode.rs
@@ -53,7 +53,7 @@ impl BytecodeBuilder {
 
     /// Init bytecode wrapping the runtime in the standard constructor that
     /// copies it out as the deployed code.
-    pub fn deployable(&self) -> Bytes {
+    pub fn deployable(self) -> Bytes {
         const CONSTRUCTOR_LEN: u8 = 12;
 
         let runtime_len = u8::try_from(self.runtime.len()).expect("runtime length fits a PUSH1");

--- a/crates/edr_provider/tests/common/bytecode.rs
+++ b/crates/edr_provider/tests/common/bytecode.rs
@@ -1,0 +1,79 @@
+//! Tiny EVM assembler for hand-built test contracts.
+#![cfg(feature = "test-utils")]
+
+use edr_primitives::Bytes;
+
+/// Opcodes used by hand-built test contracts.
+pub mod opcode {
+    pub const CODECOPY: u8 = 0x39;
+    pub const POP: u8 = 0x50;
+    pub const MSTORE: u8 = 0x52;
+    pub const PUSH1: u8 = 0x60;
+    pub const RETURN: u8 = 0xf3;
+
+    // EIP-8024 stack instructions (Amsterdam).
+    pub const DUPN: u8 = 0xe6;
+    pub const SWAPN: u8 = 0xe7;
+    pub const EXCHANGE: u8 = 0xe8;
+}
+
+/// Assembles a contract's runtime code opcode by opcode, encapsulating the
+/// deploy-wrapper and length bookkeeping.
+#[derive(Default)]
+pub struct BytecodeBuilder {
+    runtime: Vec<u8>,
+}
+
+impl BytecodeBuilder {
+    /// Appends a plain opcode.
+    pub fn opcode(&mut self, opcode: u8) -> &mut Self {
+        self.runtime.push(opcode);
+        self
+    }
+
+    /// Appends an opcode followed by its one-byte immediate operand.
+    pub fn opcode_with_immediate(&mut self, opcode: u8, immediate: u8) -> &mut Self {
+        self.runtime.extend([opcode, immediate]);
+        self
+    }
+
+    /// Appends `PUSH1 value`.
+    pub fn push1(&mut self, value: u8) -> &mut Self {
+        self.opcode_with_immediate(opcode::PUSH1, value)
+    }
+
+    /// Appends code returning the top of the stack as a 32-byte word.
+    pub fn return_top_word(&mut self) -> &mut Self {
+        self.push1(0)
+            .opcode(opcode::MSTORE)
+            .push1(0x20)
+            .push1(0)
+            .opcode(opcode::RETURN)
+    }
+
+    /// Init bytecode wrapping the runtime in the standard constructor that
+    /// copies it out as the deployed code.
+    pub fn deployable(&self) -> Bytes {
+        const CONSTRUCTOR_LEN: u8 = 12;
+
+        let runtime_len = u8::try_from(self.runtime.len()).expect("runtime length fits a PUSH1");
+        let mut code = vec![
+            opcode::PUSH1,
+            runtime_len,
+            opcode::PUSH1,
+            CONSTRUCTOR_LEN,
+            opcode::PUSH1,
+            0x00,
+            opcode::CODECOPY,
+            opcode::PUSH1,
+            runtime_len,
+            opcode::PUSH1,
+            0x00,
+            opcode::RETURN,
+        ];
+        assert_eq!(code.len(), usize::from(CONSTRUCTOR_LEN));
+
+        code.extend_from_slice(&self.runtime);
+        code.into()
+    }
+}

--- a/crates/edr_provider/tests/common/mod.rs
+++ b/crates/edr_provider/tests/common/mod.rs
@@ -1,6 +1,7 @@
 /// Test utilities for blob transactions.
 #[allow(dead_code)]
 pub mod blob;
+pub mod bytecode;
 pub mod provider;
 
 pub fn help_test_method_invocation_serde<MethodInvocation>(call: MethodInvocation)

--- a/crates/edr_provider/tests/integration/eip8024.rs
+++ b/crates/edr_provider/tests/integration/eip8024.rs
@@ -1,0 +1,154 @@
+#![cfg(feature = "test-utils")]
+
+//! EIP-8024: Backward compatible SWAPN, DUPN and EXCHANGE.
+//! see <https://eips.ethereum.org/EIPS/eip-8024>
+//!
+//! From Amsterdam onward, the DUPN (`0xe6`), SWAPN (`0xe7`) and EXCHANGE
+//! (`0xe8`) opcodes manipulate the stack beyond the reach of DUP16/SWAP16,
+//! each taking a one-byte immediate operand in a backward-compatible encoding.
+//! On earlier hardforks the opcodes are undefined.
+
+use core::str::FromStr as _;
+
+use edr_chain_l1::rpc::call::L1CallRequest;
+use edr_primitives::{address, Address, Bytes, U256};
+use edr_provider::{
+    test_utils::deploy_contract, MethodInvocation, ProviderError, ProviderRequest,
+    TransactionFailureReason,
+};
+
+use crate::common::{
+    bytecode::{
+        opcode::{DUPN, EXCHANGE, POP, SWAPN},
+        BytecodeBuilder,
+    },
+    provider::{new_provider, new_provider_with_config},
+};
+
+const SENDER: Address = address!("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+
+/// Marker value each contract plants on the stack and must return. The stack
+/// slots around it hold `0` or `7`, so a wrong stack manipulation returns a
+/// different value instead of failing outright.
+const MARKER: u8 = 42;
+
+/// DUPN/SWAPN immediate decoding to operand value 17, the smallest the
+/// backward-compatible encoding can express. Like DUP1/SWAP1, the two opcodes
+/// read it off by one: DUPN duplicates the 17th stack item, while SWAPN swaps
+/// the top with the item 17 below it (the 18th).
+const OPERAND_17_IMMEDIATE: u8 = 0x80;
+
+/// EXCHANGE immediate decoding to the (2nd, 3rd) stack item pair.
+const SECOND_AND_THIRD_IMMEDIATE: u8 = 0x8e;
+
+fn contracts() -> [(&'static str, Bytes); 3] {
+    // The marker followed by 16 zeros, making it the 17th stack item; DUPN
+    // duplicates it to the top.
+    let mut dupn = BytecodeBuilder::default();
+    dupn.push1(MARKER);
+    for _ in 0..16 {
+        dupn.push1(0);
+    }
+    dupn.opcode_with_immediate(DUPN, OPERAND_17_IMMEDIATE)
+        .return_top_word();
+
+    // The marker, 16 zeros and a 7 on top, making the marker the 18th stack
+    // item; SWAPN swaps it with the top.
+    let mut swapn = BytecodeBuilder::default();
+    swapn.push1(MARKER);
+    for _ in 0..16 {
+        swapn.push1(0);
+    }
+    swapn
+        .push1(7)
+        .opcode_with_immediate(SWAPN, OPERAND_17_IMMEDIATE)
+        .return_top_word();
+
+    // The marker, a 7 and a 0 on top; EXCHANGE swaps the 2nd and 3rd items and
+    // POP drops the untouched top, leaving the marker there.
+    let mut exchange = BytecodeBuilder::default();
+    exchange
+        .push1(MARKER)
+        .push1(7)
+        .push1(0)
+        .opcode_with_immediate(EXCHANGE, SECOND_AND_THIRD_IMMEDIATE)
+        .opcode(POP)
+        .return_top_word();
+
+    [
+        ("DUPN", dupn.deployable()),
+        ("SWAPN", swapn.deployable()),
+        ("EXCHANGE", exchange.deployable()),
+    ]
+}
+
+fn call_request(contract_address: Address) -> L1CallRequest {
+    L1CallRequest {
+        from: Some(SENDER),
+        to: Some(contract_address),
+        ..L1CallRequest::default()
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn opcodes_available_from_amsterdam() -> anyhow::Result<()> {
+    let provider = new_provider(edr_chain_l1::Hardfork::Amsterdam)?;
+
+    for (opcode, contract) in contracts() {
+        let contract_address = deploy_contract(&provider, SENDER, contract)?;
+
+        let response = provider.handle_request(ProviderRequest::with_single(
+            MethodInvocation::Call(call_request(contract_address), None, None),
+        ))?;
+
+        let call_result: String = response.deserialize_result()?;
+        let returned_value = U256::from_str(&call_result)?;
+
+        assert_eq!(
+            returned_value,
+            U256::from(MARKER),
+            "{opcode} should retrieve the marker from the stack on Amsterdam"
+        );
+    }
+
+    Ok(())
+}
+
+// Before Amsterdam the opcodes are undefined, so executing them must fail
+// rather than return a value.
+#[tokio::test(flavor = "multi_thread")]
+async fn opcodes_unavailable_before_amsterdam() -> anyhow::Result<()> {
+    let provider = new_provider_with_config(|config| {
+        config.hardfork = edr_chain_l1::Hardfork::Osaka;
+        // Surface the resulting halt as an error instead of empty output.
+        config.bail_on_call_failure = true;
+    })?;
+
+    for (opcode, contract) in contracts() {
+        // The init bytecode never executes the new opcodes (it only copies the
+        // runtime out), so deployment succeeds even pre-Amsterdam.
+        let contract_address = deploy_contract(&provider, SENDER, contract)?;
+
+        let result = provider.handle_request(ProviderRequest::with_single(MethodInvocation::Call(
+            call_request(contract_address),
+            None,
+            None,
+        )));
+
+        // The opcodes are recognized by revm but gated on the hardfork, so they
+        // halt with `NotActivated` rather than a generic failure.
+        assert!(
+            matches!(
+                &result,
+                Err(ProviderError::TransactionFailed(failure))
+                    if matches!(
+                        failure.failure.reason,
+                        TransactionFailureReason::Inner(edr_chain_l1::HaltReason::NotActivated)
+                    )
+            ),
+            "{opcode} should be inactive before Amsterdam, got {result:?}"
+        );
+    }
+
+    Ok(())
+}

--- a/crates/edr_provider/tests/integration/eip8024.rs
+++ b/crates/edr_provider/tests/integration/eip8024.rs
@@ -27,9 +27,7 @@ use crate::common::{
 
 const SENDER: Address = address!("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
 
-/// Marker value each contract plants on the stack and must return. The stack
-/// slots around it hold `0` or `7`, so a wrong stack manipulation returns a
-/// different value instead of failing outright.
+/// Marker value each contract plants on the stack and must return.
 const MARKER: u8 = 42;
 
 /// DUPN/SWAPN immediate decoding to operand value 17, the smallest the

--- a/crates/edr_provider/tests/integration/mod.rs
+++ b/crates/edr_provider/tests/integration/mod.rs
@@ -14,6 +14,7 @@ mod eip7825;
 mod eip7843;
 mod eip7928;
 mod eip7981;
+mod eip8024;
 mod estimate_gas;
 mod eth_get_proof;
 mod eth_max_priority_fee_per_gas;


### PR DESCRIPTION
- added integration test to assert the instructions introduced by EIP-8024 are properly gated by Amsterdam
- Bonus: Introduce new bytecode module to encapsulate hand-built bytecode. I'll refactor existing tests to use this instead in a follow-up PR