### PR TITLE
perf(edr_napi): lower the call trace arena external memory report

### DIFF
--- a/crates/edr_napi/src/provider/response.rs
+++ b/crates/edr_napi/src/provider/response.rs
@@ -13,19 +13,20 @@ use crate::{
 
 /// Bytes reported for one recorded call trace arena, without stack snapshots.
 ///
-/// A `CallTraceStep` is 192 bytes, so this is a trace of roughly 5,400 steps.
-/// A complex contract call runs many more, which is the intended direction:
-/// over-reporting costs a collection on every request, while under-reporting
-/// only forgoes some of the benefit.
-const CALL_TRACE_EXTERNAL_MEM_SIZE: i64 = 1024 * 1024;
+/// A `CallTraceNode` is 384 bytes, so this stands for roughly 85 calls. The
+/// EVM steps that an arena also records are deliberately not counted.
+///
+/// The figure under-reports on purpose. V8 asks for a collection every 64 MiB
+/// reported, and collecting a multi-gigabyte heap costs more than the arenas
+/// it releases.
+const CALL_TRACE_EXTERNAL_MEM_SIZE: i64 = 32 * 1024;
 
 /// Bytes reported for one recorded call trace arena whose steps also carry
 /// stack snapshots, as `verbose_raw_tracing` records them.
 ///
-/// A snapshot is a `Box<[U256]>`, so a step costs roughly 448 bytes rather than
-/// 192. PR #1301 measured 4.9x more retained memory in this configuration, so
-/// 4x stays on the low side of the only figures available.
-const VERBOSE_CALL_TRACE_EXTERNAL_MEM_SIZE: i64 = 4 * 1024 * 1024;
+/// PR #1301 measured 4.9x more retained memory in this configuration, so 4x
+/// stays on the low side of the only figures available.
+const VERBOSE_CALL_TRACE_EXTERNAL_MEM_SIZE: i64 = 4 * 32 * 1024;
 
 /// Bytes reported for a stack trace, which is a handful of frames of strings.
 const STACK_TRACE_EXTERNAL_MEM_SIZE: i64 = 4 * 1024;
@@ -39,8 +40,8 @@ const VALUE_DATA_EXTERNAL_MEM_SIZE: i64 = 256 * 1024 * 1024;
 
 /// Bytes a response reports for each call trace arena it carries.
 ///
-/// Recording stack snapshots takes a step from roughly 192 bytes to 448, so a
-/// verbosely recorded arena stands for several times as much.
+/// Recording stack snapshots retains several times as much, so a verbosely
+/// recorded arena stands for more.
 pub(crate) const fn call_trace_external_mem_size(verbose_tracing: bool) -> i64 {
     if verbose_tracing {
         VERBOSE_CALL_TRACE_EXTERNAL_MEM_SIZE


### PR DESCRIPTION
#1722 made each response report external memory to V8 for the call trace arenas it carries, at a flat 1 MiB per arena. V8 asks for a collection every 64 MiB reported, so that is one full collection per 64 arenas. However, recent optimisations in #1702, #1703, and #1704 reduced the actual memory size.

At `-vvvv` Hardhat requests traces for every call and transaction (`verbosityToIncludeTraces` → `IncludeTraces.All`), and gas estimation contributes one arena per gas probe. A full collection therefore incorrectly landed every few transactions, on a multi-gigabyte heap. The hh3 regression benchmark regressed accordingly, measured on the two push runs either side of the merge (334d190 → 8e4e1f1b):

| benchmark | metric | before | after | Δ |
| --- | --- | --- | --- | --- |
| openzeppelin-contracts / test mocha -vvvv | cpu | 70.1 s | 276.4 s | +294% |
| openzeppelin-contracts / test mocha -vvvv | wall | 64.5 s | 90.4 s | +40% |
| openzeppelin-contracts / test mocha -vvv | cpu | 64.2 s | 89.5 s | +39% |
| lidofinance-core / test mocha -vvvv | cpu | 387.9 s | 512.8 s | +32% |
| ens-contracts / test vitest -vvvv | wall | 4.65 s | 5.65 s | +21% |

The cost tracks verbosity exactly, i.e. the number of arenas per response: `test mocha` without `-v` is unchanged (+0.1%), and all 60 `test solidity` entries are flat within ±2%. The other commit in that measurement window, #1698, runs on every response regardless of verbosity, so it is not implicated.

## Fix

Report 32 KiB per arena instead of 1 MiB, and 128 KiB instead of 4 MiB when stack snapshots are recorded. The 4x ratio between the two is unchanged.

32 KiB is roughly 85 `CallTraceNode`s, and the figure now deliberately excludes the EVM steps an arena also records. Steps are the bulk of an arena, so leaving them out under-reports on purpose: V8 now asks for a collection every ~2048 arenas rather than every 64.

## What this gives up

Peak RSS also improved in those runs — 6% for openzeppelin-contracts, but 49% and 70% for lidofinance-core at `-vvv` and `-vvvv` (4042 MB → 1214 MB). Reporting 32x less memory means the garbage collector will be triggered less often and some of those gains might be reduced. That is the intended trade: runtime over memory.

## Validation
- [ ] A `/bench` run before merging, to confirm the CPU recovery and measure how much RSS comes back.