### PR TITLE
refactor(tests): reuse the bytecode builder in pre-existing tests

### DIFF
--- a/crates/edr_provider/tests/common/bytecode.rs
+++ b/crates/edr_provider/tests/common/bytecode.rs
@@ -5,9 +5,13 @@ use edr_primitives::Bytes;
 
 /// Opcodes used by hand-built test contracts.
 pub mod opcode {
+    pub const STOP: u8 = 0x00;
+    pub const CALLDATALOAD: u8 = 0x35;
     pub const CODECOPY: u8 = 0x39;
+    pub const SLOTNUM: u8 = 0x4b;
     pub const POP: u8 = 0x50;
     pub const MSTORE: u8 = 0x52;
+    pub const SSTORE: u8 = 0x55;
     pub const PUSH1: u8 = 0x60;
     pub const RETURN: u8 = 0xf3;
 
@@ -49,6 +53,12 @@ impl BytecodeBuilder {
             .push1(0x20)
             .push1(0)
             .opcode(opcode::RETURN)
+    }
+
+    /// The assembled runtime code, for contracts seeded directly into state
+    /// rather than deployed.
+    pub fn runtime(&self) -> Bytes {
+        self.runtime.clone().into()
     }
 
     /// Init bytecode wrapping the runtime in the standard constructor that

--- a/crates/edr_provider/tests/common/bytecode.rs
+++ b/crates/edr_provider/tests/common/bytecode.rs
@@ -1,9 +1,8 @@
 //! Tiny EVM assembler for hand-built test contracts.
 #![cfg(feature = "test-utils")]
 
-use edr_primitives::Bytes;
-
 pub use edr_primitives::bytecode::opcode;
+use edr_primitives::Bytes;
 
 /// Assembles a contract's runtime code opcode by opcode, encapsulating the
 /// deploy-wrapper and length bookkeeping.

--- a/crates/edr_provider/tests/common/bytecode.rs
+++ b/crates/edr_provider/tests/common/bytecode.rs
@@ -3,23 +3,7 @@
 
 use edr_primitives::Bytes;
 
-/// Opcodes used by hand-built test contracts.
-pub mod opcode {
-    pub const STOP: u8 = 0x00;
-    pub const CALLDATALOAD: u8 = 0x35;
-    pub const CODECOPY: u8 = 0x39;
-    pub const SLOTNUM: u8 = 0x4b;
-    pub const POP: u8 = 0x50;
-    pub const MSTORE: u8 = 0x52;
-    pub const SSTORE: u8 = 0x55;
-    pub const PUSH1: u8 = 0x60;
-    pub const RETURN: u8 = 0xf3;
-
-    // EIP-8024 stack instructions (Amsterdam).
-    pub const DUPN: u8 = 0xe6;
-    pub const SWAPN: u8 = 0xe7;
-    pub const EXCHANGE: u8 = 0xe8;
-}
+pub use edr_primitives::bytecode::opcode;
 
 /// Assembles a contract's runtime code opcode by opcode, encapsulating the
 /// deploy-wrapper and length bookkeeping.
@@ -57,7 +41,7 @@ impl BytecodeBuilder {
 
     /// The assembled runtime code, for contracts seeded directly into state
     /// rather than deployed.
-    pub fn runtime(&self) -> Bytes {
+    pub fn runtime(self) -> Bytes {
         self.runtime.clone().into()
     }
 

--- a/crates/edr_provider/tests/integration/eip7778.rs
+++ b/crates/edr_provider/tests/integration/eip7778.rs
@@ -13,7 +13,7 @@ use edr_chain_l1::{
     L1ChainSpec,
 };
 use edr_eth::PreEip1898BlockSpec;
-use edr_primitives::{address, bytes, Address, Bytecode, Bytes, B256, U256};
+use edr_primitives::{address, Address, Bytecode, Bytes, B256, U256};
 use edr_provider::{
     test_utils::{one_ether, set_genesis_state_with_owned_accounts},
     AccountOverride, MethodInvocation, Provider, ProviderRequest,
@@ -21,7 +21,13 @@ use edr_provider::{
 use edr_state_api::{EvmStorage, EvmStorageSlot, TransactionId};
 use edr_test_utils::secret_key::secret_key_from_str;
 
-use crate::common::provider::{new_provider_with_config, send_transaction};
+use crate::common::{
+    bytecode::{
+        opcode::{CALLDATALOAD, SSTORE, STOP},
+        BytecodeBuilder,
+    },
+    provider::{new_provider_with_config, send_transaction},
+};
 
 const CHAIN_ID: u64 = 0x7a69;
 
@@ -33,7 +39,16 @@ const CONTRACT: Address = address!("0x000000000000000000000000000000000000c0de")
 
 /// Deployed code `SSTORE(calldataload(0), calldataload(32))`: calling it with
 /// `[slot(32) || value(32)]` writes `value` to storage `slot`.
-const STORAGE_WRITER_CODE: Bytes = bytes!("0x6020356000355500");
+fn storage_writer_code() -> Bytes {
+    let mut code = BytecodeBuilder::default();
+    code.push1(0x20)
+        .opcode(CALLDATALOAD)
+        .push1(0)
+        .opcode(CALLDATALOAD)
+        .opcode(SSTORE)
+        .opcode(STOP);
+    code.runtime()
+}
 
 /// Storage slot seeded into [`CONTRACT`] and cleared by the refunding
 /// transaction.
@@ -61,7 +76,7 @@ fn new_provider(hardfork: edr_chain_l1::Hardfork) -> anyhow::Result<Provider<L1C
         config.genesis_state.insert(
             CONTRACT,
             AccountOverride {
-                code: Some(Bytecode::new_raw(STORAGE_WRITER_CODE)),
+                code: Some(Bytecode::new_raw(storage_writer_code())),
                 storage: Some(seeded_storage()),
                 ..AccountOverride::default()
             },

--- a/crates/edr_provider/tests/integration/eip7843.rs
+++ b/crates/edr_provider/tests/integration/eip7843.rs
@@ -8,41 +8,32 @@
 //! omitted from the RPC response. EDR has no consensus layer, so it simulates
 //! one slot per mined block.
 
-use std::{str::FromStr as _, sync::Arc};
+use std::str::FromStr as _;
 
-use edr_chain_l1::{
-    rpc::{block::L1RpcBlock, call::L1CallRequest},
-    L1ChainSpec,
-};
+use edr_chain_l1::rpc::{block::L1RpcBlock, call::L1CallRequest};
 use edr_eth::BlockSpec;
-use edr_primitives::{address, bytes, Address, Bytes, B256, U256};
+use edr_primitives::{address, Address, Bytes, B256, U256};
 use edr_provider::{
-    test_utils::{create_test_config, deploy_contract, get_latest_block, mine_block},
-    time::CurrentTime,
-    MethodInvocation, NoopLogger, Provider, ProviderError, ProviderRequest,
-    TransactionFailureReason,
+    test_utils::{deploy_contract, get_latest_block, mine_block},
+    MethodInvocation, ProviderError, ProviderRequest, TransactionFailureReason,
 };
-use edr_solidity::contract_decoder::ContractDecoder;
-use parking_lot::RwLock;
-use tokio::runtime;
 
-use crate::common::provider::new_provider;
+use crate::common::{
+    bytecode::{opcode::SLOTNUM, BytecodeBuilder},
+    provider::{new_provider, new_provider_with_config},
+};
 
 const SLOT_NUMBER_JSON_KEY: &str = "slotNumber";
 
 const SENDER: Address = address!("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
 
-/// Init bytecode for a contract that returns the current block's slot number.
-///
-/// `SLOTNUM` (`0x4b`) has no Solidity/Yul builtin, so this is hand-assembled
-/// instead of compiled. The deployed runtime is `4b60005260206000f3`
-/// (`SLOTNUM; PUSH1 0; MSTORE; PUSH1 0x20; PUSH1 0; RETURN`): it writes the
-/// slot number to memory and returns it as a 32-byte word. The `6009600c…f3`
-/// prefix is the standard constructor that copies that runtime out as the
-/// deployed code.
-// TODO: once Solidity exposes SLOTNUM, replace this hand-assembled bytecode
-// with a compiled Solidity source for readability.
-const SLOT_NUMBER_CONTRACT: Bytes = bytes!("0x6009600c60003960096000f34b60005260206000f3");
+/// Init bytecode for a contract that returns the current block's slot number
+/// as a 32-byte word.
+fn slot_number_contract() -> Bytes {
+    let mut contract = BytecodeBuilder::default();
+    contract.opcode(SLOTNUM).return_top_word();
+    contract.deployable()
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn block_header_includes_slot_number_on_amsterdam() -> anyhow::Result<()> {
@@ -155,7 +146,7 @@ async fn slot_number_continues_after_reserved_blocks() -> anyhow::Result<()> {
 async fn slotnum_opcode_returns_block_slot_number() -> anyhow::Result<()> {
     let provider = new_provider(edr_chain_l1::Hardfork::Amsterdam)?;
 
-    let contract_address = deploy_contract(&provider, SENDER, SLOT_NUMBER_CONTRACT.clone())?;
+    let contract_address = deploy_contract(&provider, SENDER, slot_number_contract())?;
 
     // Mine a few more blocks so the call executes in a block well after deployment.
     mine_block(&provider);
@@ -194,26 +185,15 @@ async fn slotnum_opcode_returns_block_slot_number() -> anyhow::Result<()> {
 // fail rather than return a value.
 #[tokio::test(flavor = "multi_thread")]
 async fn slotnum_opcode_unavailable_before_amsterdam() -> anyhow::Result<()> {
-    let logger = Box::new(NoopLogger::<L1ChainSpec>::default());
-    let subscriber = Box::new(|_event| {});
-
-    let mut config = create_test_config();
-    config.hardfork = edr_chain_l1::Hardfork::Osaka;
-    // Surface the resulting halt as an error instead of empty output.
-    config.bail_on_call_failure = true;
-
-    let provider = Provider::new(
-        runtime::Handle::current(),
-        logger,
-        subscriber,
-        config,
-        Arc::new(RwLock::<ContractDecoder>::default()),
-        CurrentTime,
-    )?;
+    let provider = new_provider_with_config(|config| {
+        config.hardfork = edr_chain_l1::Hardfork::Osaka;
+        // Surface the resulting halt as an error instead of empty output.
+        config.bail_on_call_failure = true;
+    })?;
 
     // The init bytecode never executes 0x4b (it only copies the runtime out), so
     // deployment succeeds even pre-Amsterdam.
-    let contract_address = deploy_contract(&provider, SENDER, SLOT_NUMBER_CONTRACT.clone())?;
+    let contract_address = deploy_contract(&provider, SENDER, slot_number_contract())?;
 
     let result = provider.handle_request(ProviderRequest::with_single(MethodInvocation::Call(
         L1CallRequest {


### PR DESCRIPTION
#1738 introduced a bytecode test module to help build hand-written bytecode, so the intent of a constructed contract is readable from code. This PR refactors the pre-existing hand-assembled contracts to use it